### PR TITLE
Developer Achievement Count Fix

### DIFF
--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1440,7 +1440,7 @@ function GetDeveloperStatsFull($count, $sortBy)
         Permissions,
         ContribCount,
         ContribYield,
-        COUNT(ach.ID) AS Achievements,
+        COUNT(DISTINCT(ach.ID)) AS Achievements,
         COUNT(tick.ID) AS OpenTickets,
         COUNT(tick.ID)/COUNT(ach.ID) AS TicketRatio,
         LastLogin


### PR DESCRIPTION
This fixes an issue where a developers achievement count on the developer list page would increases if that developer has multiple tickets open for the same achievement.

![image](https://user-images.githubusercontent.com/16140035/74620733-16a93e80-5108-11ea-96d3-83a4fa3cec4d.png)
