### PR TITLE
Add console filtering to most requested sets

### DIFF
--- a/lib/database/setrequest.php
+++ b/lib/database/setrequest.php
@@ -274,7 +274,7 @@ function getMostRequestedSetsList($console, $offset, $count)
 /**
  * Gets the number of set-less games with at least one set request.
  *
- * @param int $consoletem the console to get game count for
+ * @param int $console the console to get game count for
  * @return bool|mixed|string
  */
 function getGamesWithRequests($console)

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -60,7 +60,7 @@ RenderToolbar($user, $permissions);
                 {
                     if ($selectedConsole == $console['ID'])
                     {
-                        echo "<option selected>" . getGamesWithRequests( $console['ID']) . " - " . $console['Name'] . "</option>";
+                        echo "<option selected>" . $totalRequestedGames . " - " . $console['Name'] . "</option>";
                     }
                     else
                     {
@@ -99,13 +99,13 @@ RenderToolbar($user, $permissions);
             echo "<div class='rightalign row'>";
             if ($offset > 0) {
                 $prevOffset = $offset - $maxCount;
-                echo "<a href='/setRequestList.php'>First</a> - ";
-                echo "<a href='/setRequestList.php?o=$prevOffset'>&lt; Previous $maxCount</a> - ";
+                echo "<a href='/setRequestList.php?s=$selectedConsole'>First</a> - ";
+                echo "<a href='/setRequestList.php?o=$prevOffset&s=$selectedConsole'>&lt; Previous $maxCount</a> - ";
             }
             if ($gameCounter == $maxCount && $offset != ($totalRequestedGames - $maxCount)) {
                 $nextOffset = $offset + $maxCount;
-                echo "<a href='/setRequestList.php?o=$nextOffset'>Next $maxCount &gt;</a>";
-                echo " - <a href='/setRequestList.php?o=" . ($totalRequestedGames - $maxCount) . "'>Last</a>";
+                echo "<a href='/setRequestList.php?o=$nextOffset&s=$selectedConsole'>Next $maxCount &gt;</a>";
+                echo " - <a href='/setRequestList.php?o=" . ($totalRequestedGames - $maxCount) . "&s=$selectedConsole'>Last</a>";
             }
             echo "</div>";
         } else {

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -8,6 +8,7 @@ $offset = 0;
 
 $username = seekGET('u');
 $errorCode = seekGET('e');
+$selectedConsole = seekGET('s');
 $count = seekGET('c', $maxCount);
 $offset = seekGET('o', $offset);
 $flag = seekGET('f', 0); //0 - display only active user set requests, else display all user set requests
@@ -16,12 +17,19 @@ if ($offset < 0) {
 }
 
 if ($username === null) {
-    $setRequestList = getMostRequestedSetsList($offset, $count);
-    $totalRequestedGames = getGamesWithRequests();
+    $setRequestList = getMostRequestedSetsList($selectedConsole, $offset, $count);
+    $totalRequestedGames = getGamesWithRequests($selectedConsole);
 } else {
     $setRequestList = getUserRequestList($username);
     $userSetRequestInformation = getUserRequestsInformation($username, $setRequestList);
 }
+
+//Get and srot the console list
+$consoles = getConsoleIDs();
+
+usort($consoles, function($a, $b) {
+    return $a['Name'] <=> $b['Name'];
+});
 
 RenderHtmlStart();
 RenderHtmlHead("Set Requests");
@@ -42,8 +50,37 @@ RenderToolbar($user, $permissions);
             //Looking at most requested sets
             echo "<h2 class='longheader'>Most Requested Sets</h2>";
 
+            echo "<div align='right'>";
+            echo "Filter by console: ";
+            echo "<td><select class='gameselector' onchange='window.location = \"/setRequestList.php\" + this.options[this.selectedIndex].value'><option value=''>-- All Systems --</option>";
+
+            foreach ($consoles as $console)
+            {
+                if ($selectedConsole != null)
+                {
+                    if ($selectedConsole == $console['ID'])
+                    {
+                        echo "<option selected>" . getGamesWithRequests( $console['ID']) . " - " . $console['Name'] . "</option>";
+                    }
+                    else
+                    {
+                        echo "<option value='?s=" . $console['ID'] . "'>" . getGamesWithRequests( $console['ID']) . " - " . $console['Name'] . "</option>";
+                        echo "<a href=\"/setRequestList.php\">" . $console['Name'] . "</a><br>";
+                    }
+                }
+                else
+                {
+                    echo "<option value='?s=" . $console['ID'] . "'>" . getGamesWithRequests( $console['ID']) . " - " . $console['Name'] . "</option>";
+                    echo "<a href=\"/setRequestList.php\">" . $console['Name'] . "</a><br>";
+                }
+            }
+
+            echo "</td>";
+            echo "</select>";
+            echo "</div>";
+
             //Create table headers
-            echo "<table><tbody>";
+            echo "</br><table><tbody>";
             echo "<th>Game</th>";
             echo "<th>Requests</th>";
 

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -47,8 +47,14 @@ RenderToolbar($user, $permissions);
         $gameCounter = 0;
 
         if ($username === null) {
-            //Looking at most requested sets
-            echo "<h2 class='longheader'>Most Requested Sets</h2>";
+            if ($selectedConsole != null)
+            {
+                echo "<h2 class='longheader'>Most Requested " . array_column($consoles, 'Name', 'ID')[$selectedConsole] . " Sets</h2>";
+            }
+            else
+            {
+                echo "<h2 class='longheader'>Most Requested Sets</h2>";
+            }
 
             echo "<div align='right'>";
             echo "Filter by console: ";


### PR DESCRIPTION
Add a console filter drop down allowing users to view requested sets for desired consoles. The drop down also lists how many games per console that have set requests for them

![image](https://user-images.githubusercontent.com/16140035/72237495-b07d4900-35a8-11ea-809e-5eb59ad95cd0.png)
![image](https://user-images.githubusercontent.com/16140035/72237510-bbd07480-35a8-11ea-8741-86e162c55b32.png)

This PR would resolve #392.
