### PR TITLE
Add TotalRanked to API_GetUserSummary and API_GetUserRankAndScore

### DIFF
--- a/public/API/API_GetUserRankAndScore.php
+++ b/public/API/API_GetUserRankAndScore.php
@@ -10,5 +10,6 @@ $retVal = [];
 
 $retVal['Score'] = getScore($user);
 $retVal['Rank'] = getUserRank($user);
+$retVal['TotalRanked'] = countRankedUsers($user);
 
 echo json_encode($retVal);

--- a/public/API/API_GetUserRankAndScore.php
+++ b/public/API/API_GetUserRankAndScore.php
@@ -10,6 +10,6 @@ $retVal = [];
 
 $retVal['Score'] = getScore($user);
 $retVal['Rank'] = getUserRank($user);
-$retVal['TotalRanked'] = countRankedUsers($user);
+$retVal['TotalRanked'] = countRankedUsers();
 
 echo json_encode($retVal);

--- a/public/API/API_GetUserSummary.php
+++ b/public/API/API_GetUserSummary.php
@@ -27,6 +27,7 @@ $retVal['Points'] = $userDetails['RAPoints'];
 $retVal['Motto'] = $userDetails['Motto'];
 $retVal['UserPic'] = "/UserPic/" . $user . ".png";
 $retVal['Rank'] = getUserRank($user);
+$retVal['TotalRanked'] = countRankedUsers($user);
 
 //	Find out if we're online or offline
 $retVal['LastActivity'] = getActivityMetadata($userDetails['LastActivityID']);

--- a/public/API/API_GetUserSummary.php
+++ b/public/API/API_GetUserSummary.php
@@ -27,7 +27,7 @@ $retVal['Points'] = $userDetails['RAPoints'];
 $retVal['Motto'] = $userDetails['Motto'];
 $retVal['UserPic'] = "/UserPic/" . $user . ".png";
 $retVal['Rank'] = getUserRank($user);
-$retVal['TotalRanked'] = countRankedUsers($user);
+$retVal['TotalRanked'] = countRankedUsers();
 
 //	Find out if we're online or offline
 $retVal['LastActivity'] = getActivityMetadata($userDetails['LastActivityID']);


### PR DESCRIPTION
In the current APIs API_GetUserSummary and API_GetUserRankAndScore, user "Rank" is available, but the total ranked users information is never available, so it's impossible to count the users rank given the total ranked user and calculate the "top percent" value, as it exists in the /public/userInfo.php page that displays -> " 43018 / 83792 ranked users (Top 52%) ".