### PR TITLE
Display awards since ticket creation

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -1365,3 +1365,35 @@ function recalculateTrueRatio($gameID)
         return false;
     }
 }
+
+/*
+ * Gets the number of softcore and hardcore awarded for an achieveemnt since a given time.
+ *
+ * @param int $id offset achievement to gets awards count for
+ * @param string $date the date to get awards since
+ * @return array
+ */
+function getAwardsSince($id, $date)
+{
+    settype($id, "integer");
+    settype($date, "string");
+
+    $query = "
+        SELECT
+            COALESCE(SUM(CASE WHEN HardcoreMode = 0 THEN 1 ELSE 0 END), 0) AS softcoreCount,
+            COALESCE(SUM(CASE WHEN HardcoreMode = 1 THEN 1 ELSE 0 END), 0) AS hardcoreCount
+        FROM
+            Awarded
+        WHERE
+            AchievementID = $id
+        AND
+            Date > '$date'";
+
+    $dbResult = s_mysql_query($query);
+
+    if ($dbResult !== false) {
+        return mysqli_fetch_assoc($dbResult);
+    } else {
+        return 0;
+    }
+}

--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -1367,10 +1367,10 @@ function recalculateTrueRatio($gameID)
 }
 
 /*
- * Gets the number of softcore and hardcore awarded for an achieveemnt since a given time.
+ * Gets the number of softcore and hardcore awards for an achieveemnt since a given time.
  *
- * @param int $id offset achievement to gets awards count for
- * @param string $date the date to get awards since
+ * @param int $id achievement to gets awards count for
+ * @param string $date the date to get awards count since
  * @return array
  */
 function getAwardsSince($id, $date)

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -529,6 +529,16 @@ RenderHtmlHead($pageTitle);
                     echo "</tr>";
                 }
 
+                echo "<tr>";
+                echo "<td></td><td colspan='6'>";
+                echo "<div class='temp'>";
+                $awardCount = getAwardsSince($achID, $reportedAt);
+                echo "This achievement has been earned " . $awardCount['softcoreCount'] . " <b>(" .  $awardCount['hardcoreCount'] . ")</b> "
+                    . ($awardCount['hardcoreCount'] == 1 ? "time": "times") . " since this ticket was created.";
+                echo "</div>";
+                echo "</td>";
+                echo "</tr>";
+
                 if ($permissions >= \RA\Permissions::Developer) {
                     echo "<tr>";
 


### PR DESCRIPTION
This update will show how many times an achievement has been awarded since any given ticket was created against it. It should assist in determining if older tickets are valid or not.

![image](https://user-images.githubusercontent.com/16140035/72231193-0d1c3c00-3588-11ea-80fc-0a3bb8b113ff.png)
softcore **(Hardcore)**