### PR TITLE
fix rendering links to games and achievements

### DIFF
--- a/lib/render/achievement.php
+++ b/lib/render/achievement.php
@@ -72,7 +72,7 @@ function GetAchievementAndTooltipDiv(
     }
 
     return "<div class='bb_inline' onmouseover=\"Tip('$tooltip')\" onmouseout=\"UnTip()\" >" .
-        "<a href='/Achievement/$achID'>" .
+        "<a href='/achievement/$achID'>" .
         "$smallBadge" .
         "$displayable" .
         "</a>" .

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -66,7 +66,7 @@ function GetGameAndTooltipDiv(
     }
 
     return "<div class='bb_inline' onmouseover=\"Tip('$tooltip')\" onmouseout=\"UnTip()\" >" .
-        "<a href='/Game/$gameID'>" .
+        "<a href='/game/$gameID'>" .
         "$displayable" .
         "</a>" .
         "</div>";


### PR DESCRIPTION
It's a fix for functions creating URLs for games and achievements. URLs starting with uppercase lead to 302 redirection, which does uneccessary hassle for browser and server.