### PR TITLE
Adjust ranking requirement to 500 points

### DIFF
--- a/cronjobs/cron_1m.php
+++ b/cronjobs/cron_1m.php
@@ -20,7 +20,7 @@ function GetNextHighestGameID($givenID)
 function GetNextHighestUserID($givenID)
 {
     $query = "SELECT MIN(ID) AS NextID FROM UserAccounts
-				  WHERE ID > $givenID";
+				  WHERE ID > $givenID AND RAPoints > 0";
 
     $dbResult = s_mysql_query($query);
 

--- a/lib/bootstrap.php
+++ b/lib/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 define('VERSION', '1.71.0');
+define('MIN_POINTS', 500);
 
 if (!file_exists(__DIR__ . '/../.env')) {
     // .env file does not exist - do not attempt to load it nor try connecting to a database

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -806,7 +806,7 @@ function countRankedUsers()
     $query = "
         SELECT COUNT(*) AS count
         FROM UserAccounts
-        WHERE RAPoints > 0
+        WHERE RAPoints >= 500
           AND NOT Untracked
     ";
 

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -806,7 +806,7 @@ function countRankedUsers()
     $query = "
         SELECT COUNT(*) AS count
         FROM UserAccounts
-        WHERE RAPoints >= ". MIN_POINTS ."
+        WHERE RAPoints >= " . MIN_POINTS . "
           AND NOT Untracked
     ";
 

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -806,7 +806,7 @@ function countRankedUsers()
     $query = "
         SELECT COUNT(*) AS count
         FROM UserAccounts
-        WHERE RAPoints >= 500
+        WHERE RAPoints >= ". MIN_POINTS ."
           AND NOT Untracked
     ";
 

--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -75,6 +75,10 @@ function GetUserAndTooltipDiv(
         $tooltip .= "<tr>";
         $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Untracked</td>";
         $tooltip .= "</tr>";
+    } elseif ($userPoints < 500) {
+        $tooltip .= "<tr>";
+        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Needs at least 500 points </td>";
+        $tooltip .= "</tr>";
     } else {
         $tooltip .= "<tr>";
         $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> $userRank</td>";

--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -77,7 +77,7 @@ function GetUserAndTooltipDiv(
         $tooltip .= "</tr>";
     } elseif ($userPoints < MIN_POINTS) {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Needs at least ". MIN_POINTS ." points </td>";
+        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Needs at least " . MIN_POINTS . " points </td>";
         $tooltip .= "</tr>";
     } else {
         $tooltip .= "<tr>";

--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -75,9 +75,9 @@ function GetUserAndTooltipDiv(
         $tooltip .= "<tr>";
         $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Untracked</td>";
         $tooltip .= "</tr>";
-    } elseif ($userPoints < 500) {
+    } elseif ($userPoints < MIN_POINTS) {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Needs at least 500 points </td>";
+        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Needs at least ". MIN_POINTS ." points </td>";
         $tooltip .= "</tr>";
     } else {
         $tooltip .= "<tr>";

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -272,8 +272,8 @@ RenderHtmlStart(true);
         echo "Site Rank: ";
         if ($userIsUntracked) {
             echo "<b>Untracked</b>";
-        } elseif ($totalPoints < 500) {
-            echo "<i>Needs at least 500 points.</i>";
+        } elseif ($totalPoints < MIN_POINTS) {
+            echo "<i>Needs at least ". MIN_POINTS ." points.</i>";
         } else {
             $countRankedUsers = countRankedUsers();
             $rankPct = sprintf("%1.0f", (($userRank / $countRankedUsers) * 100.0) + 1.0);

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -273,7 +273,7 @@ RenderHtmlStart(true);
         if ($userIsUntracked) {
             echo "<b>Untracked</b>";
         } elseif ($totalPoints < MIN_POINTS) {
-            echo "<i>Needs at least ". MIN_POINTS ." points.</i>";
+            echo "<i>Needs at least " . MIN_POINTS . " points.</i>";
         } else {
             $countRankedUsers = countRankedUsers();
             $rankPct = sprintf("%1.0f", (($userRank / $countRankedUsers) * 100.0) + 1.0);

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -272,8 +272,8 @@ RenderHtmlStart(true);
         echo "Site Rank: ";
         if ($userIsUntracked) {
             echo "<b>Untracked</b>";
-        } elseif ($userTruePoints <= 0) {
-            echo "<i>This user has not earned any points.</i>";
+        } elseif ($totalPoints < 500) {
+            echo "<i>Needs at least 500 points.</i>";
         } else {
             $countRankedUsers = countRankedUsers();
             $rankPct = sprintf("%1.0f", (($userRank / $countRankedUsers) * 100.0) + 1.0);


### PR DESCRIPTION
Adjusts the Site Ranked users to exclude users with less than 500 points. This will make the Top X% more accurate as a large number of users have less than 500 points (~ 70%). Users with less than 500 points will instead see a message saying they need at least 500 points in order to be ranked (image below has initial proposed 100 point threshold but shows the idea). 
![image](https://user-images.githubusercontent.com/4047771/119421719-5d072900-bccd-11eb-8122-7f6a6ffe3aad.png)