### PR TITLE
Links to supplementary ticket info are now provided after certain fields

### DIFF
--- a/lib/render/layout.php
+++ b/lib/render/layout.php
@@ -32,13 +32,6 @@ function RenderHtmlHead($pageTitle = null)
 
 function RenderSharedHeader()
 {
-    echo "<link rel='stylesheet' href='/css/styles.css?v=" . VERSION . "' media='screen'>\n";
-
-    $customCSS = RA_ReadCookie('RAPrefs_CSS');
-    if ($customCSS !== false && mb_strlen($customCSS) > 2) {
-        echo "<link rel='stylesheet' href='$customCSS?v=" . VERSION . "' media='screen'>\n";
-    }
-
     echo "<link rel='icon' type='image/png' href='/favicon.png'>\n";
     echo "<link rel='image_src' href='/Images/RA_Logo10.png'>\n";
     echo "<meta http-equiv='content-type' content='text/html; charset=UTF-8'>\n";
@@ -62,11 +55,23 @@ function RenderSharedHeader()
     echo "<script src='https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.js'></script>\n";
     echo "<script src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.23/jquery-ui.js'></script>\n";
 
+    // jQuery Modal
+    echo "<script src='https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.js'></script>";
+    echo "<link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.css' />";
+
+    echo "<script src='https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js'></script>";
+
     //    jQuery, and custom js
     //echo "<script src='//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js'></script>\n";
     //echo "<script src='/vendor/jquery-ui-1.10.2.custom.min.js'></script>\n";
     echo "<script src='/js/all.js?v=" . VERSION . "'></script>\n";
     echo "<script>window.assetUrl='" . getenv('ASSET_URL') . "'</script>\n";
+
+    echo "<link rel='stylesheet' href='/css/styles.css?v=" . VERSION . "' media='screen'>\n";
+    $customCSS = RA_ReadCookie('RAPrefs_CSS');
+    if ($customCSS !== false && mb_strlen($customCSS) > 2) {
+        echo "<link rel='stylesheet' href='$customCSS?v=" . VERSION . "' media='screen'>\n";
+    }
 }
 
 function RenderOpenGraphMetadata($title, $OGType, $imageURL, $thisURL, $description)

