### PR TITLE
escape html characters in alt & title attributes of badge image tags

### DIFF
--- a/lib/render/achievement.php
+++ b/lib/render/achievement.php
@@ -55,8 +55,9 @@ function GetAchievementAndTooltipDiv(
     }
 
     if ($inclSmallBadge) {
+        $achNameAttr = htmlspecialchars($achName, ENT_QUOTES);
         $smallBadgePath = "/Badge/$badgeName" . ".png";
-        $smallBadge = "<img width='$smallBadgeSize' height='$smallBadgeSize' src=\"" . getenv('ASSET_URL') . "$smallBadgePath\" alt='$achNameStr' title='$achNameStr' class='$imgclass' />";
+        $smallBadge = "<img width='$smallBadgeSize' height='$smallBadgeSize' src=\"" . getenv('ASSET_URL') . "$smallBadgePath\" alt='$achNameAttr' title='$achNameAttr' class='$imgclass' />";
 
         if ($smallBadgeOnly) {
             $displayable = "";


### PR DESCRIPTION
Problem was noticed in http://retroachievements.org/game/16191, because the second to last achievement's title contains the word _hidden_ after a single quote, which is an actual html attribute and ends up hiding the badge's image tag.

![image](https://user-images.githubusercontent.com/623942/79459322-07048400-7feb-11ea-918b-e861ae5cb69f.png)
