### PR TITLE
Leaderboard ranking ties

### DIFF
--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -136,6 +136,7 @@ RenderHtmlStart(true);
             $localUserFound = false;
             $resultsDrawn = 0;
             $prevScore = 0;
+            $nextRank = 0;
 
             $count = 0;
             //for( $i = 0; $i < $numEntries; $i++ )

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -144,7 +144,6 @@ RenderHtmlStart(true);
                 //$nextEntry = $lbData[$i];
                 //var_dump( $nextEntry );
 
-                $nextRank = $nextEntry['Rank'];
                 $nextUser = $nextEntry['User'];
                 $nextScore = $nextEntry['Score'];
                 if ($prevScore != $nextScore){

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -135,6 +135,7 @@ RenderHtmlStart(true);
             $numActualEntries = 0;
             $localUserFound = false;
             $resultsDrawn = 0;
+            $prevScore = 0;
 
             $count = 0;
             //for( $i = 0; $i < $numEntries; $i++ )
@@ -146,6 +147,10 @@ RenderHtmlStart(true);
                 $nextRank = $nextEntry['Rank'];
                 $nextUser = $nextEntry['User'];
                 $nextScore = $nextEntry['Score'];
+                if ($prevScore != $nextScore){
+                    $nextRank = $nextEntry['Rank'];
+                }
+                $prevScore = $nextScore;
                 $nextScoreFormatted = GetFormattedLeaderboardEntry($lbFormat, $nextScore);
                 $nextSubmitAt = $nextEntry['DateSubmitted'];
                 $nextSubmitAtNice = getNiceDate($nextSubmitAt);

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -146,7 +146,7 @@ RenderHtmlStart(true);
 
                 $nextUser = $nextEntry['User'];
                 $nextScore = $nextEntry['Score'];
-                if ($prevScore != $nextScore){
+                if ($prevScore != $nextScore) {
                     $nextRank = $nextEntry['Rank'];
                 }
                 $prevScore = $nextScore;


### PR DESCRIPTION
Allow users to share the same rank when having a tied score/value for a leaderboard. The first user to obtain the best score/value will continue to be the one that is shown as the leader of the leaderboard but this will allow for multiple No.1 rankings.
![image](https://user-images.githubusercontent.com/4047771/119278797-8f455780-bbf5-11eb-8521-8d2bfce03aa4.png)
