### PR TITLE
Enable JSONP API responses

### DIFF
--- a/lib/util/jsonp.php
+++ b/lib/util/jsonp.php
@@ -1,0 +1,10 @@
+// This is a helper function that enables JSONP API responses (JSON with a callback)
+// and falls back to static JSON if a callback parameter is not specified. This allows
+// the API to be used cross-domain without having to deal with server-side cross-origin
+// configuration settings applied.
+
+function jsonp_encode($value, $options = 0, $depth = 512) {
+  $callback = $_GET['callback'];
+  $json = json_encode($value, $options, $depth);
+  return (isset($callback) && !empty($callback)) ? "${callback}(${json})" : $json;
+}

--- a/public/API/API_GetAchievementCount.php
+++ b/public/API/API_GetAchievementCount.php
@@ -9,4 +9,4 @@ if (!ValidateAPIKey(seekGET('z'), seekGET('y'))) {
 
 $gameID = seekGET('i');
 
-echo json_encode(getAchievementIDs($gameID));
+echo jsonp_encode(getAchievementIDs($gameID));

--- a/public/API/API_GetAchievementOfTheWeek.php
+++ b/public/API/API_GetAchievementOfTheWeek.php
@@ -66,7 +66,7 @@ usort($winnerInfo, function ($a, $b) {
     return strtotime($a['DateAwarded']) - strtotime($b['DateAwarded']);
 });
 
-echo json_encode([
+echo jsonp_encode([
     'Achievement' => $achievement,
     'Console' => $console,
     'ForumTopic' => $forumTopic,

--- a/public/API/API_GetAchievementUnlocks.php
+++ b/public/API/API_GetAchievementUnlocks.php
@@ -46,7 +46,7 @@ usort($winnerInfo, function ($a, $b) {
     return strtotime($a['DateAwarded']) - strtotime($b['DateAwarded']);
 });
 
-echo json_encode([
+echo jsonp_encode([
     'Achievement' => $achievement,
     'Console' => $console,
     'Game' => $game,

--- a/public/API/API_GetAchievementsEarnedBetween.php
+++ b/public/API/API_GetAchievementsEarnedBetween.php
@@ -21,4 +21,4 @@ foreach ($data as &$nextData) {
     $nextData['GameURL'] = "/Game/" . $nextData['GameID'];
 }
 
-echo json_encode($data);
+echo jsonp_encode($data);

--- a/public/API/API_GetAchievementsEarnedOnDay.php
+++ b/public/API/API_GetAchievementsEarnedOnDay.php
@@ -17,4 +17,4 @@ foreach ($data as &$nextData) {
     $nextData['GameURL'] = "/Game/" . $nextData['GameID'];
 }
 
-echo json_encode($data);
+echo jsonp_encode($data);

--- a/public/API/API_GetConsoleIDs.php
+++ b/public/API/API_GetConsoleIDs.php
@@ -9,4 +9,4 @@ if (!ValidateAPIKey(seekGET('z'), seekGET('y'))) {
 
 $data = getConsoleIDs();
 
-echo json_encode($data);
+echo jsonp_encode($data);

--- a/public/API/API_GetFeed.php
+++ b/public/API/API_GetFeed.php
@@ -34,4 +34,4 @@ if (isset($user)) {
 
 getFeed($user, $count, $offset, $feedData, 0, $type);
 
-echo json_encode($feedData);
+echo jsonp_encode($feedData);

--- a/public/API/API_GetGame.php
+++ b/public/API/API_GetGame.php
@@ -17,4 +17,4 @@ $gameData['ConsoleID'] = $consoleID;
 $gameData['Console'] = $consoleName;
 $gameData['ForumTopicID'] = $forumTopicID;
 
-echo json_encode($gameData);
+echo jsonp_encode($gameData);

--- a/public/API/API_GetGameExtended.php
+++ b/public/API/API_GetGameExtended.php
@@ -16,4 +16,4 @@ foreach ($achData as &$achievement) {
 $gameData['Achievements'] = $achData;
 $gameData['RichPresencePatch'] = md5($gameData['RichPresencePatch'] ?? null);
 
-echo json_encode($gameData);
+echo jsonp_encode($gameData);

--- a/public/API/API_GetGameInfoAndUserProgress.php
+++ b/public/API/API_GetGameInfoAndUserProgress.php
@@ -38,4 +38,4 @@ if ($gameData['NumAchievements'] ?? false) {
     $gameData['UserCompletionHardcore'] = sprintf("%01.2f%%", ($gameData['NumAwardedToUserHardcore'] / $gameData['NumAchievements']) * 100.0);
 }
 
-echo json_encode($gameData);
+echo jsonp_encode($gameData);

--- a/public/API/API_GetGameList.php
+++ b/public/API/API_GetGameList.php
@@ -11,4 +11,4 @@ $consoleID = seekGET('i');
 
 getGamesList($consoleID, $dataOut);
 
-echo json_encode(utf8ize($dataOut));
+echo jsonp_encode(utf8ize($dataOut));

--- a/public/API/API_GetGameRankAndScore.php
+++ b/public/API/API_GetGameRankAndScore.php
@@ -12,4 +12,4 @@ $username = seekGET('u');
 
 $gameTopAchievers = getGameTopAchievers($gameId, 0, 10, $username);
 
-echo json_encode($gameTopAchievers);
+echo jsonp_encode($gameTopAchievers);

--- a/public/API/API_GetGameRating.php
+++ b/public/API/API_GetGameRating.php
@@ -22,4 +22,4 @@ $gameData['Ratings']['Achievements'] = $gameRating[\RA\ObjectType::Achievement][
 $gameData['Ratings']['GameNumVotes'] = $gameRating[\RA\ObjectType::Game]['NumVotes'];
 $gameData['Ratings']['AchievementsNumVotes'] = $gameRating[\RA\ObjectType::Achievement]['NumVotes'];
 
-echo json_encode($gameData);
+echo jsonp_encode($gameData);

--- a/public/API/API_GetTopTenUsers.php
+++ b/public/API/API_GetTopTenUsers.php
@@ -10,4 +10,4 @@ if (!ValidateAPIKey(seekGET('z'), seekGET('y'))) {
 $dataOut = [];
 $numFound = getTopUsersByScore(10, $dataOut, null);
 
-echo json_encode($dataOut);
+echo jsonp_encode($dataOut);

--- a/public/API/API_GetUserGameRankAndScore.php
+++ b/public/API/API_GetUserGameRankAndScore.php
@@ -12,4 +12,4 @@ $username = seekGET('u');
 
 $results = getGameRankAndScore($gameId, $username);
 
-echo json_encode($results);
+echo jsonp_encode($results);

--- a/public/API/API_GetUserProgress.php
+++ b/public/API/API_GetUserProgress.php
@@ -12,4 +12,4 @@ $gameCSV = seekGET('i', "");
 
 getUserProgress($user, $gameCSV, $data);
 
-echo json_encode($data);
+echo jsonp_encode($data);

--- a/public/API/API_GetUserRankAndScore.php
+++ b/public/API/API_GetUserRankAndScore.php
@@ -14,4 +14,4 @@ $retVal = [];
 $retVal['Score'] = getScore($user);
 $retVal['Rank'] = getUserRank($user);
 
-echo json_encode($retVal);
+echo jsonp_encode($retVal);

--- a/public/API/API_GetUserRecentlyPlayedGames.php
+++ b/public/API/API_GetUserRecentlyPlayedGames.php
@@ -34,4 +34,4 @@ if (count($recentlyPlayedData) > 0) {
     $libraryOut['Awarded'] = $awardedData;
 }
 
-echo json_encode($recentlyPlayedData);
+echo jsonp_encode($recentlyPlayedData);

--- a/public/API/API_GetUserSummary.php
+++ b/public/API/API_GetUserSummary.php
@@ -37,4 +37,4 @@ $retVal['Status'] = $status;
 unset($retVal['Friendship'], $retVal['FriendReciprocation']);
 
 
-echo json_encode($retVal);
+echo jsonp_encode($retVal);


### PR DESCRIPTION
The web server for RA API does not allow CORS (cross-origin requests), so a simple alternative would be to enable JSONP responses from the API if the end-user so chooses.

A JSONP response is a JSON response passed in as the argument of a function call that is named via a GET parameter. This enables API consumers to use the API via JavaScript without having to configure the RA web server to allow cross-domain requests, while still giving developers a means to consume the API through client-side solutions.

I've built a helper function called `jsonp_encode` that maps its arguments directly to a standard PHP `json_encode`, as is done with the current API responses. If the GET request includes a `callback` parameter (the typical parameter name for a JSONP request), then the function outputs the JSON response as a parameter in the user-defined function. They can then use this as in a `<script>` element on a page to perform a callback on the API response, without having to create a PHP proxy server with cURL requests or anything like that.

Feel free to reach out if you have questions or concerns about this approach along. I'll try to help out on some of the other issues as well.

P.S. Sorry for all the commits in this PR. I was editing the files through GitHub.com UI instead of pulling down locally, so it created a new commit for each file I edited.