### PR TITLE
Dev Stats Update

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -1552,24 +1552,21 @@ function getObtainersOfSpecificUser($user)
 /**
  * Gets recently obtained achievements created by the user.
  *
- * @param String $user to get obtained achievement data for
+ * @param array $achievementIDs array of achievement IDs
  * @param Integer $offset starting point to return items
  * @param Integer $count number of items to return
  * @return array of recently obtained achievements
  */
-function getRecentObtainedAchievements($user, $offset = 0, $count = 100)
+function getRecentObtainedAchievements($achievementIDs, $offset = 0, $count = 200)
 {
     $retVal = [];
-    $query = "SELECT aw.User, c.Name AS ConsoleName, aw.Date, a.ID, a.GameID, aw.HardcoreMode, a.Title, a.Description, a.BadgeName, a.Points, a.TrueRatio, gd.Title AS GameTitle, gd.ImageIcon as GameIcon, COUNT(*) AS Grouped
-              FROM Awarded as aw
+    $query = "SELECT aw.User, c.Name AS ConsoleName, aw.Date, aw.AchievementID, a.GameID, aw.HardcoreMode, a.Title, a.Description, a.BadgeName, a.Points, a.TrueRatio, gd.Title AS GameTitle, gd.ImageIcon as GameIcon
+              FROM Awarded AS aw
               LEFT JOIN Achievements as a ON a.ID = aw.AchievementID
               LEFT JOIN GameData AS gd ON gd.ID = a.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-              LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
-              WHERE Author LIKE '$user'
+              WHERE aw.AchievementID IN (" . implode(",", $achievementIDs) . ")
               AND gd.ConsoleID NOT IN (100, 101)
-              AND Untracked = 0
-              GROUP BY aw.User, aw.Date, a.ID, a.GameID
               ORDER BY aw.Date DESC
               LIMIT $offset, $count";
 

--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -1417,6 +1417,7 @@ function getUserAchievemetnsPerConsole($user)
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               WHERE a.Author = '$user'
               AND a.Flags = '3'
+              AND gd.ConsoleID NOT IN (100, 101)
               GROUP BY ConsoleName
               ORDER BY AchievementCount DESC, ConsoleName";
 
@@ -1445,6 +1446,7 @@ function getUserSetsPerConsole($user)
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               WHERE a.Author = '$user'
               AND a.Flags = '3'
+              AND gd.ConsoleID NOT IN (100, 101)
               GROUP BY ConsoleName
               ORDER BY SetCount DESC, ConsoleName";
 
@@ -1466,13 +1468,14 @@ function getUserSetsPerConsole($user)
 function getUserAchievementInformation($user)
 {
     $retVal = [];
-    $query = "SELECT c.Name AS ConsoleName, a.ID, a.GameID, a.Title, a.Description, a.BadgeName, a.Points, a.TrueRatio, a.Author, a.DateCreated, ua.ContribCount, ua.ContribYield
+    $query = "SELECT c.Name AS ConsoleName, a.ID, a.GameID, a.Title, a.Description, a.BadgeName, a.Points, a.TrueRatio, a.Author, a.DateCreated, gd.Title AS GameTitle, LENGTH(a.MemAddr) AS MemLength, ua.ContribCount, ua.ContribYield
               FROM Achievements AS a
               LEFT JOIN GameData AS gd ON gd.ID = a.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               LEFT JOIN UserAccounts AS ua ON ua.User = '$user'
               WHERE Author LIKE '$user'
               AND a.Flags = '3'
+              AND gd.ConsoleID NOT IN (100, 101)
               ORDER BY a.DateCreated";
 
     $dbResult = s_mysql_query($query);
@@ -1485,7 +1488,7 @@ function getUserAchievementInformation($user)
 }
 
 /**
- * Gets the unmber of time the user has obtained (softcore and hardcore) their own achievements.
+ * Gets the number of time the user has obtained (softcore and hardcore) their own achievements.
  *
  * @param String $user to get obtained achievement data for
  * @return array|NULL of obtained achievement data
@@ -1497,9 +1500,12 @@ function getOwnAchievementsObtained($user)
               SUM(CASE WHEN aw.HardcoreMode = 1 THEN 1 ELSE 0 END) AS HardcoreCount
               FROM Achievements AS a
               LEFT JOIN Awarded AS aw ON aw.AchievementID = a.ID
+              LEFT JOIN GameData AS gd ON gd.ID = a.GameID
+              LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               WHERE a.Author LIKE '$user'
               AND aw.User LIKE '$user'
-              AND a.Flags = '3'";
+              AND a.Flags = '3'
+              AND gd.ConsoleID NOT IN (100, 101)";
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {
@@ -1523,11 +1529,49 @@ function getObtainersOfSpecificUser($user)
               SUM(CASE WHEN aw.HardcoreMode = 1 THEN 1 ELSE 0 END) AS HardcoreCount
               FROM Achievements AS a
               LEFT JOIN Awarded AS aw ON aw.AchievementID = a.ID
+              LEFT JOIN GameData AS gd ON gd.ID = a.GameID
+              LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
+              LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
               WHERE a.Author LIKE '$user'
               AND aw.User NOT LIKE '$user'
               AND a.Flags = '3'
+              AND gd.ConsoleID NOT IN (100, 101)
+              AND Untracked = 0
               GROUP BY aw.User
               ORDER BY ObtainCount DESC";
+
+    $dbResult = s_mysql_query($query);
+    if ($dbResult !== false) {
+        while ($db_entry = mysqli_fetch_assoc($dbResult)) {
+            $retVal[] = $db_entry;
+        }
+    }
+    return $retVal;
+}
+
+/**
+ * Gets recently obtained achievements created by the user.
+ *
+ * @param String $user to get obtained achievement data for
+ * @param Integer $offset starting point to return items
+ * @param Integer $count number of items to return
+ * @return array of recently obtained achievements
+ */
+function getRecentObtainedAchievements($user, $offset = 0, $count = 100)
+{
+    $retVal = [];
+    $query = "SELECT aw.User, c.Name AS ConsoleName, aw.Date, a.ID, a.GameID, aw.HardcoreMode, a.Title, a.Description, a.BadgeName, a.Points, a.TrueRatio, gd.Title AS GameTitle, gd.ImageIcon as GameIcon, COUNT(*) AS Grouped
+              FROM Awarded as aw
+              LEFT JOIN Achievements as a ON a.ID = aw.AchievementID
+              LEFT JOIN GameData AS gd ON gd.ID = a.GameID
+              LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
+              LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
+              WHERE Author LIKE '$user'
+              AND gd.ConsoleID NOT IN (100, 101)
+              AND Untracked = 0
+              GROUP BY aw.User, aw.Date, a.ID, a.GameID
+              ORDER BY aw.Date DESC
+              LIMIT $offset, $count";
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {

--- a/lib/database/codenote.php
+++ b/lib/database/codenote.php
@@ -186,13 +186,14 @@ function submitCodeNote($user, $gameID, $address, $note)
 function getCodeNoteCounts($user)
 {
     $retVal = [];
-    $query = "SELECT gd.Title as GameTitle, gd.ImageIcon as GameIcon, c.Name as ConsoleName, cn.GameID as GameID, COUNT(cn.GameID) as NoteCount
+    $query = "SELECT gd.Title as GameTitle, gd.ImageIcon as GameIcon, c.Name as ConsoleName, cn.GameID as GameID, COUNT(cn.GameID) as TotalNotes,
+              SUM(CASE WHEN ua.User = '$user' THEN 1 ELSE 0 END) AS NoteCount
               FROM CodeNotes AS cn
               LEFT JOIN UserAccounts AS ua ON ua.ID = cn.AuthorID
               LEFT JOIN GameData AS gd ON gd.ID = cn.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-              WHERE ua.User = '$user'
               GROUP BY GameID
+              HAVING NoteCount > 0
               ORDER BY NoteCount DESC";
 
     $dbResult = s_mysql_query($query);

--- a/lib/database/ticket.php
+++ b/lib/database/ticket.php
@@ -753,7 +753,7 @@ function getUserGameWithMostTickets($user)
  */
 function getUserAchievementWithMostTickets($user)
 {
-    $query = "SELECT a.ID as AchievementID, a.Title as AchievementTitle, a.Description as AchievementDescription, a.Points as AchievementPoints, a.BadgeName as AchievementBadge, c.Name as ConsoleName, COUNT(*) as TicketCount
+    $query = "SELECT a.ID as AchievementID, a.Title as AchievementTitle, a.Description as AchievementDescription, a.Points as AchievementPoints, a.BadgeName as AchievementBadge, gd.Title AS GameTitle, COUNT(*) as TicketCount
               FROM Ticket AS t
               LEFT JOIN Achievements as a ON a.ID = t.AchievementID
               LEFT JOIN GameData AS gd ON gd.ID = a.GameID

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1632,12 +1632,14 @@ function recalculateDevelopmentContributions($user)
 function getMostAwardedUsers($gameIDs)
 {
     $retVal = [];
-    $query = "SELECT User,
+    $query = "SELECT ua.User,
               SUM(CASE WHEN AwardDataExtra LIKE '0' THEN 1 ELSE 0 END) AS Completed,
               SUM(CASE WHEN AwardDataExtra LIKE '1' THEN 1 ELSE 0 END) AS Mastered
-              FROM SiteAwards
+              FROM SiteAwards AS sa
+              LEFT JOIN UserAccounts AS ua ON ua.User = sa.User
               WHERE AwardType LIKE '1'
               AND AwardData IN (" . implode(",", $gameIDs) . ")
+              AND Untracked = 0
               GROUP BY User
               ORDER BY User";
 
@@ -1660,11 +1662,12 @@ function getMostAwardedGames($gameIDs)
 {
     $retVal = [];
     $query = "SELECT gd.Title, sa.AwardData AS ID, c.Name AS ConsoleName, gd.ImageIcon as GameIcon,
-              SUM(CASE WHEN AwardDataExtra LIKE '0' THEN 1 ELSE 0 END) AS Completed,
-              SUM(CASE WHEN AwardDataExtra LIKE '1' THEN 1 ELSE 0 END) AS Mastered
+              SUM(CASE WHEN AwardDataExtra LIKE '0' AND Untracked = 0 THEN 1 ELSE 0 END) AS Completed,
+              SUM(CASE WHEN AwardDataExtra LIKE '1' AND Untracked = 0 THEN 1 ELSE 0 END) AS Mastered
               FROM SiteAwards AS sa
               LEFT JOIN GameData AS gd ON gd.ID = sa.AwardData
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
+              LEFT JOIN UserAccounts AS ua ON ua.User = sa.User
               WHERE sa.AwardType LIKE '1'
               AND AwardData IN(" . implode(",", $gameIDs) . ")
               GROUP BY sa.AwardData, gd.Title

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -223,6 +223,11 @@ a:hover {
   overflow-y: scroll;
 }
 
+#devstatsscrollpane {
+  max-height: 25.0em;
+  overflow-y: scroll;
+}
+
 span.news {
   padding: 6px 10px 10px;
   /*border-radius: 8px; */

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -50,66 +50,69 @@ if ($userContribCount > 0) {
     // Get user game list data
     getGamesListByDev($dev, 0, $gamesList, 1, false, false);
     foreach ($gamesList as $game) {
-        // Any part developer
-        if (count($anyDevGameIDs) == 0) {
-            $anyDevHardestGame = $game;
-            $anyDevEasiestGame = $game;
-        } else {
-            if (($anyDevHardestGame['TotalTruePoints'] / $anyDevHardestGame['MaxPointsAvailable']) < ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])) {
+        $consoleID = $game['ConsoleID'];
+        if ($consoleID != 100 && $consoleID != 101) {
+            // Any part developer
+            if (count($anyDevGameIDs) == 0) {
                 $anyDevHardestGame = $game;
-            }
-            if ($anyDevEasiestGame['TotalTruePoints'] == 0 || ($game['TotalTruePoints'] > 0 && (($anyDevEasiestGame['TotalTruePoints'] / $anyDevEasiestGame['MaxPointsAvailable']) > ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])))) {
                 $anyDevEasiestGame = $game;
-            }
-        }
-        array_push($anyDevGameIDs, $game['ID']);
-        $anyDevRichPresenceCount += $game['RichPresence'];
-        $anyDevLeaderboardTotal += $game['NumLBs'];
-        if (isset($game['NumLBs'])) {
-            $anyDevLeaderboardCount++;
-        }
-
-        // Majority developer
-        if ($game['MyAchievements'] >= $game['NotMyAchievements']) {
-            if (count($majorityDevGameIDs) == 0) {
-                $majorityDevHardestGame = $game;
-                $majorityDevEasiestGame = $game;
             } else {
-                if (($majorityDevHardestGame['TotalTruePoints'] / $majorityDevHardestGame['MaxPointsAvailable']) < ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])) {
+                if (($anyDevHardestGame['TotalTruePoints'] / $anyDevHardestGame['MaxPointsAvailable']) < ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])) {
+                    $anyDevHardestGame = $game;
+                }
+                if ($anyDevEasiestGame['TotalTruePoints'] == 0 || ($anyDevEasiestGame['TotalTruePoints'] / $anyDevEasiestGame['MaxPointsAvailable']) < 1 || ($game['TotalTruePoints'] > 0 && (($anyDevEasiestGame['TotalTruePoints'] / $anyDevEasiestGame['MaxPointsAvailable']) > ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])))) {
+                    $anyDevEasiestGame = $game;
+                }
+            }
+            array_push($anyDevGameIDs, $game['ID']);
+            $anyDevRichPresenceCount += $game['RichPresence'];
+            $anyDevLeaderboardTotal += $game['NumLBs'];
+            if (isset($game['NumLBs'])) {
+                $anyDevLeaderboardCount++;
+            }
+
+            // Majority developer
+            if ($game['MyAchievements'] >= $game['NotMyAchievements']) {
+                if (count($majorityDevGameIDs) == 0) {
                     $majorityDevHardestGame = $game;
-                }
-                if ($majorityDevEasiestGame['TotalTruePoints'] == 0 || ($game['TotalTruePoints'] > 0 && (($majorityDevEasiestGame['TotalTruePoints'] / $majorityDevEasiestGame['MaxPointsAvailable']) > ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])))) {
                     $majorityDevEasiestGame = $game;
+                } else {
+                    if (($majorityDevHardestGame['TotalTruePoints'] / $majorityDevHardestGame['MaxPointsAvailable']) < ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])) {
+                        $majorityDevHardestGame = $game;
+                    }
+                    if ($majorityDevEasiestGame['TotalTruePoints'] == 0 || ($majorityDevEasiestGame['TotalTruePoints'] / $majorityDevEasiestGame['MaxPointsAvailable']) < 1 || ($game['TotalTruePoints'] > 0 && (($majorityDevEasiestGame['TotalTruePoints'] / $majorityDevEasiestGame['MaxPointsAvailable']) > ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])))) {
+                        $majorityDevEasiestGame = $game;
+                    }
+                }
+                array_push($majorityDevGameIDs, $game['ID']);
+                $majorityDevAchievementCount += $game['MyAchievements'];
+                $majorityDevRichPresenceCount += $game['RichPresence'];
+                $majorityDevLeaderboardTotal += $game['NumLBs'];
+                if (isset($game['NumLBs'])) {
+                    $majorityDevLeaderboardCount++;
                 }
             }
