### PR TITLE
Add PC-88 to Site Pages

### DIFF
--- a/lib/dynrender.php
+++ b/lib/dynrender.php
@@ -788,6 +788,7 @@ function RenderToolbar( $user, $permissions = 0 )
     echo "<li><a href='/gameList.php?c=25'>- Atari 2600</a></li>";
     echo "<li><a href='/gameList.php?c=51'>- Atari 7800</a></li>";
     echo "<li><a href='/gameList.php?c=27'>- Arcade</a></li>";
+    echo "<li><a href='/gameList.php?c=47'>- PC-8000/8800</a></li>";
     echo "<li><a href='/awardedList.php'>Commonly Won Achievements</a></li>";
     echo "<li><a href='/gameSearch.php?p=0'>Hardest Achievements</a></li>";
     echo "<li><a href='/userList.php'>User List</a></li>";


### PR DESCRIPTION
Closes #271.

https://github.com/RetroAchievements/RAWeb/issues/272 is also needed to match the naming scheme of `SG-1000/Othello Multivision`.