### PR TITLE
adds a "More Info" box with useful links to regular users

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -485,23 +485,25 @@ $numGridlines = $numAchievements;
 
                 if( isset( $user ) && $permissions >= \RA\Permissions::Developer )
                 {
-                    echo "<p style='text-align:center'>";
-                    if( $flags == 5 )
-                        echo "<b><a href='/Game/$gameID'>Core</a> | Unofficial</b>";
-                    else
-                        echo "<b>Core | <a href='/gameInfo.php?ID=$gameID&f=5'>Unofficial</a></b>";
-                    echo "</p>";
-
                     echo "<div class='devbox'>";
                     echo "<span onclick=\"$('#devboxcontent').toggle(500); return false;\">Dev (Click to show):</span><br/>";
                     echo "<div id='devboxcontent'>";
                     echo "<ul>";
+
+                    if( $flags == 5 )
+                        echo "<li><a href='/Game/$gameID'>View Core Achievements</a></li>";
+                    else
+                        echo "<li><a href='/gameInfo.php?ID=$gameID&f=5'>View Unofficial Achievements</a></li>";
+
                     echo "<li><a href='/achievementinspector.php?g=$gameID'>Manage Achievements</a></li>";
                     echo "<li><a href='/leaderboardList.php?g=$gameID'>Manage Leaderboards</a></li>";
+
                     if( $numAchievements == 0 )
                         echo "<li><a href='/attemptmerge.php?g=$gameID'>Merge Game</a></li>";
+
                     echo "<li><a href='/attemptrename.php?g=$gameID'>Rename Game</a></li>";
                     echo "<li><a href='/attemptunlink.php?g=$gameID'>Unlink Game</a></li>";
+
                     if( $numLeaderboards == 0 )
                         echo "<li><a href='/requestcreatenewlb.php?u=$user&amp;c=$cookie&amp;g=$gameID'>Create First Leaderboard</a></li>";
                     echo "<li><a href='/request.php?r=recalctrueratio&amp;g=$gameID&amp;b=1'>Recalculate True Ratios</a></li>";
@@ -606,11 +608,17 @@ $numGridlines = $numAchievements;
                     echo "</div>";
                 }
 
-                echo "<h4>";
                 if( $flags == 5 )
