### PR TITLE
Fix game ID error handling on the game information page

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -40,9 +40,8 @@ function GetGameData( $gameID )
 			  WHERE gd.ID = $gameID";
 
     $dbResult = s_mysql_query( $query );
-    if( $dbResult !== FALSE )
+    if( $retVal = mysqli_fetch_assoc( $dbResult ) )
     {
-        $retVal = mysqli_fetch_assoc( $dbResult );
         settype( $retVal[ 'ID' ], 'integer' );
         settype( $retVal[ 'ConsoleID' ], 'integer' );
         settype( $retVal[ 'Flags' ], 'integer' );

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -37,6 +37,13 @@ if( !isset( $user ) && ( $sortBy == 3 || $sortBy == 13 ) )
 
 
 $numAchievements = getGameMetadataByFlags( $gameID, $user, $achievementData, $gameData, $sortBy, NULL, $flags );
+
+if( !isset($gameData) )
+{
+	echo "Invalid game ID!";
+	exit;
+}
+
 $gameAlts = GetGameAlternatives( $gameID );
 
 $numDistinctPlayersCasual = $gameData[ 'NumDistinctPlayersCasual' ];


### PR DESCRIPTION
a MySQLi query object cannot be `FALSE` unless the request was not sanitized correctly. `$dbResult` represents not a result, but a query object.
As a result, `$gameData` in `gameInfo.php` was always set to a default zero-valued result set.
This solves that issue, avoids filling game data with default values, and aborts game information page loading for invalid IDs (e.g. /Game/0).