### PR TITLE
Most Requested Sets Fixes

### DIFF
--- a/lib/render/layout.php
+++ b/lib/render/layout.php
@@ -239,7 +239,7 @@ function RenderToolbar($user, $permissions = 0)
     echo "<ul>";
     echo "<li><a href='/gameList.php'>All Games</a></li>";
     // echo "<li><a href='/popularGames.php'>Most Played</a></li>";
-    // echo "<li><a href='/setRequestList.php'>Most Requested</a></li>";
+    echo "<li><a href='/setRequestList.php'>Most Requested</a></li>";
     echo "</ul>";
     echo "</li>";
 

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -65,11 +65,11 @@ RenderToolbar($user, $permissions);
                     if ($selectedConsole == $console['ID']) {
                         echo "<option selected>" . $totalRequestedGames . " - " . $console['Name'] . "</option>";
                     } else {
-                        echo "<option value='?s=" . $console['ID'] . "'>" . getGamesWithRequests($console['ID']) . " - " . $console['Name'] . "</option>";
+                        echo "<option value='?s=" . $console['ID'] . "'>" . $console['Name'] . "</option>";
                         echo "<a href=\"/setRequestList.php\">" . $console['Name'] . "</a><br>";
                     }
                 } else {
-                    echo "<option value='?s=" . $console['ID'] . "'>" . getGamesWithRequests($console['ID']) . " - " . $console['Name'] . "</option>";
+                    echo "<option value='?s=" . $console['ID'] . "'>" . $console['Name'] . "</option>";
                     echo "<a href=\"/setRequestList.php\">" . $console['Name'] . "</a><br>";
                 }
             }
@@ -83,7 +83,7 @@ RenderToolbar($user, $permissions);
             echo "<th>Game</th>";
             echo "<th>Requests</th>";
 
-            // Loop through each hash and display its information
+            // Loop through each set request and display its information
             foreach ($setRequestList as $request) {
                 echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
 

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -61,6 +61,7 @@ RenderToolbar($user, $permissions);
             echo "<td><select class='gameselector' onchange='window.location = \"/setRequestList.php\" + this.options[this.selectedIndex].value'><option value=''>-- All Systems --</option>";
 
             foreach ($consoles as $console) {
+                sanitize_outputs($console['Name']);
                 if ($selectedConsole != null) {
                     if ($selectedConsole == $console['ID']) {
                         echo "<option selected>" . $totalRequestedGames . " - " . $console['Name'] . "</option>";


### PR DESCRIPTION
Removed the game count from each individual console in the console filter dropdown on the Most Requested Sets page. Added the page link back to the "Games" toolbar.

I'm fairly certain that this is causing the extreme load times on this page. I can't do a fully accurate test as my local DB only has ~3K set requests, but the page loads up instantly verses taking ~5 seconds after making this change. Worth checking to see if the new page load speed is acceptable with a production sized DB as many users have asked where this page link went.

