### PR TITLE
Add Latest Masters Tab to Game High Score Section

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -865,15 +865,28 @@ function getTotalUniquePlayers($gameID, $requestedBy)
     return $data['UniquePlayers'];
 }
 
-function getGameTopAchievers($gameID, $offset, $count, $requestedBy, $totalPossible, $order)
+/**
+ * Gets a games high scoreres or latests masters.
+ * 
+ * @param integer $gameID Game ID to get high score information for.
+ * @param integer $offset Query offset value.
+ * @param integer $count Query number of returned rows.
+ * @param string $requestedBy User requesting the information.
+ * @param integer $type The type of data to return.
+ *          0 - High Scores
+ *          1 - Latest Masters
+ * 
+ * @return Array of user informtion to display on the High Scores section of a game page.
+ */
+function getGameTopAchievers($gameID, $offset, $count, $requestedBy, $type = 0)
 {
     $retval = [];
     $havingQuery = "";
-    if ($order == 1) {
-        $havingQuery = "HAVING SUM(ach.points) = $totalPossible*2";
-        $order2 = "DESC";
+    if ($type == 1) {
+        $havingQuery = "HAVING TotalScore = (SELECT SUM(Points * 2) AS Points FROM Achievements WHERE GameID = $gameID AND Flags = 3)";
+        $order = "DESC";
     } else {
-        $order2 = "ASC";
+        $order = "ASC";
     }
 
     $query = "SELECT aw.User, SUM(ach.points) AS TotalScore, MAX(aw.Date) AS LastAward
@@ -886,7 +899,7 @@ function getGameTopAchievers($gameID, $offset, $count, $requestedBy, $totalPossi
                   AND gd.ID = $gameID
                 GROUP BY aw.User
                 $havingQuery
-                ORDER BY TotalScore DESC, LastAward $order2
+                ORDER BY TotalScore DESC, LastAward $order
                 LIMIT $offset, $count";
 
     $dbResult = s_mysql_query($query);

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -865,9 +865,16 @@ function getTotalUniquePlayers($gameID, $requestedBy)
     return $data['UniquePlayers'];
 }
 
-function getGameTopAchievers($gameID, $offset, $count, $requestedBy)
+function getGameTopAchievers($gameID, $offset, $count, $requestedBy, $totalPossible, $order)
 {
     $retval = [];
+    $havingQuery = "";
+    if ($order == 1) {
+        $havingQuery = "HAVING SUM(ach.points) = $totalPossible*2";
+        $order2 = "DESC";
+    } else {
+        $order2 = "ASC";
+    }
 
     $query = "SELECT aw.User, SUM(ach.points) AS TotalScore, MAX(aw.Date) AS LastAward
                 FROM Awarded AS aw
@@ -878,7 +885,8 @@ function getGameTopAchievers($gameID, $offset, $count, $requestedBy)
                   AND ach.Flags = 3 
                   AND gd.ID = $gameID
                 GROUP BY aw.User
-                ORDER BY TotalScore DESC, LastAward ASC
+                $havingQuery
+                ORDER BY TotalScore DESC, LastAward $order2
                 LIMIT $offset, $count";
 
     $dbResult = s_mysql_query($query);

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -245,18 +245,72 @@ function RenderScoreLeaderboardComponent($user, $friendsOnly, $numToFetch = 10)
     echo "</div>";
 }
 
-function RenderTopAchieversComponent($gameTopAchievers)
+/**
+ * Creates the High scores tables on game pages
+ * 
+ * @param String $user The logged in user.
+ * @param Array $gameTopAchievers Top 10 highest scoreres for the game.
+ * @param Array $gameLatestMasters Top 10 latest masters for the game.
+ */
+function RenderTopAchieversComponent($user, $gameTopAchievers, $gameLatestMasters)
 {
-    $numItems = count($gameTopAchievers);
-
     echo "<div id='leaderboard' class='component' >";
 
-    echo "<h3>High Scores</h3>";
+    $numLatestMasters = count($gameLatestMasters);
+    $numTopAchievers = count($gameTopAchievers);
+    $masteryThreshold = 10; //Number of masters neede for the "Latest Masters" tab to be selected by default
 
+    echo "<h3>High Scores</h3>";
+    echo "<div class='tab'>";
+    echo "<button class='scores" . ($numLatestMasters >= $masteryThreshold ? " active" : "") . "' onclick='tabClick(event, \"latestmasters\", \"scores\")'>Latest Masters</button>";
+    echo "<button class='scores" . ($numLatestMasters >= $masteryThreshold ? "" : " active") . "' onclick='tabClick(event, \"highscores\", \"scores\")'>High Scores</button>";
+    echo "</div>";
+
+    //Latest Masters Tab
+    echo "<div id='latestmasters' class='tabcontentscores' style=\"display: " . ($numLatestMasters >= $masteryThreshold ? "block" : "none") . "\">";
+    echo "<table class='smalltable'><tbody>";
+    echo "<tr><th>Pos</th><th colspan='2' style='max-width:30%'>User</th><th>Mastery Date</th></tr>";
+
+    for ($i = 0; $i < $numLatestMasters; $i++) {
+        if (!isset($gameLatestMasters[$i])) {
+            continue;
+        }
+
+        $nextUser = $gameLatestMasters[$i]['User'];
+        $nextLastAward = $gameLatestMasters[$i]['LastAward'];
+
+        //Outline user if they are in the list
+        if ($user !== null && $user == $nextUser) {
+            echo "<tr style='outline: thin solid'>";
+        } else {
+            echo "<tr>";
+        }
+
+        echo "<td class='rank'>";
+        echo $i + 1;
+        echo "</td>";
+
+        echo "<td>";
+        echo GetUserAndTooltipDiv( $nextUser, TRUE );
+        echo "</td>";
+
+        echo "<td class='user'>";
+        echo GetUserAndTooltipDiv( $nextUser, FALSE );
+        echo "</td>";
+
+        echo "<td>$nextLastAward</td>";
+
+        echo "</tr>";
+    }
+    echo "</tbody></table>";
+    echo "</div>";
+
+    //High Scores Tab
+    echo "<div id='highscores' class='tabcontentscores' style=\"display: " . ($numLatestMasters >= $masteryThreshold ? "none" : "block") . "\">";
     echo "<table><tbody>";
     echo "<tr><th>Pos</th><th colspan='2' style='max-width:30%'>User</th><th>Points</th></tr>";
 
-    for ($i = 0; $i < $numItems; $i++) {
+    for ($i = 0; $i < $numTopAchievers; $i++) {
         if (!isset($gameTopAchievers[$i])) {
             continue;
         }
@@ -265,7 +319,12 @@ function RenderTopAchieversComponent($gameTopAchievers)
         $nextPoints = $gameTopAchievers[$i]['TotalScore'];
         $nextLastAward = $gameTopAchievers[$i]['LastAward'];
 
-        echo "<tr>";
+        //Outline user if they are in the list
+        if ($user !== null && $user == $nextUser) {
+            echo "<tr style='outline: thin solid'>";
+        } else {
+            echo "<tr>";
+        }
 
         echo "<td class='rank'>";
         echo $i + 1;
@@ -286,7 +345,7 @@ function RenderTopAchieversComponent($gameTopAchievers)
         echo "</tr>";
     }
     echo "</tbody></table>";
-
+    echo "</div>";
     echo "</div>";
 }
 

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -248,9 +248,9 @@ function RenderScoreLeaderboardComponent($user, $friendsOnly, $numToFetch = 10)
 /**
  * Creates the High scores tables on game pages
  * 
- * @param String $user The logged in user.
- * @param Array $gameTopAchievers Top 10 highest scoreres for the game.
- * @param Array $gameLatestMasters Top 10 latest masters for the game.
+ * @param string $user The logged in user.
+ * @param array $gameTopAchievers Top 10 highest scoreres for the game.
+ * @param array $gameLatestMasters Top 10 latest masters for the game.
  */
 function RenderTopAchieversComponent($user, $gameTopAchievers, $gameLatestMasters)
 {

--- a/public/API/API_GetGameRankAndScore.php
+++ b/public/API/API_GetGameRankAndScore.php
@@ -12,7 +12,9 @@ if ($gameId <= 0) {
 }
 
 $username = seekGET('z');
+$type = seekGET('t', 0);
+settype($type, 'integer');
 
-$gameTopAchievers = getGameTopAchievers($gameId, 0, 10, $username);
+$gameTopAchievers = getGameTopAchievers($gameId, 0, 10, $username, $type);
 
 echo json_encode($gameTopAchievers);

--- a/public/css/rac_green.css
+++ b/public/css/rac_green.css
@@ -24,3 +24,7 @@ a {
 .tabcontentglobaltab  {
   border: 1px solid rgb(12, 255, 12);
 }
+
+.tabcontentscores  {
+  border: 1px solid rgb(12, 255, 12);
+}

--- a/public/css/rac_red.css
+++ b/public/css/rac_red.css
@@ -29,3 +29,7 @@ a {
 .tabcontentglobaltab  {
   border: 1px solid rgb(255, 12, 0);
 }
+
+.tabcontentscores  {
+  border: 1px solid rgb(255, 12, 0);
+}

--- a/public/css/rac_white.css
+++ b/public/css/rac_white.css
@@ -65,3 +65,7 @@ tr:nth-child(odd) {
 .tabcontentglobaltab  {
   border: 1px solid rgb(66, 66, 66);
 }
+
+.tabcontentscores  {
+  border: 1px solid rgb(66, 66, 66);
+}

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1416,3 +1416,24 @@ svg > g > g:last-child { pointer-events: none }
   padding: 2px 2px 25px;
   border: 1px solid rgb(44, 151, 250);
 }
+
+/* Style the high scores tab content */
+.tabcontenthighscores  {
+  display: none;
+  padding: 2px 2px 25px;
+  border: 1px solid rgb(44, 151, 250);
+}
+
+/* Style the latest masters tab content */
+.tabcontentlatestmasters  {
+  display: none;
+  padding: 2px 2px 2px;
+  border: 1px solid rgb(44, 151, 250);
+}
+
+/* Style the scores tab content */
+.tabcontentscores  {
+  display: none;
+  padding: 2px 2px 2px;
+  border: 1px solid rgb(44, 151, 250);
+}

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -129,8 +129,8 @@ if (isset($achievementData)) {
 }
 
 //Get the top ten players at this game:
-$gameTopAchievers  = getGameTopAchievers($gameID, 0, 10, $user, $totalPossible, 0);
-$gameLatestMasters = getGameTopAchievers($gameID, 0, 10, $user, $totalPossible, 1);
+$gameTopAchievers  = getGameTopAchievers($gameID, 0, 10, $user, 0);
+$gameLatestMasters = getGameTopAchievers($gameID, 0, 10, $user, 1);
 
 RenderHtmlStart(true);
 ?>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -60,9 +60,6 @@ $consoleID = $gameData['ConsoleID'];
 $forumTopicID = $gameData['ForumTopicID'];
 $richPresenceData = $gameData['RichPresencePatch'];
 
-// Get the top ten players at this game:
-$gameTopAchievers = getGameTopAchievers($gameID, 0, 10, $user);
-
 $totalUniquePlayers = getTotalUniquePlayers($gameID, $user);
 if ($numDistinctPlayersCasual < $totalUniquePlayers) {
     $numDistinctPlayersCasual = $totalUniquePlayers;
@@ -130,6 +127,10 @@ if (isset($achievementData)) {
     $authorInfo = array_combine($authorName, $authorCount);
     array_multisort($authorCount, SORT_DESC, $authorInfo);
 }
+
+//Get the top ten players at this game:
+$gameTopAchievers  = getGameTopAchievers($gameID, 0, 10, $user, $totalPossible, 0);
+$gameLatestMasters = getGameTopAchievers($gameID, 0, 10, $user, $totalPossible, 1);
 
 RenderHtmlStart(true);
 ?>
@@ -1021,7 +1022,7 @@ RenderHtmlStart(true);
         echo "<div id='chart_distribution'></div>";
         echo "</div>";
 
-        RenderTopAchieversComponent($gameTopAchievers);
+        RenderTopAchieversComponent($user, $gameTopAchievers, $gameLatestMasters);
         RenderGameLeaderboardsComponent($gameID, $lbData);
         ?>
     </div>


### PR DESCRIPTION
This updates the High Scores section on game pages to turn it into a tabbed section, one tab have the existing high scorers of the set and a new tab showing the latest masters of the set. Most games will show the same 10 users forever unless there is a revision to the set. When that happens some users will try to snipe the top spots so their names will always show up. The new tab would show more recognition to the users who were not one of the first 10 users to master the set. The Latest Masters tab will automatically be selected if 10 or more users have mastered the set, otherwise the High Scores tab will be automatically selected. I've also outlined the logged in user if they are in the list.

Here is how it would look for a game with 10+ masters and a game with less than 10 masters.
![image](https://user-images.githubusercontent.com/16140035/89750745-49226b80-da9b-11ea-9a3d-92aec5992cde.png)

