### PR TITLE
fix: #516 revise order of active players

### DIFF
--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -750,7 +750,8 @@ function getLatestRichPresenceUpdates()
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               WHERE ua.RichPresenceMsgDate > TIMESTAMPADD( MINUTE, -$recentMinutes, NOW() )
                 AND ua.LastGameID !=0
-                AND ua.Permissions >= $permissionsCutoff";
+                AND ua.Permissions >= $permissionsCutoff
+              ORDER BY ua.RAPoints DESC;";
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {


### PR DESCRIPTION
This fix updates the Active Players list to put them in Site Rank order instead of the default ordering by UserID (i.e. order the user was created).