### PR TITLE
Admin Tool - Get Winners of Achievements

### DIFF
--- a/public/admin.php
+++ b/public/admin.php
@@ -290,6 +290,44 @@ switch ($action) {
             $message = implode(', ', $ids["AchievementIDs"] ?? []);
         }
         break;
+    case 'getWinnersOfAchievements':
+        $achievementIDs = requestInputSanitized('a', 0, 'string');
+        $startTime = requestInputSanitized('s', null, 'string');
+        $endTime = requestInputSanitized('e', null, 'string');
+        $hardcoreMode = requestInputSanitized('h', 0, 'integer');
+        $dateString = "";
+        if (isset($achievementIDs)) {
+            if (strtotime($startTime)) {
+                if (strtotime($endTime)) {
+                    //valid start and end
+                    $dateString = " between $startTime and $endTime";
+                } else {
+                    //valid start, invalid end
+                    $dateString = " since $startTime";
+                }
+            } else {
+                if (strtotime($endTime)) {
+                    //invalid start, valid end
+                    $dateString = " before $endTime";
+                } else {
+                    //invalid start and end
+                    //no date string needed
+                }
+            }
+
+            $ids = str_replace(',', ' ', $achievementIDs);
+            $ids = str_replace('  ', ' ', $ids);
+            $ids = explode(' ', $ids);
+            $winners = getWinnersOfAchievements($ids, $startTime, $endTime, $hardcoreMode);
+
+            $keys = array_keys($winners);
+            for($i = 0; $i < count($winners); $i++) {
+                $message .= "<strong>Winners of " . $keys[$i] . " in " . ($hardcoreMode ? "Hardcore mode" : "Softcore mode") . "$dateString:</strong><br>";
+                $message .= implode(', ', $winners[$keys[$i]]) . "<br><br>";
+            }
+        }
+
+        break;
     case 'giveaward':
         $awardAchievementID = requestInputSanitized('a', null);
         $awardAchievementUser = requestInputSanitized('u');
@@ -465,6 +503,73 @@ RenderHtmlHead('Admin Tools');
                 <input type='hidden' name='action' value='getachids'>
                 <input type='submit' value='Submit'>
             </form>
+        </div>
+
+        <div id='fullcontainer'>
+            <?php
+            $winnersStartTime = $staticData['winnersStartTime'] ?? null;
+            $winnersEndTime = $staticData['winnersEndTime'] ?? null;
+            ?>
+            <h4>Get Winners of Achievements</h4>
+            <form method='post' action='admin.php'>
+                <table class="mb-1">
+                    <colgroup>
+                        <col>
+                        <col>
+                        <col>
+                        <col class="fullwidth">
+                    </colgroup>
+                    <tbody>
+                    <tr>
+                        <td class="text-nowrap">
+                            <label for='winnersAchievementIDs'>Achievement IDs</label>
+                        </td>
+                        <td>
+                            <input id='winnersAchievementIDs' name='a'>
+                        </td>
+                        <td></td>
+                        <td></td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap">
+                            <label for='startTime'>Start At (UTC time)</label>
+                        </td>
+                        <td>
+                            <input id='startTime' name='s' value='<?= $winnersStartTime ?>'>
+                        </td>
+                        <td class="text-nowrap">
+                            <label for='endTime'>End At (UTC time)</label>
+                        </td>
+                        <td>
+                            <input id='endTime' name='e' value='<?= $winnersEndTime ?>'>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="text-nowrap">
+                            <label for='hardcoreWinners'>Hardcore winners?</label>
+                        </td>
+                        <td>
+                            <input id='hardcoreWinners' type='checkbox' name='h' value='1'>
+                        </td>
+                        <td></td>
+                        <td></td>
+                    </tr>
+                    </tbody>
+                </table>
+                <input type='hidden' name='action' value='getWinnersOfAchievements'>
+                <input type='submit' value='Submit'>
+            </form>
+
+            <script>
+            jQuery('#startTime').datetimepicker({
+                format: 'Y-m-d H:i:s',
+                mask: true, // '9999/19/39 29:59' - digit is the maximum possible for a cell
+            });
+            jQuery('#endTime').datetimepicker({
+                format: 'Y-m-d H:i:s',
+                mask: true, // '9999/19/39 29:59' - digit is the maximum possible for a cell
+            });
+            </script>
         </div>
 
         <div id='fullcontainer'>


### PR DESCRIPTION
Allows admins to get a list of winners for a input list of achievement IDs. ID's can be entered in comma and/or space delimited format. Optional start and end times can be entered, if left blank then the return list will be all time winners. Hardcore checkbox will return either all hardcore or all softcore winners. Untracked users will not be returned in the list.

Sample input/output (extends way beyond the screenshot) without a defined timerange:
![image](https://user-images.githubusercontent.com/16140035/112924930-ff949880-90de-11eb-920b-444b4e557305.png)
![image](https://user-images.githubusercontent.com/16140035/112924967-0d4a1e00-90df-11eb-8af8-dd8dc8cab001.png)

Sample input/output with a defined timerange:
![image](https://user-images.githubusercontent.com/16140035/112924523-4a61e080-90de-11eb-910c-7bc2af9ff506.png)
![image](https://user-images.githubusercontent.com/16140035/112924666-8dbc4f00-90de-11eb-8fc7-e7888c1bb3ac.png)



