### PR TITLE
fix: #425 keep querystring parameters in youtube embed links

### DIFF
--- a/lib/util/bbcode.php
+++ b/lib/util/bbcode.php
@@ -194,7 +194,7 @@ function linkifyYouTubeURLs($text)
         ([?=&+%\w.-]*)        # Consume any URL (query) remainder.
         ~ix';
 
-    $text = preg_replace($pattern, makeEmbeddedVideo('//www.youtube-nocookie.com/embed/$1'), $text);
+    $text = preg_replace($pattern, makeEmbeddedVideo('//www.youtube-nocookie.com/embed/$1$2'), $text);
 
     return $text;
 }


### PR DESCRIPTION
This will fix the embedded video links so they retain the querystring parameters, such as start/end timecodes.