### PR TITLE
Leaderboard Count Fix for Leaderboards Without Any Entries

### DIFF
--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -356,7 +356,15 @@ function getLeaderboardsForGame($gameID, &$dataOut, $localUser)
         //error_log( $query );
     }
 
-    return count($dataOut);
+    // Get the number of leaderboards for the game
+    $query = "SELECT COUNT(*) AS lbCount FROM LeaderboardDef WHERE GameID = $gameID";
+
+    $dbResult = s_mysql_query($query);
+    if ($dbResult !== false) {
+        return mysqli_fetch_assoc($dbResult)['lbCount'];
+    } else {
+        return 0;
+    }
 }
 
 function GetLeaderboardEntriesDataJSON($lbID, $user, $numToFetch, $offset, $friendsOnly)


### PR DESCRIPTION
The getLeaderboardsForGame() function only returns the number of leaderboards with entries. I've updated it to return the number of leaderboards regardless of the number of entries for them. This fixes an issue where the "Manage Leaderboards" and "Create First Leaderboard" links may show incorrectly if the created leaderboards do not have any entries.