### PR TITLE
Fixed various page layouts

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -451,7 +451,7 @@ function getGamesListData($consoleID, $officialFlag = false)
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               $leftJoinAch
               $whereClause
-              ORDER BY ConsoleID, Title";
+              ORDER BY ConsoleName, Title";
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -44,7 +44,14 @@
 
 <div id="mainpage">
 	<?php
-	echo "<div id='leftcontainer'>";
+    if( count( $codeNotes ) > 0 )
+    {
+        echo "<div id='leftcontainer'>";
+    }
+    else
+    {
+        echo "<div id='fullcontainer'>";
+    }
 	echo "<div id='warning' class='rightfloat'>Status: OK!</div>";
 	
 	echo "<h2 class='longheader'>Achievement Inspector</h2>";
@@ -125,7 +132,9 @@
 	else
 	{
 		echo "<h3>Pick a game to modify:</h3>";
-		
+        
+        echo "<table><tbody>";
+
 		$lastConsole = 'NULL';
 		foreach( $gamesList as $gameEntry )
 		{
@@ -135,35 +144,38 @@
 			
 			if( $lastConsole == 'NULL' )
 			{
-				echo "$console:<select class='gameselector' onchange='window.location = \"/achievementinspector.php?g=\" + this.options[this.selectedIndex].value'><option>--</option>";
+                echo "<tr><td>$console:</td>";
+                echo "<td><select class='gameselector' onchange='window.location = \"/achievementinspector.php?g=\" + this.options[this.selectedIndex].value'><option>--</option>";
 				$lastConsole = $console;
 			}
 			else if( $lastConsole !== $console )
 			{
-				echo "</select><br/>$console:<select class='gameselector' onchange='window.location = \"/achievementinspector.php?g=\" + this.options[this.selectedIndex].value'><option>--</option>";
+                echo "<tr><td></select>$console:</td>";
+                echo "<td><select class='gameselector' onchange='window.location = \"/achievementinspector.php?g=\" + this.options[this.selectedIndex].value'><option>--</option>";
 				$lastConsole = $console;
 			}
 			
 			echo "<option value='$gameID'>$gameTitle</option>";
 			echo "<a href=\"/achievementinspector.php?g=$gameID\">$gameTitle</a><br/>";
-			
-			
 		}
-		echo "</select>";
+        echo "</td>";
+        echo "</select>";
+        echo "</tbody></table>";
 	}
 	
 	echo "</div>";
 	
-	echo "<div id='rightcontainer'>";
-	
 	if( count( $codeNotes ) > 0 )
-		RenderCodeNotes( $codeNotes );
-		
-	echo "</div>";
+    {
+        echo "<div id='rightcontainer'>";
+        RenderCodeNotes( $codeNotes );
+        echo "</div>";
+    }
+
 	?>
 </div>
 
-<?php RenderFooter(); ?>	
+<?php RenderFooter(); ?>
 
 </body>
 </html>

--- a/public/awardedList.php
+++ b/public/awardedList.php
@@ -73,20 +73,24 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 		// else echo "</b>";
 		// echo "<br/>";
 		
-		echo "Show: ";
+		echo "<p>Show: ";
 		
 		echo "<a href='awardedList.php?s=$sortBy&amp;o=0&amp;p=$params&amp;i=0'>All consoles</a>";
 		
 		foreach( $consoleList as $nextConsoleID => $nextConsoleName )
 		{
 			if( $nextConsoleID == $consoleIDInput )
-				echo ", <b>$nextConsoleName</b>";
-			else
-				echo ", <a href='awardedList.php?s=$sortBy&amp;o=0&amp;p=$params&amp;i=$nextConsoleID'>$nextConsoleName</a>";
-		}
-		
-		echo "<br/>";
-		
+            {
+                echo " | <b>$nextConsoleName</b>";
+            }
+            else
+            {
+                echo " | <a href='awardedList.php?s=$sortBy&amp;o=0&amp;p=$params&amp;i=$nextConsoleID'>$nextConsoleName</a>";
+            }
+        
+
+        echo "</p>";
+
 		// if( $user !== NULL )
 		// {
 			// echo "&nbsp;- ";

--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -727,7 +727,9 @@
 
 </div>
 
-<?php RenderFooter(); ?>
+</div>
+    <?php RenderFooter(); ?>
+</div>
 
 </body>
 </html>

