### PR TITLE
do not award Unofficial cheevos

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -413,6 +413,12 @@ function AddEarnedAchievementJSON( $user, $achIDToAward, $isHardcore, $validatio
             $retVal[ 'Success' ] = FALSE;
             $retVal[ 'Error' ] = "User data cannot be found for $user";
         }
+        else if( $achData[ 'Flags' ] == 5 ) // Unofficial achievement
+        {
+            // should we return TRUE? does it affect something in the emulator's end?
+            $retVal[ 'Success' ] = FALSE;
+            $retVal[ 'Error' ] = "Unofficial achievements aren't registered on the RetroAchievements.org database";
+        }
         else
         {
             $hasAwardTypes = HasAward( $user, $achIDToAward );

--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -413,9 +413,8 @@ function AddEarnedAchievementJSON( $user, $achIDToAward, $isHardcore, $validatio
             $retVal[ 'Success' ] = FALSE;
             $retVal[ 'Error' ] = "User data cannot be found for $user";
         }
-        else if( $achData[ 'Flags' ] == 5 ) // Unofficial achievement
+        else if( ( $achData[ 'Flags' ] & 4 ) != 0 ) // (almost) the same as Flags = 5. Unofficial achievement
         {
-            // should we return TRUE? does it affect something in the emulator's end?
             $retVal[ 'Success' ] = FALSE;
             $retVal[ 'Error' ] = "Unofficial achievements aren't registered on the RetroAchievements.org database";
         }

--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -413,7 +413,7 @@ function AddEarnedAchievementJSON( $user, $achIDToAward, $isHardcore, $validatio
             $retVal[ 'Success' ] = FALSE;
             $retVal[ 'Error' ] = "User data cannot be found for $user";
         }
-        else if( ( $achData[ 'Flags' ] & 4 ) != 0 ) // (almost) the same as Flags = 5. Unofficial achievement
+        else if( $achData[ 'Flags' ] == 5 ) // do not award Unofficial achievements
         {
             $retVal[ 'Success' ] = FALSE;
             $retVal[ 'Error' ] = "Unofficial achievements aren't registered on the RetroAchievements.org database";


### PR DESCRIPTION
## Description

This PR makes Unofficial Achievements not being actually awarded in the server's database.

## Reasoning

Currently when someone earn an Unofficial achievement, it remains awarded for the user when the achievement is promoted to the Core. This is not a good approach because while in Unofficial the achievement is a work in progress

Example of why it isn't good: if a challenging cheevo, worthing many points, are in development and an user got it while the code wasn't very accurate (triggering at a wrong time), when the cheevo is promoted to the Core, that user still have the cheevo as awarded. And it is clearly unfair.

If you guys agree with this PR we could make the Unofficial Achievements page (#139, [example for Sonic](http://retroachievements.org/gameInfo.php?ID=1&f=5)) available to regular users too. This way they will can help developers with testing, but not getting the cheevos actually awarded they're not in Core.

This is part of my attempt to reinforce the attitude of **treating users as responsible for the project quality, not just mere consumers**. They should help us (and the devs) to make a good work and solve the issues, not just making demands and complain.

@JuliaWolska said several times (and any dev easily agrees) how useful it would be to have testers while developing a set. But asking users to open the emulator (first con: requires Windows), load the game, open the Achievement Set dialog box, and click on Unofficial radio box... Although simple, it's not as straight forward than just viewing the list of Unofficial cheevos on the site.