### PR TITLE
Site Award Image Hosting Update

### DIFF
--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -188,17 +188,17 @@ function RenderSiteAwards($userAwards)
                 $tooltip = "Awarded for producing many valuable achievements, providing over " . RA\AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$awardData] . " points to the community!";
 
                 if ($awardData == 0) {
-                    $imagepath = "/Images/00133.png";
+                    $imagepath = "/Images/trophy-green.png";
                 } elseif ($awardData == 1) {
-                    $imagepath = "/Images/00134.png";
+                    $imagepath = "/Images/trophy-bronze.png";
                 } elseif ($awardData == 2) {
-                    $imagepath = "/Images/00137.png";
+                    $imagepath = "/Images/trophy-platinum.png";
                 } elseif ($awardData == 3) {
-                    $imagepath = "/Images/00135.png";
+                    $imagepath = "/Images/trophy-silver.png";
                 } elseif ($awardData == 4) {
-                    $imagepath = "/Images/00136.png";
+                    $imagepath = "/Images/trophy-gold.png";
                 } else {
-                    $imagepath = "/Images/00136.png";
+                    $imagepath = "/Images/trophy-gold.png";
                 }
 
                 $linkdest = ''; //    TBD: referrals page?
@@ -206,17 +206,17 @@ function RenderSiteAwards($userAwards)
                 $tooltip = "Referred $awardData members";
 
                 if ($awardData < 2) {
-                    $imagepath = "/Images/00083.png";
+                    $imagepath = "/Badge/00083.png";
                 } elseif ($awardData < 3) {
-                    $imagepath = "/Images/00083.png";
+                    $imagepath = "/Badge/00083.png";
                 } elseif ($awardData < 5) {
-                    $imagepath = "/Images/00083.png";
+                    $imagepath = "/Badge/00083.png";
                 } elseif ($awardData < 10) {
-                    $imagepath = "/Images/00083.png";
+                    $imagepath = "/Badge/00083.png";
                 } elseif ($awardData < 15) {
-                    $imagepath = "/Images/00083.png";
+                    $imagepath = "/Badge/00083.png";
                 } else {
-                    $imagepath = "/Images/00083.png";
+                    $imagepath = "/Badge/00083.png";
                 }
 
                 $linkdest = ''; //    TBD: referrals page?

--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -181,24 +181,24 @@ function RenderSiteAwards($userAwards)
             } elseif ($awardType == 2) { //    Developed a number of earned achievements
                 $tooltip = "Awarded for being a hard-working developer and producing achievements that have been earned over " . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . " times!";
 
-                $imagepath = getenv('ASSET_URL') . "/Images/_Trophy" . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . ".png";
+                $imagepath = "/Images/_Trophy" . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . ".png";
 
                 $linkdest = ''; //    TBD: referrals page?
             } elseif ($awardType == 3) { //    Yielded an amount of points earned by players
                 $tooltip = "Awarded for producing many valuable achievements, providing over " . RA\AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$awardData] . " points to the community!";
 
                 if ($awardData == 0) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00133.png";
+                    $imagepath = "/Images/00133.png";
                 } elseif ($awardData == 1) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00134.png";
+                    $imagepath = "/Images/00134.png";
                 } elseif ($awardData == 2) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00137.png";
+                    $imagepath = "/Images/00137.png";
                 } elseif ($awardData == 3) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00135.png";
+                    $imagepath = "/Images/00135.png";
                 } elseif ($awardData == 4) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00136.png";
+                    $imagepath = "/Images/00136.png";
                 } else {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00136.png";
+                    $imagepath = "/Images/00136.png";
                 }
 
                 $linkdest = ''; //    TBD: referrals page?
