### PR TITLE
prevent Code Notes vandalism - closes #309

### DIFF
--- a/lib/database/utility.php
+++ b/lib/database/utility.php
@@ -631,7 +631,7 @@ function submitCodeNote2($user, $gameID, $address, $note)
     $i = array_search($addressHex, array_column($currentNotes, 'Address'));
 
     if (
-        $i === false
+        $i !== false
         && getUserPermissions($user) < \RA\Permissions::Developer
         && $currentNotes[$i]['User'] !== $user
         && !empty($currentNotes[$i]['Note'])

--- a/lib/database/utility.php
+++ b/lib/database/utility.php
@@ -87,7 +87,8 @@ function RA_ReadCookieCredentials(
     &$unreadMessagesOut,
     &$permissionOut,
     $minPermissions = null
-) {
+)
+{
     //    Promise some values:
     $userOut = RA_ReadCookie('RA_User');
     $cookie = RA_ReadCookie('RA_Cookie');
@@ -153,7 +154,8 @@ function RA_ReadTokenCredentials(
     &$unreadMessagesOut,
     &$permissionOut,
     $permissionRequired = null
-) {
+)
+{
     if ($userOut == null || $userOut == '') {
         error_log(__FUNCTION__ . " failed: no user given: $userOut, $token ");
         return false;
@@ -611,7 +613,7 @@ function getCodeNotes($gameID, &$codeNotesOut)
  * @param $note
  * @return bool
  */
-function SubmitCodeNote2($user, $gameID, $address, $note)
+function submitCodeNote2($user, $gameID, $address, $note)
 {
     //    Hack for 'development tutorial game'
     if ($gameID == 10971) {
@@ -621,6 +623,20 @@ function SubmitCodeNote2($user, $gameID, $address, $note)
     global $db;
 
     if (!isset($user) || !isset($gameID) || !isset($address)) {
+        return false;
+    }
+
+    $addressHex = '0x' . str_pad(dechex($address), 6, '0', STR_PAD_LEFT);
+    $currentNotes = getCodeNotesData($gameID);
+    $i = array_search($addressHex, array_column($currentNotes, 'Address'));
+
+    if (
+        $i === false
+        && getUserPermissions($user) < \RA\Permissions::Developer
+        && $currentNotes[$i]['User'] !== $user
+        && !empty($currentNotes[$i]['Note'])
+    )
+    {
         return false;
     }
 
@@ -650,9 +666,9 @@ function SubmitCodeNote2($user, $gameID, $address, $note)
  * @param $note
  * @return bool
  * @deprecated
- * @see SubmitCodeNote2()
+ * @see submitCodeNote2()
  */
-function SubmitCodeNote($user, $gameID, $address, $note)
+function submitCodeNote($user, $gameID, $address, $note)
 {
     //    Hack for 'development tutorial game'
     if ($gameID == 10971) {

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -432,7 +432,7 @@ if( $credentialsOK )
         case "submitcodenote":
             $note = seekPOSTorGET( 'n' );
             $address = seekPOSTorGET( 'm', 0, 'integer' );
-            $response[ 'Success' ] = SubmitCodeNote2( $user, $gameID, $address, $note );
+            $response[ 'Success' ] = submitCodeNote2( $user, $gameID, $address, $note );
             $response[ 'GameID' ] = $gameID;     //	Repeat this back to the caller?
             $response[ 'Address' ] = $address;    //	Repeat this back to the caller?
             $response[ 'Note' ] = $note;      //	Repeat this back to the caller?

--- a/public/requestsubmitcodenote.php
+++ b/public/requestsubmitcodenote.php
@@ -20,7 +20,7 @@ return false;
 //
 // //	User privelidges to submit a code note:
 // if (validateUser_app($user, $token, $fbUser, 1)) {
-//     if (SubmitCodeNote($user, $gameID, $address, $note)) {
+//     if (submitCodeNote($user, $gameID, $address, $note)) {
 //         echo "OK";
 //     } else {
 //         echo "FAILED!";


### PR DESCRIPTION
When trying to submit a new code note, do **NOT** allow the note to be updated/submitted if:

user is not a developer
**AND**
user is not the author of original note
**AND**
code note is not empty

In other words:
regular users can only submit/edit Code Notes when they are the original Author or the Note is empty.