### PR TITLE
show cheevo's Author in the tickemanager's main page and columns rearrangement

### DIFF
--- a/lib/database/tickets.php
+++ b/lib/database/tickets.php
@@ -191,7 +191,7 @@ function getAllTickets( $offset = 0, $limit = 50, $assignedToUser = NULL, $given
 
 
     $query = "SELECT tick.ID, tick.AchievementID, ach.Title AS AchievementTitle, ach.Description AS AchievementDesc, ach.Points, ach.BadgeName,
-				ach.GameID, c.Name AS ConsoleName, gd.Title AS GameTitle, gd.ImageIcon AS GameIcon,
+				ach.Author AS AchievementAuthor, ach.GameID, c.Name AS ConsoleName, gd.Title AS GameTitle, gd.ImageIcon AS GameIcon,
 				tick.ReportedAt, tick.ReportType, tick.ReportNotes, ua.User AS ReportedBy, tick.ResolvedAt, ua2.User AS ResolvedBy, tick.ReportState
 			  FROM Ticket AS tick
 			  LEFT JOIN Achievements AS ach ON ach.ID = tick.AchievementID

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -121,12 +121,12 @@ RenderDocType();
                 echo "<table><tbody>";
 
                 echo "<th>ID</th>";
+                echo "<th>Status</th>";
                 echo "<th>Achievement</th>";
                 echo "<th>Game</th>";
                 echo "<th>Developer</th>";
                 echo "<th>Reporter</th>";
                 echo "<th>Reported At</th>";
-                echo "<th colspan=2>Ticket State</th>";
 
                 $rowCount = 0;
 
@@ -165,6 +165,12 @@ RenderDocType();
                     echo "<td>";
                     echo "<a href='/ticketmanager.php?i=$ticketID'>$ticketID</a>";
                     echo "</td>";
+                    
+                    echo "<td>";
+                    $reportStates = array( "Closed", "Open", "Resolved" );
+                    echo $reportStates[ $tickState ];
+                    echo "</td>";
+
 
                     echo "<td style='min-width:25%'>";
                     echo GetAchievementAndTooltipDiv( $achID, $achTitle, $achDesc, $achPoints, $gameTitle, $achBadgeName, TRUE );
@@ -189,11 +195,6 @@ RenderDocType();
                     // echo "<td>";
                     // echo $reportNotes;
                     // echo "</td>";
-
-                    echo "<td>";
-                    $reportStates = array( "Closed", "Open", "Resolved" );
-                    echo "<a href='/ticketmanager.php?i=$ticketID'>" . $reportStates[ $tickState ] . "</a>";
-                    echo "</td>";
 
                     echo "</tr>";
                 }

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -121,8 +121,9 @@ RenderDocType();
                 echo "<table><tbody>";
 
                 echo "<th>ID</th>";
-                echo "<th>Game</th>";
                 echo "<th>Achievement</th>";
+                echo "<th>Game</th>";
+                echo "<th>Developer</th>";
                 echo "<th>Reporter</th>";
                 echo "<th>Reported At</th>";
                 echo "<th colspan=2>Ticket State</th>";
@@ -138,6 +139,7 @@ RenderDocType();
                     $achID = $nextTicket[ 'AchievementID' ];
                     $achTitle = $nextTicket[ 'AchievementTitle' ];
                     $achDesc = $nextTicket[ 'AchievementDesc' ];
+                    $achAuthor = $nextTicket[ 'AchievementAuthor' ];
                     $achPoints = $nextTicket[ 'Points' ];
                     $achBadgeName = $nextTicket[ 'BadgeName' ];
                     $gameID = $nextTicket[ 'GameID' ];
@@ -164,12 +166,16 @@ RenderDocType();
                     echo "<a href='/ticketmanager.php?i=$ticketID'>$ticketID</a>";
                     echo "</td>";
 
+                    echo "<td style='min-width:25%'>";
+                    echo GetAchievementAndTooltipDiv( $achID, $achTitle, $achDesc, $achPoints, $gameTitle, $achBadgeName, TRUE );
+                    echo "</td>";
+
                     echo "<td>";
                     echo GetGameAndTooltipDiv( $gameID, $gameTitle, $gameBadge, $consoleName );
                     echo "</td>";
 
-                    echo "<td style='min-width:25%'>";
-                    echo GetAchievementAndTooltipDiv( $achID, $achTitle, $achDesc, $achPoints, $gameTitle, $achBadgeName, TRUE );
+                    echo "<td>";
+                    echo GetUserAndTooltipDiv( $achAuthor, NULL, NULL, NULL, NULL, TRUE );
                     echo "</td>";
 
                     echo "<td>";
@@ -186,11 +192,7 @@ RenderDocType();
 
                     echo "<td>";
                     $reportStates = array( "Closed", "Open", "Resolved" );
-                    echo $reportStates[ $tickState ];
-                    echo "</td>";
-
-                    echo "<td>";
-                    echo "<div style='float:right;'><a href='/ticketmanager.php?i=$ticketID'>Show&nbsp;&nbsp;</a></div>";
+                    echo "<a href='/ticketmanager.php?i=$ticketID'>" . $reportStates[ $tickState ] . "</a>";
                     echo "</td>";
 
                     echo "</tr>";
@@ -436,4 +438,3 @@ RenderDocType();
 
 </body>
 </html>
-


### PR DESCRIPTION
changing from:
![ticketmanagerbefore](https://user-images.githubusercontent.com/8508804/40454572-a357206e-5ebf-11e8-8a50-c62040b8ed2e.png)

to (I just repeated the reporter user in the dev's user for this mockup):
![ticketmanagerafter](https://user-images.githubusercontent.com/8508804/40454573-a38335d2-5ebf-11e8-9197-2b3f7a41893f.png)