--- a/lib/render/news.php
+++ b/lib/render/news.php
@@ -29,7 +29,6 @@ function RenderNewsComponent()
 
 function RenderNewsHeader($newsData)
 {
-    $dataID = $newsData['ID'];
     $title = $newsData['Title'];
     $payload = $newsData['Payload'];
     $image = $newsData['Image'];
@@ -38,38 +37,27 @@ function RenderNewsHeader($newsData)
 
     $author = $newsData['Author'];
     $authorLink = GetUserAndTooltipDiv($author, false);
-    $timestampStr = date("d M", $newsData['TimePosted']);
     $niceDate = getNiceDate($newsData['TimePosted']);
-
-    //if( isset( $link ) )
-    //else
-    //    echo "<h4>$title</h4>";
-
-    $zPos = $dataID;
-    $zPos2 = $dataID + 10;
 
     echo "<div class='newsbluroverlay'>";
     echo "<div>";
 
-    //echo "<span id='NEWSIMG_" . $dataID . "' class='newsimage'><img style='position: absolute; right: 0px; top:0px; width: 100%; z-index:$zPos; opacity: 0.4' src='$image' align='right' /></span>";
     //    BG
-    echo "<div class='newscontainer' style='background: url(\"$image\") repeat scroll; z-index:$zPos; opacity:0.5; width: 470px; height:222px; background-size: 100% auto;' >";
+    echo "<div class='newscontainer' style='background: url(\"$image\") repeat scroll; opacity:0.5; width: 470px; height:222px; background-size: 100% auto;' >";
     echo "</div>";
 
     echo "<div class='news' >";
 
     //    Title
-    echo "<h4 style='z-index:$zPos2; position: absolute; width: 460px; top:2px; left:10px; white-space: nowrap;' ><a class='newstitle shadowoutline' href='$link'>$title</a></h4>";
+    echo "<h4 style='position: absolute; width: 460px; top:2px; left:10px; white-space: nowrap;' ><a class='newstitle shadowoutline' href='$link'>$title</a></h4>";
 
     //    Text
-    //echo "<small>[" . $timestampStr . "] </small>";
-    echo "<div class='newstext shadowoutline' style='z-index:$zPos2; position: absolute; width: 90%; top: 40px; left:10px;'>$payload</div>";
+    echo "<div class='newstext shadowoutline' style='position: absolute; width: 90%; top: 40px; left:10px;'>$payload</div>";
 
     //    Author
-    echo "<div class='newsauthor shadowoutline' style='z-index:$zPos2; position: absolute; width: 470px; top: 196px; left:0px; text-align: right'>~~$authorLink, $niceDate</div>";
+    echo "<div class='newsauthor shadowoutline' style='position: absolute; width: 470px; top: 196px; left:0px; text-align: right'>~~$authorLink, $niceDate</div>";
 
     echo "</div>";
-    //echo "<div style='clear:both'></div>";
 
     echo "</div>";
     echo "</div>";

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -708,7 +708,6 @@ td, tr, img {
   max-width: 100%;
   width: 980px;
   position: relative;
-  z-index: 1000;
   font-size: x-small;
   margin: auto;
   /*overflow:hidden; this breaks the dropdown! :S*/
@@ -1501,4 +1500,8 @@ svg > g > g:last-child { pointer-events: none }
 .table-wrapper{
   max-width:100%;
   overflow-x:auto;
+}
+
+.modal {
+  background-color: #1a1a1a;
 }

--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -147,7 +147,7 @@ RenderHtmlHead("Report Broken Achievement");
                         <textarea class="requiredinput fullwidth forum" name="note[description]" id="description"
                                   style="height:160px" rows="5" cols="61" placeholder="Describe your issue here..."
                                   required data-bind="textInput: description"></textarea>
-                        <p data-bind="visible: descriptionIsUnhelpful">Please be more specific with your issue--such as by adding specific reproduction steps or what you did before encountering it--instead of simply stating that it doesn't work. The more specific, the better.</p>
+                        <p data-bind="visible: descriptionIsUnhelpful">Please be more specific with your issue&mdash;such as by adding specific reproduction steps or what you did before encountering it&mdash;instead of simply stating that it doesn't work. The more specific, the better.</p>
                     </td>
                 </tr>
                 <tr>

--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -68,39 +68,40 @@ RenderHtmlHead("Report Broken Achievement");
             <table>
                 <tbody>
                 <tr>
-                    <td>Game:</td>
+                    <td>Game</td>
                     <td style="width:80%">
                         <?php echo GetGameAndTooltipDiv($gameID, $gameTitle, $gameBadge, $consoleName, false) ?>
                     </td>
                 </tr>
                 <tr>
-                    <td>Achievement:</td>
+                    <td>Achievement</td>
                     <td>
                         <?php echo GetAchievementAndTooltipDiv(
-    $achievementID,
-    $achievementTitle,
-    $desc,
-    $achPoints,
-    $gameTitle,
-    $achBadgeName,
-    true
-) ?>
+                            $achievementID,
+                            $achievementTitle,
+                            $desc,
+                            $achPoints,
+                            $gameTitle,
+                            $achBadgeName,
+                            true)
+                        ?>
                     </td>
                 </tr>
                 <tr class="alt">
-                    <td><label for="issue">Issue:</label></td>
+                    <td><label for="issue">Issue</label></td>
                     <td>
                         <select name="p" id="issue" required>
                             <option value="" disabled selected hidden>Select your issue...</option>
                             <option value="1">Triggered at wrong time</option>
                             <option value="2">Doesn't Trigger</option>
                         </select>
+                        <a href="/views/issueDescriptionModal.html" rel="modal:open">?</a>
                     </td>
                 </tr>
                 <tr>
-                    <td><label for="emulator">Emulator:</label></td>
+                    <td><label for="emulator">Emulator</label></td>
                     <td>
-                        <select name="note[emulator]" id="emulator" onchange="displayCore()" required>
+                        <select name="note[emulator]" id="emulator" required data-bind="value: emulatorValue">
                             <option value="" disabled selected hidden>Select your emulator...</option>
                             <?php foreach ($emulators as $emulator): ?>
                                 <option><?= $emulator['handle'] ?></option>
@@ -108,9 +109,16 @@ RenderHtmlHead("Report Broken Achievement");
                         </select>
                     </td>
                 </tr>
-                <tr id="core-row" style="display: none">
+                <tr>
+                    <td><label for="version">Emulator Version</label></td>
                     <td>
-                        <label for="core">Core:</label>
+                        <input type="text" name="note[emulatorVersion]" id="version" required />
+                        <a href="/views/versionDescriptionModal.html" rel="modal:open">Why?</a>
+                    </td>
+                </tr>
+                <tr id="core-row">
+                    <td>
+                        <label for="core">Core</label>
                     </td>
                     <td>
                         <input type="text" name="note[core]" id="core" placeholder="Which core did you use?"
@@ -118,7 +126,7 @@ RenderHtmlHead("Report Broken Achievement");
                     </td>
                 </tr>
                 <tr>
-                    <td><label for="checksum">Checksum:</label></td>
+                    <td><label for="checksum">Checksum</label></td>
                     <td>
                         <select name="note[checksum]" id="checksum" required>
                             <option value="Unknown">I don't know.</option>
@@ -130,20 +138,22 @@ RenderHtmlHead("Report Broken Achievement");
                             }
                             ?>
                         </select>