--- a/public/createaccount.php
+++ b/public/createaccount.php
@@ -21,7 +21,7 @@
 <?php RenderToolbar( $user, $permissions ); ?>
 
 <div id="mainpage">
-	<div id="achievement" class="left">
+	<div id="fullcontainer">
 		<h3>create account</h3>
 		<div class="infobox">
 			<form method=post action="requestcreateuser.php">

--- a/public/css/style54.css
+++ b/public/css/style54.css
@@ -82,12 +82,26 @@ a:hover {
     text-decoration: none; /* Removes underline from links */
 }
 
+#fullcontainer {
+    padding: 5px 20px;
+    display: block;
+    border: 2px solid rgb(20, 20, 20);
+    border-radius: 8px;
+    align-self: start;
+    grid-column: span 2;
+
+    background: #1a1a1a; /* for non-css3 browsers */
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#2a2a2a', endColorstr='#1a1a1a'); /* for IE */
+    background: -webkit-gradient(linear, left top, left bottom, from(#2a2a2a), to(#1a1a1a)); /* for webkit browsers */
+    background: -moz-linear-gradient(top,  #2a2a2a,  #1a1a1a); /* for firefox 3.6+ */
+}
+
 #leftcontainer {
     padding: 5px 20px;
     display: block;
     border: 2px solid rgb(20, 20, 20);
     border-radius: 8px;
-	align-self: start;
+    align-self: start;
 
     background: #1a1a1a; /* for non-css3 browsers */
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#2a2a2a', endColorstr='#1a1a1a'); /* for IE */
@@ -96,11 +110,10 @@ a:hover {
 }
 
 #rightcontainer {
-	align-self: start;
-
     padding: 5px 20px;
     border: 2px solid rgb(20, 20, 20);
     border-radius: 10px;
+    align-self: start;
 
     background: #1a1a1a; /* for non-css3 browsers */
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#1a1a1a', endColorstr='#2a2a2a'); /* for IE */

--- a/public/editpost.php
+++ b/public/editpost.php
@@ -68,7 +68,7 @@
 <?php RenderToolbar( $user, $permissions ); ?>
 
 <div id="mainpage">
-	<div id="forums" class="both">
+	<div id="fullcontainer">
 		
 		<?php
 		echo "<div class='navpath'>";

--- a/public/friends.php
+++ b/public/friends.php
@@ -87,12 +87,17 @@
 		}
 		?>
 </div>
-<div id="rightcontainer"> 
-</div>
+<div id="rightcontainer">
+    <?php
+        if( $user !== NULL )
+        {
+            RenderScoreLeaderboardComponent( $user, $points, TRUE );
+        }
+    ?>
+</div>	
 </div>	
   
 <?php RenderFooter(); ?>
-
 </body>
 </html>
 

--- a/public/gameSearch.php
+++ b/public/gameSearch.php
@@ -50,17 +50,23 @@
 
 		echo "<p>Showing: games by largest RetroRatio:</p>";
 		
-		echo "<p>Filter: ";
+		echo "<p>Show: ";
 		
 		foreach( $consoleList as $nextConsoleID => $nextConsoleName )
 		{
 			if( $nextConsoleID > 0 )
+            {
 				echo " | ";
+            }
 			
 			if( $nextConsoleID == $consoleID )
+            {
 				echo "<b>$nextConsoleName</b>";
+            }
 			else
+            {
 				echo "<a href='gameSearch.php?o=0&amp;p=$method&amp;i=$nextConsoleID'>$nextConsoleName</a>";
+            }
 		}
 		
 		echo "</p>";

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -238,12 +238,12 @@
 			
 		?>
 	</div>
-	
+	</div>
 	<div id='rightcontainer'>
-	<?php
-	//	Right
-	RenderScoreLeaderboardComponent( $user, $points, TRUE );
-	?>
+        <?php
+        //	Right
+        RenderScoreLeaderboardComponent( $user, $points, TRUE );
+        ?>
 	</div>
 </div>
 

--- a/public/latesthasheslinked.php
+++ b/public/latesthasheslinked.php
@@ -38,7 +38,7 @@ RenderToolbar($user, $permissions);
 
 <div id='mainpage'>
 
-    <div id='leftcontainer'>
+    <div id='fullcontainer'>
         <?php
         RenderErrorCodeWarning('left', $errorCode);
 

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -111,8 +111,16 @@ function onUpdateComplete( data )
 <?php RenderToolbar( $user, $permissions ); ?>
 
 <div id="mainpage">
-<div id='leftcontainer'>
-<?php	
+<?php
+    if(count( $codeNotes ) > 0)
+    {
+        echo "<div id='leftcontainer'>";
+    }
+    else
+    {
+        echo "<div id='fullcontainer'>";
+    }
+
 	echo "<div class='left'>";
 		echo "<div class='navpath'>";
 		if( $gameID != 0 )
@@ -452,18 +460,15 @@ function onUpdateComplete( data )
 	</div> 
 </div>
 
-<div id='rightcontainer'>
-	<?php /*RenderRecentlyUploadedComponent( 10 );*/ ?>
-	
-	<?php
-	echo "<div class='right'>";
-		if( isset( $gameData ) && isset( $user ) && $permissions >= 3 )
-		{
-			RenderCodeNotes( $codeNotes );
-		}
-	echo "</div>";
+
+<?php
+    if(count( $codeNotes ) > 0 && $permissions >= 3)
+    {
+        echo "<div id='rightcontainer'>";
+        RenderCodeNotes( $codeNotes );
+        echo "</div>";
+    }
 ?>
-</div>
 
 
 </div>

--- a/public/resetPassword.php
+++ b/public/resetPassword.php
@@ -32,7 +32,7 @@
 <?php RenderToolbar( $user, 0 ); ?>
 
 <div id="mainpage">
-	<div id="passwordreset" class="left">
+	<div id="fullcontainer">
 		
 		<?php
 		echo "<div class='navpath'>";

--- a/public/searchresults.php
+++ b/public/searchresults.php
@@ -27,7 +27,7 @@
 <?php RenderToolbar( $user, $permissions ); ?>
 
 <div id="mainpage">
-	<div id="search" class="left">
+	<div id="fullcontainer">
 		
 		<?php
 		echo "<div class='navpath'>";

--- a/public/submitnews.php
+++ b/public/submitnews.php
@@ -121,7 +121,7 @@ function onUploadImageComplete( data )
 	
 	RenderErrorCodeWarning( 'left', $errorCode );
 	
-	echo "<div id='rsslist' class='left'>";
+	echo "<div id='fullcontainer'>";
 		
 		echo "<div class='navpath'>";
 		echo "<b>$pageTitle</b>";

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -176,7 +176,7 @@ RenderDocType();
 
     <div id="mainpage">
         <?php RenderErrorCodeWarning( 'left', $errorCode ); ?>
-        <div class='left'>
+        <div id="fullcontainer">
             <?php
             echo "<div class='navpath'>";
             if( $gamesTableFlag == 1 )

--- a/public/userList.php
+++ b/public/userList.php
@@ -44,7 +44,7 @@ RenderDocType();
     <?php RenderToolbar( $user, $permissions ); ?>
 
     <div id="mainpage">
-        <div id="userlist" class="left">
+        <div id="fullcontainer">
 
             <?php
             echo "<div class='navpath'>";

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -82,7 +82,7 @@
 
 <div id="mainpage">
     <?php RenderErrorCodeWarning( 'both', $errorCode ); ?>
-    <div id="fullcontainer" class="both">
+    <div id="fullcontainer">
 
         <?php
         echo "<div class='navpath'>";

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -82,7 +82,7 @@
 
 <div id="mainpage">
     <?php RenderErrorCodeWarning( 'both', $errorCode ); ?>
-    <div id="forums" class="both">
+    <div id="fullcontainer" class="both">
 
         <?php
         echo "<div class='navpath'>";


### PR DESCRIPTION
- In several pages, there was no rightcontatiner div, or an empty div, so I converted the leftcontainer div to a fullcontainer div so there was not a large blank area on the right side of the page.

Before:
![image](https://user-images.githubusercontent.com/16140035/67178500-fb6c3380-f3a0-11e9-9678-5e85f92944d7.png)

After:
![image](https://user-images.githubusercontent.com/16140035/67178488-e98a9080-f3a0-11e9-8c43-34f381cce3be.png)

- In the messages page, the rightcontainer div is moved out of the leftcontainer div and the footer is fixed.
- In the friends list page, the friends leaderboard is added to the rightcontainer div.
- In the settings page, the footer is fixed.
- In the achievement inspector page, the fields are organized in a table and sorted alphabetically.
![image](https://user-images.githubusercontent.com/16140035/67178589-4c7c2780-f3a1-11e9-9f5b-ec0bdb263aec.png)
