### PR TITLE
Advanced Ticket Filtering

### DIFF
--- a/lib/database/ticket.php
+++ b/lib/database/ticket.php
@@ -247,7 +247,7 @@ function getAllTickets(
     if ($md5Cond === null) {
         return $retVal;
     }
-    
+
     //Emulator condition
     $emulatorCond = getEmulatorCondition($ticketFilters);
     if ($emulatorCond === null) {
@@ -447,8 +447,8 @@ function countOpenTickets(
     $unofficialFlag = false,
     $ticketFilters = 2041, //2041 sets all filters active except for Closed and Resolved
     $assignedToUser = null,
-    $gameID = null)
-{
+    $gameID = null
+) {
     //State condition
     $stateCond = getStateCondition($ticketFilters);
     if ($stateCond === null) {
@@ -466,7 +466,7 @@ function countOpenTickets(
     if ($md5Cond === null) {
         return 0;
     }
-    
+
     //Emulator condition
     $emulatorCond = getEmulatorCondition($ticketFilters);
     if ($emulatorCond === null) {
@@ -567,7 +567,7 @@ function getStateCondition($ticketFilters)
 
     if ($openTickets && $closedTickets && $resolvedTickets) {
         return "";
-    } else if ($openTickets || $closedTickets || $resolvedTickets) {
+    } elseif ($openTickets || $closedTickets || $resolvedTickets) {
         $stateCond = " AND tick.ReportState IN (";
         if ($openTickets) {
             $stateCond .= "1";
@@ -606,7 +606,7 @@ function getReportTypeCondition($ticketFilters)
 
     if ($triggeredTickets && $didNotTriggerTickets) {
         return "";
-    } else if ($triggeredTickets || $didNotTriggerTickets) {
+    } elseif ($triggeredTickets || $didNotTriggerTickets) {
         $reportTypeCond = " AND tick.ReportType IN (";
         if ($triggeredTickets) {
             $reportTypeCond .= "1";
@@ -638,7 +638,7 @@ function getMD5Condition($ticketFilters)
 
     if ($md5KnownTickets && $md5UnknownTickets) {
         return "";
-    } else if ($md5KnownTickets || $md5UnknownTickets) {
+    } elseif ($md5KnownTickets || $md5UnknownTickets) {
         $md5Cond = " AND (";
         if ($md5KnownTickets) {
             $md5Cond .= "tick.ReportNotes REGEXP 'MD5: [a-fA-F0-9]{32}' ";
@@ -672,7 +672,7 @@ function getEmulatorCondition($ticketFilters)
 
     if ($raEmulatorTickets && $rarchKnownTickets && $rarchUnknownTickets && $emulatorUnknownTickets) {
         return "";
-    } else if ($raEmulatorTickets || $rarchKnownTickets || $rarchUnknownTickets || $emulatorUnknownTickets) {
+    } elseif ($raEmulatorTickets || $rarchKnownTickets || $rarchUnknownTickets || $emulatorUnknownTickets) {
         $emulatorCond = " AND (";
         if ($raEmulatorTickets) {
             $emulatorCond .= "tick.ReportNotes Like '%Emulator: RA%' ";

--- a/lib/database/ticket.php
+++ b/lib/database/ticket.php
@@ -208,14 +208,14 @@ function getAllTickets(
     $assignedToUser = null,
     $givenGameID = null,
     $givenAchievementID = null,
-    $ticketState = 1,
+    $ticketFilters = 2041, //2041 sets all filters active except for Closed and Resolved
     $getUnofficial = false
 ) {
     global $db;
 
     $retVal = [];
     settype($givenGameID, 'integer');
-    settype($ticketState, 'integer');
+    settype($ticketFilters, 'integer');
     settype($givenAchievementID, 'integer');
 
     $innerCond = "TRUE";
@@ -226,11 +226,32 @@ function getAllTickets(
     if ($givenGameID != 0) {
         $innerCond .= " AND gd.ID = $givenGameID";
     }
-    if ($ticketState != 0) {
-        $innerCond .= " AND tick.ReportState = $ticketState";
-    }
     if ($givenAchievementID != 0) {
         $innerCond .= " AND tick.AchievementID = $givenAchievementID";
+    }
+
+    //State condition
+    $stateCond = getStateCondition($ticketFilters);
+    if ($stateCond === null) {
+        return $retVal;
+    }
+
+    //Report Type condition
+    $reportTypeCond = getReportTypeCondition($ticketFilters);
+    if ($reportTypeCond === null) {
+        return $retVal;
+    }
+
+    //MD5 condition
+    $md5Cond = getMD5Condition($ticketFilters);
+    if ($md5Cond === null) {
+        return $retVal;
+    }
+    
+    //Emulator condition
+    $emulatorCond = getEmulatorCondition($ticketFilters);
+    if ($emulatorCond === null) {
+        return $retVal;
     }
 
     settype($getUnofficial, 'boolean');
@@ -245,7 +266,7 @@ function getAllTickets(
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               LEFT JOIN UserAccounts AS ua ON ua.ID = tick.ReportedByUserID
               LEFT JOIN UserAccounts AS ua2 ON ua2.ID = tick.ResolvedByUserID
-              WHERE $innerCond $unofficialCond
+              WHERE $innerCond $unofficialCond $stateCond $reportTypeCond $md5Cond $emulatorCond
               ORDER BY tick.ID DESC
               LIMIT $offset, $limit";
 
@@ -422,19 +443,62 @@ function countOpenTicketsByAchievement($achievementID)
     }
 }
 
-function countOpenTickets($unofficialFlag = false)
+function countOpenTickets(
+    $unofficialFlag = false,
+    $ticketFilters = 2041, //2041 sets all filters active except for Closed and Resolved
+    $assignedToUser = null,
+    $gameID = null)
 {
+    //State condition
+    $stateCond = getStateCondition($ticketFilters);
+    if ($stateCond === null) {
+        return 0;
+    }
+
+    //Report Type condition
+    $reportTypeCond = getReportTypeCondition($ticketFilters);
+    if ($reportTypeCond === null) {
+        return 0;
+    }
+
+    //MD5 condition
+    $md5Cond = getMD5Condition($ticketFilters);
+    if ($md5Cond === null) {
+        return 0;
+    }
+    
+    //Emulator condition
+    $emulatorCond = getEmulatorCondition($ticketFilters);
+    if ($emulatorCond === null) {
+        return 0;
+    }
+
+    //Author condition
+    $authorCond = "";
+    if ($assignedToUser != null) {
+        $authorCond = " AND ach.Author LIKE '$assignedToUser'";
+    }
+
+    //Game condition
+    $gameCond = "";
+    if ($gameID != null) {
+        $gameCond = " AND ach.GameID LIKE '$gameID'";
+    }
+
     if ($unofficialFlag === true) {
         $query = "
             SELECT count(*) as count
             FROM Ticket AS tick
             LEFT JOIN Achievements AS ach ON ach.ID = tick.AchievementID
-            WHERE tick.ReportState = 1 AND ach.Flags <> 3";
+            LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
+            WHERE ach.Flags <> 3 $stateCond $gameCond $reportTypeCond $md5Cond $emulatorCond $authorCond";
     } else {
         $query = "
             SELECT COUNT(*) as count
-            FROM Ticket
-            WHERE ReportState = 1";
+            FROM Ticket AS tick
+            LEFT JOIN Achievements AS ach ON ach.ID = tick.AchievementID
+            LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
+            WHERE TRUE $stateCond $gameCond $reportTypeCond $md5Cond $emulatorCond $authorCond";
     }
 
     $dbResult = s_mysql_query($query);
@@ -487,4 +551,156 @@ function gamesSortedByOpenTickets($count)
     }
 
     return $retVal;
+}
+
+/*
+ * Gets the ticket state condition to put into the main ticket query.
+ *
+ * @param int $ticketFilters the current ticket filters in place
+ * @return string|null
+ */
+function getStateCondition($ticketFilters)
+{
+    $openTickets            = ($ticketFilters & (1 << 0));
+    $closedTickets          = ($ticketFilters & (1 << 1));
+    $resolvedTickets        = ($ticketFilters & (1 << 2));
+
+    if ($openTickets && $closedTickets && $resolvedTickets) {
+        return "";
+    } else if ($openTickets || $closedTickets || $resolvedTickets) {
+        $stateCond = " AND tick.ReportState IN (";
+        if ($openTickets) {
+            $stateCond .= "1";
+        }
+
+        if ($closedTickets) {
+            if ($openTickets) {
+                $stateCond .= ",";
+            }
+            $stateCond .= "0";
+        }
+
+        if ($resolvedTickets) {
+            if ($openTickets || $closedTickets) {
+                $stateCond .= ",";
+            }
+            $stateCond .= "2";
+        }
+        $stateCond .= ")";
+        return $stateCond;
+    } else {
+        return null;
+    }
+}
+
+/*
+ * Gets the ticket report type condition to put into the main ticket query.
+ *
+ * @param int $ticketFilters the current ticket filters in place
+ * @return string|null
+ */
+function getReportTypeCondition($ticketFilters)
+{
+    $triggeredTickets       = ($ticketFilters & (1 << 3));
+    $didNotTriggerTickets   = ($ticketFilters & (1 << 4));
+
+    if ($triggeredTickets && $didNotTriggerTickets) {
+        return "";
+    } else if ($triggeredTickets || $didNotTriggerTickets) {
+        $reportTypeCond = " AND tick.ReportType IN (";
+        if ($triggeredTickets) {
+            $reportTypeCond .= "1";
+        }
+
+        if ($didNotTriggerTickets) {
+            if ($triggeredTickets) {
+                $reportTypeCond .= ",";
+            }
+            $reportTypeCond .= "2";
+        }
+        $reportTypeCond .= ")";
+        return $reportTypeCond;
+    } else {
+        return null;
+    }
+}
+
+/*
+ * Gets the ticket MD5 condition to put into the main ticket query.
+ *
+ * @param int $ticketFilters the current ticket filters in place
+ * @return string|null
+ */
+function getMD5Condition($ticketFilters)
+{
+    $md5KnownTickets        = ($ticketFilters & (1 << 5));
+    $md5UnknownTickets      = ($ticketFilters & (1 << 6));
+
+    if ($md5KnownTickets && $md5UnknownTickets) {
+        return "";
+    } else if ($md5KnownTickets || $md5UnknownTickets) {
+        $md5Cond = " AND (";
+        if ($md5KnownTickets) {
+            $md5Cond .= "tick.ReportNotes REGEXP 'MD5: [a-fA-F0-9]{32}' ";
+        }
+
+        if ($md5UnknownTickets) {
+            if ($md5KnownTickets) {
+                $md5Cond .= " OR ";
+            }
+            $md5Cond .= "tick.ReportNotes LIKE '%MD5: U%' OR tick.ReportNotes NOT LIKE '%MD5: %'";
+        }
+        $md5Cond .= ")";
+        return $md5Cond;
+    } else {
+        return null;
+    }
+}
+
+/*
+ * Gets the ticket emulator condition to put into the main ticket query.
+ *
+ * @param int $ticketFilters the current ticket filters in place
+ * @return string|null
+ */
+function getEmulatorCondition($ticketFilters)
+{
+    $raEmulatorTickets      = ($ticketFilters & (1 << 7));
+    $rarchKnownTickets      = ($ticketFilters & (1 << 8));
+    $rarchUnknownTickets    = ($ticketFilters & (1 << 9));
+    $emulatorUnknownTickets = ($ticketFilters & (1 << 10));
+
+    if ($raEmulatorTickets && $rarchKnownTickets && $rarchUnknownTickets && $emulatorUnknownTickets) {
+        return "";
+    } else if ($raEmulatorTickets || $rarchKnownTickets || $rarchUnknownTickets || $emulatorUnknownTickets) {
+        $emulatorCond = " AND (";
+        if ($raEmulatorTickets) {
+            $emulatorCond .= "tick.ReportNotes Like '%Emulator: RA%' ";
+        }
+
+        if ($rarchKnownTickets) {
+            if ($raEmulatorTickets) {
+                $emulatorCond .= " OR ";
+            }
+            $emulatorCond .= "tick.ReportNotes LIKE '%Emulator: RetroArch (_%)%' ";
+        }
+
+        if ($rarchUnknownTickets) {
+            if ($raEmulatorTickets || $rarchKnownTickets) {
+                $emulatorCond .= " OR ";
+            }
+            $emulatorCond .= "tick.ReportNotes LIKE '%Emulator: RetroArch ()%'";
+        }
+
+        if ($emulatorUnknownTickets) {
+            if ($raEmulatorTickets || $rarchKnownTickets || $rarchUnknownTickets) {
+                $emulatorCond .= " OR ";
+            }
+            $emulatorCond .= "(tick.ReportNotes NOT LIKE '%Emulator: RA%' AND tick.ReportNotes NOT LIKE '%Emulator: RetroArch%')";
+        }
+        $emulatorCond .= ")";
+        return $emulatorCond;
+    } else {
+        return null;
+    }
 }

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -238,7 +238,7 @@ RenderHtmlHead($pageTitle);
             if ($ticketID == 0) {
                 echo "<h4>Filters - " . $filteredTicketsCount . " Ticket" . ($filteredTicketsCount == 1 ? "" : "s") . " Filtered</h4>";
                 echo "<div class='embedded mb-1'>";
-                
+
                 /*
                     Each filter is represented by a bit in the $ticketFilters variable.
                     This allows us to easily determine which filters are active as well as toggle them back and forth.
@@ -336,7 +336,7 @@ RenderHtmlHead($pageTitle);
                     echo "<a href='/ticketmanager.php?g=$gameIDGiven&u=$assignedToUser&f=$gamesTableFlag&t=" . ($ticketFilters | (1 << 10)) . "'>Emulator Unknown</a>";
                 }
                 echo "</div>";
-                
+
                 //Clear Filter
                 if ($ticketFilters != $defaultFilter) {
                     echo "<div>";


### PR DESCRIPTION
This feature adds several new ways of filter tickets on the Ticket Manager page. Each filter can be individually toggled which allows for a good amount of custom filtering. Total open tickets and total filtered tickets will always display in the headers on the page.

Default Filter:
![image](https://user-images.githubusercontent.com/16140035/73140609-ddba0480-4048-11ea-9692-172a60bb4abc.png)

Custom Filter:
![image](https://user-images.githubusercontent.com/16140035/73140617-e7dc0300-4048-11ea-8757-588ca043be66.png)

The filters are also compatible with the existing user and game filters as well as tickets for achievements in unofficial.
![image](https://user-images.githubusercontent.com/16140035/73140673-86686400-4049-11ea-9781-0008cff0c2c8.png)


The filters are broken into the following categories:

**Ticket State** - The state of the ticket
 * Open
 * Closed
 * Resolved

**Report Type** - Why is this ticket being written
 * Triggered at wrong time
 * Doesn't Trigger

**MD5** - Does the ticket include a MD5
 * Contains MD5 - (e.g. `MD5: e9b45d6455e0753b8e0e825a36458253`)
 * MD5 Unknown - (e.g. `MD5: Unknown` or `MD5:` is not in the notes at all)

**Emulator** - Does the ticket specify an emulator
 * RA Emulator - (e.g. `Emulator: RANES`)
 * RetroArch - Defined - (e.g. `Emulator: RetroArch (Mupen64Plus-Next OpenGL)`)
 * RetroArch - Undefined - (e.g. `Emulator: RetroArch ()`)
 * Emulator Unknown - (e.g. `Emulator: Something` or `Emulator:` is not in the notes at all)