### PR TITLE
Fix responsiveness for some pages

### DIFF
--- a/lib/bootstrap.php
+++ b/lib/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-define('VERSION', '1.72.0');
+define('VERSION', '1.73.0');
 define('MIN_POINTS', 500);
 
 if (!file_exists(__DIR__ . '/../.env')) {

--- a/public/achievementList.php
+++ b/public/achievementList.php
@@ -107,8 +107,9 @@ RenderHtmlHead("Achievement List" . $requestedConsole);
         echo "</div>";
 
         echo "<div class='rightfloat'>* = ordered by</div>";
+        echo "<br style='clear:both;' />";
 
-        echo "<table><tbody>";
+        echo "<div class='table-wrapper'><table><tbody>";
 
         $sort1 = ($sortBy == 1) ? 11 : 1;
         $sort2 = ($sortBy == 2) ? 12 : 2;
@@ -214,7 +215,7 @@ RenderHtmlHead("Achievement List" . $requestedConsole);
             echo "</tr>";
         }
 
-        echo "</tbody></table>";
+        echo "</tbody></table></div>";
         echo "</div>";
 
         echo "<div class='rightalign row'>";

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1342,6 +1342,13 @@ a.setRequestLabel {
   margin-bottom: 1rem !important;
 }
 
+.download-flex {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+  align-items: start;
+}
+
 /* --- MOBILE STYLES --- */
 @media only screen and (max-width: 980px) {
   #mainpage {
@@ -1386,6 +1393,10 @@ a.setRequestLabel {
   }
   .commentavatar{
 	padding: 10px 5px;
+  }
+
+  .download-flex {
+    flex-direction: column;
   }
 }
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1001,6 +1001,7 @@ th {
 .commentpayload {
   padding: 6px 4px;
   vertical-align: top;
+  word-break: break-word;
 }
 
 .smalltext {
@@ -1344,7 +1345,8 @@ a.setRequestLabel {
 /* --- MOBILE STYLES --- */
 @media only screen and (max-width: 980px) {
   #mainpage {
-    grid-template-columns: 100%;
+    grid-template-columns: 1fr;
+    grid-column-gap: 0;
   }
 
   #logocontainer {
@@ -1371,6 +1373,19 @@ a.setRequestLabel {
 
   .gamescreenshots td {
     display: inline-block;
+  }
+
+  #forums div.lastpost {
+    width: auto;
+  }
+
+  .topiccommentsheader th, .commentavatar, .commentpayload, .table-wrapper .fullwidth, .table-forum-history th, .table-forum-history td {
+    display: block;
+	max-width:100%;
+	box-sizing: border-box;
+  }
+  .commentavatar{
+	padding: 10px 5px;
   }
 }
 
@@ -1464,4 +1479,10 @@ svg > g > g:last-child { pointer-events: none }
 
 .info-button span{
   margin-right: 15px;
+}
+
+/* Table wrapper */
+.table-wrapper{
+  max-width:100%;
+  overflow-x:auto;
 }

--- a/public/developerstats.php
+++ b/public/developerstats.php
@@ -22,7 +22,8 @@ RenderToolbar($user, $permissions);
         $devStatsList = GetDeveloperStatsFull(100, $type);
 
         echo "<div class='rightfloat'>* = ordered by</div>";
-        echo "<table><tbody>";
+        echo "<br style='clear:both;'>";
+        echo "<div class='table-wrapper'><table><tbody>";
         echo "<th></th>";
         echo "<th><a href='/developerstats.php?t=6'>Name</a>" . ($type == 6 ? "*" : "") . "</th>";
         echo "<th class='text-right text-nowrap'><a href='/developerstats.php?t=3'>Open Tickets</a>" . ($type == 3 ? "*" : "") . "</th>";
@@ -59,7 +60,7 @@ RenderToolbar($user, $permissions);
             echo "<td class='text-right'>" . $devStats['ContribYield'] . "</td>";
             // echo "<td class='text-right smalldate'>" . getNiceDate( strtotime( $devStats[ 'LastLogin' ] ) ) . "</td>";
         }
-        echo "</tbody></table>";
+        echo "</tbody></table></div>";
         ?>
     </div>
 </div>

--- a/public/download.php
+++ b/public/download.php
@@ -38,7 +38,7 @@ RenderHtmlHead("Download a client");
                     <a class="" href="<?= $emulator['link'] ?>" target="_blank">Documentation</a>
                 <?php endif ?>
             </div>
-            <div class="mb-3" style="display: flex; justify-content: space-between; flex-direction: row; align-items: start">
+            <div class="mb-3 download-flex">
                 <div style="flex-grow: 1">
                     <?php if (!empty($emulator['systems'])): ?>
                         <?php sort($emulator['systems']) ?>

--- a/public/forum.php
+++ b/public/forum.php
@@ -55,6 +55,7 @@ RenderHtmlHead($pageTitle);
 
             $forumIter = 0;
 
+            echo "<div class='table-wrapper'>";
             foreach ((array) $forumList as $forumData) {
                 $nextCategory = $forumData['CategoryName'];
                 $nextCategoryID = $forumData['CategoryID'];
@@ -134,7 +135,7 @@ RenderHtmlHead($pageTitle);
             }
 
             echo "</tbody></table>";
-
+            echo "</div>";
             ?>
 
             <br>

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -35,7 +35,8 @@ RenderHtmlHead("Forum Recent Posts");
 
             $forumIter = 0;
 
-            echo "<table>";
+            echo "<div class='table-wrapper'>";
+            echo "<table class='table-forum-history'>";
             echo "<tbody>";
 
             echo "<tr>";
@@ -70,7 +71,7 @@ RenderHtmlHead("Forum Recent Posts");
                 echo "</tr>";
             }
 
