### PR TITLE
change correctUserCase() -> validateUsername()

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -486,7 +486,10 @@ function addEarnedAchievement(
     $isHardcore = 0,
     $silent = false
 ) {
-    $user = correctUserCase($userIn);
+    $user = validateUsername($userIn);
+    if (!$user) {
+        return false;
+    }
 
     //    Sanitise!
     settype($achIDToAward, "integer");

--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -65,7 +65,10 @@ function postActivity($userIn, $activity, $customMsg, $isalt = null)
 {
     global $db;
 
-    $user = correctUserCase($userIn);
+    $user = validateUsername($userIn);
+    if (!$user) {
+        return false;
+    }
 
     userActivityPing($user);
 

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -640,7 +640,7 @@ function getUserForumPostAuth($user)
     }
 }
 
-function correctUserCase($userIn)
+function validateUsername($userIn)
 {
     $query = "SELECT uc.User FROM UserAccounts AS uc WHERE uc.User LIKE '$userIn'";
     $dbResult = s_mysql_query($query);
@@ -651,7 +651,7 @@ function correctUserCase($userIn)
     } else {
         log_sql_fail();
         // error_log(__FUNCTION__ . " issues! $userIn");
-        return $userIn;
+        return null;
     }
 }
 


### PR DESCRIPTION
Assure a valid username is being used before proceeding with "give-award".

To achieve this goal I've changed the behavior of `correctUserCase()` in the case where it fails to find the given username (now it returns `null`, instead of the given username). Also renamed the function to `validateUsername` to describe it better.

In this PR I'm also changing the two clients of that function, making them abort when no valid username is given.
