### PR TITLE
Show entered cores when creating tickets with RALibRetro chosen

### DIFF
--- a/public/request/ticket/create.php
+++ b/public/request/ticket/create.php
@@ -22,7 +22,7 @@ if (isset($_POST['note'])) {
     if (!empty(trim($_POST['note']['emulator']))) {
         $appendNote .= "<br>Emulator: " . $_POST['note']['emulator'];
 
-        if ($_POST['note']['emulator'] == "RetroArch") {
+        if ($_POST['note']['emulator'] == "RetroArch" || $_POST['note']['emulator'] == "RALibRetro") {
             $appendNote .= " (" . $_POST['note']['core'] . ")";
         }
     }


### PR DESCRIPTION
Update to show entered core when choosing the RALibRetro Emulator when creating tickets.

This would resolve issue #490.