### PR TITLE
Cut auto recalc time roughly in half by excluding users with 0 points

### DIFF
--- a/cronjobs/cron_1m.php
+++ b/cronjobs/cron_1m.php
@@ -20,7 +20,7 @@ function GetNextHighestGameID($givenID)
 function GetNextHighestUserID($givenID)
 {
     $query = "SELECT MIN(ID) AS NextID FROM UserAccounts
-				  WHERE ID > $givenID";
+				  WHERE ID > $givenID AND RAPoints > 0";
 
     $dbResult = s_mysql_query($query);
 


### PR DESCRIPTION
If I'm understanding this correctly it looks like a cron job runs every minute and does the Recalculate Score on 3 users each run.

https://github.com/RetroAchievements/RAWeb/blob/111a426503f62e8dc5f78ccbe1b182cd7432906d/cronjobs/cron_1m.php#L44-L50

The selection of users could easily check for only users that have points to speed up the process
https://github.com/RetroAchievements/RAWeb/blob/111a426503f62e8dc5f78ccbe1b182cd7432906d/cronjobs/cron_1m.php#L20-L23

Going by current total users on the site: 158811
It checks 3 (per run) * 1 run per minute * 60 runs per hour * 24 hours in a day = 4320 users per day.
So it currently should take around 37 days to fully go through all users but based on data from an older dump it seems like roughly 40% of the users on the site have 0 points so that would drop the time down to around 22 days from 37.

Further optimizations could likely be made such exclude untracked or banned users but the number of those is fairly low. Possibly something like only recalculating for users that have logged in to the site in the past month would also likely cut down a large amount but upon returning after a large break their score would have potential for a big fluctuation.