### PR TITLE
Improvements for Developer Stats page

### DIFF
--- a/public/developerstats.php
+++ b/public/developerstats.php
@@ -6,15 +6,6 @@
 	$playersOnlineCSV = file_get_contents( "./cronjobs/playersonline.log" );
 	$playersCSV = preg_split('/\n|\r\n?/', $playersOnlineCSV);
 	
-	$hoursInADay = 24;
-	$numDays = 2;
-	
-	$numDataPoints = 2 * $hoursInADay * $numDays;	//	2 30segments * 24hrs * 2 days worth
-	
-	//$playersOnlineArray = Array();
-	//for( $i = 0; $i < $numDataPoints; $i++ )
-	//	$playersOnlineArray[] = $playersCSV[count($playersCSV)-($i+2)];
-
 	$staticData = getStaticData();
 	$errorCode = seekGET( 'e' );
 	$type = seekGET( 't', 0 );
@@ -25,87 +16,6 @@
 <head>
 	<!--Load the AJAX API-->
 	<script type="text/javascript" src="https://www.google.com/jsapi"></script>
-	<script type="text/javascript">
-
-		// Load the Visualization API and the piechart package.
-		//google.load('visualization', '1.0', {'packages':['corechart']});
-
-		// Set a callback to run when the Google Visualization API is loaded.
-		//google.setOnLoadCallback(drawCharts);
-
-		// Callback that creates and populates a data table,
-		// instantiates the pie chart, passes in the data and
-		// draws it.
-//		function drawCharts()
-//		{
-//			var dataTotalScore = new google.visualization.DataTable();
-//
-//			// Declare columns
-//			dataTotalScore.addColumn('datetime', 'Time');
-//			dataTotalScore.addColumn('number', 'Players Online');
-//			dataTotalScore.addColumn('number', 'Players Online Yesterday');
-//
-//			dataTotalScore.addRows([
-//				<?php
-//					$largestWonByCount = 0;
-//					$count = 0;
-//					$now = date("Y/m/d G:0:0");
-//					//error_log( $now );
-//
-//					for( $i = 0; $i < $hoursInADay; $i++ )
-//					{
-//						$numPlayers = $playersOnlineArray[$i];
-//						$numPlayersYDay = $playersOnlineArray[$i+$hoursInADay];
-//
-//						if( $i != 0 )
-//							echo ", ";
-//
-//						$mins = $i * 30;
-//
-//						$timestamp = strtotime("-$mins minutes", strtotime($now));
-//
-//						$yr = date("Y", $timestamp);
-//						$month = date("m", $timestamp);
-//						$day = date("d", $timestamp);
-//						$hour = date("G", $timestamp);
-//						$min = date("i", $timestamp);
-//
-//						echo "[ new Date($yr,$month,$day,$hour,$min), {v:$numPlayers, f:\"$numPlayers online\"}, {v:$numPlayersYDay, f:\"$numPlayersYDay online yesterday\"} ] ";
-//					}
-//				?>
-//			]);
-//
-//			<?php //
-//				$numGridlines = $hoursInADay;
-//			?>
-//
-//			var optionsTotalScore = {
-//				backgroundColor: 'transparent',
-//				//title: 'Achievement Distribution',
-//				titleTextStyle: {color: '#186DEE'}, //cc9900
-//				//hAxis: {textStyle: {color: '#186DEE'}, gridlines:{count:24, color: '#334433'}, minorGridlines:{count:0}, format:'#', slantedTextAngle:90, maxAlternation:0 },
-//				hAxis: {textStyle: {color: '#186DEE'} },
-//				vAxis: {textStyle: {color: '#186DEE'}, viewWindow:{min:0}, format: '#' },
-//				legend: {position: 'none' },
-//				chartArea: {'width': '85%', 'height': '78%'},
-//				height: 260,
-//				colors: ['#cc9900'],
-//				pointSize: 3
-//			};
-//
-//			function resize ()
-//			{
-//				chartScoreProgress = new google.visualization.AreaChart(document.getElementById('chart_usersonline'));
-//				chartScoreProgress.draw(dataTotalScore, optionsTotalScore);
-//
-//				//google.visualization.events.addListener(chartScoreProgress, 'select', selectHandlerScoreProgress );
-//			}
-//
-//			window.onload = resize();
-//			window.onresize = resize;
-//		}
-	</script>
-
 <?php
 	RenderSharedHeader( $user );
 	RenderTitleTag( "Developer Stats", $user );
