### PR TITLE
Leaderboard ranking tie

### DIFF
--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -136,6 +136,7 @@ RenderHtmlStart(true);
             $localUserFound = false;
             $resultsDrawn = 0;
             $prevScore = 0;
+            $nextRank = 0;
 
             $count = 0;
             //for( $i = 0; $i < $numEntries; $i++ )

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -144,7 +144,6 @@ RenderHtmlStart(true);
                 //$nextEntry = $lbData[$i];
                 //var_dump( $nextEntry );
 
-                $nextRank = $nextEntry['Rank'];
                 $nextUser = $nextEntry['User'];
                 $nextScore = $nextEntry['Score'];
                 if ($prevScore != $nextScore){

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -135,6 +135,7 @@ RenderHtmlStart(true);
             $numActualEntries = 0;
             $localUserFound = false;
             $resultsDrawn = 0;
+            $prevScore = 0;
 
             $count = 0;
             //for( $i = 0; $i < $numEntries; $i++ )
@@ -146,6 +147,10 @@ RenderHtmlStart(true);
                 $nextRank = $nextEntry['Rank'];
                 $nextUser = $nextEntry['User'];
                 $nextScore = $nextEntry['Score'];
+                if ($prevScore != $nextScore){
+                    $nextRank = $nextEntry['Rank'];
+                }
+                $prevScore = $nextScore;
                 $nextScoreFormatted = GetFormattedLeaderboardEntry($lbFormat, $nextScore);
                 $nextSubmitAt = $nextEntry['DateSubmitted'];
                 $nextSubmitAtNice = getNiceDate($nextSubmitAt);

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -146,7 +146,7 @@ RenderHtmlStart(true);
 
                 $nextUser = $nextEntry['User'];
                 $nextScore = $nextEntry['Score'];
-                if ($prevScore != $nextScore){
+                if ($prevScore != $nextScore) {
                     $nextRank = $nextEntry['Rank'];
                 }
                 $prevScore = $nextScore;

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -136,7 +136,7 @@ RenderHtmlStart(true);
             $localUserFound = false;
             $resultsDrawn = 0;
             $prevScore = 0;
-            $nextRank = 0;
+            $nextRank = 1;
 
             $count = 0;
             //for( $i = 0; $i < $numEntries; $i++ )


### PR DESCRIPTION
Missed a case where best score is 0 would set first place rank to 0, updated nextRank to initialize at 1 instead to fix.