### PR TITLE
Similar Games Duplicate ID Fix

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -689,7 +689,7 @@ function requestModifyGameAlt($gameID, $toAdd = null, $toRemove = null)
 
         $values = implode(", ", $valuesArray);
         if (!empty($values)) {
-            $query = "INSERT INTO GameAlternatives (gameID, gameIDAlt) VALUES $values";
+            $query = "INSERT INTO GameAlternatives (gameID, gameIDAlt) VALUES $values ON DUPLICATE KEY UPDATE Updated = CURRENT_TIMESTAMP";
             if (s_mysql_query($query)) {
                 // error_log("Added game alt(s): $values");
             } else {


### PR DESCRIPTION
Fixes issue where similar games would not be added to the database if one of the IDs entered in the field is already linked. The `Updated` time for existing entries in the database will be updated to the current time.