### PR TITLE
fix: #373 escape achievement description for attributes

### DIFF
--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -119,10 +119,11 @@ RenderHtmlStart(true);
 
         echo "<table class='nicebox'><tbody>";
 
+        $escapeForAttributes = "htmlentities"; // sanitize_outputs uses null for 2nd param, so it won't convert quotes to entities
         echo "<tr>";
         echo "<td style='width:70px'>";
         echo "<div id='achievemententryicon'>";
-        echo "<a href=\"/achievement/$achievementID\"><img src=\"$badgeFullPath\" title=\"$gameTitle ($achPoints)\n$desc\" alt=\"$desc\" align=\"left\" width=\"64\" height=\"64\" /></a>";
+        echo "<a href=\"/achievement/$achievementID\"><img src=\"$badgeFullPath\" title=\"$gameTitle ($achPoints)\n{$escapeForAttributes($desc)}\" alt=\"{$escapeForAttributes($desc)}\" align=\"left\" width=\"64\" height=\"64\" /></a>";
         echo "</div>"; //achievemententryicon
         echo "</td>";
 


### PR DESCRIPTION
The sanitization function uses a null value for the second parameter, so it won't convert quotes to HTML entities. Since this string function is used throughout the site, a simple solution is to only convert the entities that are being used within attribute values.