### PR TITLE
Add Sega CD and 32X to site

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -1279,6 +1279,8 @@ function isValidConsoleID($consoleID)
         case 6: // Gameboy Color
         case 7: // NES
         case 8: // PC Engine
+        case 9: // Sega CD
+        case 10: // Sega 32X
         case 11: // Master System
         case 12: // PlayStation
         case 13: // Atari Lynx

--- a/lib/dynrender.php
+++ b/lib/dynrender.php
@@ -801,6 +801,8 @@ function RenderToolbar($user, $permissions = 0)
     echo "<li><a href='/gameList.php?c=11'>- Master System</a></li>";
     echo "<li><a href='/gameList.php?c=33'>- SG-1000</a></li>";
     echo "<li><a href='/gameList.php?c=15'>- Game Gear</a></li>";
+    echo "<li><a href='/gameList.php?c=9'>- Sega CD</a></li>";
+    echo "<li><a href='/gameList.php?c=10'>- Sega 32X</a></li>";
     echo "<li><a href='/gameList.php?c=3'>- Super Nintendo</a></li>";
     echo "<li><a href='/gameList.php?c=4'>- Gameboy</a></li>";
     echo "<li><a href='/gameList.php?c=6'>- Gameboy Color</a></li>";


### PR DESCRIPTION
Changes validate Sega CD and Sega 32X as well as adds them to the "Site Pages" drop down. 