### PR TITLE
Fix email notifications for game ticket subscribers

### DIFF
--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -413,7 +413,7 @@ function getSubscribersOfAchievement($achievementID, $gameID, $achievementAuthor
     $achievementSubs = getSubscribersOfArticle(2, $achievementID, (1 << 1), $achievementAuthor);
 
     // devs subscribed to the achievement through the game
-    $gameAchievementsSubs = getSubscribersOf(\RA\SubscriptionSubjectType::GameAchievements, $gameID, (1 << 0));
+    $gameAchievementsSubs = getSubscribersOf(\RA\SubscriptionSubjectType::GameAchievements, $gameID, (1 << 0) /*(1 << 1)*/);
 
     return mergeSubscribers($achievementSubs, $gameAchievementsSubs);
 }
@@ -434,7 +434,7 @@ function getSubscribersOfTicket($ticketID, $ticketAuthor, $gameID)
     $ticketSubs = getSubscribersOfArticle(7, $ticketID, (1 << 1), $ticketAuthor, true);
 
     // devs subscribed to the ticket through the game
-    $gameTicketsSubs = getSubscribersOf(\RA\SubscriptionSubjectType::GameTickets, $gameID, (1 << 1));
+    $gameTicketsSubs = getSubscribersOf(\RA\SubscriptionSubjectType::GameTickets, $gameID, (1 << 0) /*(1 << 1)*/);
 
     return mergeSubscribers($ticketSubs, $gameTicketsSubs);
 }

--- a/lib/database/tickets.php
+++ b/lib/database/tickets.php
@@ -177,7 +177,7 @@ $bugReportDetails";
                 postActivity($userSubmitter, ActivityType::OpenedTicket, $achID);
 
                 // notify subscribers other than the achievement's author
-                $subscribers = getSubscribersOf(\RA\SubscriptionSubjectType::GameTickets, $gameID, (1 << 1));
+                $subscribers = getSubscribersOf(\RA\SubscriptionSubjectType::GameTickets, $gameID, (1 << 0) /*(1 << 1)*/);
                 $emailHeader = "Bug Report ($gameTitle)";
                 foreach ($subscribers as $sub)
                 {

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -401,13 +401,13 @@ function sendRAEmail($to, $header, $body)
     if (isAtHome())
     {
         error_log(__FUNCTION__ . " dumping mail, not sending... no mailserver!");
-        error_log($email);
+        error_log($to);
         error_log($header);
         error_log($body);
         return true;
     }
 
-    return mail_utf8($email, "RetroAchievements.org", "noreply@retroachievements.org", $header, $body);
+    return mail_utf8($to, "RetroAchievements.org", "noreply@retroachievements.org", $header, $body);
 }
 
 function SendPrivateMessageEmail($user, $email, $title, $contentIn, $fromUser)


### PR DESCRIPTION
PR #349 introduced the capability of developers subscribing to tickets of a given game, including their creation. The ticket creation email notifications (both for the author and subscribers) is sent from a different piece of code than most other notifications. The code that sent the email to subscribers had a variable typo that kept the emails from going out. The notification for the achievement author was unaffected.

While searching for this problem I also noticed that in some places the user settings notification flag being used was incorrect, so I fixed that as well.