### PR TITLE
getHashListByGameID(): only get User if explicitly requested

### DIFF
--- a/lib/database/rom.php
+++ b/lib/database/rom.php
@@ -30,7 +30,7 @@ function getMD5List($consoleID)
     return $retVal;
 }
 
-function getHashListByGameID($gameID)
+function getHashListByGameID($gameID, $getUser = false)
 {
     sanitize_sql_inputs($gameID);
     settype($gameID, 'integer');
@@ -38,8 +38,13 @@ function getHashListByGameID($gameID)
         return false;
     }
 
+    $selectString = "SELECT MD5 AS hash";
+    if ($getUser === true) {
+        $selectString .= ", User";
+    }
+
     $query = "
-    SELECT MD5 AS hash, User
+    $selectString
     FROM GameHashLibrary
     WHERE GameID = $gameID";
 

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -21,7 +21,7 @@ if ($gameIDSpecified) {
     $consoleID = $gameData['ConsoleID'];
     $gameTitle = $gameData['Title'];
     $gameIcon = $gameData['ImageIcon'];
-    $hashes = getHashListByGameID($gameID);
+    $hashes = getHashListByGameID($gameID, true);
 } else {
     //	Immediate redirect: this is pointless otherwise!
     header("Location: " . getenv('APP_URL'));


### PR DESCRIPTION
The User being returned in every `getHashListByGameID()` call is causing this:

![](https://cdn.discordapp.com/attachments/481902907252539402/848534661470224384/ftfttft.png)

reported by @StingX2 on discord