-            echo "</tbody></table>";
+            echo "</tbody></table></div>";
 
             echo "<div class='rightalign row'>";
             if ($offset > 0) {

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -98,7 +98,7 @@ RenderHtmlHead("Supported Games" . $requestedConsole);
                 echo "</a>";
                 echo "</h3>";
 
-                echo "<table><tbody>";
+                echo "<div class='table-wrapper'><table><tbody>";
 
                 $sort1 = ($sortBy == 1) ? 11 : 1;
                 $sort2 = ($sortBy == 2) ? 12 : 2;
@@ -200,7 +200,7 @@ RenderHtmlHead("Supported Games" . $requestedConsole);
                 }
                 echo "<td></td>";
                 echo "</tr>";
-                echo "</tbody></table>";
+                echo "</tbody></table></div>";
             }
             ?>
             <br>

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -82,7 +82,7 @@ RenderToolbar($user, $permissions);
             echo "</div>";
 
             //Create table headers
-            echo "</br><table><tbody>";
+            echo "</br><div class='table-wrapper'><table><tbody>";
             echo "<th>Game</th>";
             echo "<th>Requests</th>";
 
@@ -95,7 +95,7 @@ RenderToolbar($user, $permissions);
                 echo "</td>";
                 echo "<td><a href='/setRequestors.php?g=" . $request['GameID'] . "'>" . $request['Requests'] . "</a></td>";
             }
-            echo "</tbody></table>";
+            echo "</tbody></table></div>";
 
             //Add page traversal links
             echo "<div class='rightalign row'>";
@@ -134,7 +134,7 @@ RenderToolbar($user, $permissions);
             echo "<br>";
 
             //Create table headers
-            echo "<table><tbody>";
+            echo "<div class='table-wrapper'><table><tbody>";
             echo "<th>Game</th>";
 
             // Loop through each set request and display them if they do not have any acheivements
@@ -163,7 +163,7 @@ RenderToolbar($user, $permissions);
                     }
                 }
             }
-            echo "</tbody></table>";
+            echo "</tbody></table></div>";
         }
         ?>
     </div>

--- a/public/userList.php
+++ b/public/userList.php
@@ -96,7 +96,7 @@ RenderHtmlHead("Users");
             echo "</p>";
         }
 
-        echo "<table><tbody>";
+        echo "<div class='table-wrapper'><table><tbody>";
 
         $sort1 = ($sortBy == 1) ? 11 : 1;
         $sort2 = ($sortBy == 2) ? 12 : 2;
@@ -147,7 +147,7 @@ RenderHtmlHead("Users");
 
             echo "</tr>";
         }
-        echo "</tbody></table>";
+        echo "</tbody></table></div>";
 
         echo "<div class='rightalign row'>";
         if ($offset > 0) {

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -171,6 +171,7 @@ RenderHtmlStart();
             echo "</div>";
         }
 
+        echo "<div class='table-wrapper'>";
         echo "<table><tbody>";
 
         if ($numTotalComments > $count) {
@@ -296,6 +297,7 @@ RenderHtmlStart();
             }
             echo "</div>";
 
+            echo "<br style='clear:both;'>";
             echo "<div class='topiccommenttext'>";
             RenderTopicCommentPayload($nextCommentPayload);
             echo "</div>";
@@ -377,9 +379,9 @@ RenderHtmlStart();
             //echo "</td>";
             echo "</tr>";
 
-            echo "</tbody></table>";
+            echo "</tbody></table></div>";
         } else {
-            echo "</tbody></table>";
+            echo "</tbody></table></div>";
             RenderLoginComponent($user, $points, $errorCode, true);
         }
 


### PR DESCRIPTION
Despite earlier improvements on responsiveness of RA, there are still pages which have elements wider than the screen size. Mostly that are pages with tables, as tabular data is difficult to present on narrow screens (there is too much info in horizontal space). Changes from this Pull Request are introducing "table wrapper" – tables on mobile will be scrollable horizontaly within it, without expanding page's layout with its size.

Also, there is also a change in forum topic table layout, transforming table cells in row as one column on mobile devices. It will help to save space, because left column with username and avatar had a little of content, but was taking space of whole row's height (and, dependent on username length, it was letting less space for the post content).

There is also a change on downloads page – style of flex elements is moved into CSS file and direction of flex is changed for mobile screen sizes, so the buttons are stacked one under another, not next to them.

These changes are not complex and there still could be situation, that website is ideally responsive, but it's fixing the most problematic pages and forum pages and should be better than present situation.