-                    echo "<b>Unofficial</b> ";
-                echo "Achievements</h4>";
-                echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br/>";
+                {
+                    echo "<h4><b>Unofficial</b> Achievements</h4>";
+                    echo "<a href='/Game/$gameID'><b>Click here to view the Core Achievements</b></a><br>";
+                    echo "There are <b>$numAchievements Unofficial</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br/>";
+                }
+                else
+                {
+                    echo "<h4>Achievements</h4>";
+                    echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br/>";
+                }
 
                 if( $numAchievements > 0 )
                 {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -483,20 +483,20 @@ $numGridlines = $numAchievements;
                 echo "<div style='clear:both;'></div>";
                 echo "</br>";
 
-                if( isset( $user ) )
-                    echo "<p><a href='/linkedhashes.php?g=$gameID'><b>View the list of hashes linked to this game</b></a></p>";
-
-                if( isset( $user ) && $permissions >= 2 )
+                if( isset( $user ) && $permissions >= \RA\Permissions::Developer )
                 {
+                    echo "<p style='text-align:center'>";
+                    if( $flags == 5 )
+                        echo "<b><a href='/Game/$gameID'>Core</a> | Unofficial</b>";
+                    else
+                        echo "<b>Core | <a href='/gameInfo.php?ID=$gameID&f=5'>Unofficial</a></b>";
+                    echo "</p>";
+
                     echo "<div class='devbox'>";
                     echo "<span onclick=\"$('#devboxcontent').toggle(500); return false;\">Dev (Click to show):</span><br/>";
                     echo "<div id='devboxcontent'>";
                     echo "<ul>";
                     echo "<li><a href='/achievementinspector.php?g=$gameID'>Manage Achievements</a></li>";
-                    if( $flags == 5 )
-                        echo "<li><a href='/Game/$gameID'>View Core Achievements</a></li>";
-                    else
-                        echo "<li><a href='/gameInfo.php?ID=$gameID&f=5'>View Unofficial Achievements</a></li>";
                     echo "<li><a href='/leaderboardList.php?g=$gameID'>Manage Leaderboards</a></li>";
                     if( $numAchievements == 0 )
                         echo "<li><a href='/attemptmerge.php?g=$gameID'>Merge Game</a></li>";
@@ -606,17 +606,12 @@ $numGridlines = $numAchievements;
                     echo "</div>";
                 }
 
+                echo "<h4>";
                 if( $flags == 5 )
-                {
-                    echo "<h4><b>Unofficial</b> Achievements</h4>";
-                    echo "<a href='/Game/$gameID'><b>Click here to view the Core Achievements</b></a><br>";
-                    echo "There are <b>$numAchievements</b> <b>Unofficial</b> achievements worth <b>$totalPossible</b> points.<br/>";
-                }
-                else
-                {
-                    echo "<h4>Achievements</h4>";
-                    echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br/>";
-                }
+                    echo "<b>Unofficial</b> ";
+                echo "Achievements</h4>";
+                echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br/>";
+
                 if( $numAchievements > 0 )
                 {
                     echo "<b>Authors:</b> ";
@@ -872,15 +867,15 @@ $numGridlines = $numAchievements;
             if( isset( $user ) )
             {
                 echo "<h3>More Info</h3>";
-                echo "About \"$gameTitle ($consoleName)\":<br>";
+                echo "<b>About \"$gameTitle ($consoleName)\":</b><br>";
                 echo "<ul>";
                 echo "<li>- <a href='/viewtopic.php?t=$forumTopicID'>Official forum topic</a></li>";
                 echo "<li>- <a href='/linkedhashes.php?g=$gameID'>Hashes linked to this game</a></li>";
                 echo "<li>- <a href='/ticketmanager.php?g=$gameID&ampt=1'>Open Tickets for this game</a></li>";
-                if( $flags == 5 )
-                    echo "<li>- <a href='/game/$gameid'>view core achievements</a></li>";
-                else
-                    echo "<li>- <a href='/gameInfo.php?ID=$gameID&f=5'>View Unofficial Achievements</a></li>";
+                //if( $flags == 5 )
+                    //echo "<li>- <a href='/Game/$gameID'>View Core Achievements</a></li>";
+                //else
+                    //echo "<li>- <a href='/gameInfo.php?ID=$gameID&f=5'>View Unofficial Achievements</a></li>";
                 echo "</ul><br>";
             }
 

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -22,16 +22,13 @@ if( RA_ReadCookieCredentials( $user, $points, $truePoints, $unreadMessageCount, 
 
 $errorCode = seekGET( 'e' );
 
-$flags = 3; // achievements from the Core set
+$flags = seekGET( 'f', 3 ); // flags = 3 means Core achievements
+settype( $flags, 'integer' );
+
 $defaultSort = 1;
 if( isset( $user ) )
 {
     $defaultSort = 13;
-    if( $permissions >= \RA\Permissions::Developer )
-    {
-        $flags = seekGET( 'f' );
-        settype( $flags, 'integer' );
-    }
 }
 $sortBy = seekGET( 's', $defaultSort );
 
@@ -613,11 +610,13 @@ $numGridlines = $numAchievements;
                 {
                     echo "<h4><b>Unofficial</b> Achievements</h4>";
                     echo "<a href='/Game/$gameID'><b>Click here to view the Core Achievements</b></a><br>";
+                    echo "There are <b>$numAchievements</b> <b>Unofficial</b> achievements worth <b>$totalPossible</b> points.<br/>";
                 }
                 else
+                {
                     echo "<h4>Achievements</h4>";
-
-                echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br/>";
+                    echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br/>";
+                }
                 if( $numAchievements > 0 )
                 {
                     echo "<b>Authors:</b> ";
@@ -869,6 +868,21 @@ $numGridlines = $numAchievements;
             <?php
             //	Render game box art
             RenderBoxArt( $gameData[ 'ImageBoxArt' ] );
+
+            if( isset( $user ) )
+            {
+                echo "<h3>More Info</h3>";
+                echo "About \"$gameTitle ($consoleName)\":<br>";
+                echo "<ul>";
+                echo "<li>- <a href='/viewtopic.php?t=$forumTopicID'>Official forum topic</a></li>";
+                echo "<li>- <a href='/linkedhashes.php?g=$gameID'>Hashes linked to this game</a></li>";
+                echo "<li>- <a href='/ticketmanager.php?g=$gameID&ampt=1'>Open Tickets for this game</a></li>";
+                if( $flags == 5 )
+                    echo "<li>- <a href='/game/$gameid'>view core achievements</a></li>";
+                else
+                    echo "<li>- <a href='/gameInfo.php?ID=$gameID&f=5'>View Unofficial Achievements</a></li>";
+                echo "</ul><br>";
+            }
 
             if( count( $gameAlts ) > 0 )
                 RenderGameAlts( $gameAlts );


### PR DESCRIPTION
This PR adds a "More Info" box in the right container, available for any logged in user.

It looks like this screenshot (don't mind the missing boxart, also the link to Unofficial was removed by @GameDragon2k's request):

![rightcontainer](https://user-images.githubusercontent.com/8508804/40690914-c3bbc156-637f-11e8-95a9-06bc0a58c80d.png)


Also in this PR I've made the link for unofficial achievements (available only for devs) work like a tab (as suggested by @GameDragon2k). As you can see in the 2 screenshots below:

![coreunofficial](https://user-images.githubusercontent.com/8508804/40691152-e867e3a8-6380-11e8-82e9-b26d3c75c6c1.png)

![unofficialcore](https://user-images.githubusercontent.com/8508804/40691153-e88ab4b4-6380-11e8-8cdc-4c080108fd76.png)