+                        <a href="/views/checksumDescriptionModal.html" rel="modal:open">?</a>
                     </td>
                 </tr>
                 <tr>
-                    <td><label for="description">Description:</label></td>
+                    <td><label for="description">Description</label></td>
                     <td colspan="2">
                         <textarea class="requiredinput fullwidth forum" name="note[description]" id="description"
                                   style="height:160px" rows="5" cols="61" placeholder="Describe your issue here..."
-                                  required></textarea>
+                                  required data-bind="textInput: description"></textarea>
+                        <p data-bind="visible: descriptionIsUnhelpful">Please be more specific with your issue--such as by adding specific reproduction steps or what you did before encountering it--instead of simply stating that it doesn't work. The more specific, the better.</p>
                     </td>
                 </tr>
                 <tr>
                     <td></td>
                     <td colspan="2" class="fullwidth">
-                        <input style="float:right" type="submit" value="Submit Issue Report" size="37">
+                        <input style="float:right" type="submit" value="Submit Issue Report" size="37" data-bind="disable: descriptionIsUnhelpful" />
                     </td>
                 </tr>
                 </tbody>
@@ -151,6 +161,22 @@ RenderHtmlHead("Report Broken Achievement");
         </form>
     </div>
 </div>
+<script type="text/javascript">
+    let ReportViewModel = function() {
+        this.description = ko.observable('');
+        this.emulatorValue = ko.observable();
+        this.emulatorValue.subscribe(function() {
+            displayCore();
+        });
+
+        this.descriptionIsUnhelpful = ko.pureComputed(function() {
+            let unhelpfulRegex = /(n'?t|not?).*work/ig;
+            return this.description().length < 25 && unhelpfulRegex.test(this.description());
+        }, this);
+    }
+
+    ko.applyBindings(new ReportViewModel());
+</script>
 <?php RenderFooter(); ?>
 </body>
 <?php RenderHtmlEnd(); ?>

--- a/public/request/ticket/create.php
+++ b/public/request/ticket/create.php
@@ -28,6 +28,10 @@ if (isset($_POST['note'])) {
         }
     }
 
+    if (!empty(trim($_POST['note']['emulatorVersion']))) {
+        $appendNote .= "\nEmulator Version: " . $_POST['note']['emulatorVersion'];
+    }
+
     $note = $appendNote;
 }
 

