### PR TITLE
Add pagination on topics list on forum

### DIFF
--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -13,6 +13,8 @@ if ($permissions >= \RA\Permissions::Admin) {
     $numUnofficialLinks = count($unofficialLinks);
 }
 
+$numTotalTopics = 0;
+
 if ($requestedForumID == 0) {
     if ($permissions >= \RA\Permissions::Admin) {
         //	Continue

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -43,7 +43,7 @@ if ($requestedForumID == 0) {
     $thisCategoryID = $forumDataOut['CategoryID'];
     $thisCategoryName = $forumDataOut['CategoryName'];
 
-    $topicList = getForumTopics($requestedForumID, $offset, $count);
+    $topicList = getForumTopics($requestedForumID, $offset, $count, $numTotalTopics);
 
     $requestedForum = $thisForumTitle;
 }
@@ -85,6 +85,47 @@ RenderHtmlHead("View forum: $thisForumTitle");
             if ($permissions >= \RA\Permissions::Registered) {
                 echo "<a href='createtopic.php?f=$thisForumID'><div class='rightlink'>[Create New Topic]</div></a>";
             }
+
+            /* Forum pagination */
+            $forumPagination = "";
+
+            if ($numTotalTopics > $count) {
+                $forumPagination .= "<tr>";
+
+                $forumPagination .= "<td class='forumpagetabs' colspan='2'>";
+                $forumPagination .= "<div class='forumpagetabs'>";
+
+                $forumPagination .= "Page:&nbsp;";
+                $pageOffset = ($offset / $count);
+                $numPages = ceil($numTotalTopics / $count);
+
+                if ($pageOffset > 0) {
+                    $prevOffs = $offset - $count;
+                    $forumPagination .= "<a class='forumpagetab' href='/viewforum.php?f=$requestedForumID&amp;o=$prevOffs'>&lt;</a> ";
+                }
+
+                for ($i = 0; $i < $numPages; $i++) {
+                    $nextOffs = $i * $count;
+                    $pageNum = $i + 1;
+
+                    if ($nextOffs == $offset) {
+                        $forumPagination .= "<span class='forumpagetab current'>$pageNum</span> ";
+                    } else {
+                        $forumPagination .= "<a class='forumpagetab' href='/viewforum.php?f=$requestedForumID&amp;o=$nextOffs'>$pageNum</a> ";
+                    }
+                }
+
+                if ($offset + $count < $numTotalTopics) {
+                    $nextOffs = $offset + $count;
+                    $forumPagination .= "<a class='forumpagetab' href='/viewforum.php?f=$requestedForumID&amp;o=$nextOffs'>&gt;</a> ";
+                }
+
+                $forumPagination .= "</div>";
+                $forumPagination .= "</td>";
+                $forumPagination .= "</tr>";
+            }
+
+            echo $forumPagination;
 
             echo "<table><tbody>";
             echo "<tr class='forumsheader'>";
@@ -158,6 +199,8 @@ RenderHtmlHead("View forum: $thisForumTitle");
             }
 
             echo "</tbody></table>";
+
+            echo $forumPagination;
 
             echo "<br>";
 


### PR DESCRIPTION
This commit will add pagination on topics list on forum.

It's done the same way how other paginations here works: it limits query by parameter "o" in the URL (and "c", which is the count on one page and it is set by default as 25). In fact, most of the work was prepared already, but the query lacked LIMIT command and there was no COUNT query to get number of all topics in a category.
I did most of things by analogy to posts pagination, only except pagination links – just saved generated links in variable and displayed in two places (DRY rule).

This pull request addresses the issue #506 – solves the problem with performance, caused by rendering long list of topics. I'm not sure, if second issue mentioned there is solved by now.