### PR TITLE
immediately update rich presence when starting a new session

### DIFF
--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -124,7 +124,12 @@ function postActivity($userIn, $activity, $customMsg, $isalt = null)
 
         case ActivityType::StartedPlaying:
             $gameID = $customMsg;
+
+            /**
+             * Switch the rich presence to the new game immediately
+             */
             getGameTitleFromID($gameID, $gameTitle, $consoleIDOut, $consoleName, $forumTopicID, $gameData);
+            UpdateUserRichPresence($user, $gameID, "Playing $gameTitle");
 
             /**
              * Check for recent duplicate:
@@ -152,8 +157,6 @@ function postActivity($userIn, $activity, $customMsg, $isalt = null)
                      */
                 }
             }
-
-            $gameTitle = str_replace("'", "''", $gameTitle);
 
             $query .= "(NOW(), $activity, '$user', '$gameID', NULL)";
             break;


### PR DESCRIPTION
When starting a new game, the user's "Last seen in" doesn't update until the first Rich Presence message is sent.

This PR sets the Rich Presence to "Playing [Game Name]" when a new session is started. It will be updated normally when the first Rich Presence message is sent.

In addition to immediately updating the "Last seen in", this addresses an issue reported by the DuckStation devs where they don't send Rich Presence messages for games that don't have Rich Presence: https://discord.com/channels/310192285306454017/310195854642249728/884134268605980695 
> The last game I played is Gran Turismo, but "Last seen" shows the last game I played that had rich presence

The "Playing [Game Name]" will remain as the last activity until replaced by something else.