### PR TITLE
Leaderboard navigation

### DIFF
--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -438,7 +438,6 @@ function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly)
             $entries = [];
 
             while ($db_entry = mysqli_fetch_assoc($dbResult)) {
-                //$db_entry['Rank'] = $numResultsFound + $offset + 1;
                 $db_entry['DateSubmitted'] = strtotime($db_entry['DateSubmitted']);
                 settype($db_entry['Score'], 'integer');
 

--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -417,7 +417,10 @@ function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly)
         $retVal['Entries'] = [];
 
         //    Now get entries:
-        $query = "SELECT ua.User, le.Score, le.DateSubmitted
+        $query = "SELECT ua.User, le.Score, le.DateSubmitted, 
+                  CASE WHEN !lbd.LowerIsBetter 
+                  THEN RANK() OVER(ORDER BY le.score DESC)
+                  ELSE RANK() OVER(ORDER BY le.score ASC) END AS Rank
                   FROM LeaderboardEntry AS le
                   LEFT JOIN UserAccounts AS ua ON ua.ID = le.UserID
                   LEFT JOIN LeaderboardDef AS lbd ON lbd.ID = le.LeaderboardID
@@ -435,7 +438,7 @@ function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly)
             $entries = [];
 
             while ($db_entry = mysqli_fetch_assoc($dbResult)) {
-                $db_entry['Rank'] = $numResultsFound + $offset + 1;
+                //$db_entry['Rank'] = $numResultsFound + $offset + 1;
                 $db_entry['DateSubmitted'] = strtotime($db_entry['DateSubmitted']);
                 settype($db_entry['Score'], 'integer');
 
@@ -453,10 +456,17 @@ function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly)
 
             if ($userFound == false) {
                 //    Go find user's score in this table, if it exists!
-                $query = "SELECT ua.User, le.Score, le.DateSubmitted
+                $query = "SELECT User, Score, DateSubmitted, Rank FROM
+                         (SELECT ua.User, le.Score, le.DateSubmitted, 
+                          CASE WHEN !lbd.LowerIsBetter 
+                          THEN RANK() OVER(ORDER BY le.score DESC)
+                          ELSE RANK() OVER(ORDER BY le.score ASC) END AS Rank
                           FROM LeaderboardEntry AS le
                           LEFT JOIN UserAccounts AS ua ON ua.ID = le.UserID
-                          WHERE le.LeaderboardID = $lbID AND ua.User='$user' ";
+                          LEFT JOIN LeaderboardDef AS lbd ON lbd.ID = le.LeaderboardID
+                          WHERE !ua.Untracked AND le.LeaderboardID = $lbID) InnerTable
+                          WHERE InnerTable.User = '$user'";
+
                 $dbResult = s_mysql_query($query);
                 if ($dbResult !== false) {
                     if (mysqli_num_rows($dbResult) > 0) {
@@ -464,12 +474,6 @@ function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly)
                         $db_entry = mysqli_fetch_assoc($dbResult);
                         $db_entry['DateSubmitted'] = strtotime($db_entry['DateSubmitted']);
                         settype($db_entry['Score'], 'integer');
-
-                        //    Also fetch our user rank!
-                        getLeaderboardRanking($user, $lbID, $userRank, $totalEntries);
-                        $db_entry['Rank'] = $userRank;
-
-                        //$retVal['Entries'][ $db_entry['Rank'] ] = $db_entry;
                         $entries[] = $db_entry;
                     }
                 } else {

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -154,7 +154,7 @@ RenderHtmlStart(true);
 
                 $isLocal = (strcmp($nextUser, $user) == 0);
                 $lastEntry = ($resultsDrawn + 1 == $numEntries);
-                $userAppendedInResults = ($numEntries !== $count);
+                $userAppendedInResults = ($numEntries > $count);
 
                 //echo "$isLocal, $lastEntry, $userAppendedInResults ($numEntries, $count)<br>";
 
@@ -167,9 +167,10 @@ RenderHtmlStart(true);
 
                 if ($isLocal) {
                     $localUserFound = true;
+                    echo "<tr style='outline: thin solid'>";
+                } else {
+                    echo "<tr>";
                 }
-
-                echo "<tr>";
 
                 $injectFmt1 = $isLocal ? "<b>" : "";
                 $injectFmt2 = $isLocal ? "</b>" : "";

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -137,10 +137,7 @@ RenderHtmlStart(true);
             $numActualEntries = 0;
             $localUserFound = false;
             $resultsDrawn = 0;
-            $prevScore = 0;
-            $nextRank = 1;
 
-            $count = 0;
             //for( $i = 0; $i < $numEntries; $i++ )
             //var_dump( $lbData );
             foreach ($lbData['Entries'] as $nextEntry) {
@@ -149,10 +146,7 @@ RenderHtmlStart(true);
 
                 $nextUser = $nextEntry['User'];
                 $nextScore = $nextEntry['Score'];
-                if ($prevScore != $nextScore) {
-                    $nextRank = $nextEntry['Rank'];
-                }
-                $prevScore = $nextScore;
+                $nextRank = $nextEntry['Rank'];
                 $nextScoreFormatted = GetFormattedLeaderboardEntry($lbFormat, $nextScore);
                 $nextSubmitAt = $nextEntry['DateSubmitted'];
                 $nextSubmitAtNice = getNiceDate($nextSubmitAt);

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -137,6 +137,7 @@ RenderHtmlStart(true);
             $numActualEntries = 0;
             $localUserFound = false;
             $resultsDrawn = 0;
+            $nextRank = 1;
 
             //for( $i = 0; $i < $numEntries; $i++ )
             //var_dump( $lbData );


### PR DESCRIPTION
Allows for navigation through all leaderboard entries for a given leaderboard which should solve some of the issue in #493

Slight update to the way ranks are calculated so that they will stay accurate when navigating to entries past the first 50. Also previously the users own displayed rank when not in the top 50 included Untracked users in the total even though they aren't displayed which has been fixed.

Navigation added
![image](https://user-images.githubusercontent.com/4047771/119934111-483bc700-bf53-11eb-807b-5bcaf53b9db7.png)

Properly keeps rank across pages (Second page showing entries 51+ tied for 38th)
![image](https://user-images.githubusercontent.com/4047771/119933468-2e4db480-bf52-11eb-93c6-171e724a9b66.png)
