### PR TITLE
[WiP] add support for RAQUASI88 (NEC PC-8000/8800 emulator) - closes #254

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -1431,7 +1431,7 @@ function isValidConsoleID( $consoleID ) {
         case 27: // Arcade
         case 28: // Virtual Boy
         case 23: // Events (not an actual console)
-	case 47: // PC-8800
+        case 47: // PC-8800
         case 51: // Atari7800
             return TRUE;
         default:

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -1431,6 +1431,7 @@ function isValidConsoleID( $consoleID ) {
         case 27: // Arcade
         case 28: // Virtual Boy
         case 23: // Events (not an actual console)
+	case 47: // PC-8800
         case 51: // Atari7800
             return TRUE;
         default:

--- a/lib/dynrender.php
+++ b/lib/dynrender.php
@@ -788,6 +788,7 @@ function RenderToolbar( $user, $permissions = 0 )
     echo "<li><a href='/gameList.php?c=25'>- Atari 2600</a></li>";
     echo "<li><a href='/gameList.php?c=51'>- Atari 7800</a></li>";
     echo "<li><a href='/gameList.php?c=27'>- Arcade</a></li>";
+    echo "<li><a href='/gameList.php?c=47'>- PC-8000/8800</a></li>";
     echo "<li><a href='/awardedList.php'>Commonly Won Achievements</a></li>";
     echo "<li><a href='/gameSearch.php?p=0'>Hardest Achievements</a></li>";
     echo "<li><a href='/userList.php'>User List</a></li>";

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -210,6 +210,9 @@ if( $credentialsOK )
                     case \RA\Emulators::RAMeka:
                         $versionFile = "LatestRAMekaVersion.html";
                         break;
+                    case \RA\Emulators::RAQUASI88:
+                        $versionFile = "LatestRAQUASI88Version.html";
+                        break;
                     default:
                         $versionFile = NULL;
                         $errMsg = "EmulatorID: $emulatorID";
@@ -242,6 +245,9 @@ if( $credentialsOK )
                         break;
                     case 25:
                         $versionFile = "LatestRALibretroVersion.html";
+                        break;
+                    case 47:
+                        $versionFile = "LatestRAQUASI88Version.html";
                         break;
                     default:
                         $versionFile = NULL;

--- a/public/download.php
+++ b/public/download.php
@@ -9,6 +9,7 @@ $latestRAPCEVer = file_get_contents( "./LatestRAPCEVersion.html" );
 $latestRASnesVer = file_get_contents( "./LatestRASnesVersion.html" );
 $latestRAVBAVer = file_get_contents( "./LatestRAVBAVersion.html" );
 $latestRALibretroVer = file_get_contents( "./LatestRALibretroVersion.html" );
+$latestRAQUASI88Ver = file_get_contents( "./LatestRAQUASI88Version.html" );
 
 RA_ReadCookieCredentials( $user, $points, $truePoints, $unreadMessageCount, $permissions );
 
@@ -92,6 +93,15 @@ RenderDocType();
             <div class='largeicon'>
                 <span class='clickablebutton'>
                     <a href="/bin/RALibretro.zip">Download RALibretro v<?php echo $latestRALibretroVer; ?> for Windows</a>
+                </span>
+            </div>
+
+            <br/>
+            <h2 class='longheader' id='raquasi88'>NEC PC-8000/8800 Emulator</h2>
+
+            <div class='largeicon'>
+                <span class='clickablebutton'>
+                    <a href="/bin/RAQUASI88.zip">Download RAQUASI88 v<?php echo $latestRAQUASI88Ver; ?> for Windows</a>
                 </span>
             </div>
 

--- a/src/Emulators.php
+++ b/src/Emulators.php
@@ -16,4 +16,5 @@ abstract class Emulators
     const RAPCE = 6;
     const RALibretro = 7;
     const RAMeka = 8;
+    const RAQUASI88 = 9;
 }


### PR DESCRIPTION
# This PR is ready to be merged *as soon as RAIntegration 0.75 is released*.

Got some boring time ~~while at work~~ and decided to do these things in advance.

- added a RAQUASI88 entry to `src/Emulators.php`
- added a RAQUASI88 entry to `latestclient` in `public/dorequest.php`
- added the PC-8800 console ID as valid in `isValidConsoleID()` (`lib/database/game.php`)
- added an entry in the downloads page

~~Waiting the RAQUASI88 binary to finish the next steps:~~
Steps already taken (09/January/2019) outside this PR
- created a `LatestRAQUASI88Version.html`: http://retroachievements.org/LatestRAQUASI88Version.html
- uploaded the `RAQUASI88.zip` binary: retroachievements.org/bin/RAQUASI88.zip
