### PR TITLE
disregard untracked users in achievement-related stats

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -1176,24 +1176,8 @@ function getAchievementWonData($achID, &$numWinners, &$numPossibleWinners, &$num
     $data = mysqli_fetch_assoc($dbResult);
     $numWinners = $data['NumEarned'];
     $gameID = $data['GameID'];   //    Grab GameID at this point
-    //$query = "SELECT COUNT(*) FROM UserAccounts WHERE Permissions>0";
-    $query = "SELECT MAX( Inner1.MaxAwarded ) AS TotalPlayers FROM
-              (
-                  SELECT ach.ID, COUNT(*) AS MaxAwarded
-                  FROM Awarded AS aw
-                  LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
-                  LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
-                  WHERE gd.ID = $gameID AND aw.HardcoreMode = 0
-                  GROUP BY ach.ID
-              ) AS Inner1";
 
-    $dbResult = s_mysql_query($query);
-    if ($dbResult == false) {
-        return false;
-    }
-
-    $arrayResult = mysqli_fetch_assoc($dbResult);
-    $numPossibleWinners = $arrayResult['TotalPlayers'];
+    $numPossibleWinners = getTotalUniquePlayers($gameID, $user);
 
     $numRecentWinners = 0;
 

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -162,16 +162,8 @@ function getGameMetadataByFlags(
     $query = "
     SELECT
         ach.ID, 
-        IF(
-            IFNULL(!ua.Untracked, FALSE) || ua.User = '$user',
-            ( COUNT( aw.AchievementID ) - SUM( IFNULL( aw.HardcoreMode, 0 ) ) ),
-            0
-        ) AS NumAwarded, 
-        IF(
-            IFNULL(!ua.Untracked, FALSE) || ua.User = '$user',
-            ( SUM( IFNULL( aw.HardcoreMode, 0 ) ) ),
-            0
-        ) AS NumAwardedHardcore, 
+        (COUNT(aw.AchievementID) - SUM(IFNULL(aw.HardcoreMode, 0))) AS NumAwarded, 
+        (SUM(IFNULL(aw.HardcoreMode, 0))) AS NumAwardedHardcore, 
         ach.Title,
         ach.Description,
         ach.Points,
@@ -190,6 +182,7 @@ function getGameMetadataByFlags(
         UserAccounts AS ua ON ua.User = aw.User
     WHERE
         ach.GameID = $gameID AND ach.Flags = $flags
+        AND (NOT ua.Untracked" . (isset($user) ? " OR ua.User = '$user'" : "") . ")
     GROUP BY ach.ID
     $orderBy";
 
@@ -712,7 +705,7 @@ function requestModifyGameForumTopic($gameID, $newForumTopic)
     return false;
 }
 
-function getAchievementDistribution($gameID, $hardcore)
+function getAchievementDistribution($gameID, $hardcore, $requestedBy)
 {
     settype($hardcore, 'integer');
     $retval = [];
@@ -725,7 +718,9 @@ function getAchievementDistribution($gameID, $hardcore)
             FROM Awarded AS aw
             LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
             LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
+            LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
             WHERE gd.ID = $gameID AND aw.HardcoreMode = $hardcore
+              AND (NOT ua.Untracked" . (isset($requestedBy) ? " OR ua.User = '$requestedBy'" : "") . ")
             GROUP BY aw.User
             ORDER BY AwardedCount DESC
         ) AS InnerTable
@@ -841,17 +836,19 @@ function getGameListSearch($offset, $count, $method, $consoleID = null)
     return $retval;
 }
 
-function getTotalUniquePlayers($gameID)
+function getTotalUniquePlayers($gameID, $requestedBy)
 {
     settype($gameID, 'integer');
 
-    $query = "SELECT COUNT(*) AS UniquePlayers FROM
-              ( SELECT COUNT(aw.User)
-              FROM Awarded AS aw
-              LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
-              LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
-              WHERE gd.ID = $gameID
-              GROUP BY aw.User ) AS InnerTable";
+    $query = "
+        SELECT COUNT(DISTINCT aw.User) As UniquePlayers
+        FROM Awarded AS aw
+        LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
+        LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
+        LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
+        WHERE gd.ID = $gameID
+          AND (NOT ua.Untracked" . (isset($requestedBy) ? " OR ua.User = '$requestedBy'" : "") . ")
+    ";
 
     $dbResult = s_mysql_query($query);
     SQL_ASSERT($dbResult);

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -63,7 +63,7 @@ $richPresenceData = $gameData['RichPresencePatch'];
 // Get the top ten players at this game:
 $gameTopAchievers = getGameTopAchievers($gameID, 0, 10, $user);
 
-$totalUniquePlayers = getTotalUniquePlayers($gameID);
+$totalUniquePlayers = getTotalUniquePlayers($gameID, $user);
 if ($numDistinctPlayersCasual < $totalUniquePlayers) {
     $numDistinctPlayersCasual = $totalUniquePlayers;
 }
@@ -71,7 +71,7 @@ if ($numDistinctPlayersHardcore < $totalUniquePlayers) {
     $numDistinctPlayersHardcore = $totalUniquePlayers;
 }
 
-$achDist = getAchievementDistribution($gameID, 0); //    for now, only retrieve casual!
+$achDist = getAchievementDistribution($gameID, 0, $user); //    for now, only retrieve casual!
 for ($i = 1; $i <= $numAchievements; $i++) {
     if (!array_key_exists($i, $achDist)) {
         $achDist[$i] = 0;


### PR DESCRIPTION
Ignore untracked users in:
  * achievement stats shown in game and achievement pages
  * achievement distribution graph in game page

Fixes #301. The total unique players of the set is used, not the amount
of earners of the most earned achievement in the set. Both for the game
and achievement pages.

Also fixes the infamous won-by-0-of-0 bug.