### PR TITLE
ticketmananager improvements - closes #160

### DIFF
--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -845,6 +845,26 @@ function getUserStats( $user )
 
 }
 
+function getUserUnlockAchievement( $user, $achievementID, &$dataOut )
+{
+    $query = "SELECT ach.ID, aw.HardcoreMode, aw.Date
+        FROM Achievements AS ach
+        LEFT JOIN Awarded AS aw ON ach.ID = aw.AchievementID
+        WHERE ach.ID = '$achievementID' AND aw.User = '$user'";
+
+    $dbResult = s_mysql_query( $query );
+
+    $dataOut = array();
+
+    if( $dbResult === FALSE )
+        return FALSE;
+
+    while( $data = mysqli_fetch_assoc( $dbResult ) )
+        $dataOut[] = $data;
+
+    return count( $dataOut );
+}
+
 function getUserUnlocksDetailed( $user, $gameID, &$dataOut )
 {
     $query = "SELECT ach.Title, ach.ID, ach.Points, aw.HardcoreMode

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -556,50 +556,30 @@ RenderDocType();
 
                     echo "<form method=post action='ticketmanager.php?i=$ticketID'>";
                     echo "<input type='hidden' name='i' value='$ticketID'>";
+
+                    echo "<select name='action' required>";
+                    echo "<option value='' disabled selected hidden>Choose an action...</option>";
                     if( $reportState == 1 )
                     {
                         if( $user == $reportedBy ) // only the reporter can close as a mistaken report
-                        {
-                            echo "<label>";
-                            echo "<input type='radio' name='action' value='closed-mistaken' required> Close - Mistaken report</input>";
-                            echo "</label><br>";
-                        }
+                            echo "<option value='closed-mistaken'>Close - Mistaken report</option>";
 
                         if( $permissions >= \RA\Permissions::Developer )
                         {
-                            echo "<label>";
-                            echo "<input type='radio' name='action' value='resolved' required> Resolve as fixed (add comments about your fix below)</input>";
-                            echo "</label><br>";
-
-                            echo "<label>";
-                            echo "<input type='radio' name='action' value='demoted'> Demote achievement to Unofficial</input>";
-                            echo "</label><br>";
-
-                            echo "<label>";
-                            echo "<input type='radio' name='action' value='not-enough-info'> Close - Not enough information</input>";
-                            echo "</label><br>";
-
-                            echo "<label>";
-                            echo "<input type='radio' name='action' value='wrong-rom'> Close - Wrong ROM</input>";
-                            echo "</label><br>";
-
-                            echo "<label>";
-                            echo "<input type='radio' name='action' value='network'> Close - Network problems</input>";
-                            echo "</label><br>";
-
-                            echo "<label>";
-                            echo "<input type='radio' name='action' value='closed-other'> Close - Another reason (add comments below)</input>";
-                            echo "</label><br>";
+                            echo "<option value='resolved'>Resolve as fixed (add comments about your fix below)</option>";
+                            echo "<option value='demoted'>Demote achievement to Unofficial</option>";
+                            echo "<option value='not-enough-info'>Close - Not enough information</option>";
+                            echo "<option value='wrong-rom'>Close - Wrong ROM</option>";
+                            echo "<option value='network'>Close - Network problems</option>";
+                            echo "<option value='closed-other'>Close - Another reason (add comments below)</option>";
                         }
                     }
-                    else
-                    {
-                        echo "<label>";
-                        echo "<input type='radio' name='action' value='reopen' required> Reopen this ticket</input>";
-                        echo "</label><br>";
-                    }
+                    else // ticket is not open
+                        echo "<option value='reopen'>Reopen this ticket</option>";
 
-                    echo "<input type='submit' value='Perform action'>";
+                    echo "</select>";
+
+                    echo " <input type='submit' value='Perform action'>";
                     echo "</form>";
 
                     echo "</span>";

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -549,8 +549,7 @@ RenderDocType();
                 echo "<tr>";
                 echo "<td></td><td colspan='6'>";
 
-                $userAwarded = getUserUnlockAchievement( $reportedBy, $achID, $unlockData );
-                if( $userAwarded )
+                if( getUserUnlockAchievement( $reportedBy, $achID, $unlockData ) )
                 {
                     echo "$reportedBy earned this achievement at ". getNiceDate( strtotime( $unlockData[0][ 'Date' ] ) );
                     if( $unlockData[0][ 'Date' ] >= $reportedAt )

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -533,7 +533,8 @@ RenderDocType();
                 {
                     echo "<tr>";
 
-                    echo "<td></td><td colspan='6'>";
+                    echo "<td>Reporter:</td>";
+                    echo "<td colspan='6'>";
                     echo "<div class='smallicon'>";
                     echo "<span>";
                     $msgPayload = "Hi [user=$reportedBy], I'm contacting you about ticket www.retroachievements.org/ticketmanager.php?i=$ticketID ";
@@ -542,9 +543,23 @@ RenderDocType();
                     echo "</span>";
                     echo "</div>";
                     echo "</td>";
-
                     echo "</tr>";
                 }
+
+                echo "<tr>";
+                echo "<td></td><td colspan='6'>";
+
+                $userAwarded = getUserUnlockAchievement( $reportedBy, $achID, $unlockData );
+                if( $userAwarded )
+                {
+                    echo "$reportedBy earned this achievement at ". getNiceDate( strtotime( $unlockData[0][ 'Date' ] ) );
+                    if( $unlockData[0][ 'Date' ] >= $reportedAt )
+                        echo " (after the report).";
+                    else
+                        echo " (before the report).";
+                }
+                else
+                    echo "$reportedBy did not earn this achievement.";
 
                 if( $user == $reportedBy || $permissions >= \RA\Permissions::Developer )
                 {
@@ -554,6 +569,7 @@ RenderDocType();
                     echo "<div class='smallicon'>";
                     echo "<span>";
 
+                    echo "<b>Please, add some comments about the action you're going to take.</b><br>";
                     echo "<form method=post action='ticketmanager.php?i=$ticketID'>";
                     echo "<input type='hidden' name='i' value='$ticketID'>";
 
@@ -568,9 +584,9 @@ RenderDocType();
                         {
                             echo "<option value='resolved'>Resolve as fixed (add comments about your fix below)</option>";
                             echo "<option value='demoted'>Demote achievement to Unofficial</option>";
+                            echo "<option value='network'>Close - Network problems</option>";
                             echo "<option value='not-enough-info'>Close - Not enough information</option>";
                             echo "<option value='wrong-rom'>Close - Wrong ROM</option>";
-                            echo "<option value='network'>Close - Network problems</option>";
                             echo "<option value='closed-other'>Close - Another reason (add comments below)</option>";
                         }
                     }


### PR DESCRIPTION
Implementing improvements mentioned in #160.

## Allowing tickets to be reopened

Option available for devs, admins and the reporter. Also, automatically add a comment when a ticket is reopened and who reopened it.

## Adding more ways to close a ticket

Actually this was the original request made by @JuliaWolska in #160. In this PR I'm allowing tickets to be closed (and not exactly being marked as "Resolved") and offering some options for the reason of closing.

Again, any change on the ticket status, automatically add a comment saying what was done and who did it.

## Screenshots

Developer view of an open ticket (in the comments you can notice some comments automatically added when I changed the ticket status):

**EDIT:** changed radio buttons to a dropdown list. [See the comment below](https://github.com/RetroAchievements/RAWeb/pull/167#issuecomment-395936233)

![devview](https://user-images.githubusercontent.com/8508804/41137982-b06b7a4c-6ab4-11e8-824b-dc6cd1ae2ebe.png)

Reporter view of an open ticket:

**EDIT:** changed radio buttons to a dropdown list. [See the comment below](https://github.com/RetroAchievements/RAWeb/pull/167#issuecomment-395936233)

![ticketreporterview](https://user-images.githubusercontent.com/8508804/41137983-b08fef12-6ab4-11e8-97a5-2df7ce8b337b.png)


Anything more complex than that I would prefer to implement after launching RAWeb 2.0.