@@ -206,29 +206,29 @@ function RenderSiteAwards($userAwards)
                 $tooltip = "Referred $awardData members";
 
                 if ($awardData < 2) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } elseif ($awardData < 3) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } elseif ($awardData < 5) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } elseif ($awardData < 10) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } elseif ($awardData < 15) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } else {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 }
 
                 $linkdest = ''; //    TBD: referrals page?
             } elseif ($awardType == 5) { //    Signed up for facebook!
                 $tooltip = "Awarded for associating their account with Facebook! Thanks for spreading the word!";
 
-                $imagepath = getenv('ASSET_URL') . "/Images/_FBAssoc.png";
+                $imagepath = "/Images/_FBAssoc.png";
                 $linkdest = "/controlpanel.php#facebook";
             } elseif ($awardType == 6) {  //  Patreon Supporter
                 $tooltip = 'Awarded for being a Patreon supporter! Thank-you so much for your support!';
 
-                $imagepath = getenv('ASSET_URL') . '/Badge/PatreonBadge.png';
+                $imagepath = '/Images/PatreonBadge.png';
                 $linkdest = 'https://www.patreon.com/retroachievements';
             } else {
                 // error_log("Unknown award type" . $awardType);

--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -84,49 +84,49 @@ RenderHtmlHead("Reorder Site Awards");
             } elseif ($awardType == 2) { //    Developed a number of earned achievements
                 $tooltip = "Awarded for being a hard-working developer and producing achievements that have been earned over " . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . " times!";
                 $awardTitle = "Achievements Earned by Others";
-                $imagepath = getenv('ASSET_URL') . "/Images/_Trophy" . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . ".png";
+                $imagepath = "/Images/_Trophy" . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . ".png";
             } elseif ($awardType == 3) { //    Yielded an amount of points earned by players
                 $tooltip = "Awarded for producing many valuable achievements, providing over " . RA\AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$awardData] . " points to the community!";
                 $awardTitle = "Achievement Points Earned by Others";
 
                 if ($awardData == 0) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00133.png";
+                    $imagepath = "/Images/00133.png";
                 } elseif ($awardData == 1) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00134.png";
+                    $imagepath = "/Images/00134.png";
                 } elseif ($awardData == 2) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00137.png";
+                    $imagepath = "/Images/00137.png";
                 } elseif ($awardData == 3) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00135.png";
+                    $imagepath = "/Images/00135.png";
                 } elseif ($awardData == 4) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00136.png";
+                    $imagepath = "/Images/00136.png";
                 } else {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00136.png";
+                    $imagepath = "/Images/00136.png";
                 }
             } elseif ($awardType == 4) { //    Referrals
                 $tooltip = "Referred $awardData members";
                 $awardTitle = "Referral Award";
 
                 if ($awardData < 2) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } elseif ($awardData < 3) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } elseif ($awardData < 5) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } elseif ($awardData < 10) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } elseif ($awardData < 15) {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 } else {
-                    $imagepath = getenv('ASSET_URL') . "/Badge/00083.png";
+                    $imagepath = "/Images/00083.png";
                 }
             } elseif ($awardType == 5) { //    Signed up for facebook!
                 $tooltip = "Awarded for associating their account with Facebook! Thanks for spreading the word!";
                 $awardTitle = "Facebook Association";
-                $imagepath = getenv('ASSET_URL') . "/Images/_FBAssoc.png";
+                $imagepath = "/Images/_FBAssoc.png";
             } elseif ($awardType == 6) {  //  Patreon Supporter
                 $tooltip = 'Awarded for being a Patreon supporter! Thank-you so much for your support!';
                 $awardTitle = "Patreon Supporter";
-                $imagepath = getenv('ASSET_URL') . '/Badge/PatreonBadge.png';
+                $imagepath = '/Images/PatreonBadge.png';
             } else {
                 // error_log("Unknown award type" . $awardType);
                 continue;


### PR DESCRIPTION
This updates the site awards images to be read from the RA server rather than amazon. Also moves them to the `/Images` folder rather than the `/Badge` folder. Images in the `/Badge` folder can be used as achievement badges, which is the driving force for this update.

Will resolve #832 after the proper images are moved the the correct directories and the amazon badges updated back to their originals.