### PR TITLE
added a menu with useful links for regular users

### DIFF
--- a/public/css/style54.css
+++ b/public/css/style54.css
@@ -791,6 +791,13 @@ th {
     border-bottom: 2px dashed;
 }
 
+.userinfobox {
+    padding: 4px 0px;
+}
+.userinfobox span {
+    border-bottom: 2px dashed;
+}
+
 .leftfloat {
     float: left;
 }

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -584,6 +584,23 @@ $numGridlines = $numAchievements;
                     echo "</div>";
                 }
 
+                if( isset( $user ) )
+                {
+                    echo "<div class='devbox'>";
+                    echo "<span onclick=\"$('#devboxcontent').toggle(500); return false;\">More info (Click to show):</span><br/>";
+                    echo "<div id='devboxcontent'>";
+                    echo "<ul>";
+
+                    echo "<li><a href='/linkedhashes.php?g=$gameID'>Show linked hashes to this game</a></li>";
+                    echo "<li><a href='/ticketmanager.php?g=$gameID&ampt=1'>View open tickets for this game</a></li>";
+
+                    echo "</ul>";
+
+                    echo "</div>";
+
+                    echo "</div>";
+                }
+
                 echo "<h4>Achievements</h4>";
 
                 echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br/>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -586,9 +586,9 @@ $numGridlines = $numAchievements;
 
                 if( isset( $user ) )
                 {
-                    echo "<div class='devbox'>";
-                    echo "<span onclick=\"$('#devboxcontent').toggle(500); return false;\">More info (Click to show):</span><br/>";
-                    echo "<div id='devboxcontent'>";
+                    echo "<div class='userinfobox'>";
+                    echo "<span onclick=\"$('#userinfoboxcontent').toggle(500); return false;\">More info (Click to show):</span><br/>";
+                    echo "<div id='userinfoboxcontent'>";
                     echo "<ul>";
 
                     echo "<li><a href='/linkedhashes.php?g=$gameID'>Show linked hashes to this game</a></li>";

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -521,6 +521,7 @@ $('.searchuser').val(ui.item.id);
         });
         };
         $('#devboxcontent').hide();
+        $('#userinfoboxcontent').hide();
         $('.msgPayload').hide();
         $('#managevids').hide();
         $('#chatinput').width('75%');

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -1,0 +1,91 @@
+<?php
+require_once __DIR__ . '/../lib/bootstrap.php';
+
+if( isset( $user ) )
+{
+    //	Immediate redirect if we cannot validate user!	//TBD: pass args?
+    header( "Location: http://" . AT_HOST );
+    exit;
+}
+
+$gameID = seekGET( 'g' );
+$errorCode = seekGET( 'e' );
+
+$achievementList = array();
+$gamesList = array();
+
+$gameIDSpecified = ( isset( $gameID ) && $gameID != 0 );
+if( $gameIDSpecified )
+{
+    getGameMetadata( $gameID, $user, $achievementData, $gameData );
+}
+else
+{
+    //	Immediate redirect: this is pointless otherwise!
+    header( "Location: http://" . AT_HOST );
+}
+
+$query = "SELECT MD5 FROM GameHashLibrary WHERE GameID=$gameID";
+$dbResult = s_mysql_query( $query );
+
+$hashList = array();
+while( $db_entry = mysqli_fetch_assoc( $dbResult ) )
+{
+    $hashList[] = $db_entry[ 'MD5' ];
+}
+
+$numLinks = count( $hashList );
+
+$consoleName = $gameData[ 'ConsoleName' ];
+$consoleID = $gameData[ 'ConsoleID' ];
+$gameTitle = $gameData[ 'Title' ];
+$gameIcon = $gameData[ 'ImageIcon' ];
+
+$pageTitle = "Rename Game Entry ($consoleName)";
+
+//$numGames = getGamesListWithNumAchievements( $consoleID, $gamesList, 0 );
+//var_dump( $gamesList );
+RenderDocType();
+?>
+
+<head>
+    <?php RenderSharedHeader( $user ); ?>
+    <?php RenderTitleTag( $pageTitle, $user ); ?>
+    <?php RenderGoogleTracking(); ?>
+</head>
+<body>
+
+    <?php RenderTitleBar( $user, $points, $truePoints, $unreadMessageCount, $errorCode ); ?>
+    <?php RenderToolbar( $user, $permissions ); ?>
+
+    <div id="mainpage">
+        <div class='left'>
+
+            <h2>Show Linked Hashes</h2>
+
+            <?php
+            echo GetGameAndTooltipDiv( $gameID, $gameTitle, $gameIcon, $consoleName, FALSE, 96 );
+            echo "</br></br>";
+
+            echo "<strong>Linked hashes to <a href='/Game/$gameID'>$gameTitle</a> ($consoleName).</strong><br/>";
+
+            echo "Currently this game has <b>$numLinks</b> unique ROM(s) registered for it with the following MD5s:<br/><br/>";
+
+            echo "<ul>";
+            for( $i = 0; $i < $numLinks; $i++ )
+            {
+                echo "<li><code>" . $hashList[ $i ] . "</code></li>";
+            }
+            echo "</ul>";
+
+            echo "<br/>";
+
+            ?>
+            <br/>
+        </div>
+    </div>
+
+    <?php RenderFooter(); ?>
+
+</body>
+</html>


### PR DESCRIPTION
**WARNING: do not merge this for now!!**

I'm not smart enough to reproduce an environment similar to the prod locally, then this PR was "blind-coded". @luchaos said to me he will test it when he have a chance.

---

Added a "click-to-show" menu with useful links for regular users.

The screenshots below explains better.

"unclicked" version:
![moreinfo-unclicked](https://user-images.githubusercontent.com/8508804/39089890-ec4f116e-45a6-11e8-85d3-327bfdd12efc.png)

"clicked" version:
![moreinfo-clicked](https://user-images.githubusercontent.com/8508804/39089889-ebf94d6a-45a6-11e8-8d05-2af824825dc5.png)

This PR also adds the file `linkedhashes.php` wich is responsible to list all linked hashes to a game. Very similar to what we see on the `attemptunlink.php` but without the button to unlink anything.

closes #1 