### PR TITLE
API_GetAchievementUnlocks also returns 'MemAddr'

### DIFF
--- a/public/API/API_GetAchievementUnlocks.php
+++ b/public/API/API_GetAchievementUnlocks.php
@@ -28,6 +28,7 @@ $achievement = [
     'Author' => $achievementData['Author'] ?? null,
     'DateCreated' => $achievementData['DateCreated'] ?? null,
     'DateModified' => $achievementData['DateModified'] ?? null,
+    'MemAddr' => $achievementData['MemAddr'] ?? null,
 ];
 
 $game = [


### PR DESCRIPTION
It'll allow me to easily make the RABot's `!mem` command show the logic of an actual achievement on discord (https://github.com/RetroAchievements/RABot/issues/27).

IMO it'll be extremely useful for jrdevs and code reviewers.