### PR TITLE
Fix Set Request Queries

### DIFF
--- a/lib/database/setrequest.php
+++ b/lib/database/setrequest.php
@@ -216,7 +216,7 @@ function getSetRequestorsList($gameID)
 }
 
 /**
- * Gets a list of the most requested sets.
+ * Gets a list of the most requested sets without core achievements.
  *
  * @param int $offset offset starting position for returned games
  * @param int $count number of games to return
@@ -239,6 +239,8 @@ function getMostRequestedSetsList($offset, $count)
             GameData gd ON (sr.GameID = gd.ID)
         LEFT JOIN
             Console c ON (gd.ConsoleID = c.ID)
+        WHERE 
+            sr.GameID NOT IN (SELECT DISTINCT(GameID) FROM Achievements where Flags = '3')
         GROUP BY
             sr.GameID
         ORDER BY
@@ -271,7 +273,9 @@ function getGamesWithRequests()
         SELECT
             COUNT(DISTINCT GameID) AS Games
         FROM
-            SetRequest";
+            SetRequest
+        WHERE
+             GameID NOT IN (SELECT DISTINCT(GameID) FROM Achievements where Flags = '3')";
 
     $dbResult = s_mysql_query($query);
 

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -49,14 +49,12 @@ RenderToolbar($user, $permissions);
 
             // Loop through each hash and display its information
             foreach ($setRequestList as $request) {
-                if (count(getAchievementIDs($request['GameID'])['AchievementIDs']) == 0) {
-                    echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
+                echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
 
-                    echo "<td>";
-                    echo GetGameAndTooltipDiv($request['GameID'], $request['GameTitle'], $request['GameIcon'], $request['ConsoleName']);
-                    echo "</td>";
-                    echo "<td><a href='/setRequestors.php?g=" . $request['GameID'] . "'>" . $request['Requests'] . "</a></td>";
-                }
+                echo "<td>";
+                echo GetGameAndTooltipDiv($request['GameID'], $request['GameTitle'], $request['GameIcon'], $request['ConsoleName']);
+                echo "</td>";
+                echo "<td><a href='/setRequestors.php?g=" . $request['GameID'] . "'>" . $request['Requests'] . "</a></td>";
             }
             echo "</tbody></table>";
 


### PR DESCRIPTION
Some set request queries were returning games that already have sets which prevented the "Next 50" link from showing up in some cases.