### PR TITLE
parse MemAddr with RegEx and show a fancy table

### DIFF
--- a/lib/database/utility.php
+++ b/lib/database/utility.php
@@ -1267,10 +1267,10 @@ function GetAchievementPatchReadableHTML( $mem, $memNotes )
             $res .= "\n  <td> (". $hits .") </td>";
             $res .= "\n</tr>\n";
         }
-        $res .= "<tr><td colspan=10><ul>";
+        $res .= "<tr><td colspan=10><ul><small>";
         foreach( $codeNotes as $nextCodeNote )
             $res .= "<li>". $nextCodeNote ."</li>\n";
-        $res .= "</ul></td></tr>";
+        $res .= "</small></ul></td></tr>";
     }
     $res .= "\n</table>\n";
 


### PR DESCRIPTION
**First of all**: huge thanks to @stt for showing me that it's possible to parse MemAddr with Regular Expressions :nerd_face:

This PR changes the behavior of `GetAchievementPatchReadableHTML()`, making it produce this output:
![parsememaddr](https://user-images.githubusercontent.com/8508804/45581102-18b20280-b86f-11e8-9f2c-73d131a49439.png)

rather than the current buggy one:
![oldparsememaddr](https://user-images.githubusercontent.com/8508804/45581128-45661a00-b86f-11e8-90e4-7117945f0b0f.png)
