### PR TITLE
Remove Events and Hubs from Average Completion calculation

### DIFF
--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -86,8 +86,10 @@ $userCompletedGamesList = $userCompletedGames;
 
 foreach ($userCompletedGamesList as $nextGame) {
     if ($nextGame['PctWon'] > 0) {
-        $totalPctWon += $nextGame['PctWon'];
-        $numGamesFound++;
+        if (!in_array($nextGame['ConsoleName'], $excludeConsole)) { 
+            $totalPctWon += $nextGame['PctWon'];
+            $numGamesFound++;
+        }
     }
 }
 

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -84,6 +84,8 @@ usort($userCompletedGames, "scorePctCompare");
 
 $userCompletedGamesList = $userCompletedGames;
 
+$excludeConsole = array("Hubs", "Events");
+
 foreach ($userCompletedGamesList as $nextGame) {
     if ($nextGame['PctWon'] > 0) {
         if (!in_array($nextGame['ConsoleName'], $excludeConsole)) { 


### PR DESCRIPTION
Resolves #564 by removing Hubs and Events from the calculation. Future excluded "consoles" can be added to the $excludeConsole.