### PR TITLE
Fix comments permissions

### DIFF
--- a/lib/render/comment.php
+++ b/lib/render/comment.php
@@ -1,12 +1,15 @@
 <?php
 
+use RA\Permissions;
+use RA\SubscriptionSubjectType;
+
 function RenderCommentsComponent(
     $user,
     $numComments,
     $commentData,
     $articleID,
     $articleTypeID,
-    $forceAllowDeleteComments
+    $permissions
 ) {
     $userID = getUserIDFromUser($user);
 
@@ -21,7 +24,7 @@ function RenderCommentsComponent(
     echo "</div>";
 
     if (isset($user)) {
-        $subjectType = \RA\SubscriptionSubjectType::fromArticleType($articleTypeID);
+        $subjectType = SubscriptionSubjectType::fromArticleType($articleTypeID);
         if ($subjectType !== null) {
             $isSubscribed = isUserSubscribedToArticleComments($articleTypeID, $articleID, $userID);
             echo "<div class='smalltext rightfloat'>";
@@ -52,8 +55,7 @@ function RenderCommentsComponent(
             $lastID = $commentData[$i]['ID'];
         }
 
-        $canDeleteComments = ($articleTypeID == 3) && ($userID == $articleID);
-        $canDeleteComments |= $forceAllowDeleteComments;
+        $canDeleteComments = ($articleTypeID == 3) && ($userID == $articleID) || $permissions >= Permissions::Admin;
 
         RenderArticleComment(
             $articleID,
@@ -97,7 +99,7 @@ function RenderArticleComment(
     $class = '';
     $deleteIcon = '';
 
-    if ($user == $localUser || $allowDelete) {
+    if ($user && $user == $localUser || $allowDelete) {
         $class .= ' localuser';
 
         $img = "<img src='" . getenv('ASSET_URL') . "/Images/cross.png' width='16' height='16' alt='delete comment'/>";

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -2,12 +2,14 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
+use RA\ArticleType;
 use RA\Permissions;
 
 RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
 
 $achievementID = requestInputSanitized('ID', 0, 'integer');
 
+$dataOut = null;
 if ($achievementID == 0 || getAchievementMetadata($achievementID, $dataOut) == false) {
     header("Location: " . getenv('APP_URL') . "?e=unknownachievement");
     exit;
@@ -255,9 +257,14 @@ RenderHtmlStart(true);
             echo parseTopicCommentPHPBB($embedVidURL, true);
         }
 
-        //    Comments:
-        $forceAllowDeleteComments = $permissions >= Permissions::Admin;
-        RenderCommentsComponent($user, $numArticleComments, $commentData, $achievementID, \RA\ArticleType::Achievement, $forceAllowDeleteComments);
+        RenderCommentsComponent(
+            $user,
+            $numArticleComments,
+            $commentData,
+            $achievementID,
+            ArticleType::Achievement,
+            $permissions
+        );
 
         echo "</div>"; //achievement
 

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
+use RA\ArticleType;
 use RA\Permissions;
 
 RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
@@ -233,8 +234,14 @@ RenderHtmlStart(true);
             echo "</div>";
 
             //    Render article comments
-            $forceAllowDeleteComments = $permissions >= Permissions::Admin;
-            RenderCommentsComponent($user, $numArticleComments, $commentData, $lbID, \RA\ArticleType::Leaderboard, $forceAllowDeleteComments);
+            RenderCommentsComponent(
+                $user,
+                $numArticleComments,
+                $commentData,
+                $lbID,
+                ArticleType::Leaderboard,
+                $permissions
+            );
 
             RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions);
             echo "<br><br>";

--- a/public/request/comment/delete.php
+++ b/public/request/comment/delete.php
@@ -3,13 +3,15 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
+use RA\Permissions;
+
 $articleID = requestInput('a', 0, 'integer');
 $commentID = requestInput('c', 0, 'integer');
 
 $response = [];
 $response['ArtID'] = $articleID;
 $response['CommentID'] = $commentID;
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, \RA\Permissions::Registered, $userID)) {
+if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered, $userID)) {
     $response['Success'] = RemoveComment($articleID, $commentID, $userID, $permissions);
 } else {
     $response['Success'] = false;

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -2,6 +2,9 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
+use RA\ArticleType;
+use RA\Permissions;
+
 if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
     header("Location: " . getenv('APP_URL'));
     exit;
@@ -41,48 +44,48 @@ if ($ticketID != 0) {
             break;
 
         case "resolved":
-            if ($permissions >= \RA\Permissions::Developer) {
+            if ($permissions >= Permissions::Developer) {
                 $ticketState = 2;
             }
             break;
 
         case "demoted":
-            if ($permissions >= \RA\Permissions::Developer) {
+            if ($permissions >= Permissions::Developer) {
                 $ticketState = 0;
                 $reason = "Demoted";
             }
             break;
 
         case "not-enough-info":
-            if ($permissions >= \RA\Permissions::Developer) {
+            if ($permissions >= Permissions::Developer) {
                 $ticketState = 0;
                 $reason = "Not enough information";
             }
             break;
 
         case "wrong-rom":
-            if ($permissions >= \RA\Permissions::Developer) {
+            if ($permissions >= Permissions::Developer) {
                 $ticketState = 0;
                 $reason = "Wrong ROM";
             }
             break;
 
         case "network":
-            if ($permissions >= \RA\Permissions::Developer) {
+            if ($permissions >= Permissions::Developer) {
                 $ticketState = 0;
                 $reason = "Network problems";
             }
             break;
 
         case "unable-to-reproduce":
-            if ($permissions >= \RA\Permissions::Developer) {
+            if ($permissions >= Permissions::Developer) {
                 $ticketState = 0;
                 $reason = "Unable to reproduce";
             }
             break;
 
         case "closed-other":
-            if ($permissions >= \RA\Permissions::Developer) {
+            if ($permissions >= Permissions::Developer) {
                 $ticketState = 0;
                 $reason = "See the comments";
             }
@@ -100,7 +103,7 @@ if ($ticketID != 0) {
     if ($action != null &&
         $ticketState != $ticketData['ReportState'] &&
         (
-            $permissions >= \RA\Permissions::Developer ||
+            $permissions >= Permissions::Developer ||
             $user == $ticketData['ReportedBy']
         )
     ) {
@@ -695,7 +698,7 @@ RenderHtmlHead($pageTitle);
                 echo "</td>";
                 echo "</tr>";
 
-                if ($permissions >= \RA\Permissions::Developer) {
+                if ($permissions >= Permissions::Developer) {
                     echo "<tr>";
 
                     echo "<td>Reporter:</td>";
@@ -725,7 +728,7 @@ RenderHtmlHead($pageTitle);
                     echo "$reportedBy did not earn this achievement.";
                 }
 
-                if ($user == $reportedBy || $permissions >= \RA\Permissions::Developer) {
+                if ($user == $reportedBy || $permissions >= Permissions::Developer) {
                     echo "<tr>";
 
                     echo "<td>Action: </td><td colspan='6'>";
@@ -743,7 +746,7 @@ RenderHtmlHead($pageTitle);
                             echo "<option value='closed-mistaken'>Close - Mistaken report</option>";
                         }
 
-                        if ($permissions >= \RA\Permissions::Developer) {
+                        if ($permissions >= Permissions::Developer) {
                             echo "<option value='resolved'>Resolve as fixed (add comments about your fix below)</option>";
                             echo "<option value='demoted'>Demote achievement to Unofficial</option>";
                             echo "<option value='network'>Close - Network problems</option>";
@@ -771,8 +774,13 @@ RenderHtmlHead($pageTitle);
                 echo "<div class='commentscomponent'>";
 
                 echo "<h4>Comments</h4>";
-                $forceAllowDeleteComments = $permissions >= \RA\Permissions::Admin;
-                RenderCommentsComponent($user, $numArticleComments, $commentData, $ticketID, \RA\ArticleType::AchievementTicket, $forceAllowDeleteComments);
+                RenderCommentsComponent($user,
+                    $numArticleComments,
+                    $commentData,
+                    $ticketID,
+                    ArticleType::AchievementTicket,
+                    $permissions
+                );
 
                 echo "</div>";
                 echo "</td>";
@@ -781,7 +789,7 @@ RenderHtmlHead($pageTitle);
                 echo "</tbody></table>";
                 echo "</div>";
 
-                if ($permissions >= \RA\Permissions::Developer && getAchievementMetadata($achID, $dataOut)) {
+                if ($permissions >= Permissions::Developer && getAchievementMetadata($achID, $dataOut)) {
                     getCodeNotes($gameID, $codeNotes);
                     $achMem = $dataOut['MemAddr'];
                     echo "<div class='devbox'>";

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
+use RA\ArticleType;
 use RA\Permissions;
 
 $userPage = requestInputSanitized('ID');
@@ -546,14 +547,13 @@ RenderHtmlStart(true);
 
         if ($userWallActive) {
             echo "<h4>User Wall</h4>";
-            $forceAllowDeleteComments = $permissions >= Permissions::Admin;
             RenderCommentsComponent(
                 $user,
                 $numArticleComments,
                 $commentData,
                 $userPageID,
-                \RA\ArticleType::User,
-                $forceAllowDeleteComments
+                ArticleType::User,
+                $permissions
             );
         }
 


### PR DESCRIPTION
Fixes delete button being available for delete users' comments when not logged in.

Reason: positively compared `null` to `null` here: https://github.com/RetroAchievements/RAWeb/pull/679/files#diff-19a5e613d5b30767be3889ef2bfb1634f7b8affab4670d8492e2de28f481665aR102

![Capture](https://user-images.githubusercontent.com/1280590/129487144-81356512-e117-4e3c-b00a-2de382454a1d.png)
