### PR TITLE
Fix for Leaderboards with No Entries

### DIFF
--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -407,12 +407,33 @@ function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly, $n
     $retVal = [];
 
     //    Get raw LB data
-    $query = "SELECT ld.ID AS LBID, gd.ID AS GameID, gd.Title AS GameTitle, ld.LowerIsBetter, ld.Title AS LBTitle, ld.Description AS LBDesc, ld.Format AS LBFormat, ld.Mem AS LBMem, ld.Author AS LBAuthor, gd.ConsoleID, c.Name AS ConsoleName, gd.ForumTopicID, gd.ImageIcon AS GameIcon, ld.Created AS LBCreated, ld.Updated AS LBUpdated,
-              (SELECT COUNT(UserID) FROM LeaderboardEntry AS le LEFT JOIN UserAccounts AS ua ON ua.ID = le.UserID WHERE !ua.Untracked AND le.LeaderboardID = $lbID) AS TotalEntries
-              FROM LeaderboardDef AS ld
-              LEFT JOIN GameData AS gd ON gd.ID = ld.GameID
-              LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-              WHERE ld.ID = $lbID";
+    $query = "
+      SELECT
+        ld.ID AS LBID,
+        gd.ID AS GameID,
+        gd.Title AS GameTitle,
+        ld.LowerIsBetter,
+        ld.Title AS LBTitle,
+        ld.Description AS LBDesc,
+        ld.Format AS LBFormat,
+        ld.Mem AS LBMem,
+        ld.Author AS LBAuthor,
+        gd.ConsoleID,
+        c.Name AS ConsoleName,
+        gd.ForumTopicID,
+        gd.ImageIcon AS GameIcon,
+        ld.Created AS LBCreated,
+        ld.Updated AS LBUpdated,
+        (
+          SELECT COUNT(UserID)
+          FROM LeaderboardEntry AS le
+          LEFT JOIN UserAccounts AS ua ON ua.ID = le.UserID
+          WHERE !ua.Untracked AND le.LeaderboardID = $lbID
+        ) AS TotalEntries
+      FROM LeaderboardDef AS ld
+      LEFT JOIN GameData AS gd ON gd.ID = ld.GameID
+      LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
+      WHERE ld.ID = $lbID";
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {

--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -407,14 +407,12 @@ function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly, $n
     $retVal = [];
 
     //    Get raw LB data
-    $query = "SELECT ld.ID AS LBID, gd.ID AS GameID, gd.Title AS GameTitle, ld.LowerIsBetter, ld.Title AS LBTitle, ld.Description AS LBDesc, ld.Format AS LBFormat, ld.Mem AS LBMem, ld.Author AS LBAuthor, gd.ConsoleID, c.Name AS ConsoleName, gd.ForumTopicID, gd.ImageIcon AS GameIcon, ld.Author AS LBAuthor, ld.Created AS LBCreated, ld.Updated AS LBUpdated, COUNT(le.UserID) AS TotalEntries
+    $query = "SELECT ld.ID AS LBID, gd.ID AS GameID, gd.Title AS GameTitle, ld.LowerIsBetter, ld.Title AS LBTitle, ld.Description AS LBDesc, ld.Format AS LBFormat, ld.Mem AS LBMem, ld.Author AS LBAuthor, gd.ConsoleID, c.Name AS ConsoleName, gd.ForumTopicID, gd.ImageIcon AS GameIcon, ld.Created AS LBCreated, ld.Updated AS LBUpdated,
+              (SELECT COUNT(UserID) FROM LeaderboardEntry AS le LEFT JOIN UserAccounts AS ua ON ua.ID = le.UserID WHERE !ua.Untracked AND le.LeaderboardID = $lbID) AS TotalEntries
               FROM LeaderboardDef AS ld
               LEFT JOIN GameData AS gd ON gd.ID = ld.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-              LEFT JOIN LeaderboardEntry le ON le.LeaderboardID = ld.ID
-              LEFT JOIN UserAccounts AS ua ON ua.ID = le.UserID
-              WHERE ld.ID = $lbID
-              AND !ua.Untracked";
+              WHERE ld.ID = $lbID";
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {


### PR DESCRIPTION
Updated GetLeaderboardData() query to have a subselect statement to get the number of entries for the leaderboard. Previously the query would return null for all values if the leaderboard had no entries in it.

This prevented jr. devs from being able to edit their own leaderboards if there were no entries.

This also caused the leaderboard page to show unknown values if there were no entries.
![image](https://user-images.githubusercontent.com/16140035/127793369-5272d453-088a-4eb4-bb2d-cea3e44cb07d.png)
