### PR TITLE
Revert $deleteIcon changes

### DIFF
--- a/lib/dynrender.php
+++ b/lib/dynrender.php
@@ -586,7 +586,7 @@ function RenderArticleComment(
         $class = 'localuser';
 
         $img = "<img src='" . getenv('APP_STATIC_URL') . "/Images/cross.png' width='16' height='16' alt='delete comment'/>";
-        $deleteIcon = " href='#'>$img</a></div>";
+        $deleteIcon = "<div style='float: right;'><a onclick=\"removeComment($articleID, $commentID); return false;\" href='#'>$img</a></div>";
     }
 
     $artCommentID = "artcomment_" . $articleID . "_" . $commentID;

--- a/public/css/rac_2016.css
+++ b/public/css/rac_2016.css
@@ -67,6 +67,14 @@ h1, h2, h3, h4 {
     font-size: 2.0em;
 	background-repeat: no-repeat;
 }
+
+h3.longheader {
+    margin: 10px 0px;
+}
+
+h3 {
+    margin: 10px 0px 25px 0px
+}
 	
 h4 { 
 	font-size: 1.5em; 
@@ -110,4 +118,18 @@ h4 {
 	color: #eeeeff; 
 	margin-bottom: 0px; 
 	text-decoration: none; /* Removes underline from links */
+}
+
+/* Make completed/mastered badges larger on hover to show off artwork */
+
+div#siteawards.component {
+	overflow: visible
+}
+
+div.trophyimage {
+    transition: all .2s;
+}
+
+div.trophyimage:hover {
+    transform: scale(2.0);
 }

--- a/public/css/style54.css
+++ b/public/css/style54.css
@@ -56,6 +56,14 @@ h1, h2, h3, h4 {
     background-repeat: no-repeat;
 }
 
+h3.longheader {
+    margin: 10px 0px;
+}
+
+h3 {
+    margin: 10px 0px 25px 0px
+}
+
 h4 {
     font-size: 1.5em;
     border-bottom-width:0px
@@ -998,4 +1006,18 @@ div.rating a.starlit {
 
 .mb-3, .my-3 {
     margin-bottom: 1rem !important;
+}
+
+/* Make completed/mastered badges appear larger on hover to show off artwork. */
+
+div#siteawards.component {
+    overflow: visible
+}
+
+div.trophyimage {
+    transition: all .2s;
+}
+
+div.trophyimage:hover {
+    transform: scale(2.0);
 }

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -12,7 +12,7 @@
 	settype( $count, "integer" );
 	
 	$numUnofficialLinks = 0;
-	if( $permissions >= \RA\Permissions::Developer )
+	if( $permissions >= \RA\Permissions::Admin )
 	{
 		$unofficialLinks = getUnauthorisedForumLinks();
 		$numUnofficialLinks = count( $unofficialLinks );
@@ -20,7 +20,7 @@
 
 	if( $requestedForumID == 0 )
 	{
-		if( $permissions >= \RA\Permissions::Developer )
+		if( $permissions >= \RA\Permissions::Admin )
 		{
 			//	Continue
 			$viewingUnauthorisedForumLinks = true;
@@ -92,7 +92,7 @@
 		
 		if( $numUnofficialLinks > 0 )
 		{
-			echo "</br><a href='/viewforum.php?f=0'><b>Developer Notice:</b> $numUnofficialLinks unofficial posts need authorising: please verify them!</a></br>";
+			echo "</br><a href='/viewforum.php?f=0'><b>Administrator Notice:</b> $numUnofficialLinks unofficial posts need authorising: please verify them!</a></br>";
 		}
 	
 		//echo "<h2 class='longheader'><a href='/forum.php?c=$nextCategoryID'>$nextCategory</a></h2>";


### PR DESCRIPTION
The previous commit broke the ability to remove comments as we can see here: 
![glitched_comments](https://user-images.githubusercontent.com/39404689/59811515-e63aa780-92cf-11e9-927b-d8f120becfa4.png)
This reverts the change and fixes the issue.