### PR TITLE
Properly show complete & mastered site awards for same title games

### DIFF
--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1576,12 +1576,12 @@ function getUsersSiteAwards($user)
             if ($retVal[$i]['AwardType'] == 1 &&
                 $retVal[$i]['AwardDataExtra'] == 1)
             {
-                $masteredGames[] = $retVal[$i]['Title'];
+                $masteredGames[] = $retVal[$i]['AwardData'];
             }
             elseif ($retVal[$i]['AwardType'] == 1 &&
                     $retVal[$i]['AwardDataExtra'] == 0)
             {
-                $completedGames[] = $retVal[$i]['Title'];
+                $completedGames[] = $retVal[$i]['AwardData'];
             }
         }
 
@@ -1596,8 +1596,8 @@ function getUsersSiteAwards($user)
                 $index = 0;
                 foreach($retVal as $award)
                 {
-                    if(isset($award['Title']) &&
-                       $award['Title'] == $game &&
+                    if(isset($award['AwardData']) &&
+                       $award['AwardData'] == $game &&
                        $award['AwardDataExtra'] == 0)
                     {
                         $retVal[$index] = "";


### PR DESCRIPTION
It was recently found that when player had completed a game and mastered a game of the same name on a different system, the complete game award did not show up on the users page.

The fix for this was to change 'Title' to 'AwardData' when squashing any same game awards into one.