### PR TITLE
Friends Ranking URL Fix

### DIFF
--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -218,7 +218,7 @@ function RenderScoreLeaderboardComponent($user, $friendsOnly, $numToFetch = 10)
                     echo GetUserAndTooltipDiv($userData[0]['User'], false);
                     echo "</td>";
                     if ($j == 0) {
-                        echo "<td><a href='historyexamine.php?d=$dateUnix&u=" . $userData[0]['User'] . "'>" . $userData[0]['Points'] . "</a>";
+                        echo "<td><a href='/historyexamine.php?d=$dateUnix&u=" . $userData[0]['User'] . "'>" . $userData[0]['Points'] . "</a>";
                     } else {
                         echo "<td>" . $userData[0]['Points'];
                     }


### PR DESCRIPTION
Fixed bad URL in the Friends Ranking section when clicking on your daily point count.

![image](https://user-images.githubusercontent.com/16140035/119053607-4e9ad380-b994-11eb-8b65-14b4463ad278.png)
