### PR TITLE
WIP: add support for RAppleWin (Apple II emulator)

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -1432,6 +1432,7 @@ function isValidConsoleID( $consoleID ) {
         case 28: // Virtual Boy
         case 23: // Events (not an actual console)
         case 33: // SG-1000
+        case 38: // Apple II
         case 44: // ColecoVision
         case 47: // PC-8800
         case 51: // Atari7800

--- a/lib/dynrender.php
+++ b/lib/dynrender.php
@@ -791,6 +791,7 @@ function RenderToolbar( $user, $permissions = 0 )
     echo "<li><a href='/gameList.php?c=44'>- ColecoVision</a></li>";
     echo "<li><a href='/gameList.php?c=27'>- Arcade</a></li>";
     echo "<li><a href='/gameList.php?c=47'>- PC-8000/8800</a></li>";
+    echo "<li><a href='/gameList.php?c=38'>- RAppleWin</a></li>";
     echo "<li><a href='/awardedList.php'>Commonly Won Achievements</a></li>";
     echo "<li><a href='/gameSearch.php?p=0'>Hardest Achievements</a></li>";
     echo "<li><a href='/userList.php'>User List</a></li>";

--- a/lib/dynrender.php
+++ b/lib/dynrender.php
@@ -791,7 +791,7 @@ function RenderToolbar( $user, $permissions = 0 )
     echo "<li><a href='/gameList.php?c=44'>- ColecoVision</a></li>";
     echo "<li><a href='/gameList.php?c=27'>- Arcade</a></li>";
     echo "<li><a href='/gameList.php?c=47'>- PC-8000/8800</a></li>";
-    echo "<li><a href='/gameList.php?c=38'>- RAppleWin</a></li>";
+    echo "<li><a href='/gameList.php?c=38'>- Apple II</a></li>";
     echo "<li><a href='/awardedList.php'>Commonly Won Achievements</a></li>";
     echo "<li><a href='/gameSearch.php?p=0'>Hardest Achievements</a></li>";
     echo "<li><a href='/userList.php'>User List</a></li>";

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -213,6 +213,9 @@ if( $credentialsOK )
                     case \RA\Emulators::RAQUASI88:
                         $versionFile = "LatestRAQUASI88Version.html";
                         break;
+                    case \RA\Emulators::RAppleWin:
+                        $versionFile = "LatestRAppleWinVersion.html";
+                        break;
                     default:
                         $versionFile = NULL;
                         $errMsg = "EmulatorID: $emulatorID";
@@ -245,6 +248,9 @@ if( $credentialsOK )
                         break;
                     case 25:
                         $versionFile = "LatestRALibretroVersion.html";
+                        break;
+                    case 38:
+                        $versionFile = "LatestRAppleWinVersion.html";
                         break;
                     case 47:
                         $versionFile = "LatestRAQUASI88Version.html";

--- a/public/download.php
+++ b/public/download.php
@@ -10,6 +10,7 @@ $latestRASnesVer = file_get_contents( "./LatestRASnesVersion.html" );
 $latestRAVBAVer = file_get_contents( "./LatestRAVBAVersion.html" );
 $latestRALibretroVer = file_get_contents( "./LatestRALibretroVersion.html" );
 $latestRAQUASI88Ver = file_get_contents( "./LatestRAQUASI88Version.html" );
+$latestRAQUASI88Ver = file_get_contents( "./LatestRAppleWinVersion.html" );
 
 RA_ReadCookieCredentials( $user, $points, $truePoints, $unreadMessageCount, $permissions );
 
@@ -110,6 +111,15 @@ RenderDocType();
             <div class='largeicon'>
                 <span class='clickablebutton'>
                     <a href="/bin/RAQUASI88.zip">Download RAQUASI88 v<?php echo $latestRAQUASI88Ver; ?> for Windows</a>
+                </span>
+            </div>
+
+            <br/>
+            <h2 class='longheader' id='rapplewin'>Apple II Emulator</h2>
+
+            <div class='largeicon'>
+                <span class='clickablebutton'>
+                    <a href="/bin/RAppleWin.zip">Download RAppleWin v<?php echo $latestRAQUASI88Ver; ?> for Windows</a>
                 </span>
             </div>
 

--- a/public/download.php
+++ b/public/download.php
@@ -10,7 +10,7 @@ $latestRASnesVer = file_get_contents( "./LatestRASnesVersion.html" );
 $latestRAVBAVer = file_get_contents( "./LatestRAVBAVersion.html" );
 $latestRALibretroVer = file_get_contents( "./LatestRALibretroVersion.html" );
 $latestRAQUASI88Ver = file_get_contents( "./LatestRAQUASI88Version.html" );
-$latestRAQUASI88Ver = file_get_contents( "./LatestRAppleWinVersion.html" );
+$latestRAppleWinVer = file_get_contents( "./LatestRAppleWinVersion.html" );
 
 RA_ReadCookieCredentials( $user, $points, $truePoints, $unreadMessageCount, $permissions );
 
@@ -119,7 +119,7 @@ RenderDocType();
 
             <div class='largeicon'>
                 <span class='clickablebutton'>
-                    <a href="/bin/RAppleWin.zip">Download RAppleWin v<?php echo $latestRAQUASI88Ver; ?> for Windows</a>
+                    <a href="/bin/RAppleWin.zip">Download RAppleWin v<?php echo $latestRAppleWinVer; ?> for Windows</a>
                 </span>
             </div>
 

--- a/src/Emulators.php
+++ b/src/Emulators.php
@@ -17,4 +17,5 @@ abstract class Emulators
     const RALibretro = 7;
     const RAMeka = 8;
     const RAQUASI88 = 9;
+    const RAppleWin = 10;
 }


### PR DESCRIPTION
# This PR is only to be merged after RAIntegration 0.76 is released.

- added a RAppleWin entry to `src/Emulators.php`
- added a RAppleWin entry to `latestclient` in `public/dorequest.php`
- added the RAppleWin console ID (`38`) as valid in `isValidConsoleID()` (`lib/database/game.php`)
- added an entry in the downloads page
- added "Apple II" to the list in `lib/dynrenderer.php`

On the server side I did:
- created a `LatestRAppleWinVersion.html`: https://retroachievements.org/LatestRAppleWinVersion.html
- uploaded the `RAppleWin.zip` binary: https://retroachievements.org/bin/RAppleWin.zip
