### PR TITLE
Implement Set Request Feature

### DIFF
--- a/database/20191218_000000_Add_SetRequest.sql
+++ b/database/20191218_000000_Add_SetRequest.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS `SetRequest` (
+  `User` varchar(32) COLLATE latin1_general_ci NOT NULL COMMENT 'Username',
+  `GameID` int(10) unsigned NOT NULL COMMENT 'Unique Game ID',
+  `Updated` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Timestamp for when this was last modified via API',
+  PRIMARY KEY (`User`,`GameID`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/lib/dynrender.php
+++ b/lib/dynrender.php
@@ -800,6 +800,7 @@ function RenderToolbar($user, $permissions = 0)
         //echo "<li><a href='/feed.php'>Friends Feed</a></li>";
         echo "<li><a href='/achievementList.php?s=14&p=1'>My Best Awards</a></li>";
         echo "<li><a href='/history.php'>My Legacy</a></li>";
+        echo "<li><a href='/setRequestList.php?u=$user'>My Requested Sets</a></li>";
         echo "<li><a href='/friends.php'>Friends List</a></li>";
         echo "<li><a href='/inbox.php'>Messages</a></li>";
         // echo "<li><a href='/createmessage.php'>New Message</a></li>";
@@ -823,6 +824,7 @@ function RenderToolbar($user, $permissions = 0)
             echo "<li><a href='/ticketmanager.php'>Ticket Manager</a></li>";
             echo "<li><a href='/ticketmanager.php?f=1'>Most Reported Games</a></li>";
             echo "<li><a href='/achievementinspector.php'>Achievement Inspector</a></li>";
+            echo "<li><a href='/setRequestList.php'>Most Requested Sets</a></li>";
             echo "<li class='divider'></li>";
             echo "<li><a href='/latesthasheslinked.php'>Latest Linked Hashes</a></li>";
         }

--- a/public/API/API_GetSetRequests.php
+++ b/public/API/API_GetSetRequests.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/../../lib/bootstrap.php';
+
+$gameID = seekGET( 'i' );
+$user = seekGET( 'u' );
+
+settype( $gameID, 'integer' );
+
+$setRequestList = getUserRequestList($user, 1, 1);
+$totalRequests = getUserRequestsInformation($user, $setRequestList, $gameID);
+$totalRequests['gameRequests'] = getSetRequestCount($gameID);
+
+echo json_encode( $totalRequests );

--- a/public/API/API_SetSetRequest.php
+++ b/public/API/API_SetSetRequest.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/../../lib/bootstrap.php';
+
+$gameID = seekGET( 'i' );
+$user = seekGET( 'u' );
+
+settype( $gameID, 'integer' );
+
+$setRequestList = getUserRequestList($user, 1, 1);
+$totalRequests = getUserRequestsInformation($user, $setRequestList, $gameID);
+$totalRequests['gameRequests'] = getSetRequestCount($gameID);
+
+$success = toggleSetRequest($user, $gameID, $totalRequests['remaining']);
+
+echo json_encode( $success );

--- a/public/css/style54.css
+++ b/public/css/style54.css
@@ -1054,6 +1054,11 @@ div.rating a.starlit {
     background: url('/Images/star_full.png') no-repeat 0 0px;
 }
 
+
+a.setRequestLabel {
+    cursor: pointer;
+}
+
 #preload-01 { background: url('/Images/dropdown.gif') no-repeat -9999px -9999px; }
 #preload-02 { background: url('/Images/center_hassub.png') no-repeat -9999px -9999px; }
 #preload-03 { background: url('/Images/sub_hover.png') no-repeat -9999px -9999px; }

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -414,7 +414,93 @@ $numGridlines = $numAchievements;
                 SubmitRating('<?php echo $user; ?>', <?php echo $gameID; ?>, ratingType, numStars);
             });
 