@@ -125,9 +35,38 @@
 <div id='leftcontainer'>
 <?php
 	RenderErrorCodeWarning( 'left', $errorCode );
-	RenderDeveloperStats( $user, $type );
-	//echo "<h3>Users Online</h3>";
-	//echo "<div id='chart_usersonline'></div>";
+	//RenderDeveloperStats( $user, $type );
+    $devStatsList = GetDeveloperStatsFull( 100, $type );
+
+    echo "<div class='rightfloat'>* = ordered by</div>";
+    echo "<table class='smalltable'><tbody>";
+    echo "<th>Developer</th>";
+    echo "<th>" . ($type == 3 ? "*" : "") . "<a href='/developerstats.php?t=3'>Open Tickets</a></th>";
+    echo "<th>" . ($type == 0 ? "*" : "") . "<a href='/developerstats.php?'>Achievements</a></th>";
+    echo "<th>" . ($type == 1 ? "*" : "") . "<a href='/developerstats.php?t=1'>Achievements won by others</a></th>";
+    echo "<th>" . ($type == 2 ? "*" : "") . "<a href='/developerstats.php?t=2'>Points allocated to achievements</a></th>";
+    
+    $userCount = 0;
+    foreach( $devStatsList as $devStats )
+    {
+        if( $userCount++ % 2 == 0 )
+            echo "<tr>";
+        else
+            echo "<tr class=\"alt\">";
+
+        $dev = $devStats[ 'Author' ];
+        echo "<td><div class='fixheightcell'>";
+        echo GetUserAndTooltipDiv( $dev, NULL, NULL, NULL, NULL, true );
+        echo GetUserAndTooltipDiv( $dev, NULL, NULL, NULL, NULL, false );
+        echo "</div></td>";
+
+        echo "<td>" . $devStats[ 'OpenTickets' ] . "</td>";
+        echo "<td>" . $devStats[ 'ContribCount' ] . "</td>";
+        echo "<td>" . $devStats[ 'ContribYield' ] . "</td>";
+        echo "<td>" . $devStats[ 'Achievements' ] . "</td>";
+
+    }
+    echo "</tbody></table>";
 ?>	
 </div>
 

--- a/public/developerstats.php
+++ b/public/developerstats.php
@@ -44,7 +44,7 @@
     echo "<th>" . ($type == 3 ? "*" : "") . "<a href='/developerstats.php?t=3'>Open Tickets</a></th>";
     echo "<th>" . ($type == 0 ? "*" : "") . "<a href='/developerstats.php?'>Achievements</a></th>";
     echo "<th>" . ($type == 1 ? "*" : "") . "<a href='/developerstats.php?t=1'>Achievements won by others</a></th>";
-    echo "<th>" . ($type == 2 ? "*" : "") . "<a href='/developerstats.php?t=2'>Points allocated to achievements</a></th>";
+    echo "<th>" . ($type == 2 ? "*" : "") . "<a href='/developerstats.php?t=2'>Points awarded to others</a></th>";
     
     $userCount = 0;
     foreach( $devStatsList as $devStats )

--- a/public/developerstats.php
+++ b/public/developerstats.php
@@ -33,9 +33,9 @@
 <div id='mainpage'>
 
 <div id='leftcontainer'>
+<h3>Developer Stats</h3>
 <?php
-	RenderErrorCodeWarning( 'left', $errorCode );
-	//RenderDeveloperStats( $user, $type );
+    RenderErrorCodeWarning( 'left', $errorCode );
     $devStatsList = GetDeveloperStatsFull( 100, $type );
 
     echo "<div class='rightfloat'>* = ordered by</div>";


### PR DESCRIPTION
Showing:
- number of open tickets
- number of achievements on the Core set
- number of achievements won by others
- number of points allocated to achievements

Also adding an option to sort by those criteria (always in descending order).

It'll look like in the example below (don't mind the missing userpics and the outdated numbers):

![developerstats](https://user-images.githubusercontent.com/8508804/40570139-1d24819e-605e-11e8-8543-2dc7cb3b9345.png)
