### PR TITLE
Fix Awardlist Page

### DIFF
--- a/public/awardedList.php
+++ b/public/awardedList.php
@@ -87,7 +87,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
             {
                 echo " | <a href='awardedList.php?s=$sortBy&amp;o=0&amp;p=$params&amp;i=$nextConsoleID'>$nextConsoleName</a>";
             }
-        
+        }
 
         echo "</p>";
 


### PR DESCRIPTION
I missed a closing curly bracket on the awardlist page in my last PR which is causing a syntax error.