### PR TITLE
Allow Users to Hide Site Awards

### DIFF
--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1253,12 +1253,17 @@ function getUsersCompletedGamesAndMax($user)
     return $retVal;
 }
 
-function getUsersSiteAwards($user)
+function getUsersSiteAwards($user, $showHidden = false)
 {
     $retVal = [];
 
     if (!isValidUsername($user)) {
         return $retVal;
+    }
+
+    $hiddenQuery = "";
+    if ($showHidden == false) {
+        $hiddenQuery = "AND saw.DisplayOrder > -1";
     }
 
     $query = "
@@ -1267,14 +1272,14 @@ function getUsersSiteAwards($user)
                   FROM SiteAwards AS saw
                   LEFT JOIN GameData AS gd ON ( gd.ID = saw.AwardData AND saw.AwardType = 1 )
                   LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-                  WHERE saw.AwardType = 1 AND saw.User = '$user'
+                  WHERE saw.AwardType = 1 AND saw.User = '$user' $hiddenQuery
                   GROUP BY saw.AwardType, saw.AwardData, saw.AwardDataExtra
     )
     UNION
     (
     SELECT UNIX_TIMESTAMP( saw.AwardDate ) as AwardedAt, saw.AwardType, MAX( saw.AwardData ), saw.AwardDataExtra, saw.DisplayOrder, NULL, NULL, NULL, NULL
                   FROM SiteAwards AS saw
-                  WHERE saw.AwardType > 1 AND saw.User = '$user'
+                  WHERE saw.AwardType > 1 AND saw.User = '$user' $hiddenQuery
                   GROUP BY saw.AwardType
 
     )

--- a/public/history.php
+++ b/public/history.php
@@ -33,7 +33,6 @@ $userPagePoints = getScore($userPage);
 
 getUserActivityRange($userPage, $userSignedUp, $unused);
 
-$userAwards = getUsersSiteAwards($userPage);
 $userCompletedGamesList = getUsersCompletedGamesAndMax($userPage);
 
 $userCompletedGames = [];

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -219,7 +219,7 @@ function updateDisplayOrder(user, objID) {
 
 function updateAwardDisplayOrder(user, awardType, awardData, awardDataExtra, objID) {
   var inputText = $('#' + objID).val();
-  var inputNum = Math.max(0, Math.min(Number(inputText), 10000));
+  var inputNum = Math.max(-1, Math.min(Number(inputText), 10000));
   var posting = $.post('/request/user/update-site-award.php',
     {
       u: user,

--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -15,8 +15,6 @@ if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $
 
 $errorCode = seekGET('e');
 
-$userAwards = getUsersSiteAwards($user);
-
 RenderHtmlStart();
 RenderHtmlHead("Reorder Site Awards");
 ?>
@@ -48,7 +46,7 @@ RenderHtmlHead("Reorder Site Awards");
         $imageSize = 48;
 
         $counter = 0;
-        foreach ($userAwards as $elem) {
+        foreach (getUsersSiteAwards($user, true) as $elem) {
             $awardType = $elem['AwardType'];
             $awardData = $elem['AwardData'];
             $awardDataExtra = $elem['AwardDataExtra'];
@@ -141,7 +139,7 @@ RenderHtmlHead("Reorder Site Awards");
         ?>
     </div>
     <div id="rightcontainer">
-        <?php RenderSiteAwards($userAwards) ?>
+        <?php RenderSiteAwards(getUsersSiteAwards($user, false)) ?>
     </div>
 </div>
 <?php RenderFooter(); ?>

--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -31,7 +31,8 @@ RenderHtmlHead("Reorder Site Awards");
 
         echo "<p><b>Instructions:</b> These are your site awards as displayed on your user page. " .
             "The awards will be ordered by 'Display Order', the column found on the right, in order from smallest to greatest. " .
-            "Adjust the numbers on the right to set an order for them to appear in. Any changes you make on this page will instantly " .
+            "Adjust the numbers on the right to set an order for them to appear in. Setting a 'Display Order' value to -1 " .
+            "will hide the site award. Any changes you make on this page will instantly " .
             "take effect on the website, but you will need to press 'Refresh Page' to see the new order on this page. " .
             "The right panel represents how the site awards will look on your user page.</p><br>";
 

--- a/public/request/user/update-site-award.php
+++ b/public/request/user/update-site-award.php
@@ -37,8 +37,7 @@ if (in_array($awardType, [2, 3])) {
 } else {
     $query = "UPDATE SiteAwards SET DisplayOrder = $value WHERE User = '$user' " .
         "AND AwardType = $awardType " .
-        "AND AwardData = $awardData " .
-        "AND AwardDataExtra = $awardDataExtra";
+        "AND AwardData = $awardData";
 }
 
 if (s_mysql_query($query)) {

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -40,13 +40,7 @@ $numArticleComments = getArticleComments(3, $userPageID, 0, 100, $commentData);
 
 //    Get user's feed
 //$numFeedItems = getFeed( $userPage, 20, 0, $feedData, 0, 'individual' );
-//    Get user's site awards
 
-$userAwards = getUsersSiteAwards($userPage);
-
-//var_dump( $userAwards );
-//    Find out which games are causing 'invalid' or out of date site awards for completed games
-//var_dump( $userAwards );
 //    Calc avg pcts:
 $totalPctWon = 0.0;
 $numGamesFound = 0;
@@ -99,24 +93,6 @@ foreach ($userCompletedGamesList as $nextGame) {
 $avgPctWon = "0.0";
 if ($numGamesFound > 0) {
     $avgPctWon = sprintf("%01.2f", ($totalPctWon / $numGamesFound) * 100.0);
-}
-
-//foreach( $userAwards as $nextKey => &$nextAward )
-for ($i = 0; $i < count($userAwards); $i++) {
-    $nextAward = $userAwards[$i];
-
-    if ($nextAward['AwardType'] == 1) {
-        $nextAward['Incomplete'] = 0;
-        foreach ($userCompletedGamesList as $nextGame) {
-            // if( $nextGame[ 'GameID' ] == $nextAward[ 'AwardData' ] )
-            // {
-            //    I have this game listed as a game I've got awards for, do I have the same number
-            //     of completed awards as there are possible achievements?    //NB> FLAWED!!! DOESNT CATER FOR HARDCORE
-            //if( $nextGame['NumAwarded'] < $nextGame['MaxPossible'] )
-            //    $nextAward['Incomplete'] = 1;
-            // }
-        }
-    }
 }
 
 settype($userMassData['Friendship'], 'integer');
@@ -569,7 +545,7 @@ RenderHtmlStart(true);
     </div>
     <div id="rightcontainer">
         <?php
-        RenderSiteAwards($userAwards);
+        RenderSiteAwards(getUsersSiteAwards($user, false));
         RenderCompletedGamesList($userPage, $userCompletedGamesList);
 
         echo "<div id='achdistribution' class='component' >";


### PR DESCRIPTION
This update will allow users to hide site awards if they set the Display Order value to -1. Hidden site awards will still be visible on the Reorder Site Awards page so users can make them visible again.

![image](https://user-images.githubusercontent.com/16140035/74120969-82812980-4b93-11ea-8b8d-d1984a56dfe7.png)

This would resolve #380.