### PR TITLE
Mem Explained Updates for RAIntegration 0.79

### DIFF
--- a/lib/util/trigger.php
+++ b/lib/util/trigger.php
@@ -5,7 +5,7 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
     $tableHeader = '
     <tr>
       <th>ID</th>
-      <th>Special?</th>
+      <th>Flag</th>
       <th>Type</th>
       <th>Size</th>
       <th>Memory</th>
@@ -27,6 +27,9 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
         'M' => 'Measured',
         'Q' => 'Measured If',
         'I' => 'Add Address',
+        'Z' => 'Reset Next If',
+        'D' => 'Sub Hits',
+        'T' => 'Trigger',
         '' => '',
     ];
 
@@ -55,17 +58,18 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
         'p' => 'Prior',
         'm' => 'Mem',
         'v' => 'Value',
+        'b' => 'BCD',
         '' => '',
     ];
 
     // kudos to user "stt" for showing that it's possible to parse MemAddr with regex
-    $operandRegex = '(d|p)?(' . implode('|', array_keys($memSize)) . ')?([0-9a-f]*)';
+    $operandRegex = '(d|p|b)?(' . implode('|', array_keys($memSize)) . ')?([0-9a-f]*)';
     $memRegex = '/(?:([' . implode(
         '',
         array_keys($specialFlags)
-    ) . ']):)?' . $operandRegex . '(<=|>=|<|>|=|!=)' . $operandRegex . '(?:[(.](\\d+)[).])?/';
+    ) . ']):)?' . $operandRegex . '(<=|>=|<|>|=|!=|)' . $operandRegex . '(?:[(.](\\d+)[).])?/';
     // memRegex is this monster:
-    // (?:([RPABC]):)?(d)?(0xM|0xN|0xO|0xP|0xQ|0xR|0xS|0xT|0xL|0xU|0xH|0xX|0x |0x|)?([0-9a-f]*)(<=|>=|<|>|=|!=)(d)?(0xM|0xN|0xO|0xP|0xQ|0xR|0xS|0xT|0xL|0xU|0xH|0xX|0x |0x|)?([0-9a-f]*)(?:[(.](\d+)[).])?
+    // (?:([RPABCNOMQIZDT]):)?(d|p|b)?(0xM|0xN|0xO|0xP|0xQ|0xR|0xS|0xT|0xL|0xU|0xH|0xW|0xK|0xX|0x |0x|)?([0-9a-f]*)(<=|>=|<|>|=|!=|)(d|p|b)?(0xM|0xN|0xO|0xP|0xQ|0xR|0xS|0xT|0xL|0xU|0xH|0xW|0xK|0xX|0x |0x|)?([0-9a-f]*)(?:[(.](\d+)[).])?/
     // I was about to add comments explaining this long RegEx, but realized that the best way
     // is to copy the regex string and paste it in the proper field at https://regex101.com/
 
@@ -97,10 +101,10 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
             $lMemory = '0x' . str_pad(($lSize ? $lMemory : dechex($lMemory)), 6, '0', STR_PAD_LEFT);
             $rMemVal = '0x' . str_pad(($rSize ? $rMemVal : dechex($rMemVal)), 6, '0', STR_PAD_LEFT);
             $hits = $hits ? $hits : "0";
-            if ($lType !== "d" && $lType !== "p") {
+            if ($lType !== "d" && $lType !== "p" && $lType !== "b") {
                 $lType = $lSize === '' ? 'v' : 'm';
             }
-            if ($rType !== "d" && $rType !== "p") {
+            if ($rType !== "d" && $rType !== "p" && $rType !== "b") {
                 $rType = $rSize === '' ? 'v' : 'm';
             }
 

--- a/lib/util/trigger.php
+++ b/lib/util/trigger.php
@@ -67,9 +67,9 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
     $memRegex = '/(?:([' . implode(
         '',
         array_keys($specialFlags)
-    ) . ']):)?' . $operandRegex . '(<=|>=|<|>|=|!=|)' . $operandRegex . '(?:[(.](\\d+)[).])?/';
+    ) . ']):)?' . $operandRegex . '(<=|>=|<|>|=|!=|\*|\/|&|)' . $operandRegex . '(?:[(.](\\d+)[).])?/';
     // memRegex is this monster:
-    // (?:([RPABCNOMQIZDT]):)?(d|p|b)?(0xM|0xN|0xO|0xP|0xQ|0xR|0xS|0xT|0xL|0xU|0xH|0xW|0xK|0xX|0x |0x|)?([0-9a-f]*)(<=|>=|<|>|=|!=|)(d|p|b)?(0xM|0xN|0xO|0xP|0xQ|0xR|0xS|0xT|0xL|0xU|0xH|0xW|0xK|0xX|0x |0x|)?([0-9a-f]*)(?:[(.](\d+)[).])?/
+    // (?:([RPABCNOMQIZDT]):)?(d|p|b)?(0xM|0xN|0xO|0xP|0xQ|0xR|0xS|0xT|0xL|0xU|0xH|0xW|0xK|0xX|0x |0x|)?([0-9a-f]*)(<=|>=|<|>|=|!=|\*|\/|&|)(d|p|b)?(0xM|0xN|0xO|0xP|0xQ|0xR|0xS|0xT|0xL|0xU|0xH|0xW|0xK|0xX|0x |0x|)?([0-9a-f]*)(?:[(.](\d+)[).])?/
     // I was about to add comments explaining this long RegEx, but realized that the best way
     // is to copy the regex string and paste it in the proper field at https://regex101.com/
 
@@ -130,7 +130,7 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
             $res .= "\n  <td> " . $memTypes[$lType] . " </td>";
             $res .= "\n  <td> " . $memSize[$lSize] . " </td>";
             $res .= "\n  <td" . $lTooltip . "> " . $lMemory . " </td>";
-            if ($flag == 'A' || $flag == 'B' || $flag == 'I') {
+            if (($flag == 'A' || $flag == 'B' || $flag == 'I') && ($cmp != '*' && $cmp != '/' && $cmp != '&')) {
                 $res .= "\n  <td colspan=5 style='text-align: center'> </td>";
             } else {
                 $res .= "\n  <td> " . htmlspecialchars($cmp) . " </td>";


### PR DESCRIPTION
- Fixed Add Source, Sub Source, and Add Address flags displaying all 0's due to `=0` being removed from the logic string.
- Added in Reset Next If, Sub Hits, Trigger, and the BCD size type
- Renamed `Special?` to `Flag` to match the achievement editor.

`A:0xH00b3a3_46134=b0xX000234_D:d0xH00b406=0_B:p0xH00b4b5_Q:b0xH00b546=0_O:0xH00b57a=d0xH000000_T:46289=0_Z:b0xH00b4f9=p0xH000000_I:0xH00b578_d0xH00b4cb=b0xH004321`
![image](https://user-images.githubusercontent.com/16140035/118597329-8e866e80-b77a-11eb-8a96-8357ccfa14f5.png)

