### PR TITLE
fix incorrect key for hardcore check in gamecompare page

### DIFF
--- a/public/gamecompare.php
+++ b/public/gamecompare.php
@@ -149,13 +149,12 @@ RenderHtmlHead("Game Compare");
                 $awardedLeft = isset($nextAch['DateEarned']) ? $nextAch['DateEarned'] : null;
                 $awardedRight = isset($nextAch['DateEarnedFriend']) ? $nextAch['DateEarnedFriend'] : null;
                 $awardedHCLeft = isset($nextAch['DateEarnedHardcore']) ? $nextAch['DateEarnedHardcore'] : null;
-                $awardedHCRight = isset($nextAch['DateEarnedHardcoreFriend']) ? $nextAch['DateEarnedHardcoreFriend'] : null;
+                $awardedHCRight = isset($nextAch['DateEarnedFriendHardcore']) ? $nextAch['DateEarnedFriendHardcore'] : null;
 
                 echo "<td class='awardlocal'>";
                 if (isset($awardedLeft)) {
                     if (isset($awardedHCLeft)) {
                         echo GetAchievementAndTooltipDiv($achID, $achTitle, $achDesc, $achPoints, $gameTitle, $badgeName, true, true, "", $iconSize, "goldimage awardLocal");
-                        $leftAwardedCount++;
                         $leftAwardedCount++;
                         $leftAwardedPoints += $achPoints;
                         $leftAwardedPoints += $achPoints;
@@ -189,8 +188,7 @@ RenderHtmlHead("Game Compare");
                         echo GetAchievementAndTooltipDiv($achID, $achTitle, $achDesc, $achPoints, $gameTitle, $badgeName, true, true, "", $iconSize, "goldimage awardremote");
                         echo "</div>";
                         $rightAwardedCount++;
-                        $rightAwardedCount++;
-                        $leftAwardedPoints += $achPoints;
+                        $rightAwardedPoints += $achPoints;
                         $rightAwardedPoints += $achPoints;
 
                         echo "<small class='smalldate leftfloat'>-=HARDCORE=-<br>unlocked on<br>$awardedHCRight</small>";


### PR DESCRIPTION
fixes #204

![image](https://user-images.githubusercontent.com/32680403/133001936-52ea3ae1-b32f-43b0-8bdb-920a5793ee0d.png)

also no longer counts hardcore achievements as two unlocks

![image](https://user-images.githubusercontent.com/32680403/133002168-821271bb-2a33-485f-9ccd-060242fa9f1e.png)

