### PR TITLE
yet another audit-log attempt

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -793,6 +793,7 @@ function UploadNewAchievement( $author, $gameID, $title, $desc, $progress, $prog
             postActivity( $author, \RA\ActivityType::UploadAchievement, $idInOut );
 
             static_addnewachievement( $idInOut );
+            addArticleComment( "Server", 2, $idInOut, "\"$author\" uploaded this achievement." );
 
             error_log( __FUNCTION__ . " $author uploaded new achievement: $idInOut, $title, $desc, $progress, $progressMax, $progressFmt, $points, $mem, $type, $badge" );
 
@@ -860,6 +861,16 @@ function UploadNewAchievement( $author, $gameID, $title, $desc, $progress, $prog
                 static_setlastupdatedachievement( $idInOut );
 
                 postActivity( $author, \RA\ActivityType::EditAchievement, $idInOut );
+
+                if( $changingAchSet )
+                {
+                    if( $type == 3 )
+                        addArticleComment( "Server", 2, $idInOut, "\"$author\" promoted this achievement to the Core set." );
+                    else if( $type == 5 )
+                        addArticleComment( "Server", 2, $idInOut, "\"$author\" demoted this achievement to Unofficial." );
+                }
+                else
+                    addArticleComment( "Server", 2, $idInOut, "\"$author\" edited this achievement." );
 
                 return true;
             }

--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -499,7 +499,7 @@ function addArticleComment( $user, $articleType, $articleID, $commentPayload )
         error_log( __FUNCTION__ . " Comment on Achievement... notifying author and thread" );
 
         //	Get achievement's original author:
-        $achievementData = getAchievementMetadata( $articleID );
+        $achievementData = getAchievementMetadataJSON( $articleID );
         informAllSubscribersAboutActivity( $user, $achievementData[ 'Author' ], $articleID, $articleType );
     }
     else if( $articleType == 3 ) //	User

--- a/public/requestupdateachievement.php
+++ b/public/requestupdateachievement.php
@@ -63,9 +63,15 @@
 		if( updateAchievementFlags( $achID, $value ) )
 		{
             header( "Location: http://" . AT_HOST . "/Achievement/$achID?e=changeok" );
-		}
-		else
-		{
+
+            if( $value == 3 )
+                addArticleComment( "Server", 2, $achID, "\"$user\" promoted this achievement to the Core set." );
+            else if( $value == 5 )
+                addArticleComment( "Server", 2, $achID, "\"$user\" demoted this achievement to Unofficial." );
+
+        }
+        else
+        {
 			error_log( "requestupdateachievement.php failed?! 3" . var_dump( $_POST ) );
 			echo "FAILED!";
 		}


### PR DESCRIPTION
The problem in the previous attempts were caused by [this wrong function call here](https://github.com/RetroAchievements/RAWeb/compare/audit_log?expand=1#diff-295c69655390b9ab4408ceea39d90e70L502).