### PR TITLE
Update to Set Request calculation and adds a link on profile

### DIFF
--- a/lib/database/setrequest.php
+++ b/lib/database/setrequest.php
@@ -55,30 +55,26 @@ function getUserRequestsInformation($user, $list, $gameID = -1)
     $requests['used'] = 0;
     $requests['requestedThisGame'] = 0;
     $points = GetScore($user);
-    $age = GetAge($user);
 
-    //Determine how many requests the user can make
-    if ($points >= 2500) {
-        $requests['total']++;
+    // logic behind the amount of requests based on player's score:
+    $boundariesAndChunks = array(
+        180000 => 20000, // from 180k to infinite, +1 for each 20k chunk of points
+        20000 => 10000,  // from 20k to 180k, +1 for each 10k chunk
+        5000 => 5000,    // from 5k to 20k, +1 for each 5k chunk
+        0 => 2500,       // from 0 to 5k, +1 for each 2.5k chunk
+    );
+
+    $pointsLeft = $points;
+    foreach ($boundariesAndChunks as $boundary => $chunk) {
+        if ($pointsLeft >= $boundary) {
+            $aboveBoundary = $pointsLeft - $boundary;
+            $requests['total'] += floor($aboveBoundary / $chunk);
+            $pointsLeft = $boundary;
+        }
     }
-    if ($points >= 5000) {
-        $requests['total']++;
-    }
-    if ($points >= 10000) {
-        $requests['total']++;
-    }
-    if ($points >= 15000) {
-        $requests['total']++;
-    }
-    if ($points >= 20000) {
-        $requests['total']++;
-        $requests['total'] += floor(($points - 20000) / 10000);
-    }
-    if ($points >= 190000) {
-        $requests['total']--;
-        $requests['total'] -= floor(($points - 190000) / 20000);
-    }
-    $requests['total'] += $age;
+
+    // adding the number of years the user is here
+    $requests['total'] += GetAge($user);
 
     //Determine how many of the users current requests are still valid.
     //Requests made for games that now have achievements do no count towards a used request

--- a/lib/database/setrequest.php
+++ b/lib/database/setrequest.php
@@ -55,8 +55,12 @@ function getUserRequestsInformation($user, $list, $gameID = -1)
     $requests['used'] = 0;
     $requests['requestedThisGame'] = 0;
     $points = GetScore($user);
+    $age = GetAge($user);
 
     //Determine how many requests the user can make
+    if ($points >= 2500) {
+        $requests['total']++;
+    }
     if ($points >= 5000) {
         $requests['total']++;
     }
@@ -70,11 +74,11 @@ function getUserRequestsInformation($user, $list, $gameID = -1)
         $requests['total']++;
         $requests['total'] += floor(($points - 20000) / 10000);
     }
-
-    //Cap the allowed set requests at 20
-    if ($requests['total'] > 20) {
-        $requests['total'] = 20;
+    if ($points >= 190000) {
+        $requests['total']--;
+        $requests['total'] -= floor(($points - 190000) / 20000);
     }
+    $requests['total'] += $age;
 
     //Determine how many of the users current requests are still valid.
     //Requests made for games that now have achievements do no count towards a used request

--- a/lib/database/setrequest.php
+++ b/lib/database/setrequest.php
@@ -74,7 +74,7 @@ function getUserRequestsInformation($user, $list, $gameID = -1)
     }
 
     // adding the number of years the user is here
-    $requests['total'] += GetAge($user);
+    $requests['total'] += getAge($user);
 
     //Determine how many of the users current requests are still valid.
     //Requests made for games that now have achievements do no count towards a used request

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -678,6 +678,38 @@ function GetScore($user)
 }
 
 /**
+ * Gets the account age in years for the input user.
+ *
+ * @param String $user to get account age for
+ * @return int|NULL The number of years the account has been created for
+ */
+function GetAge($user)
+{
+    $query = "SELECT ua.Created
+              FROM UserAccounts AS ua
+              WHERE ua.User='$user'";
+
+    $dbResult = s_mysql_query($query);
+    if ($dbResult !== false) {
+        $result = mysqli_fetch_assoc($dbResult);
+
+        if (!$result) {
+            return null;
+        }
+        $created = strtotime($result['Created']);
+        $curDate = strtotime(date('Y-m-d H:i:s'));
+        $diff = $curDate - $created;
+
+        $years = floor($diff / (365*60*60*24));
+        settype($years, 'integer');
+        return $years;
+    } else {
+        // error_log(__FUNCTION__ . " failed: user:$user");
+        return 0;
+    }
+}
+
+/**
  * Gets the points or retro points rank of the user.
  *
  * @param String $user the user to get the rank for

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -683,7 +683,7 @@ function GetScore($user)
  * @param String $user to get account age for
  * @return int|NULL The number of years the account has been created for
  */
-function GetAge($user)
+function getAge($user)
 {
     $query = "SELECT ua.Created
               FROM UserAccounts AS ua

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -32,6 +32,8 @@ $userMotto = $userMassData['Motto'];
 $userPageID = $userMassData['ID'];
 $userTruePoints = $userMassData['TotalTruePoints'];
 $userRank = $userMassData['Rank'];
+$setRequestList = getUserRequestList($userPage);
+$userSetRequestInformation = getUserRequestsInformation($userPage, $setRequestList);
 $userWallActive = $userMassData['UserWallActive'];
 $userIsUntracked = $userMassData['Untracked'];
 
@@ -269,6 +271,10 @@ RenderHtmlStart(true);
             $rankOffset = (int)(($userRank - 1) / 25) * 25;
             echo "<a href='/globalRanking.php?s=5&t=2&o=$rankOffset'>$userRank</a> / $countRankedUsers ranked users (Top $rankPct%)";
         }
+        echo "<br>";
+
+        echo "<a href='/setRequestList.php?u=$userPage'> Requested Sets</a>" 
+                . " - " . $userSetRequestInformation['used'] . " of " . $userSetRequestInformation['total'] . " Requests Made";
         echo "<br><br>";
 
         if (!empty($userMassData['RichPresenceMsg']) && $userMassData['RichPresenceMsg'] !== 'Unknown') {


### PR DESCRIPTION
**Calculation** - 
Previous:
Get requests at 5000 points, 10,000 points, 15,000 points, 20,000 points, and then every 10,000 points after that until 180,000 points (caps at 20).
New:
Adds an extra request at 2500 points, an extra request for every year of the users account age and every 20,000 points after 180,000.

**Link** -
Adds a link to a users set requests on their profile page under their site rank. Also displays their current used and current max requests.
![image](https://user-images.githubusercontent.com/4047771/82772846-70f42280-9e0e-11ea-9d71-3d3583b812bf.png)
