### PR TITLE
no cheevos, empty object (rather than empty array)

### DIFF
--- a/public/API/API_GetGameInfoAndUserProgress.php
+++ b/public/API/API_GetGameInfoAndUserProgress.php
@@ -11,7 +11,7 @@ getGameMetadata($gameID, $targetUser, $achData, $gameData);
 foreach ($achData as &$achievement) {
     $achievement['MemAddr'] = md5($achievement['MemAddr'] ?? null);
 }
-$gameData['Achievements'] = $achData;
+$gameData['Achievements'] = empty($achData) ? (object)null : $achData;
 $gameData['RichPresencePatch'] = md5($gameData['RichPresencePatch'] ?? null);
 
 $gameData['NumAwardedToUser'] = 0;


### PR DESCRIPTION
When accessing `API_GetGameInfoAndUserProgress.php` end point, if a game has achievements the `Achievements` property returned via the JSON is an object, but if a game does not have any achievements it returns an empty array.

This PR is fixing it.

closes #484