-            GetRating(<?php echo $gameID; ?>);
+            if ($('.rating').length)
+            {
+                GetRating(<?php echo $gameID; ?>);
+            }
+
+        });
+
+        /*
+         * Displays set request information
+         */
+        function getSetRequestInformation(user, gameID)
+        {
+            $.ajax(
+            {
+                url: '/API/API_GetSetRequests.php?i=' + gameID + '&u=' + user,
+                dataType: 'json',
+                success: function (results)
+                {
+                    var remaining = parseInt(results.remaining);
+                    var gameTotal = parseInt(results.gameRequests);
+                    var thisGame = results.requestedThisGame;
+
+                    $('.gameRequestsLabel').html("Set Requests: <a href='/setRequestors.php?g=" + gameID + "'>" + gameTotal + "</a>");
+                    $('.userRequestsLabel').html("User Requests Remaining: <a href='/setRequestList.php?u=" + user + "'>" + remaining + "</a>");
+                    
+                    //If the user has not requested a set for this game
+                    if (thisGame == 0)
+                    {
+                        if (remaining <= 0)
+                        {
+                            $('.setRequestLabel').html("<h4>No Requests Remaining</h4>");
+
+                            //Remove clickable text
+                            $(".setRequestLabel").each(function()
+                            {
+                                $("<h4>" + $(this).html() + "</h4>").replaceAll(this);
+                            });
+                        }
+                        else
+                        {
+                            $('.setRequestLabel').html("<h4>Request Set</h4>");
+                        }
+                    }
+                    else
+                    {
+                        $('.setRequestLabel').html("<h4>Withdraw Request</h4>");
+                    }
+
+                },
+                error: function (temp, temp1, temp2)
+                {
+                    alert("Error " + temp + temp1 + temp2);
+                }
+            });
+        }
+
+        /*
+         * Submits a set requets
+         */
+        function submitSetRequest(user, gameID)
+        {
+            $.ajax(
+            {
+                url: '/API/API_SetSetRequest.php?i=' + gameID + '&u=' + user,
+                dataType: 'json',
+                success: function (results)
+                {
+                    getSetRequestInformation('<?php echo $user; ?>', <?php echo $gameID; ?>);
+                },
+                error: function (temp, temp1, temp2)
+                {
+                    alert("Error " + temp + temp1 + temp2);
+                }
+            });
+        }
+
+        $(function ()
+        {
+            $('.setRequestLabel').click(function ()
+            {
+                submitSetRequest('<?php echo $user; ?>', <?php echo $gameID; ?>);
+            });
+
+            if ($('.setRequestLabel').length)
+            {
+                getSetRequestInformation('<?php echo $user; ?>', <?php echo $gameID; ?>);
+            }
 
         });
 
@@ -733,6 +819,20 @@ $numGridlines = $numAchievements;
                 echo "</div>";
                 echo "</br>";
             }