-            array_push($majorityDevGameIDs, $game['ID']);
-            $majorityDevAchievementCount += $game['MyAchievements'];
-            $majorityDevRichPresenceCount += $game['RichPresence'];
-            $majorityDevLeaderboardTotal += $game['NumLBs'];
-            if (isset($game['NumLBs'])) {
-                $majorityDevLeaderboardCount++;
-            }
-        }
 
-        // Only developer
-        if ($game['MyAchievements'] == $game['NumAchievements']) {
-            if (count($onlyDevGameIDs) == 0) {
-                $onlyDevHardestGame = $game;
-                $onlyDevEasiestGame = $game;
-            } else {
-                if (($onlyDevHardestGame['TotalTruePoints'] / $onlyDevHardestGame['MaxPointsAvailable']) < ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])) {
+            // Only developer
+            if ($game['MyAchievements'] == $game['NumAchievements']) {
+                if (count($onlyDevGameIDs) == 0) {
                     $onlyDevHardestGame = $game;
-                }
-                if ($onlyDevEasiestGame['TotalTruePoints'] == 0 || ($game['TotalTruePoints'] > 0 && (($onlyDevEasiestGame['TotalTruePoints'] / $onlyDevEasiestGame['MaxPointsAvailable']) > ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])))) {
                     $onlyDevEasiestGame = $game;
+                } else {
+                    if (($onlyDevHardestGame['TotalTruePoints'] / $onlyDevHardestGame['MaxPointsAvailable']) < ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])) {
+                        $onlyDevHardestGame = $game;
+                    }
+                    if ($onlyDevEasiestGame['TotalTruePoints'] == 0 || ($onlyDevEasiestGame['TotalTruePoints'] / $onlyDevEasiestGame['MaxPointsAvailable']) < 1 || ($game['TotalTruePoints'] > 0 && (($onlyDevEasiestGame['TotalTruePoints'] / $onlyDevEasiestGame['MaxPointsAvailable']) > ($game['TotalTruePoints'] / $game['MaxPointsAvailable'])))) {
+                        $onlyDevEasiestGame = $game;
+                    }
                 }
