### PR TITLE
Redesign "more info" links

### DIFF
--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -170,11 +170,10 @@ function RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions 
     );
 
     if (isset($forumTopicID) && $forumTopicID != 0 && getTopicDetails($forumTopicID, $topicData)) {
-        echo "<a href='/viewtopic.php?t=$forumTopicID'>View official forum topic for $gameTitle here</a>";
+        echo "<a class='info-button' href='/viewtopic.php?t=$forumTopicID'><span>💬</span>Official forum topic</a>";
     } else {
-        echo "No forum topic";
         if ($permissions >= Permissions::Developer) {
-            echo " - <a href='/request/game/generate-forum-topic.php?g=$gameID'>Create the official forum topic for $gameTitle</a>";
+            echo "<a class='info-button' href='/request/game/generate-forum-topic.php?g=$gameID'><span>💬</span>Create the official forum topic for $gameTitle</a>";
         }
     }
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1447,3 +1447,21 @@ svg > g > g:last-child { pointer-events: none }
   padding: 2px 2px 2px;
   border: 1px solid rgb(44, 151, 250);
 }
+
+/* More info buttons */
+.info-button{
+  display:block;
+  border: 1px solid #111;
+  border-radius: 5px;
+  margin: 5px 0;
+  padding: 7px 15px;
+  background-color: #222;
+}
+
+.info-button:hover{
+  background-color: #2a2a2a;
+}
+
+.info-button span{
+  margin-right: 15px;
+}

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1044,7 +1044,6 @@ RenderHtmlStart(true);
                 }
             }
 
-            echo "<b>Forum Topic: </b>";
             RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions);
             echo "<br><br>";
 
@@ -1061,12 +1060,11 @@ RenderHtmlStart(true);
 
             if (isset($user)) {
                 echo "<h3>More Info</h3>";
-                echo "<b>About \"$gameTitle ($consoleName)\":</b><br>";
                 echo "<ul>";
-                echo "<li>- ";
+                echo "<li>";
                 RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions);
                 echo "</li>";
-                echo "<li>- <a href='/linkedhashes.php?g=$gameID'>Hashes linked to this game</a></li>";
+                echo "<li><a class='info-button' href='/linkedhashes.php?g=$gameID'><span>🔗</span>Hashes linked to this game</a></li>";
                 $numOpenTickets = countOpenTickets(
                     requestInputSanitized('f') == $unofficialFlag,
                     requestInputSanitized('t', 2041),
@@ -1075,18 +1073,18 @@ RenderHtmlStart(true);
                 );
                 if ($permissions >= Permissions::Registered) {
                     if ($flags == $unofficialFlag) {
-                        echo "<li>- <a href='/ticketmanager.php?g=$gameID&f=$flags'>($numOpenTickets) Open Unofficial Tickets for this game</a></li>";
+                        echo "<li><a class='info-button' href='/ticketmanager.php?g=$gameID&f=$flags'><span>🎫</span>($numOpenTickets) Open Unofficial Tickets for this game</a></li>";
                     } else {
-                        echo "<li>- <a href='/ticketmanager.php?g=$gameID'>($numOpenTickets) Open Tickets for this game</a></li>";
+                        echo "<li><a class='info-button' href='/ticketmanager.php?g=$gameID'><span>🎫</span>($numOpenTickets) Open Tickets for this game</a></li>";
                     }
                 }
                 if ($numAchievements == 0) {
-                    echo "<li>- <a href='/setRequestors.php?g=$gameID'>Set Requestors for this game</a></li>";
+                    echo "<li><a class='info-button' href='/setRequestors.php?g=$gameID'><span>📜</span>Set Requestors for this game</a></li>";
                 }
                 //if( $flags == $unofficialFlag )
-                //echo "<li>- <a href='/game/$gameID'>View Core Achievements</a></li>";
+                //echo "<li><a class='info-button' href='/game/$gameID'><span>🏆</span>View Core Achievements</a></li>";
                 //else
-                //echo "<li>- <a href='/gameInfo.php?ID=$gameID&f=5'>View Unofficial Achievements</a></li>";
+                //echo "<li><a class='info-button' href='/gameInfo.php?ID=$gameID&f=5'><span>🏆</span>View Unofficial Achievements</a></li>";
                 echo "</ul><br>";
             }
 

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -220,7 +220,6 @@ RenderHtmlStart(true);
             $forceAllowDeleteComments = $permissions >= Permissions::Admin;
             RenderCommentsComponent($user, $numArticleComments, $commentData, $lbID, \RA\ArticleType::Leaderboard, $forceAllowDeleteComments);
 
-            echo "<b>Forum Topic: </b>";
             RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions);
             echo "<br><br>";
             ?>


### PR DESCRIPTION
This commit introduces visual changes in "More info" section of a game page.
That's how the change looks like:
![image](https://user-images.githubusercontent.com/26091129/120080804-c797da80-c0ba-11eb-8ab6-d70c67a72c78.png)
Except this section, it also changes link to the official forum topic, in the same manner, under achievements list and on leaderboard page.

The reason behind this change is that actual "More info" section is not really readable, especially that it contains a lot of redundant words (like repeated full game name). After changes those links are cleaner, but also easier to tap on mobile screens. I prepared new look of links for every possible action, even those not used at the moment.
For created forum topics I removed the game name from the anchor, as it's rather obvious, that it's about this game, but if topic is not created, I left this info, so devs could be more sure what this option will do, when clicked (anchors can be still adjusted).
In the future, this list could've also include a link for a guides, if available :D

This pull request is a part of my interface changes to the RAWeb: #313 