+            
+            //Only show set request option for logged in users, games without achievements, and core achievement page
+            if ($user !== null && $numAchievements == 0 && $flags != 5)
+            {
+                echo "</br>";
+                echo "<div style='float: right; clear: both;'>";
+                echo "<div>";
+                echo "<a class='setRequestLabel'>Request Set</a>";
+                echo "</div>";
+                echo "<span class='gameRequestsLabel'>?</span>";
+                echo "</br>";
+                echo "<span class='userRequestsLabel'>?</span>";
+                echo "</div>";
+            }
 
             /* if( $user !== NULL && $numAchievements > 0 )
               {
@@ -924,6 +1024,10 @@ $numGridlines = $numAchievements;
             echo "</li>";
             echo "<li>- <a href='/linkedhashes.php?g=$gameID'>Hashes linked to this game</a></li>";
             echo "<li>- <a href='/ticketmanager.php?g=$gameID&ampt=1'>Open Tickets for this game</a></li>";
+            if ($numAchievements == 0)
+            {
+                echo "<li>- <a href='/setRequestors.php?g=$gameID'>Set Requestors for this game</a></li>";
+            }
             //if( $flags == 5 )
             //echo "<li>- <a href='/Game/$gameID'>View Core Achievements</a></li>";
             //else

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -1,0 +1,158 @@
+<?php
+require_once __DIR__ . '/../lib/bootstrap.php';
+
+RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+
+$maxCount = 50;
+$offset = 0;
+
+$username = seekGET( 'u');
+$errorCode = seekGET('e');
+$count = seekGET('c', $maxCount);
+$offset = seekGET('o', $offset);
+$flag = seekGET('f', 0); //0 - display only active user set requests, else display all user set requests
+if ($offset < 0)
+{
+    $offset = 0;
+}
+
+if (is_null($username))
+{
+    $setRequestList = getMostRequestedSetsList($offset, $count);
+    $totalRequestedGames = getGamesWithRequests();
+}
+else
+{
+    $setRequestList = getUserRequestList($username);
+    $userSetRequestInformation = getUserRequestsInformation($username, $setRequestList);
+}
+
+RenderDocType();
+?>
+
+<head>
+    <!--Load the AJAX API-->
+    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <?php
+    RenderSharedHeader($user);
+    RenderTitleTag("Set Requests", $user);
+    RenderGoogleTracking();
+    ?>
+</head>
+
+<body>
+    <?php
+        RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions);
+        RenderToolbar($user, $permissions);
+    ?>
+    <div id='mainpage'>
+        <div id='fullcontainer'>
+            <?php
+                RenderErrorCodeWarning('left', $errorCode);
+                
+                $gameCounter = 0;
+
+                //Looking at most requested sets
+                if (is_null($username))
+                {
+                    echo "<h2 class='longheader'>Most Requested Sets</h2>";
+                    
+                    //Create table headers
+                    echo "<table class='smalltable'><tbody>";
+                    echo "<th>Game</th>";
+                    echo "<th>Requests</th>";
+
+                    // Loop through each hash and display its information
+                    foreach ($setRequestList as $request)
+                    {   
+                        if (sizeof(getAchievementIDs($request['GameID'])['AchievementIDs']) == 0)
+                        {
+                            echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
+                            
+                            echo "<td>";
+                            echo GetGameAndTooltipDiv($request['GameID'], $request['GameTitle'], $request['GameIcon'], $request['ConsoleName']);
+                            echo "</td>";
+                            echo "<td><a href='/setRequestors.php?g=".$request['GameID']."'>".$request['Requests']."</a></td>";
+                        }
+                    }
+                    echo "</tbody></table>";
+                    
+                    //Add page traversal links
+                    echo "<div class='rightalign row'>";
+                    if ($offset > 0)
+                    {
+                        $prevOffset = $offset - $maxCount;
+                        echo "<a href='/setRequestList.php'>First</a> - ";
+                        echo "<a href='/setRequestList.php?o=$prevOffset'>&lt; Previous $maxCount</a> - ";
+                    }
+                    if ($gameCounter == $maxCount && $offset != ($totalRequestedGames - $maxCount))
+                    {
+                        $nextOffset = $offset + $maxCount;
+                        echo "<a href='/setRequestList.php?o=$nextOffset'>Next $maxCount &gt;</a>";
+                        echo " - <a href='/setRequestList.php?o=" . ($totalRequestedGames - $maxCount) . "'>Last</a>";
+                    }
+                    echo "</div>";
+                }
+                //Looking at the sets a specific user has requested
+                else
+                {
+                    echo "<h2 class='longheader'>$username's Requested Sets - "
+                        . $userSetRequestInformation['used'] . " of ". $userSetRequestInformation['total'] . " Requests Made</h2>";
+                    
+                    if ($flag == 0)
+                    {
+                        echo "<a href='/setRequestList.php?u=$username&f=1'>View All User Set Requests</a>";
+                    }
+                    else
+                    {
+                        echo "<a href='/setRequestList.php?u=$username'>View Active User Set Requests</a>";
+                    }
+                    echo "</br>";
+                    echo "</br>";
+
+                    //Create table headers
+                    echo "<table class='smalltable'><tbody>";
+                    echo "<th>Game</th>";
+
+                    // Loop through each set request and display them if they do not have any acheivements
+                    foreach ($setRequestList as $request)
+                    {
+                        if ($flag == 0)
+                        {
+                            if (sizeof(getAchievementIDs($request['GameID'])['AchievementIDs']) == 0)
+                            {
+                                echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
+                                
+                                echo "<td>";
+                                echo GetGameAndTooltipDiv($request['GameID'], $request['GameTitle'], $request['GameIcon'], $request['ConsoleName']);
+                                echo "</td>";
+                            }
+                        }
+                        else
+                        {
+                            if (sizeof(getAchievementIDs($request['GameID'])['AchievementIDs']) == 0)
+                            {
+                                echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
+                                
+                                echo "<td>";
+                                echo GetGameAndTooltipDiv($request['GameID'], $request['GameTitle'], $request['GameIcon'], $request['ConsoleName']);
+                                echo "</td>";
+                            }
+                            else
+                            {
+                                echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
+                                
+                                echo "<td>";
+                                echo GetGameAndTooltipDiv($request['GameID'], $request['GameTitle'], $request['GameIcon'], $request['ConsoleName']) . " - Set Exists";
+                                echo "</td>";
+                            }
+                        }
+                    }
+                    echo "</tbody></table>";
+                }
+            ?>
+        </div>
+    </div>
+    <?php RenderFooter(); ?>
+</body>
+</html>

--- a/public/setRequestors.php
+++ b/public/setRequestors.php
@@ -1,0 +1,64 @@
+<?php
+require_once __DIR__ . '/../lib/bootstrap.php';
+
+if( !RA_ReadCookieCredentials( $user, $points, $truePoints, $unreadMessageCount, $permissions, \RA\Permissions::Registered ) )
+{
+    //	Immediate redirect if we cannot validate user!	//TBD: pass args?
+    header( "Location: " . getenv('APP_URL') );
+    exit;
+}
+
+$gameID = seekGET( 'g' );
+$errorCode = seekGET( 'e' );
+
+$gameIDSpecified = ( isset( $gameID ) && $gameID != 0 );
+if( $gameIDSpecified )
+{
+    getGameMetadata( $gameID, $user, $achievementData, $gameData );
+    $consoleName = $gameData[ 'ConsoleName' ];
+    $consoleID = $gameData[ 'ConsoleID' ];
+    $gameTitle = $gameData[ 'Title' ];
+    $gameIcon = $gameData[ 'ImageIcon' ];
+    $requestors = getSetRequestorsList($gameID);
+}
+else
+{
+    //	Immediate redirect: this is pointless otherwise!
+    header( "Location: " . getenv('APP_URL') );
+}
+
+RenderDocType();
+?>
+
+<head>
+    <?php RenderSharedHeader( $user ); ?>
+    <?php RenderTitleTag( "Set Requestors", $user ); ?>
+    <?php RenderGoogleTracking(); ?>
+</head>
+<body>
+    <?php RenderTitleBar( $user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions ); ?>
+    <?php RenderToolbar( $user, $permissions ); ?>
+    <div id="mainpage">
+        <div id='fullcontainer'>
+            <h2>List of Set Requestors</h2>
+            <?php
+                echo GetGameAndTooltipDiv( $gameID, $gameTitle, $gameIcon, $consoleName, FALSE, 96 );
+                echo "</br></br>";
+                echo "A set for this game has been requested by the following users:<br/><br/>";
+                echo "<ul>";
+                if (!empty($requestors))
+                {
+                    foreach( $requestors as $requestor)
+                    {
+                        echo "<code><li>" . GetUserAndTooltipDiv( $requestor['Requestor'], FALSE) . "</code></li>";
+                    }
+                }
+                echo "</ul>";
+                echo "<br/>";
+            ?>
+            <br/>
+        </div>
+    </div>
+    <?php RenderFooter(); ?>
+</body>
+</html>


### PR DESCRIPTION
This gives the user the ability to request sets to be made for games that do not have any core achievements yet. It comes with various ways to view most requested sets, my requested sets, and who requested a set for a game. The request feature works similar to the game rating feature where the user just need to click the text to request or withdraw a request and the new information is displayed instantly without needing to reload the page.

`database/20191218_000000_Add_SetRequest.sql` will need to be run to create a new setrequest tabe in the database to store the user set request information.

Here is a video demo I made a few days ago https://streamable.com/seiuw. There have since been a few typos fixed and some minor updates made, but it gives the general idea of the feature.

The total number of set requests a user has is based on their points and is currently calculated as follows:
\>=5,000  +1 request 
\>=10,000  +1 request
\>=15,000  +1 request
\>=20,000  +1 request
+1 request for every 10,000 points over 20,000

I've put a 20 request cap in for now, it currently only limits the top 15 users.

If the user has a request remaining and has not requested a set for this game
![image](https://user-images.githubusercontent.com/16140035/71225062-59d06800-22a5-11ea-9207-3ea8c900ecc4.png)
If the user has requested a set for this game
![image](https://user-images.githubusercontent.com/16140035/71223733-e9c0e280-22a2-11ea-8874-d6a9ee0e4175.png)
If the user does not have requests remaining
![image](https://user-images.githubusercontent.com/16140035/71223879-137a0980-22a3-11ea-8a21-b0737d3b9e00.png)

The "Manage" menu has a new "Most Requested Sets" page that lists which sets have the most requests.
![image](https://user-images.githubusercontent.com/16140035/71223998-34425f00-22a3-11ea-8869-56dc02b7241b.png)
![image](https://user-images.githubusercontent.com/16140035/71223956-28ef3380-22a3-11ea-9e7c-5d4758bc7d24.png)

The "My Pages" menu has a new "My Requested Sets" page that lists active set requests for the user. Clicking on the "View All User Set Requests" will show active and inactive set requests for the user, inactive set requests are for games that have received achievements after a request was made.
![image](https://user-images.githubusercontent.com/16140035/71224115-59cf6880-22a3-11ea-850e-874418a1c091.png)
![image](https://user-images.githubusercontent.com/16140035/71224161-6784ee00-22a3-11ea-82f4-b0fea2a0a578.png)
![image](https://user-images.githubusercontent.com/16140035/71224185-6eabfc00-22a3-11ea-9933-d4cf66fd2d49.png)

Clicking the new "Set Requestors for this game" link will display which users have requested a set for the game.
![image](https://user-images.githubusercontent.com/16140035/71224610-f72a9c80-22a3-11ea-9996-d74f44101023.png)
![image](https://user-images.githubusercontent.com/16140035/71224645-01e53180-22a4-11ea-8e4c-76784476ba38.png)