### PR TITLE
Achievement Distribution Fix

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -713,7 +713,17 @@ function requestModifyGameForumTopic($gameID, $newForumTopic)
     return false;
 }
 
-function getAchievementDistribution($gameID, $hardcore, $requestedBy)
+/**
+ * Gets the achievement distribution to display on the game page.
+ *
+ * @param int $gameID game ID to get achievement distribution for
+ * @param int $hardcore casual (0) or hardcore (1) flag
+ * @param string $requestedBy user requesting the achievement distribution information
+ * @param int $flags core (3) or unofficial (5) achievement flag
+ *
+ * @return array of achievement distribution information to plot on the game page
+ */
+function getAchievementDistribution($gameID, $hardcore, $requestedBy, $flags)
 {
     settype($hardcore, 'integer');
     $retval = [];
@@ -727,7 +737,7 @@ function getAchievementDistribution($gameID, $hardcore, $requestedBy)
             LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
             LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
             LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
-            WHERE gd.ID = $gameID AND aw.HardcoreMode = $hardcore
+            WHERE gd.ID = $gameID AND aw.HardcoreMode = $hardcore AND ach.Flags = " . $flags . "
               AND (NOT ua.Untracked" . (isset($requestedBy) ? " OR ua.User = '$requestedBy'" : "") . ")
             GROUP BY aw.User
             ORDER BY AwardedCount DESC

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -68,7 +68,7 @@ if ($numDistinctPlayersHardcore < $totalUniquePlayers) {
     $numDistinctPlayersHardcore = $totalUniquePlayers;
 }
 
-$achDist = getAchievementDistribution($gameID, 0, $user); //    for now, only retrieve casual!
+$achDist = getAchievementDistribution($gameID, 0, $user, $flags); //    for now, only retrieve casual!
 for ($i = 1; $i <= $numAchievements; $i++) {
     if (!array_key_exists($i, $achDist)) {
         $achDist[$i] = 0;


### PR DESCRIPTION
Currently the achievement distribution chart counts unofficial achievements along with the core achievements. Because of this, sets with unofficial achievements that have been earned by several users will cause the achievement distribution chart to plot incorrect data. This updates fixes this issue and counts only core achievements when viewing the main game page, and only counts only unofficial achievements when viewing the unofficial achievements.

[Tony Hawk's Pro Skater 2 (PlayStation)](https://retroachievements.org/game/11282) is an example of the chart being incorrect because it has one achievement in unofficial that has been earned by 50+ users. Currently there are over 20 masters but the current chart shows only 2 people have 56 achievements.

![image](https://user-images.githubusercontent.com/16140035/90852489-9c22db00-e345-11ea-8187-4fa5fbf518ed.png)