--- a/public/views/checksumDescriptionModal.html
+++ b/public/views/checksumDescriptionModal.html
@@ -1,0 +1,9 @@
+<h1>Checksum</h1>
+
+<p>A checksum, or a hash, uniquely determines your ROM. Specifying the checksum of your ROM can help the developer reproduce the issue or even determine if a particular ROM is incompatible with the set.</p>
+
+<h4>Where can I find this?</h4>
+
+<p>This is dependent on whatever emulator you're using. If you're using RetroArch, this information can be found by entering the RetroArch menu while your ROM is loaded and scroll down to Information. It will be the long alphanumeric string after "RetroAchievements Hash".</p>
+
+<p>If you're using RALibRetro, this information can be found by going into RetroAchievements > View Game Hash.</p>

--- a/public/views/issueDescriptionModal.html
+++ b/public/views/issueDescriptionModal.html
@@ -12,4 +12,4 @@
 
 <h4>What if the achievement triggered but doesn't show up as earned for me on the site?</h4>
 
-<p>This normally indicates a network issue--which is to say that either your connection was interrupted while the achievement triggered or the site itself is down. <strong>Please do not create a ticket if this has happened to you!</strong> Instead, please request a manual unlock on the RetroAchievements Discord server and provide the screenshot created when the achievement triggered or some other form of proof.</p>
+<p>This normally indicates a network issue&mdash;which is to say that either your connection was interrupted while the achievement triggered or the site itself is down. <strong>Please do not create a ticket if this has happened to you!</strong> Instead, please request a manual unlock on the RetroAchievements Discord server and provide the screenshot created when the achievement triggered or some other form of proof.</p>

--- a/public/views/issueDescriptionModal.html
+++ b/public/views/issueDescriptionModal.html
@@ -1,0 +1,15 @@
+<h1>Issue</h1>
+
+<p>There are two different ways in which an achievement is considered broken. Use this dropdown to indicate which of these two types, documented below, is applicable to your situation.</p>
+
+<h4>Triggered at the Wrong Time</h4>
+
+<p>Use this when an achievement notification appears in your emulator at a time different than what is implied in the achievement's description. For instance, if the triggered achievement asks you to collect 10 of a collectable but appears when you haven't done so, then you would use this type.</p>
+
+<h4>Doesn't Trigger</h4>
+
+<p>Use this when an achievement notification <i>doesn't</i> appear when you have done what the achievement's description asked you to do. For instance, if the achievement you expected to trigger asks you to collect 10 of a collectable and you got 11, then you would use this type if you don't see the notification appear.</p>
+
+<h4>What if the achievement triggered but doesn't show up as earned for me on the site?</h4>
+
+<p>This normally indicates a network issue--which is to say that either your connection was interrupted while the achievement triggered or the site itself is down. <strong>Please do not create a ticket if this has happened to you!</strong> Instead, please request a manual unlock on the RetroAchievements Discord server and provide the screenshot created when the achievement triggered or some other form of proof.</p>

--- a/public/views/versionDescriptionModal.html
+++ b/public/views/versionDescriptionModal.html
@@ -1,0 +1,3 @@
+<h4>Why do I need this?</h4>
+
+<p>Achievements may behave differently depending on your emulator version. New features required for certain achievements to function may be added, or using save states will cause them to stop working entirely. Specifying the version can help the developer determine the root cause of your issue.</p>


### PR DESCRIPTION
Certain fields now have clickable links that will bring up a modal that gives important information for that given field. I have also added an Emulator Version field to help make tickets more useful, especially in light of recent updates making save states store hit counts.

![image](https://user-images.githubusercontent.com/5499519/128618475-7f62ab85-ecf8-4671-b203-dddaabea0963.png)

![image](https://user-images.githubusercontent.com/5499519/128618486-b7c2e41f-7929-4b5f-b620-6f5a6a014279.png)

I also added in an "Easter egg" of sorts that will prevent a user from submitting the ticket if the description has nothing but something along the lines of, "Doesn't work," prompting them to put in something more substantial, if the description is shorter than 25 characters. This won't prevent someone from making a long-ass description that says absolutely nothing, but I figure it will help educate people inclined to lazily state the obvious to be more thoughtful.

![image](https://user-images.githubusercontent.com/5499519/128618489-f10cf329-ca60-4f00-85a5-363fc2164529.png)

Intended to close #524.