### PR TITLE
Fixed broken word wrapping on the achievement logic display.

### DIFF
--- a/public/css/style54.css
+++ b/public/css/style54.css
@@ -928,7 +928,7 @@ pre, code, .code {
     font-family: monospace;
     font-size: medium;
     word-break: break-word;
-    white-space: pre;
+    white-space: pre-wrap;
 }
 
 .badgeimg {


### PR DESCRIPTION
My last PR broke word wrapping on achievement logic. The PR will fix it.

![image](https://user-images.githubusercontent.com/16140035/67538095-029a8680-f6ac-11e9-85f5-45281529e90c.png)
