### PR TITLE
Game page: Increase icon size and move game info up

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -450,25 +450,9 @@ $numGridlines = $numAchievements;
 
                 echo "<table class='iconheader'><tbody>";
                 echo "<tr>";
-                echo "<td style='width:64px;' ><img src='$imageIcon' title='$pageTitle' width='64' height='64'/></td>";
-                echo "<td><h3 class='longheader'>$pageTitle</h3></td>";
-                echo "</tr>";
-                echo "</tbody></table>";
-
-                echo "<div class='gamescreenshots'>";
-                echo "<table><tbody>";
-                echo "<tr>";
-                echo "<td>";
-                echo "<img src='$imageTitle' width='$screenshotWidth' height='$screenshotHeight' />";
-                echo "</td>";
-                echo "<td>";
-                echo "<img src='$imageIngame' width='$screenshotWidth' height='$screenshotHeight'/>";
-                echo "</td>";
-                echo "</tr>";
-                echo "</tbody></table>";
-                echo "</div>";
-
-                echo "<table class='gameinfo'><tbody>";
+                echo "<td style='width:110px;' ><img src='$imageIcon' title='$pageTitle' width='96' height='96'/></td>";
+                echo "<td><h3 class='longheader'>$pageTitle</h3>
+		echo "<table class='gameinfo'><tbody>";
                 echo "<tr>";
                 echo "<td>Developer:</td>";
                 echo "<td><b>$developer</b></td>";
@@ -485,7 +469,22 @@ $numGridlines = $numAchievements;
                 echo "<td>First released:</td>";
                 echo "<td><b>$released</b></td>";
                 echo "</tr>";
+                echo "</tbody></table>";</td>";
+                echo "</tr>";
                 echo "</tbody></table>";
+
+                echo "<div class='gamescreenshots'>";
+                echo "<table><tbody>";
+                echo "<tr>";
+                echo "<td>";
+                echo "<img src='$imageTitle' width='$screenshotWidth' height='$screenshotHeight' />";
+                echo "</td>";
+                echo "<td>";
+                echo "<img src='$imageIngame' width='$screenshotWidth' height='$screenshotHeight'/>";
+                echo "</td>";
+                echo "</tr>";
+                echo "</tbody></table>";
+                echo "</div>";
 
                 echo "<div style='clear:both;'></div>";
                 echo "</br>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -451,8 +451,8 @@ $numGridlines = $numAchievements;
                 echo "<table class='iconheader'><tbody>";
                 echo "<tr>";
                 echo "<td style='width:110px;' ><img src='$imageIcon' title='$pageTitle' width='96' height='96'/></td>";
-                echo "<td><h3 class='longheader'>$pageTitle</h3>
-		echo "<table class='gameinfo'><tbody>";
+                echo "<td><h3 class='longheader'>$pageTitle</h3>";
+		        echo "<table class='gameinfo'><tbody>";
                 echo "<tr>";
                 echo "<td>Developer:</td>";
                 echo "<td><b>$developer</b></td>";
@@ -469,7 +469,7 @@ $numGridlines = $numAchievements;
                 echo "<td>First released:</td>";
                 echo "<td><b>$released</b></td>";
                 echo "</tr>";
-                echo "</tbody></table>";</td>";
+                echo "</tbody></table>";
                 echo "</tr>";
                 echo "</tbody></table>";
 


### PR DESCRIPTION
I made an html edit test and then took a poll on preferences for this change:

Here's the supportive straw poll: (https://discordapp.com/channels/310192285306454017/511718348178849792/541536891326038016) 32 votes in favor, 4 to stick to original, 3 to only increase the game icon).

This is my attempt to modify the game page by increasing the game Icon size, increasing the indent after icon, and adding the game info under the title to make use of the empty space.

The intent is for the game pages to look like this: https://i.imgur.com/J1G46hY.png

I do not know if there is a conflict or if it is considered sloppy having a class inside a class, and I'm editing the raw code without testing, so I might be messing this up.