### PR TITLE
Dev Stats Code Notes Table Update

### DIFF
--- a/lib/database/codenote.php
+++ b/lib/database/codenote.php
@@ -192,9 +192,11 @@ function getCodeNoteCounts($user)
               LEFT JOIN UserAccounts AS ua ON ua.ID = cn.AuthorID
               LEFT JOIN GameData AS gd ON gd.ID = cn.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
+              WHERE LENGTH(Note) > 0
+              AND gd.Title IS NOT NULL
               GROUP BY GameID
               HAVING NoteCount > 0
-              ORDER BY NoteCount DESC";
+              ORDER BY NoteCount DESC, GameTitle";
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -1117,7 +1117,7 @@ RenderHtmlHead("$dev's Developer Stats");
             // Recently Obtained achievements
             echo "<table><tbody>";
             echo "</tr><tr><td colspan='4' align='center' style=\"font-size:24px; padding-top:10px; padding-bottom:10px\">Recently Obtained Achievements</td></tr>";
-            echo "<tr><td width='34%'>Achivement</td><td width='33%'>Game</td><td width='19%'>User</td><td width='11%'>Date Obtained</td></tr>";
+            echo "<tr><td width='34%'>Achievement</td><td width='33%'>Game</td><td width='19%'>User</td><td width='11%'>Date Obtained</td></tr>";
             echo "</tbody></table>";
             echo "<div id='devstatsscrollpane'>";
             echo "<table><tbody>";


### PR DESCRIPTION
Updates the code notes table on the dev stats page to ignore notes for invalid games.

![image](https://user-images.githubusercontent.com/16140035/79643811-c0419600-8172-11ea-9b3e-0221838fd822.png)

Also ignores code notes of size 0, so deleted code notes will no longer be counted.

Also fixed the "Achivement" typo in the Recently Obtained Achievements table.