### PR TITLE
Only an admin or the owner should be able to remove a comment

### DIFF
--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -277,13 +277,19 @@ function getActivityMetadata($activityID)
     return mysqli_fetch_assoc($dbResult);
 }
 
-function RemoveComment($articleID, $commentID)
+function RemoveComment($articleID, $commentID, $userID, $permissions)
 {
     settype($articleID, 'integer');
     settype($commentID, 'integer');
+    settype($userID, 'integer');
+    settype($permissions, 'integer');
 
     $query = "DELETE FROM Comment
               WHERE ArticleID = $articleID AND ID = $commentID";
+
+    if ($permissions < \RA\Permissions::Admin) {
+        $query .= " AND UserID = $userID";
+    }
 
     // log_sql($query);
 

--- a/public/request/comment/delete.php
+++ b/public/request/comment/delete.php
@@ -8,8 +8,8 @@ $commentID = seekPOSTorGET('c', 0, 'integer');
 $response = [];
 $response['ArtID'] = $articleID;
 $response['CommentID'] = $commentID;
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, \RA\Permissions::Registered)) {
-    $response['Success'] = RemoveComment($articleID, $commentID);
+if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, \RA\Permissions::Registered, $userID)) {
+    $response['Success'] = RemoveComment($articleID, $commentID, $userID, $permissions);
 } else {
     $response['Success'] = false;
 }


### PR DESCRIPTION
Hi,

I'm not sure it is a security issue but I'm able to remove easily any comment on the site by forging the appropriate HTTP request.

I think it is not a good practice and that's why I propose a fix.