### PR TITLE
Fix untracked users showing rank in user tooltip

### DIFF
--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1702,6 +1702,7 @@ function getUserCardData($user, &$userCardInfo)
     $userCardInfo['Permissions'] = $userInfo['Permissions'];
     $userCardInfo['Motto'] = htmlspecialchars($userInfo['Motto']);
     $userCardInfo['Rank'] = getUserRank($user);
+    $userCardInfo['Untracked'] = $userInfo['Untracked'];
     $userCardInfo['LastActivity'] = $userInfo['LastLogin'];
     $userCardInfo['MemberSince'] = $userInfo['Created'];
 }

--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -30,6 +30,7 @@ function GetUserAndTooltipDiv(
     $userTruePoints = $userCardInfo['TotalTruePoints'];
     $userAccountType = PermissionsToString($userCardInfo['Permissions']);
     $userRank = $userCardInfo['Rank'];
+    $userUntracked = $userCardInfo['Untracked'];
     $lastLogin = $userCardInfo['LastActivity'] ? getNiceDate(strtotime($userCardInfo['LastActivity'])) : null;
     $memberSince = $userCardInfo['MemberSince'] ? getNiceDate(strtotime($userCardInfo['MemberSince']), true) : null;
 
@@ -70,9 +71,15 @@ function GetUserAndTooltipDiv(
     }
 
     //Add the other user informaiton
-    $tooltip .= "<tr>";
-    $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> $userRank</td>";
-    $tooltip .= "</tr>";
+    if ($userUntracked) {
+        $tooltip .= "<tr>";
+        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Untracked</td>";
+        $tooltip .= "</tr>";
+    } else {
+        $tooltip .= "<tr>";
+        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> $userRank</td>";
+        $tooltip .= "</tr>";
+    }
     if ($lastLogin) {
         $tooltip .= "<tr>";
         $tooltip .= "<td class=\'usercardbasictext\'><b>Last Activity:</b> $lastLogin</td>";


### PR DESCRIPTION
Takes care of #555 by changing Untracked user info card ranking to "Untracked" as seen below
![image](https://user-images.githubusercontent.com/4047771/117383758-804d6e00-aeaf-11eb-8c22-9b8f521e0c3a.png)
