### PR TITLE
New BBCode tags and updates

### DIFF
--- a/lib/dynrender.php
+++ b/lib/dynrender.php
@@ -613,12 +613,15 @@ function RenderPHPBBIcons()
     echo "<div class='buttoncollection'>";
     echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[b]\", \"[/b]\")'><b>b</b></a></span>";
     echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[i]\", \"[/i]\")'><i>i</i></a></span>";
+    echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[u]\", \"[/u]\")'><u>u</u></a></span>";
     echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[s]\", \"[/s]\")'><s>&nbsp;s&nbsp;</s></a></span>";
+    echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[code]\", \"[/code]\")'><code>code</code></a></span>";
     echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[img=\", \"]\")'>img</a></span>";
     echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[url=\", \"]Link[/url]\")'>url</a></span>";
     echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[ach=\", \"]\")'>ach</a></span>";
     echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[game=\", \"]\")'>game</a></span>";
     echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[user=\", \"]\")'>user</a></span>";
+    echo "<span class='clickablebutton'><a href='#a' onclick='injectphpbb(\"[spoiler]\", \"[/spoiler]\")'>spoiler</a></span>";
 
     echo "</div>";
 }
@@ -2579,6 +2582,21 @@ function cb_injectGamePHPBB($matches)
     return "";
 }
 
+function cb_injectSpoilerPHPBB($matches)
+{
+    if (count($matches) > 0) {
+        $id = uniqid();
+        $spoilerBox = "<div class='devbox'>";
+        $spoilerBox .= "<span onclick=\"$('#spoiler_" . $id . "').toggle(500); return false;\">Spoiler (Click to show):</span><br/>";
+        $spoilerBox .= "<div class='spoiler' id='spoiler_" . $id . "'>";
+        $spoilerBox .= $matches[1];
+        $spoilerBox .= "</div>";
+        $spoilerBox .= "</div>";
+        return $spoilerBox;
+    }
+    return "";
+}
+
 function makeEmbeddedVideo($video_url)
 {
     return '<div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item" src="' . $video_url . '" allowfullscreen></iframe></div>';
@@ -2802,12 +2820,16 @@ function parseTopicCommentPHPBB($commentIn, $withImgur = false)
         $comment);
 
     //    [b]
-    $comment = preg_replace('/\\[b\\](.*?)\\[\\/b\\]/i', '<b>${1}</b>', $comment);
+    $comment = preg_replace('/\\[b\\](.*?)\\[\\/b\\]/is', '<b>${1}</b>', $comment);
     //    [i]
-    $comment = preg_replace('/\\[i\\](.*?)\\[\\/i\\]/i', '<i>${1}</i>', $comment);
+    $comment = preg_replace('/\\[i\\](.*?)\\[\\/i\\]/is', '<i>${1}</i>', $comment);
+    //    [u]
+    $comment = preg_replace('/\\[u\\](.*?)\\[\\/u\\]/is', '<u>${1}</u>', $comment);
     //    [s]
-    $comment = preg_replace('/\\[s\\](.*?)\\[\\/s\\]/i', '<s>${1}</s>', $comment);
-
+    $comment = preg_replace('/\\[s\\](.*?)\\[\\/s\\]/is', '<s>${1}</s>', $comment);
+    //    [code]
+    $comment = preg_replace('/\\[code\\](.*?)\\[\\/code\\]/is', '<div class=\'codetags\';><code>${1}</code></div>', $comment);
+    $comment = preg_replace("/\r\n|\r|\n/", '', $comment);
     //    [img]
     $comment = preg_replace('/(\\[img=)(.*?)(\\])/i', '<img class=\'injectinlineimage\' src=\'${2}\' />', $comment);
     //    [ach]
@@ -2816,6 +2838,8 @@ function parseTopicCommentPHPBB($commentIn, $withImgur = false)
     $comment = preg_replace_callback('/(\\[user=)(.*?)(\\])/i', 'cb_injectUserPHPBB', $comment);
     //    [game]
     $comment = preg_replace_callback('/(\\[game=)(.*?)(\\])/i', 'cb_injectGamePHPBB', $comment);
+    //    [spoiler]
+    $comment = preg_replace_callback('/\\[spoiler\\](.*?)\\[\\/spoiler\\]/is', 'cb_injectSpoilerPHPBB', $comment);
     //    [video]
     //error_log( $comment );
 

--- a/public/css/style54.css
+++ b/public/css/style54.css
@@ -830,6 +830,18 @@ th {
     border-bottom: 2px dashed;
 }
 
+.spoiler {
+    border-style: inset;
+    border-width: 3px;
+    display: none;
+}
+
+.codetags {
+    border-style: solid;
+    border-width: 1px;
+    padding: 2px;
+}
+
 .leftfloat {
     float: left;
 }
@@ -858,6 +870,7 @@ pre, code, .code {
     font-family: monospace;
     font-size: medium;
     word-break: break-word;
+    white-space: pre;
 }
 
 .badgeimg {

--- a/public/css/style54.css
+++ b/public/css/style54.css
@@ -833,6 +833,7 @@ th {
 .spoiler {
     border-style: inset;
     border-width: 3px;
+    padding: 2px;
     display: none;
 }
 


### PR DESCRIPTION
**Multiline support has been added to the basic formatting tags.**
![image](https://user-images.githubusercontent.com/16140035/67163988-b82fa780-f343-11e9-9c21-e576160afb9a.png)
![image](https://user-images.githubusercontent.com/16140035/67163992-c2ea3c80-f343-11e9-8ca2-14875d49be14.png)

**New tags were added:**
![image](https://user-images.githubusercontent.com/16140035/67164148-27f26200-f345-11e9-846d-7e21df035002.png)

- Underline tag - [u] - Text within the tags will be underlined
![image](https://user-images.githubusercontent.com/16140035/67164047-3e4bee00-f344-11e9-9fdb-18a84679f369.png)
![image](https://user-images.githubusercontent.com/16140035/67164054-4c9a0a00-f344-11e9-9e22-7db548bcd12f.png)

- Code tag - [code] - Text within the code tags is monospaced and is enclosed by a small border.
![image](https://user-images.githubusercontent.com/16140035/67164234-486eec00-f346-11e9-8fc3-6d7bbc32015c.png)
![image](https://user-images.githubusercontent.com/16140035/67164242-5290ea80-f346-11e9-92b1-c7b83e762d15.png)

- Spoiler tag - [spoiler] - The user can click on the spoiler text to display everything with the spoiler tags.
![image](https://user-images.githubusercontent.com/16140035/67164063-5c195300-f344-11e9-95e1-805e11d0800b.png)
![image](https://user-images.githubusercontent.com/16140035/67164074-69364200-f344-11e9-8251-6f751c26a3ae.png)
![image](https://user-images.githubusercontent.com/16140035/67164166-73a50b80-f345-11e9-8b75-0f54ab4aaa76.png)

 - All other tags are allowed within the spoiler tags as well.

![image](https://user-images.githubusercontent.com/16140035/67164090-908d0f00-f344-11e9-94af-ae0ac663c2ae.png)
![image](https://user-images.githubusercontent.com/16140035/67164096-9be03a80-f344-11e9-8901-9e2ad4f12928.png)