### PR TITLE
add links to RAPodcast and RANews (and emojis)

### DIFF
--- a/lib/render/content.php
+++ b/lib/render/content.php
@@ -89,7 +89,7 @@ function RenderDocsComponent()
         <!--h3>Documentation</h3-->
         <div id='docsbox' class='infobox'>
           <div>
-            Read the <a href='https://docs.retroachievements.org/' target='_blank' rel='noopener'>Documentation</a> & <a href='https://docs.retroachievements.org/FAQ/' target='_blank' rel='noopener'>FAQ</a>.
+            <a href='https://docs.retroachievements.org/' target='_blank' rel='noopener'>📘 Documentation</a> & <a href='https://docs.retroachievements.org/FAQ/' target='_blank' rel='noopener'>FAQ</a>.
           </div>
         </div>
       </div>";

--- a/public/index.php
+++ b/public/index.php
@@ -216,8 +216,10 @@ RenderToolbar($user, $permissions);
     </div>
     <div id="rightcontainer" style="padding-top: 20px">
         <?php
-        echo '<div class=\'btn-patron text-center\' style="margin-bottom: 10px"><a href=\'https://www.patreon.com/bePatron?u=5403777\' target="_blank" rel="noopener">Become a Patron!</a><!--script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script--></div>';
-        echo '<div class=\'btn-discord text-center\' style="margin-bottom: 10px"><a href=\'https://discord.gg/' . getenv('DISCORD_INVITE_ID') . '\' target="_blank" rel="noopener">Join us on Discord!</a></div>';
+        echo '<div class=\'btn-patron text-center\' style="margin-bottom: 10px"><a href=\'https://www.patreon.com/bePatron?u=5403777\' target="_blank" rel="noopener">️💙 Become a Patron!</a><!--script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script--></div>';
+        echo '<div class=\'btn-discord text-center\' style="margin-bottom: 10px"><a href=\'https://discord.gg/' . getenv('DISCORD_INVITE_ID') . '\' target="_blank" rel="noopener">💬 Join us on Discord!</a></div>';
+        echo '<div class=\'text-center\' style="margin-bottom: 10px"><a href=\'https://www.youtube.com/channel/UCIGdJGxrzmNYMaAGPsk2sIA\' target="_blank" rel="noopener">🎙️ RAPodcast</a></div>';
+        echo '<div class=\'text-center\' style="margin-bottom: 10px"><a href=\'https://news.retroachievements.org/\' target="_blank" rel="noopener">📰 RANews</a></div>';
         RenderDocsComponent();
         RenderAOTWComponent($staticData['Event_AOTW_AchievementID'], $staticData['Event_AOTW_ForumID']);
         //RenderTwitchTVStream();


### PR DESCRIPTION
I know emojis are not consistent between all platforms, but I think in this case it won't hurt.

Here's how it looks on my Linux Mint:

![RALinks](https://user-images.githubusercontent.com/8508804/90967750-2ab86900-e4ba-11ea-81c5-2acc41f892b9.png)
