### PR TITLE
Render smaller charts on mobile (individualdevstats.php)

### DIFF
--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -563,11 +563,20 @@ RenderHtmlHead("$dev's Developer Stats");
             ?>
         ]);
 
+        let chartWidth = 450;
+        let chartAreaHeight = '60%';
+
+        /* Render smaller charts on mobile */
+        if(window.innerWidth < 640){
+            chartWidth = 300;
+            chartAreaHeight = '50%';
+        }
+
         var gameOptions = {
             title: 'Games Developed for Per Console',
-               'width': 450,
+               'width': chartWidth,
                'height': 325,
-            'chartArea': {'width': '100%', 'height': '80%'},
+            'chartArea': {'width': '100%', 'height': chartAreaHeight},
             pieSliceText: 'value-and-percentage',
             titleTextStyle: {
                 color: '#2C97FA',
@@ -592,9 +601,9 @@ RenderHtmlHead("$dev's Developer Stats");
 
         var achievementOptions = {
             title: 'Achievements Created Per Console',
-               'width': 450,
+               'width': chartWidth,
                'height': 325,
-            'chartArea': {'width': '100%', 'height': '80%'},
+            'chartArea': {'width': '100%', 'height': chartAreaHeight},
             pieSliceText: 'value-and-percentage',
             titleTextStyle: {
                 color: '#2C97FA',
@@ -621,7 +630,6 @@ RenderHtmlHead("$dev's Developer Stats");
         achievementChart.draw(achievementData, achievementOptions);
         <?php } ?>
     }
-
 </script>
 <div id="mainpage">
     <div id='fullcontainer'>


### PR DESCRIPTION
This is just a small patch to #598 – as @meleu noticed, pie charts on individualdevstats.php had legend cut off on mobile screen size.

This change is only adding variables to draw charts in different sizes depending on screen width. It does only once, when charts are rendered, so it won't adapt if window size will be changed after loading the page (but I guess it's not an issue, as smaller charts concerns only really narrow screens).

After changes:
![image](https://user-images.githubusercontent.com/26091129/120937892-6900db00-c710-11eb-9fdd-7de9c8653915.png)
