### PR TITLE
Add Leaderboard Duplication

### DIFF
--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -651,7 +651,8 @@ function SubmitNewLeaderboard($gameID, &$lbIDOut)
 
     $defaultMem = "STA:0x0000=h0010_0xhf601=h0c::CAN:0xhfe13<d0xhfe13::SUB:0xf7cc!=0_d0xf7cc=0::VAL:0xhfe24*1_0xhfe25*60_0xhfe22*3600";
     $query = "INSERT INTO LeaderboardDef (GameID, Mem, Format, Title, Description, LowerIsBetter, DisplayOrder) 
-                                VALUES ($gameID, '$defaultMem', 'SCORE', 'My Leaderboard', 'My Leaderboard Description', 0, 0)";
+                                VALUES ($gameID, '$defaultMem', 'SCORE', 'My Leaderboard', 'My Leaderboard Description', 0,
+                                (SELECT * FROM (SELECT COALESCE(Max(DisplayOrder) + 1, 0) FROM LeaderboardDef WHERE  GameID = $gameID) AS temp))";
     // log_sql($query);
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {
@@ -661,6 +662,80 @@ function SubmitNewLeaderboard($gameID, &$lbIDOut)
     } else {
         return false;
     }
+}
+
+/**
+ * Duplicates a leaderboard a specified number of times.
+ *
+ * @param int $gameID the game to add new leaderboards to
+ * @param int $leaderboardID the leaderboard to duplicate
+ * @param int $duplicateNumber the number of times to duplicate the leaderboard
+ * @return boolean
+ */
+function duplicateLeaderboard($gameID, $leaderboardID, $duplicateNumber)
+{
+    settype($gameID,          'integer');
+    settype($leaderboardID,   'integer');
+    settype($duplicateNumber, 'integer');
+
+    if ($gameID == 0)
+    {
+        return false;
+    }
+
+    $lbMem          = null;
+    $lbFormat       = null;
+    $lbTitle        = null;
+    $lbDescription  = null;
+    $lbScoreType    = null;
+    $lbDisplayOrder = null;
+
+    //Get the leaderboard info to duplicate
+    $getQuery = "
+            SELECT Mem, 
+                   Format, 
+                   Title, 
+                   Description, 
+                   LowerIsBetter, 
+                   (SELECT Max(DisplayOrder) FROM LeaderboardDef WHERE GameID = $gameID) AS DisplayOrder 
+            FROM   LeaderboardDef 
+            WHERE  id = $leaderboardID";
+
+    $dbResult = s_mysql_query($getQuery);
+    if ($dbResult !== false)
+    {
+        $db_entry = mysqli_fetch_assoc($dbResult);
+
+        $lbMem           = $db_entry['Mem'];
+        $lbFormat        = $db_entry['Format'];
+        $lbTitle         = $db_entry['Title'];
+        $lbDescription   = $db_entry['Description'];
+        $lbScoreType     = $db_entry['LowerIsBetter'];
+        $lbDisplayOrder  = $db_entry['DisplayOrder'];
+    }
+    else
+    {
+        return false;
+    }
+    
+    //Create the duplicate entries
+    for ($i = 1; $i <= $duplicateNumber; $i++)
+    {
+        $query = "INSERT INTO LeaderboardDef (GameID, Mem, Format, Title, Description, LowerIsBetter, DisplayOrder) 
+                                    VALUES ($gameID, '$lbMem', '$lbFormat', '$lbTitle', '$lbDescription', $lbScoreType, ($lbDisplayOrder + $i))";
+        // log_sql($query);
+        $dbResult = s_mysql_query($query);
+        if ($dbResult !== false)
+        {
+            global $db;
+            mysqli_insert_id($db);
+        }
+        else
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 function requestResetLB($lbID)

--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -699,7 +699,7 @@ function duplicateLeaderboard($gameID, $leaderboardID, $duplicateNumber)
                    LowerIsBetter, 
                    (SELECT Max(DisplayOrder) FROM LeaderboardDef WHERE GameID = $gameID) AS DisplayOrder 
             FROM   LeaderboardDef 
-            WHERE  id = $leaderboardID";
+            WHERE  ID = $leaderboardID";
 
     $dbResult = s_mysql_query($getQuery);
     if ($dbResult !== false)

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -133,7 +133,18 @@ RenderHtmlHead($pageTitle);
         echo "<ul>";
         if (isset($gameID)) {
             echo "<li>";
-            echo "<a href='/request/leaderboard/create.php?u=$user&c=$cookie&g=$gameID'>Add New Leaderboard to " . $gameData['Title'] . "</a>";
+            echo "<a href='/request/leaderboard/create.php?u=$user&c=$cookie&g=$gameID'>Add New Leaderboard to " . $gameData['Title'] . "</a></br>";
+            echo "<form method='post' action='/request/leaderboard/create.php'> ";
+            echo "<input type='hidden' name='u' value='$user' />";
+            echo "<input type='hidden' name='c' value='$cookie' />";
+            echo "<input type='hidden' name='g' value='$gameID' />";
+            echo "Duplicate leaderboard ID: ";
+            echo "<input style='width: 10%;' type='number' min=1 value=1 name='l' /> ";
+            echo "Number of times: ";
+            echo "<input style='width: 10%;' type='number' min=1 value=1 name='n' />";
+            echo "&nbsp;&nbsp;";
+            echo "<input type='submit' value='Duplicate'/>";
+            echo "</form>";
             echo "</li>";
         } else {
             echo "<li>Add new leaderboard<br>";

--- a/public/request/leaderboard/create.php
+++ b/public/request/leaderboard/create.php
@@ -4,24 +4,44 @@ require_once __DIR__ . '/../../../lib/bootstrap.php';
 $user = seekPOST('u');
 $cookie = seekPOST('c');
 $gameID = seekPOST('g');
+$leaderboardID = seekPOST('l');
+$duplicateNumber = seekPOST('n');
 if (!isset($user)) {
     $user = seekGET('u');
     $cookie = seekGET('c');
     $gameID = seekGET('g');
+    $leaderboardID = seekGET('l');
+    $duplicateNumber = seekGET('n');
 }
 
 if (validateUser_cookie($user, $cookie, \RA\Permissions::Developer)) {
-    if (submitNewLeaderboard($gameID, $lbID)) {
-        //	Good!
-        header("Location: " . getenv('APP_URL') . "/leaderboardList.php?g=$gameID&e=ok");
-        exit;
-    } else {
-        //log_email(__FILE__ . "$user, $cookie, $gameID");
-        // error_log(__FILE__);
-        // error_log("Issues2: user $user, cookie $cookie, gameID $gameID");
+    if (isset($leaderboardID) && isset($duplicateNumber))
+    {
+        if (duplicateLeaderboard($gameID, $leaderboardID, $duplicateNumber))
+        {
+            header("Location: " . getenv('APP_URL') . "/leaderboardList.php?g=$gameID&e=ok");
+            exit;
+        }
+        else
+        {
+            header("Location: " . getenv('APP_URL') . "/leaderboardList.php&e=cannotcreate");
+            exit;
+        }
+    }
+    else
+    {
+        if (submitNewLeaderboard($gameID, $lbID)) {
+            //	Good!
+            header("Location: " . getenv('APP_URL') . "/leaderboardList.php?g=$gameID&e=ok");
+            exit;
+        } else {
+            //log_email(__FILE__ . "$user, $cookie, $gameID");
+            // error_log(__FILE__);
+            // error_log("Issues2: user $user, cookie $cookie, gameID $gameID");
 
-        header("Location: " . getenv('APP_URL') . "/leaderboardList.php&e=cannotcreate");
-        exit;
+            header("Location: " . getenv('APP_URL') . "/leaderboardList.php&e=cannotcreate");
+            exit;
+        }
     }
 } else {
     // error_log(__FILE__);


### PR DESCRIPTION
Adds leaderboard duplication ability to the Leaderboard List page. Allows user to specify a leaderboard ID and number of times to duplicate it for the currently selected game. Duplicated leaderboards will increment in display order. The input areas are restricted to numerical values greater than 0.

This is useful for games that have several nearly identical leaderboards. It will really speed up leaderboard creation in those cases.

![image](https://user-images.githubusercontent.com/16140035/72303490-7a3cd980-363b-11ea-889f-1064dfd1d3fd.png)

![image](https://user-images.githubusercontent.com/16140035/72303520-8cb71300-363b-11ea-86f6-42287293780e.png)

Also updated adding a single leaderboard to increment the display order.

This would resolve issue #386.