-            }
-            array_push($onlyDevGameIDs, $game['ID']);
-            $onlyDevAchievementCount += $game['MyAchievements'];
-            $onlyDevRichPresenceCount += $game['RichPresence'];
-            $onlyDevLeaderboardTotal += $game['NumLBs'];
-            if (isset($game['NumLBs'])) {
-                $onlyDevLeaderboardCount++;
+                array_push($onlyDevGameIDs, $game['ID']);
+                $onlyDevAchievementCount += $game['MyAchievements'];
+                $onlyDevRichPresenceCount += $game['RichPresence'];
+                $onlyDevLeaderboardTotal += $game['NumLBs'];
+                if (isset($game['NumLBs'])) {
+                    $onlyDevLeaderboardCount++;
+                }
             }
         }
     }
@@ -324,15 +327,20 @@ if ($userContribCount > 0) {
         "00137",
     );
     $achievementCount = 0;
+    $totalMemLegth = 0;
     $customBadgesCount = 0;
     $totalPoints = 0;
     $totalTruePoints = 0;
+    $shortestMemAchievement = [];
+    $longestMemAchievement = [];
     $easiestAchievement = [];
     $hardestAchievement = [];
     $firstAchievement = [];
     $lastAchievement = [];
     foreach ($userArchInfo as $achievement) {
         if ($achievementCount == 0) {
+            $shortestMemAchievement = $achievement;
+            $longestMemAchievement = $achievement;
             $easiestAchievement = $achievement;
             $hardestAchievement = $achievement;
             $firstAchievement = $achievement;
@@ -344,12 +352,19 @@ if ($userContribCount > 0) {
             if ($easiestAchievement['TrueRatio'] == 0 || ($achievement['TrueRatio'] > 0 && (($easiestAchievement['TrueRatio'] / $easiestAchievement['Points']) > ($achievement['TrueRatio'] / $achievement['Points'])))) {
                 $easiestAchievement = $achievement;
             }
+            if ($shortestMemAchievement['MemLength'] > $achievement['MemLength']) {
+                $shortestMemAchievement = $achievement;
+            }
+            if ($longestMemAchievement['MemLength'] < $achievement['MemLength']) {
+                $longestMemAchievement = $achievement;
+            }
         }
 
         if (! in_array($achievement['BadgeName'], $defaultBadges)) {
             $customBadgesCount++;
         }
         $achievementCount++;
+        $totalMemLegth += $achievement['MemLength'];
         $totalPoints += $achievement['Points'];
         $totalTruePoints += $achievement['TrueRatio'];
         $lastAchievement = $achievement;
@@ -357,8 +372,9 @@ if ($userContribCount > 0) {
 
     $averagePoints = $totalPoints / $achievementCount;
     $averageTruePoints = $totalTruePoints / $achievementCount;
+    $averageMemLength = $totalMemLegth / $achievementCount;
 
-    // Get own achievemnts earned info
+    // Get own achievements earned info
     $ownAchievementsObtained = getOwnAchievementsObtained($dev);
 
     // Initialize unique obtainers variables
@@ -377,6 +393,9 @@ if ($userContribCount > 0) {
         }
         $uniqueObtainers++;
     }
+
+    // Get last 100 achievements obtained by others
+    $recentlyObtainedAchievements = getRecentObtainedAchievements($dev);
 
     // Initialize code note variables
     $mostNotedGame = [];
@@ -437,6 +456,12 @@ if ($userContribCount > 0) {
 
     // Get closed/resolved ticket information for user
     $userCount = 0;
+    $closedTicketPlusMinus = 0;
+    $closedTicketPlusMinusRatio = 0;
+    $resolvedTicketPlusMinus = 0;
+    $resolvedTicketPlusMinusRatio = 0;
+    $totalTicketPlusMinus = 0;
+    $totalTicketPlusMinusRatio = 0;
     $closedResolvedTicketInfo = [];
     $closedResolvedTicketInfo['Count'] = 0;
     $closedResolvedTicketInfo['ClosedCount'] = 0;
@@ -464,6 +489,27 @@ if ($userContribCount > 0) {
         $closedResolvedTicketInfo['Count'] += $ticketData['TicketCount'];
         $closedResolvedTicketInfo['ClosedCount'] += $ticketData['ClosedCount'];
         $closedResolvedTicketInfo['ResolvedCount'] += $ticketData['ResolvedCount'];
+    }
+    $closedTicketPlusMinus = $closedResolvedTicketInfo['ClosedCount'] - $userTickets['closed'];
+    $closedTicketPlusMinus = ($closedTicketPlusMinus > 0) ? '+' . $closedTicketPlusMinus : $closedTicketPlusMinus;
+    $resolvedTicketPlusMinus = $closedResolvedTicketInfo['ResolvedCount'] - $userTickets['resolved'];
+    $resolvedTicketPlusMinus = ($resolvedTicketPlusMinus > 0) ? '+' . $resolvedTicketPlusMinus : $resolvedTicketPlusMinus;
+    $totalTicketPlusMinus = $closedResolvedTicketInfo['Count'] - $userTickets['total'];
+    $totalTicketPlusMinus = ($totalTicketPlusMinus > 0) ? '+' . $totalTicketPlusMinus : $totalTicketPlusMinus;
+    if ($userTickets['closed'] == 0) {
+        $closedTicketPlusMinusRatio = $closedResolvedTicketInfo['ClosedCount'];
+    } else {
+        $closedTicketPlusMinusRatio = $closedResolvedTicketInfo['ClosedCount'] / $userTickets['closed'];
+    }
+    if ($userTickets['resolved'] == 0) {
+        $resolvedTicketPlusMinusRatio = $closedResolvedTicketInfo['ResolvedCount'];
+    } else {
+        $resolvedTicketPlusMinusRatio = $closedResolvedTicketInfo['ResolvedCount'] / $userTickets['resolved'];
+    }
+    if ($userTickets['total'] == 0) {
+        $totalTicketPlusMinusRatio = $closedResolvedTicketInfo['Count'];
+    } else {
+        $totalTicketPlusMinusRatio = $closedResolvedTicketInfo['Count'] / $userTickets['total'];
     }
 }
 
@@ -788,7 +834,7 @@ RenderHtmlHead("$dev's Developer Stats");
             }
             echo "</td></tr>";
 
-            // Majority Development - Most completed game
+            // Majority Developer - Most completed game
             echo "<tr><td>Most Completed Game:</td><td>";
             if (count($majorityDevMostCompletedGame) > 0) {
                 echo $majorityDevMostCompletedGame['Completed'] . " - ";
@@ -798,7 +844,7 @@ RenderHtmlHead("$dev's Developer Stats");
             }
             echo "</td></tr>";
 
-            // Majority Development - Most mastered game
+            // Majority Developer - Most mastered game
             echo "<tr><td>Most Mastered Game:</td><td>";
             if (count($majorityDevMostMasteredGame) > 0) {
                 echo $majorityDevMostMasteredGame['Mastered'] . " - ";
@@ -891,7 +937,7 @@ RenderHtmlHead("$dev's Developer Stats");
             }
             echo "</td></tr>";
 
-            // Sole Development - Own Complete/Mastered games
+            // Sole Developer - Own Complete/Mastered games
             echo "<tr><td>Own Completed/Mastered Awards:</td><td>";
             if (count($onlyDevOwnAwards) > 0) {
                 echo $onlyDevOwnAwards['Completed'] . " <b>(" . $onlyDevOwnAwards['Mastered'] . ")</br>";
@@ -980,6 +1026,19 @@ RenderHtmlHead("$dev's Developer Stats");
             // Average achievement retro points and retro ratio
             echo "<tr><td>Average Achievement Retro Points (Average Retro Ratio):</td><td>" . number_format($averageTruePoints, 2, '.', '') . " (" . number_format($averageTruePoints / $averagePoints, 2, '.', '') . ")</td></tr>";
 
+            // Average achievement memory length
+            echo "<tr><td>Average Achievement Memory Length:</td><td>" . number_format($averageMemLength, 2, '.', '') . "</td></tr>";
+
+            // Shortest achievement by memory length
+            echo "<tr><td>Shortest Achievement by Memory Length:</td><td>" . $shortestMemAchievement['MemLength'] . " - ";
+            echo GetAchievementAndTooltipDiv($shortestMemAchievement['ID'], $shortestMemAchievement['Title'], $shortestMemAchievement['Description'], $shortestMemAchievement['Points'], $shortestMemAchievement['GameTitle'], $shortestMemAchievement['BadgeName'], true, false, '', 32);
+            echo "</td></tr>";
+
+            // Longest achievement by memory length
+            echo "<tr><td>Longest Achievement by Memory Length:</td><td>" . $longestMemAchievement['MemLength'] . " - ";
+            echo GetAchievementAndTooltipDiv($longestMemAchievement['ID'], $longestMemAchievement['Title'], $longestMemAchievement['Description'], $longestMemAchievement['Points'], $longestMemAchievement['GameTitle'], $longestMemAchievement['BadgeName'], true, false, '', 32);
+            echo "</td></tr>";
+
             // Any Development - Average achievement count per game
             echo "<tr><td>Average Achievement Count per Game:</td><td>" . number_format($achievementCount / count($anyDevGameIDs), 2, '.', '') . "</td></tr>";
 
@@ -1031,24 +1090,50 @@ RenderHtmlHead("$dev's Developer Stats");
             echo "</td></tr>";
 
             // Easiest achievement by retro ratio
-            echo "<tr><td>Easiest Achievemnet by Retro Ratio:</td><td>" . number_format($easiestAchievement['TrueRatio'] / $easiestAchievement['Points'], 2, '.', '') . " - ";
-            echo GetAchievementAndTooltipDiv($easiestAchievement['ID'], $easiestAchievement['Title'], $easiestAchievement['Description'], $easiestAchievement['Points'], $easiestAchievement['ConsoleName'], $easiestAchievement['BadgeName'], true, false, '', 32);
+            echo "<tr><td>Easiest Achievement by Retro Ratio:</td><td>" . number_format($easiestAchievement['TrueRatio'] / $easiestAchievement['Points'], 2, '.', '') . " - ";
+            echo GetAchievementAndTooltipDiv($easiestAchievement['ID'], $easiestAchievement['Title'], $easiestAchievement['Description'], $easiestAchievement['Points'], $easiestAchievement['GameTitle'], $easiestAchievement['BadgeName'], true, false, '', 32);
             echo "</td></tr>";
 
             // Hardest achievement by retro ratio
             echo "<tr><td>Hardest Achievement by Retro Ratio:</td><td>" . number_format($hardestAchievement['TrueRatio'] / $hardestAchievement['Points'], 2, '.', '') . " - ";
-            echo GetAchievementAndTooltipDiv($hardestAchievement['ID'], $hardestAchievement['Title'], $hardestAchievement['Description'], $hardestAchievement['Points'], $hardestAchievement['ConsoleName'], $hardestAchievement['BadgeName'], true, false, '', 32);
+            echo GetAchievementAndTooltipDiv($hardestAchievement['ID'], $hardestAchievement['Title'], $hardestAchievement['Description'], $hardestAchievement['Points'], $hardestAchievement['GameTitle'], $hardestAchievement['BadgeName'], true, false, '', 32);
             echo "</td></tr>";
 
             // First achievement created
             echo "<tr><td>First Achievement Created:</td><td>" . date("d M, Y H:i", strtotime($firstAchievement['DateCreated'])) . " - ";
-            echo GetAchievementAndTooltipDiv($firstAchievement['ID'], $firstAchievement['Title'], $firstAchievement['Description'], $firstAchievement['Points'], $firstAchievement['ConsoleName'], $firstAchievement['BadgeName'], true, false, '', 32);
+            echo GetAchievementAndTooltipDiv($firstAchievement['ID'], $firstAchievement['Title'], $firstAchievement['Description'], $firstAchievement['Points'], $firstAchievement['GameTitle'], $firstAchievement['BadgeName'], true, false, '', 32);
             echo "</td></tr>";
 
             // Latest achievement created
             echo "<tr><td>Latest Achievement Created:</td><td>" . date("d M, Y H:i", strtotime($lastAchievement['DateCreated'])) . " - ";
-            echo GetAchievementAndTooltipDiv($lastAchievement['ID'], $lastAchievement['Title'], $lastAchievement['Description'], $lastAchievement['Points'], $lastAchievement['ConsoleName'], $lastAchievement['BadgeName'], true, false, '', 32);
-            echo "</td></tr>";
+            echo GetAchievementAndTooltipDiv($lastAchievement['ID'], $lastAchievement['Title'], $lastAchievement['Description'], $lastAchievement['Points'], $lastAchievement['GameTitle'], $lastAchievement['BadgeName'], true, false, '', 32);
+            echo "</td></tr><tr height='10px'></td></tr>";
+            echo "</tbody></table>";
+
+            // Recently Obtained achievements
+            echo "<table><tbody>";
+            echo "</tr><tr><td colspan='4' align='center' style=\"font-size:24px; padding-top:10px; padding-bottom:10px\">Recently Obtained Achievements</td></tr>";
+            echo "<tr><td width='34%'>Achivement</td><td width='33%'>Game</td><td width='19%'>User</td><td width='11%'>Date Obtained</td></tr>";
+            echo "</tbody></table>";
+            echo "<div id='devstatsscrollpane'>";
+            echo "<table><tbody>";
+            foreach ($recentlyObtainedAchievements as $awarded) {
+                echo "<tr><td width='35%'>";
+                echo GetAchievementAndTooltipDiv($awarded['ID'], $awarded['Title'], $awarded['Description'], $awarded['Points'], $awarded['GameTitle'], $awarded['BadgeName'], true, false, '', 32);
+                if ($awarded['HardcoreMode'] == 1 || $awarded['Grouped'] == 2) {
+                    echo " <span class='hardcore'>(Hardcore!)</span>";
+                }
+                echo "</td><td width='35%'>";
+                echo GetGameAndTooltipDiv($awarded['GameID'], $awarded['GameTitle'], $awarded['GameIcon'], $awarded['ConsoleName'], false, 32);
+                echo "</td><td width='20%'>";
+                echo GetUserAndTooltipDiv($awarded['User'], true);
+                echo GetUserAndTooltipDiv($awarded['User'], false);
+                echo "</td><td width='10%'>";
+                echo $awarded['Date'];
+                echo "</td></tr>";
+            }
+            echo "</tbody></table>";
+            echo "</div>";
             echo "</table></tbody>";
             echo "</br></br>";
 
@@ -1059,18 +1144,28 @@ RenderHtmlHead("$dev's Developer Stats");
             echo "<table><tbody>";
 
             // Code notes created
-            echo "<tr><td width='50%'>Code Notes Created:</td><td>" . $userCodeNoteCount;
-            echo "</td></tr>";
-
-            // Game with most code notes
-            echo "<tr><td>Most Code Notes for a Single Game:</td><td>";
-            if ($userCodeNoteCount > 0) {
-                echo $mostNotedGame['NoteCount'] . " - ";
-                echo GetGameAndTooltipDiv($mostNotedGame['GameID'], $mostNotedGame['GameTitle'], $mostNotedGame['GameIcon'], $mostNotedGame['ConsoleName'], false, 32);
-            } else {
-                echo "N/A";
+            echo "<tr><td width='50%'>Code Notes Created:</td><td>" . $userCodeNoteCount . "</td></tr>";
+            echo "</td></tr><tr height='10px'></td></tr>";
+            echo "</tbody></table>";
+            
+            // Games with user created code notes
+            echo "<table><tbody>";
+            echo "</tr><tr><td colspan='4' align='center' style=\"font-size:24px; padding-top:10px; padding-bottom:10px\">Games with Code Notes</td></tr>";
+            echo "<tr colspan='3'><td width='50%'>Game</td><td width='35%'>Notes Created (% of Total)</td><td>Total Notes</td></tr>";
+            echo "</tbody></table>";
+            echo "<div id='devstatsscrollpane'>";
+            echo "<table><tbody>";
+            foreach ($codeNotes as $game) {
+                echo "<tr><td width='51%'>";
+                echo GetGameAndTooltipDiv($game['GameID'], $game['GameTitle'], $game['GameIcon'], $game['ConsoleName'], false, 32);
+                echo "</td><td width='36%'>";
+                echo $game['NoteCount'] . " (" . number_format($game['NoteCount'] / $game['TotalNotes'] * 100, 2, '.', '') . "%)";
+                echo "</td><td>";
+                echo $game['TotalNotes'];
+                echo "</td></tr>";
             }
-            echo "</table></tbody>";
+            echo "</tbody></table>";
+            echo "</div>";
             echo "</br></br>";
 
             /*
@@ -1108,7 +1203,7 @@ RenderHtmlHead("$dev's Developer Stats");
             echo "<tr><td>Achievement with Most Tickets:</td><td>";
             if ($mostTicketedAchievement !== null) {
                 echo $mostTicketedAchievement['TicketCount'] . " - ";
-                echo GetAchievementAndTooltipDiv($mostTicketedAchievement['AchievementID'], $mostTicketedAchievement['AchievementTitle'], $mostTicketedAchievement['AchievementDescription'], $mostTicketedAchievement['AchievementPoints'], $mostTicketedAchievement['ConsoleName'], $mostTicketedAchievement['AchievementBadge'], true);
+                echo GetAchievementAndTooltipDiv($mostTicketedAchievement['AchievementID'], $mostTicketedAchievement['AchievementTitle'], $mostTicketedAchievement['AchievementDescription'], $mostTicketedAchievement['AchievementPoints'], $mostTicketedAchievement['GameTitle'], $mostTicketedAchievement['AchievementBadge'], true);
             } else {
                 echo "N/A";
             }
@@ -1149,6 +1244,36 @@ RenderHtmlHead("$dev's Developer Stats");
                 echo "N/A";
             }
             echo "</td></tr>";
+
+            // Total Ticket Karma and +/-
+            echo "<tr><td>Ticket Karma (+/-):</td><td>" . number_format($totalTicketPlusMinusRatio, 2, '.', '');
+            if ($totalTicketPlusMinus > 0) {
+                echo " (<font color='green'>" . $totalTicketPlusMinus . "</font>)</td></tr>";
+            } elseif ($totalTicketPlusMinus < 0) {
+                echo " (<font color='red'>" . $totalTicketPlusMinus . "</font>)</td></tr>";
+            } else {
+                echo " (" . $totalTicketPlusMinus . "</font>)</td></tr>";
+            }
+
+            // Closed Ticket Karma and +/-
+            echo "<tr><td>Closed Ticket Karma (+/-):</td><td>" . number_format($closedTicketPlusMinusRatio, 2, '.', '');
+            if ($closedTicketPlusMinus > 0) {
+                echo " (<font color='green'>" . $closedTicketPlusMinus . "</font>)</td></tr>";
+            } elseif ($closedTicketPlusMinus < 0) {
+                echo " (<font color='red'>" . $closedTicketPlusMinus . "</font>)</td></tr>";
+            } else {
+                echo " (" . $closedTicketPlusMinus . "</font>)</td></tr>";
+            }
+
+            // Resolved Ticket Karma and +/-
+            echo "<tr><td>Resolved Ticket Karma (+/-):</td><td>" . number_format($resolvedTicketPlusMinusRatio, 2, '.', '');
+            if ($resolvedTicketPlusMinus > 0) {
+                echo " (<font color='green'>" . $resolvedTicketPlusMinus . "</font>)</td></tr>";
+            } elseif ($resolvedTicketPlusMinus < 0) {
+                echo " (<font color='red'>" . $resolvedTicketPlusMinus . "</font>)</td></tr>";
+            } else {
+                echo " (" . $resolvedTicketPlusMinus . "</font>)</td></tr>";
+            }
             echo "</table></tbody>";
         }
         ?>

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -1131,13 +1131,11 @@ RenderHtmlHead("$dev's Developer Stats");
                 // Only display row for Hardcore if so.
                 if ($recentlyObtainedAchievements[$i]['User'] == $recentlyObtainedAchievements[$i + 1]['User'] &&
                     $recentlyObtainedAchievements[$i]['Date'] == $recentlyObtainedAchievements[$i + 1]['Date'] &&
-                    $recentlyObtainedAchievements[$i]['AchievementID'] == $recentlyObtainedAchievements[$i + 1]['AchievementID'])
-                {
+                    $recentlyObtainedAchievements[$i]['AchievementID'] == $recentlyObtainedAchievements[$i + 1]['AchievementID']) {
                     echo " <span class='hardcore'>(Hardcore!)</span>";
                     $skipNextEntry = true;
                 } elseif ($recentlyObtainedAchievements[$i]['HardcoreMode'] == 1) {
                     echo " <span class='hardcore'>(Hardcore!)</span>";
-                    
                 }
                 echo "</td><td width='35%'>";
                 echo GetGameAndTooltipDiv($recentlyObtainedAchievements[$i]['GameID'], $recentlyObtainedAchievements[$i]['GameTitle'], $recentlyObtainedAchievements[$i]['GameIcon'], $recentlyObtainedAchievements[$i]['ConsoleName'], false, 32);
@@ -1168,7 +1166,7 @@ RenderHtmlHead("$dev's Developer Stats");
             echo "<tr><td width='50%'>Code Notes Created:</td><td>" . $userCodeNoteCount . "</td></tr>";
             echo "</td></tr><tr height='10px'></td></tr>";
             echo "</tbody></table>";
-            
+
             // Games with user created code notes
             echo "<table><tbody>";
             echo "</tr><tr><td colspan='4' align='center' style=\"font-size:24px; padding-top:10px; padding-bottom:10px\">Games with Code Notes</td></tr>";


### PR DESCRIPTION
Updates the the dev stats page to fix a few issues and add some few features.

 - Couple typos fixed on page and in code.
 - Achievement tooltip now shows game rather than console.
 - Games with a less than 1 retro ratio will no longer show as easiest game (Unless it the only game).
 - Stats no longer include "games" or "achievements" from Hubs or Events.
 - Untracked user stats are no longer counted.

 - Added average achievement memory length.
 - Added shortest and longest achievement by memory length.
![image](https://user-images.githubusercontent.com/16140035/76689628-300daf80-660e-11ea-8cea-097f46484eb9.png)

 - Added table for last 100 achievements obtained.
![image](https://user-images.githubusercontent.com/16140035/76689634-41ef5280-660e-11ea-948c-ddb7349c60cc.png)

 - Replaced game with most code notes with a table of all games with code notes created by the dev.
![image](https://user-images.githubusercontent.com/16140035/76689638-4ae02400-660e-11ea-9cb2-40847478b005.png)

 - Added total/closed/resolved ticket karma ratio (+/-).
![image](https://user-images.githubusercontent.com/16140035/76689643-529fc880-660e-11ea-8433-0f44b9e1a0d2.png)
