### PR TITLE
Forum Comment Link

### DIFF
--- a/lib/database/forum.php
+++ b/lib/database/forum.php
@@ -360,12 +360,11 @@ function getTopicCommentCommentOffset($forumTopicID, $commentID, $count, &$offse
     if ($commentID == -1) {
         $commentID = 99999999;
     }
-
-    $query = "SELECT COUNT(ID) AS CommentOffset FROM
-                ( SELECT ID FROM ForumTopicComment
-                  WHERE ForumTopicID = $forumTopicID
-                  ORDER BY ID ) AS InnerTable
-                WHERE ID < $commentID ";
+    
+    $query = "SELECT COUNT(ID) AS CommentOffset
+              FROM ForumTopicComment
+              WHERE DateCreated < (SELECT DateCreated FROM ForumTopicComment WHERE ID = $commentID)
+              AND ForumTopicID = $forumTopicID";
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -647,6 +647,23 @@ td, tr, img {
   text-align: right;
 }
 
+.forumlink {
+  padding-left: 2px;
+  cursor: pointer;
+}
+
+.forumlink img:hover {
+  filter:  brightness(0) invert(1);
+}
+
+.forumlink img:active {
+  filter:  brightness(1);
+}
+
+.highlight {
+  outline: 1px solid;
+}
+
 #topicpreview {
 }
 

--- a/public/forum.php
+++ b/public/forum.php
@@ -114,7 +114,7 @@ RenderHtmlHead($pageTitle);
                 if (isset($nextForumLastPostAuthor) && mb_strlen($nextForumLastPostAuthor) > 1) {
                     echo GetUserAndTooltipDiv($nextForumLastPostAuthor, true);
                     //echo "<a href='/User/$nextForumLastPostAuthor'>$nextForumLastPostAuthor</a>";
-                    echo " <a href='/viewtopic.php?t=$nextForumLastPostTopicID&c=$nextForumLastPostID'>[View]</a>";
+                    echo " <a href='/viewtopic.php?t=$nextForumLastPostTopicID&c=$nextForumLastPostID#$nextForumLastPostID'>[View]</a>";
                 }
                 echo "</div>";
                 echo "</td>";

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -678,3 +678,12 @@ function tabClick(evt, tabName, type) {
   document.getElementById(tabName).style.display = 'block';
   evt.currentTarget.className += ' active';
 }
+
+function copy(text) {
+  var inp = document.createElement('input');
+  document.body.appendChild(inp)
+  inp.value = text
+  inp.select();
+  document.execCommand('copy', false);
+  inp.remove();
+}

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -141,7 +141,7 @@ RenderHtmlHead("View forum: $thisForumTitle");
                 echo "<span class='smalldate'>$nextTopicLastCommentPostedNiceDate</span><br>";
                 echo GetUserAndTooltipDiv($nextTopicLastCommentAuthor, $mobileBrowser);
                 //echo "<a href='/User/$nextTopicLastCommentAuthor'>$nextTopicLastCommentAuthor</a>";
-                echo " <a href='viewtopic.php?t=$nextTopicID&amp;c=$nextTopicLastCommentID' title='View latest post' alt='View latest post'>[View]</a>";
+                echo " <a href='viewtopic.php?t=$nextTopicID&amp;c=$nextTopicLastCommentID#$nextTopicLastCommentID' title='View latest post' alt='View latest post'>[View]</a>";
                 echo "</div>";
                 echo "</td>";
                 echo "</tr>";

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -269,8 +269,10 @@ RenderHtmlStart();
 
             echo "<td class='commentpayload' id='$nextCommentID'>";
 
-            echo "<div class='smalltext rightfloat'>Posted: $nextCommentDateCreatedNiceDate";
+            echo "<div class='rightfloat forumlink'><img src='" . getenv('ASSET_URL') . "/Images/Link.png' onclick='copy(\"" . getenv('APP_URL') . "viewtopic.php?t=$thisTopicID&amp;c=$nextCommentID#$nextCommentID\"" . ")'</img></div>";
 
+            echo "<div class='smalltext rightfloat'>Posted: $nextCommentDateCreatedNiceDate";
+            
             if (($user == $nextCommentAuthor) || ($permissions >= Permissions::Admin)) {
                 echo "&nbsp;<a href='/editpost.php?c=$nextCommentID'>(Edit&nbsp;Post)</a>";
             }


### PR DESCRIPTION
Added copy comment link image to each forum comment. This allows for easily sharing links to a specific comment on the forums or in discord.

Clicking the chain link icon in the top right of any comment will copy the link to that comment to your clipboard.
![image](https://user-images.githubusercontent.com/16140035/79670897-2ab6fe00-8194-11ea-9603-aa444a429950.png)

Navigating to the copied link will take you to the page with the comment and outline it so it is distinguishable form the rest.
![image](https://user-images.githubusercontent.com/16140035/79670903-39051a00-8194-11ea-8510-f1b4f9b445e6.png)

Hovering over the icon will turn it white and as the mouse is pressed it will turn back to the original icon, indicating that the URL has been copied.
![image](https://user-images.githubusercontent.com/16140035/79671196-9d28dd80-8196-11ea-8769-4657e0055dbf.png)

Here is the new link image.
![Link](https://user-images.githubusercontent.com/16140035/79670966-8ed9c200-8194-11ea-999f-4e0ee3054f4e.png)
The image needs to be placed in `getenv('ASSET_URL') . "/Images/Link.png'`

It should be the same location as the Submit.png icon. ![image](https://user-images.githubusercontent.com/16140035/79671013-fa239400-8194-11ea-8e2a-f14bad94d2d5.png)

Fixed a few other [View] links that linked to the comment page but would not navigate down to where the comment was located.

The comment offset query was updated to determine the offset based on the date created rather than the comment ID. I found several instances where a comment ID was smaller then other even though it was created after them. It caused issues with getting the correct page offset for some comments.

This would resolve issue #442.