### PR TITLE
New Page to Track Linked Hashes

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -1270,6 +1270,84 @@ function getHashListByGameID($gameID)
     return $retVal;
 }
 
+/*
+ * Gets the list of hashes and hash information from the databased using the input offset and count.
+ */
+function getHashList($offset, $count, $searchedHash)
+{
+    $searchQuery = "";
+    if (!is_null($searchedHash) || $searchedHash != "")
+    {
+        $offset = 0;
+        $count = 1;
+        $searchQuery ="
+        WHERE
+            hash.MD5 LIKE '" . $searchedHash . "'";
+    }
+
+    $query = "
+    SELECT
+        hash.MD5 as Hash,
+        hash.GameID as GameID,
+        hash.Created as DateAdded,
+        game.Title as GameTitle,
+        game.ImageIcon as GameIcon,
+        system.name as ConsoleName
+    FROM
+        gamehashlibrary AS hash
+    LEFT JOIN
+        gamedata AS game ON (hash.GameID = game.ID)
+    LEFT JOIN
+        console AS system ON (game.consoleID = system.ID)
+        " . $searchQuery . "
+    ORDER BY
+        DateAdded DESC
+    LIMIT $offset, $count";
+
+    global $db;
+    $dbResult = mysqli_query($db, $query);
+
+    $retVal = NULL;
+
+    if ($dbResult !== false)
+    {
+        while ($nextData = mysqli_fetch_assoc($dbResult))
+        {
+            $retVal[] = $nextData;
+        }
+    }
+    else
+    {
+        error_log(__FUNCTION__ . " failed?! $count");
+        $retVal = false;
+    }
+
+    return $retVal;
+}
+
+/*
+ * Gets the total number of hashes in the databse.
+ */
+function getTotalHashes()
+{
+    $query = "
+    SELECT
+        COUNT(*) AS TotalHashes
+    FROM gamehashlibrary;";
+
+    global $db;
+    $dbResult = mysqli_query($db, $query);
+
+    if ($dbResult !== false)
+    {
+        return mysqli_fetch_assoc($dbResult)['TotalHashes'];
+    }
+    else
+    {
+        return false;
+    }
+}
+
 function isValidConsoleID($consoleID)
 {
     switch ($consoleID) {

--- a/lib/dynrender.php
+++ b/lib/dynrender.php
@@ -847,6 +847,7 @@ function RenderToolbar($user, $permissions = 0)
         echo "<li><a href='/achievementinspector.php'>Ach. Inspector</a></li>";
         echo "<li><a href='/ticketmanager.php'>Ticket Manager</a></li>";
         echo "<li><a href='/ticketmanager.php?f=1'>Most Reported Games</a></li>";
+        echo "<li><a href='/latesthasheslinked.php'>Latest Linked Hashes</a></li>";
         echo "<li><a href='/viewforum.php?f=0'>Invalid Forum Posts</a></li>";
         echo "<li><a href='/viewtopic.php?t=394'>Official To-Do List</a></li>";
         echo "</ul>";

--- a/public/latesthasheslinked.php
+++ b/public/latesthasheslinked.php
@@ -1,0 +1,132 @@
+<?php
+    require_once __DIR__ . '/../lib/bootstrap.php';
+
+    RA_ReadCookieCredentials( $user, $points, $truePoints, $unreadMessageCount, $permissions );
+
+    $maxCount = 50;
+
+    $errorCode = seekGET( 'e' );
+    $count = seekGET( 'c', $maxCount );
+    $offset = seekGET( 'o', 0 );
+    $searchedHash = seekGET( 'h', NULL );
+    if ($offset < 0)
+    {
+        $offset = 0;
+    }
+
+    $hashList = getHashList($offset, $count, $searchedHash);
+    $totalHashes = getTotalHashes();
+
+    RenderDocType();
+?>
+
+<head>
+    <!--Load the AJAX API-->
+    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+<?php
+    RenderSharedHeader( $user );
+    RenderTitleTag( "Hash List", $user );
+    RenderGoogleTracking();
+?>
+</head>
+
+<body>
+
+<?php
+    RenderTitleBar( $user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions );
+    RenderToolbar( $user, $permissions );
+?>
+
+<div id='mainpage'>
+
+<div id='leftcontainer'>
+<?php
+    RenderErrorCodeWarning( 'left', $errorCode );
+
+    echo "<h2 class='longheader'>Search</h2>";
+
+    echo "<div class='searchbox longer'>";
+    echo "<form action='/latesthasheslinked.php' method='get'>";
+    echo "<input size='50' name='h' type='text' class='searchboxinput' value='$searchedHash' />";
+    echo "&nbsp;&nbsp;";
+    echo "<input type='submit' value='Search' />";
+    echo "</form>";
+    if (is_null($hashList) || !is_null($searchedHash))
+    {
+        echo "&nbsp;&nbsp;";
+        echo "<form method='post' action='/latesthasheslinked.php'>";
+        echo "<input type='submit' name='' value='Return to Lastest Linked Hashes' />";
+        echo "</form>";
+    }
+    echo "</div>";
+
+    if (!is_null($hashList))
+    {
+        if (is_null($searchedHash))
+        {
+            echo "<h2 class='longheader'>Lastest Linked Hashes</h2>";
+        }
+        else
+        {
+            echo "<h2 class='longheader'>Search Results</h2>";
+        }
+        //Create table headers
+        echo "<table class='smalltable'><tbody>";
+        echo "<th>Hash</th>";
+        echo "<th>Game</th>";
+        echo "<th>Date Linked</th>";
+
+        $hashCount = 0;
+
+        //Loop through each hash and display its information
+        foreach( $hashList as $hash )
+        {
+            if( $hashCount++ % 2 == 0 )
+            {
+                echo "<tr>";
+            }
+            else
+            {
+                echo "<tr class=\"alt\">";
+            }
+
+            echo "<td>" . $hash[ 'Hash' ] . "</td>";
+            echo "<td>";
+            echo GetGameAndTooltipDiv( $hash[ 'GameID' ] , $hash[ 'GameTitle' ], $hash[ 'GameIcon' ], $hash[ 'ConsoleName' ] );
+            echo "</td>";
+            echo "<td>" . $hash[ 'DateAdded' ] . "</td>";
+        }
+        echo "</tbody></table>";
+
+        //Add page traversal links
+        if (is_null($searchedHash))
+        {
+            echo "<div class='rightalign row'>";
+            if( $offset > 0 )
+            {
+                $prevOffset = $offset - $maxCount;
+                echo "<a href='/latesthasheslinked.php'>First</a> - ";
+                echo "<a href='/latesthasheslinked.php?o=$prevOffset'>&lt; Previous $maxCount</a> - ";
+            }
+            if( $hashCount == $maxCount && $offset != ($totalHashes - $maxCount) )
+            {
+                $nextOffset = $offset + $maxCount;
+                echo "<a href='/latesthasheslinked.php?o=$nextOffset'>Next $maxCount &gt;</a>";
+                echo " - <a href='/latesthasheslinked.php?o=" . ($totalHashes - $maxCount) . "'>Last</a>";
+            }
+            echo "</div>";
+        }
+    }
+    else
+    {
+        echo "<h2 class='longheader'>Search Results</h2>";
+        echo "No results found!";
+    }
+?>
+</div>
+</div>
+
+<?php RenderFooter(); ?>
+
+</body>
+</html>


### PR DESCRIPTION
This would add a new page to track when hashes have been linked. The page can be found in the Developer dropdown.
![image](https://user-images.githubusercontent.com/16140035/67154527-b5916b80-f2cb-11e9-8745-e96f57cf5a37.png)

 The page displays each hash, the game it's linked to, and the date it was linked in reverse chronological order.
![image](https://user-images.githubusercontent.com/16140035/67154538-fa1d0700-f2cb-11e9-9c88-cd20ff961612.png)

I added in a search feature as well. It lets the user search for a specific hash. My plan is to eventually update the main site search with hash support, but for now a seperate search on this page will work fine. 
![image](https://user-images.githubusercontent.com/16140035/67154548-246ec480-f2cc-11e9-800e-7d040079c2f9.png)

Since a timestamp was only recently added the the gamehashlibrary database table the majority of the hashes will have the same date linked. The default entries per page is 50 and can be updated in the latesthasheslinked.php code. This page will not show hashes that have been unlinked since those are completely removed from the database.