### PR TITLE
Duplicate Leaderboard Cap

### DIFF
--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -158,7 +158,7 @@ RenderHtmlHead($pageTitle);
             echo "Duplicate leaderboard ID: ";
             echo "<input style='width: 10%;' type='number' min=1 value=1 name='l' /> ";
             echo "Number of times: ";
-            echo "<input style='width: 10%;' type='number' min=1 value=1 name='n' />";
+            echo "<input style='width: 10%;' type='number' min=1 max=25 value=1 name='n' />";
             echo "&nbsp;&nbsp;";
             echo "<input type='submit' value='Duplicate'/>";
             echo "</form>";


### PR DESCRIPTION
Cap the amount of leaderboards a user can duplicate in a single attempt at 25. Prevents cases where 100s or 1000s of duplcate leaderboards might get created by accident.

![image](https://user-images.githubusercontent.com/16140035/119932274-f1cd8900-bf50-11eb-84c0-3a7066419204.png)

