### PR TITLE
show link to open tickets for all users

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -587,7 +587,7 @@ $numGridlines = $numAchievements;
                 echo "<h4>Achievements</h4>";
 
                 echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br/>";
-
+                echo "<a href='/ticketmanager.php?g=$gameID&ampt=1'>View open tickets for this game</a><br/>";
                 if( isset( $user ) )
                 {
                     $pctAwardedCasual = 0;


### PR DESCRIPTION
The link to the list of open tickets is currently available only for devs, but I think every user should have access to it.

It can help to avoid duplicated tickets describing the same problem.

Example of how it will look like:
![link-to-open-tickets](https://user-images.githubusercontent.com/8508804/39081048-d76cae1e-4510-11e8-88a5-6f91defa88f2.png)

I kept the link on that "Dev (Click to show)" menu.

closes #7 