### PR TITLE
more descriptive email messages

### DIFF
--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -374,16 +374,20 @@ function informAllSubscribersAboutActivity($articleType, $articleID, $activityAu
     $subscribers = [];
     $subjectAuthor = null;
     $altURLTarget = null;
+    $articleTitle = '';
 
     switch ($articleType) {
         case ArticleType::Game:
+            $gameData = getGameData($articleID);
             $subscribers = getSubscribersOfGameWall($articleID);
+            $articleTitle = $gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')';
             break;
 
         case ArticleType::Achievement:
             $achievementData = getAchievementMetadataJSON($articleID);
             $subscribers = getSubscribersOfAchievement($articleID, $achievementData['GameID'], $achievementData['Author']);
             $subjectAuthor = $achievementData['Author'];
+            $articleTitle = $achievementData['AchievementTitle'] . ' (' . $achievementData['GameTitle'] . ')';
             break;
 
         case ArticleType::User:  // User wall
@@ -391,6 +395,7 @@ function informAllSubscribersAboutActivity($articleType, $articleID, $activityAu
             $subscribers = getSubscribersOfUserWall($articleID, $wallUserData['User']);
             $subjectAuthor = $wallUserData['User'];
             $altURLTarget = $wallUserData['User'];
+            $articleTitle = $wallUserData['User'];
             break;
 
         case ArticleType::News:  // News
@@ -400,6 +405,7 @@ function informAllSubscribersAboutActivity($articleType, $articleID, $activityAu
             $activityData = getActivityMetadata($articleID);
             $subscribers = getSubscribersOfFeedActivity($articleID, $activityData['User']);
             $subjectAuthor = $activityData['User'];
+            $articleTitle = $activityData['User'];
             break;
 
         case ArticleType::Leaderboard:  // Leaderboard
@@ -409,6 +415,7 @@ function informAllSubscribersAboutActivity($articleType, $articleID, $activityAu
             $ticketData = getTicket($articleID);
             $subscribers = getSubscribersOfTicket($articleID, $ticketData['ReportedBy'], $ticketData['GameID']);
             $subjectAuthor = $ticketData['ReportedBy'];
+            $articleTitle = $ticketData['AchievementTitle'] . ' (' . $ticketData['GameTitle'] . ')';
             break;
 
         default:
@@ -423,7 +430,7 @@ function informAllSubscribersAboutActivity($articleType, $articleID, $activityAu
     foreach ($subscribers as $subscriber) {
         $isThirdParty = ($subscriber['User'] != $activityAuthor && ($subjectAuthor === null || $subscriber['User'] != $subjectAuthor));
 
-        sendActivityEmail($subscriber['User'], $subscriber['EmailAddress'], $articleID, $activityAuthor, $articleType, $isThirdParty, $altURLTarget);
+        sendActivityEmail($subscriber['User'], $subscriber['EmailAddress'], $articleID, $activityAuthor, $articleType, $articleTitle, $isThirdParty, $altURLTarget);
     }
 }
 

--- a/lib/database/forum.php
+++ b/lib/database/forum.php
@@ -244,7 +244,7 @@ function submitNewTopic($user, $forumID, $topicTitle, $topicPayload, &$newTopicI
         global $db;
         $newTopicIDOut = mysqli_insert_id($db);
 
-        if (submitTopicComment($user, $newTopicIDOut, $topicPayload, $newCommentID)) {
+        if (submitTopicComment($user, $newTopicIDOut, $topicTitle, $topicPayload, $newCommentID)) {
             //error_log( __FUNCTION__ . " posted OK!" );
             //error_log( "$user posted new topic $topicTitle giving topic ID $newTopicIDOut with added comment ID $newCommentID" );
             return true;
@@ -316,7 +316,7 @@ function editTopicComment($commentID, $newPayload)
     }
 }
 
-function submitTopicComment($user, $topicID, $commentPayload, &$newCommentIDOut)
+function submitTopicComment($user, $topicID, $topicTitle, $commentPayload, &$newCommentIDOut)
 {
     sanitize_sql_inputs($user, $topicID);
     $userID = getUserIDFromUser($user);
@@ -338,7 +338,16 @@ function submitTopicComment($user, $topicID, $commentPayload, &$newCommentIDOut)
         $newCommentIDOut = mysqli_insert_id($db);
         setLatestCommentInForumTopic($topicID, $newCommentIDOut);
 
-        notifyUsersAboutForumActivity($topicID, $user, $newCommentIDOut);
+        if ($topicTitle == null) {
+            $topicData = [];
+            if (getTopicDetails($topicID, $topicData)) {
+                $topicTitle = $topicData['TopicTitle'];
+            } else {
+                $topicTitle = '';
+            }
+        }
+
+        notifyUsersAboutForumActivity($topicID, $topicTitle, $user, $newCommentIDOut);
 
         //error_log( __FUNCTION__ . " posted OK!" );
         // error_log(__FUNCTION__ . " $user posted $commentPayload for topic ID $topicID");
@@ -350,7 +359,7 @@ function submitTopicComment($user, $topicID, $commentPayload, &$newCommentIDOut)
     }
 }
 
-function notifyUsersAboutForumActivity($topicID, $author, $commentID)
+function notifyUsersAboutForumActivity($topicID, $topicTitle, $author, $commentID)
 {
     sanitize_sql_inputs($topicID, $author, $commentID);
 
@@ -375,7 +384,7 @@ function notifyUsersAboutForumActivity($topicID, $author, $commentID)
 
     $urlTarget = "viewtopic.php?t=$topicID&c=$commentID";
     foreach ($subscribers as $sub) {
-        sendActivityEmail($sub['User'], $sub['EmailAddress'], $topicID, $author, \RA\ArticleType::Leaderboard, null, $urlTarget);
+        sendActivityEmail($sub['User'], $sub['EmailAddress'], $topicID, $author, \RA\ArticleType::Forum, $topicTitle, null, $urlTarget);
     }
 }
 

--- a/public/request/forum-topic-comment/create.php
+++ b/public/request/forum-topic-comment/create.php
@@ -13,7 +13,7 @@ if (!ValidatePOSTChars("tp")) {
 }
 
 if (validateFromCookie($user, $unused, $permissions, \RA\Permissions::Registered)) {
-    if (submitTopicComment($user, $topicID, $commentPayload, $newCommentID)) {
+    if (submitTopicComment($user, $topicID, null, $commentPayload, $newCommentID)) {
         //	Good!
         header("Location: " . getenv('APP_URL') . "/viewtopic.php?t=$topicID&c=$newCommentID");
         exit;

--- a/src/ArticleType.php
+++ b/src/ArticleType.php
@@ -18,6 +18,8 @@ abstract class ArticleType
 
     public const AchievementTicket = 7;
 
+    public const Forum = 8;
+
     private const VALUES = [
         self::Game,
         self::Achievement,
@@ -26,6 +28,7 @@ abstract class ArticleType
         self::Activity,
         self::Leaderboard,
         self::AchievementTicket,
+        self::Forum,
     ];
 
     public static function values(): array


### PR DESCRIPTION
implements #649 

Changes the middle of an email message to include the title of the related record.

Before:
```
New Game Wall Comment from User123

Hello Jamiras!
A game wall discussion you've commented in on RetroAchievements has received
a new comment from User123. Click [here] to see what they have written!

Thanks! And hope to see you on the forums!

-- Your friends at RetroAchievements.org
```

After:
```
New Game Wall Comment from User123

Hello Jamiras!
User123 has commented on the game wall for Super Mario Bros. (NES). Click [here] to see what they have written!

Thanks! And hope to see you on the forums!

-- Your friends at RetroAchievements.org
```

Some other examples:
```
Jamiras has commented on the achievement wall for Master Plumber III (Super Mario Bros.).
```
```
Jamiras has commented on User123's user wall.
```
```
Jamiras has commented on a ticket for Attack of the Clone (Zen - Intergalactic Ninja).
```
```
Jamiras has commented on the forum post "Dragon Ball Z - Super Saiya Densetsu".
```




