### PR TITLE
include LowerIsBetter in leaderboard patchdata

### DIFF
--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -914,7 +914,7 @@ function GetLBPatch($gameID)
     $lbData = [];
 
     //    Always append LBs?
-    $query = "SELECT ld.ID, ld.Mem, ld.Format, ld.Title, ld.Description
+    $query = "SELECT ld.ID, ld.Mem, ld.Format, ld.LowerIsBetter, ld.Title, ld.Description
               FROM LeaderboardDef AS ld
               WHERE ld.GameID = $gameID
               ORDER BY ld.DisplayOrder, ld.ID ";
@@ -923,6 +923,7 @@ function GetLBPatch($gameID)
     if ($dbResult !== false) {
         while ($db_entry = mysqli_fetch_assoc($dbResult)) {
             settype($db_entry['ID'], 'integer');
+            settype($db_entry['LowerIsBetter'], 'boolean');
             $lbData[] = $db_entry;
         }
     } else {


### PR DESCRIPTION
Before:
```
...
"Leaderboards":[{"ID":3774,
"Mem":"STA:0xH00005c=4_0xH000043=5::CAN:0xH00005c=11::SUB:0xH00005c=12::VAL:0xH000095*10000_0xH000096*1000_0xH000097*100_0xH000098*10_0xH000099",
"Format":"SCORE",
"Title":"Waldo Challenge",
"Description":"Highest score completing the Waldo Super Challenge"}]}
```
After:
```
...
"Leaderboards":[{"ID":3774,
"Mem":"STA:0xH00005c=4_0xH000043=5::CAN:0xH00005c=11::SUB:0xH00005c=12::VAL:0xH000095*10000_0xH000096*1000_0xH000097*100_0xH000098*10_0xH000099",
"Format":"SCORE",
"LowerIsBetter":false,
"Title":"Waldo Challenge",
"Description":"Highest score completing the Waldo Super Challenge"}]}
```