### PR TITLE
faq.php: direct the reader to the docs site

### DIFF
--- a/public/faq.php
+++ b/public/faq.php
@@ -89,16 +89,10 @@
 		echo "<p>Hardcore mode is an additional feature to separate out the good gamers from the great gamers: Hardcore mode disables *all* savestate ability in the emulator: you would not be able to save and reload at any time. You would have to complete the game and get the achievements first time, just like it were on the original console. In reward for this, you will earn both the standard and the hardcore achievement, in effect earning double points! A regular game worth 400 points, is now worth 800 if you complete it fully on hardcore! For example: if you complete the game fully for 400 points, you then have the opportunity to earn another 400 on hardcore.</p>";
 		
 		echo "<h4 class='longheader' id='faq6'>I want to make achievements!</h4>";
-		echo "<p>Good to hear! There are various resources that are available to help; first I'd recommend having a look in the <a href='http://retroachievements.org/forum.php?c=7'>Developer forum</a> for further information, specifically <a href='http://retroachievements.org/viewtopic.php?t=12'> this tutorial</a>. Also the following video may be useful:<br/><br/>";
+		echo "<p><strong>Good to hear!</strong> The best place to start is here: <a href='https://retroachievements.github.io/docs/Getting-Started-as-an-Achievement-Developer'>Getting Started as an Achievement Developer</a>. Once you're familiar with the Memory Inspector and the other Achievements related dialogs, you can go to other <a href='https://retroachievements.github.io/docs/#developer-docs'>Developer Docs</a>.</p>"
 		
-		//	Development
-		echo '
-		<object type="application/x-shockwave-flash" style="width:600px; height:400px;" data="https://www.youtube-nocookie.com/v/8nYb_5cgQHY?hl=en&amp;fs=1"><param name="allowFullScreen" value="true"/><param name="allowscriptaccess" value="always"/><param name="movie" value="http://www.youtube.com/v/8nYb_5cgQHY?hl=en&amp;fs=1" /></object><br/>
-		';
-		
-		echo "Please don't hesitate to ask if you need help, don't struggle! The only recommendation I have is to make sure you're enjoying whatever it is you're doing. If you're not having fun, don't do it :) if you get frustrated, just drop a message on the forums or in the chat and someone will get back to you shortly.";
-		
-		echo "</p>";
+		echo "<p>Please don't hesitate to ask if you need help, don't struggle! The most important thing is to make sure you're enjoying whatever it is you're doing. If you're not having fun, don't do it. But if you get frustrated and want to persist, just drop a message on the <a href='http://retroachievements.org/forum.php?c=7'>forums</a> or in our <a href='https://discord.gg/TdfC3r7'>Discord server</a> and someone will get back to you shortly.</p>"
+
 		echo "<h4 class='longheader' id='faq7'>These emulators are GPL protected! Where is the source code?</h4>";
 		echo "<p>That is correct! We fully support the open-source initiative, and welcome any changes to the source that builds either emulators or the RA toolset. Please visit <a href='http://sourceforge.net/projects/retroachievers/'>our page on SourceForge</a> and help yourself to the source code. All emulators build with Visual Studio Community 2013 and <a href='http://www.microsoft.com/en-gb/download/details.aspx?id=5770'>Microsoft DirectX SDK (June 2008)</a>. Why do we use such an old DirectX SDK? Some of the emulators were built in early 2000s, and utilise DirectDraw; this is the latest version of DirectX that will support all emulators.</p>";
 		
@@ -133,4 +127,3 @@
 
 </body>
 </html>
-


### PR DESCRIPTION
On the question about creating achievements.

Also, I wonder if we should make that link on "Home" menu go to our FAQ on the docs site. :thinking: 

https://retroachievements.github.io/docs/FAQ/