### PR TITLE
Update lbinfo call and GetLeaderboardData to allow showing around user entry in overlay

### DIFF
--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -411,7 +411,7 @@ function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly, $n
               FROM LeaderboardDef AS ld
               LEFT JOIN GameData AS gd ON gd.ID = ld.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-              LEFT JOIN leaderboardentry le ON le.LeaderboardID = ld.ID
+              LEFT JOIN LeaderboardEntry le ON le.LeaderboardID = ld.ID
               LEFT JOIN UserAccounts AS ua ON ua.ID = le.UserID
               WHERE ld.ID = $lbID
               AND !ua.Untracked";

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         - '#Parameter (.*) of function htmlentities expects#'
+        - '#Cannot unset offset (.*) on array#'
     excludes_analyse:
         # disabled features
         - public/API/API_GetFeed.php

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -320,8 +320,9 @@ switch ($requestType) {
 
     case "lbinfo":
         $lbID = requestInput('i', 0, 'integer');
+        $nearby = 1;
         $friendsOnly = 0; // TBD
-        $response['LeaderboardData'] = GetLeaderboardData($lbID, $user, $count, $offset, $friendsOnly);
+        $response['LeaderboardData'] = GetLeaderboardData($lbID, $user, $count, $offset, $friendsOnly, $nearby);
         break;
 
     // case "modifyfriend":

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -320,7 +320,7 @@ switch ($requestType) {
 
     case "lbinfo":
         $lbID = requestInput('i', 0, 'integer');
-        $nearby = true;
+        $nearby = true; // Nearby entry behvaior has no effect if $user is null
         $friendsOnly = 0; // TBD
         $response['LeaderboardData'] = GetLeaderboardData($lbID, $user, $count, $offset, $friendsOnly, $nearby);
         break;

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -320,7 +320,7 @@ switch ($requestType) {
 
     case "lbinfo":
         $lbID = requestInput('i', 0, 'integer');
-        $nearby = 1;
+        $nearby = true;
         $friendsOnly = 0; // TBD
         $response['LeaderboardData'] = GetLeaderboardData($lbID, $user, $count, $offset, $friendsOnly, $nearby);
         break;

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -320,7 +320,7 @@ switch ($requestType) {
 
     case "lbinfo":
         $lbID = requestInput('i', 0, 'integer');
-        $nearby = true; // Nearby entry behvaior has no effect if $user is null
+        $nearby = true; // Nearby entry behavior has no effect if $user is null
         $friendsOnly = 0; // TBD
         $response['LeaderboardData'] = GetLeaderboardData($lbID, $user, $count, $offset, $friendsOnly, $nearby);
         break;


### PR DESCRIPTION
Update lbinfo and GetLeaderboardData to return nearby user entries when checking from emulator overlay by adding user index as well as add total entries to the returned object to allow for future scrolling/navigation. Takes care of the request in #625 