### PR TITLE
make dorequest?r=login behave like login_app

### DIFF
--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -272,40 +272,36 @@ function generateAppToken($user, &$tokenOut)
     }
 }
 
-function login_appWithToken($user, $pass, &$tokenInOut, &$scoreOut, &$messagesOut): int
+function loginApp($user, $pass, $token)
 {
     //error_log( __FUNCTION__ . "user:$user, tokenInOut:$tokenInOut" );
 
-    sanitize_sql_inputs($user);
+    sanitize_sql_inputs($user, $token);
+
+    $query = null;
+    $response = [];
 
     if (!isset($user) || $user == false || mb_strlen($user) < 2) {
         // error_log(__FUNCTION__ . " username failed: empty user");
-        return 0;
-    }
+    } else {
+        $passwordProvided = (isset($pass) && mb_strlen($pass) >= 1);
+        $tokenProvided = (isset($token) && mb_strlen($token) >= 1);
 
-    $passwordProvided = (isset($pass) && mb_strlen($pass) >= 1);
-    $tokenProvided = (isset($tokenInOut) && mb_strlen($tokenInOut) >= 1);
-
-    if (!$passwordProvided && !$tokenProvided) {
-        return 0;
-    }
-
-    $query = null;
-
-    if ($passwordProvided) {
-        $loginUser = $user;
-        $authenticated = validateUser($loginUser, $pass, $fbUser, 0);
-        if (!$authenticated) {
-            return 0;
+        if ($passwordProvided) {
+            //    Password provided, validate it
+            if (validateUser($user, $pass, $fbUser, 0)) {
+                $query = "SELECT RAPoints, Permissions, appToken FROM UserAccounts WHERE User='$user'";
+            }
+        } elseif ($tokenProvided) {
+            //    Token provided, look for match
+            $query = "SELECT RAPoints, Permissions, appToken, appTokenExpiry FROM UserAccounts WHERE User='$user' AND appToken='$token'";
         }
-        $query = "SELECT RAPoints, appToken FROM UserAccounts WHERE User='$user'";
-    } elseif ($tokenProvided) {
-        //    Token provided:
-        $query = "SELECT RAPoints, appToken, appTokenExpiry FROM UserAccounts WHERE User='$user' AND appToken='$tokenInOut'";
     }
 
     if (!$query) {
-        return 0;
+        $response['Success'] = false;
+        $response['Error'] = "Invalid User/Password combination. Please try again";
+        return $response;
     }
 
     //error_log( $query );
@@ -318,28 +314,21 @@ function login_appWithToken($user, $pass, &$tokenInOut, &$scoreOut, &$messagesOu
             if ($tokenProvided) {
                 $expiry = $data['appTokenExpiry'];
                 if (time() > strtotime($expiry)) {
-                    generateAppToken($user, $tokenInOut);
+                    generateAppToken($user, $token);
                     //    Expired!
                     // error_log(__FUNCTION__ . " failed6: user:$user, tokenInOut:$tokenInOut, $expiry, " . strtotime($expiry));
-                    return -1;
+                    $response['Success'] = false;
+                    $response['Error'] = "Automatic login failed (token expired), please login manually";
                 }
             }
 
-            $scoreOut = $data['RAPoints'];
-            settype($scoreOut, "integer");
-            $messagesOut = GetMessageCount($user, $totalMessageCount);
-
-            //if( $passwordProvided )
-            //    generateAppToken( $user, $tokenInOut );
-            //    Against my better judgement... ##SD
             if (mb_strlen($data['appToken']) != 16) {   //    Generate if new
                 generateAppToken($user, $tokenInOut);
             } else {
                 //    Return old token if not
-                $tokenInOut = $data['appToken'];
+                $token = $data['appToken'];
 
                 //    Update app token expiry now anyway
-
                 $expDays = 14;
                 $expiryStr = date("Y-m-d H:i:s", (time() + 60 * 60 * 24 * $expDays));
                 $query = "UPDATE UserAccounts SET appTokenExpiry='$expiryStr' WHERE User='$user'";
@@ -349,14 +338,27 @@ function login_appWithToken($user, $pass, &$tokenInOut, &$scoreOut, &$messagesOu
 
             postActivity($user, ActivityType::Login, "");
 
-            return 1;
+            $response['Success'] = true;
+            $response['User'] = $user;
+            $response['Token'] = $token;
+            $response['Score'] = $data['RAPoints'];
+            settype($response['Score'], "integer");
+            $response['Messages'] = GetMessageCount($user, $totalMessageCount);
+            $response['Permissions'] = $data['Permissions'];
+            settype($response['Permissions'], "integer");
+            $response['AccountType'] = PermissionsToString($response['Permissions']);
         } else {
             // error_log(__FUNCTION__ . " failed5: user:$user, tokenInOut:$tokenInOut");
-            return 0;
+            $response['Success'] = false;
+            $response['Error'] = "Invalid User/Password combination. Please try again";
         }
+    } else {
+        // query failure
+        $response['Success'] = false;
+        $response['Error'] = "Invalid User/Password combination. Please try again";
     }
 
-    return 0;
+    return $response;
 }
 
 function getUserAppToken($user)

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -281,12 +281,12 @@ function loginApp($user, $pass, $token)
     $query = null;
     $response = [];
 
+    $passwordProvided = (isset($pass) && mb_strlen($pass) >= 1);
+    $tokenProvided = (isset($token) && mb_strlen($token) >= 1);
+
     if (!isset($user) || $user == false || mb_strlen($user) < 2) {
         // error_log(__FUNCTION__ . " username failed: empty user");
     } else {
-        $passwordProvided = (isset($pass) && mb_strlen($pass) >= 1);
-        $tokenProvided = (isset($token) && mb_strlen($token) >= 1);
-
         if ($passwordProvided) {
             //    Password provided, validate it
             if (validateUser($user, $pass, $fbUser, 0)) {

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -100,19 +100,7 @@ switch ($requestType) {
     case "login": // From App!
         $user = requestInput('u');
         $rawPass = requestInput('p');
-        $success = login_appWithToken($user, $rawPass, $token, $scoreOut, $messagesOut);
-        if ($success == 1) {
-            // OK:
-            $response['User'] = $user;
-            $response['Token'] = $token;
-            $response['Score'] = $scoreOut;
-            $response['Messages'] = $messagesOut;
-        } else {
-            /**
-             * Token invalid or out of date
-             */
-            DoRequestError("Login failed. Check your credentials and try again.");
-        }
+        $response = loginApp($user, $rawPass, $token);
         break;
 
     /**

--- a/public/login_app.php
+++ b/public/login_app.php
@@ -8,30 +8,9 @@ $user = requestInputPost('u', null);
 $pass = requestInputPost('p', null);
 $token = requestInputPost('t', null);
 
-$response = [];
-
-$responseCode = login_appWithToken($user, $pass, $token, $scoreOut, $messagesOut);
-
-if ($responseCode == -1) {
+$response = loginApp($user, $pass, $token);
+if ($response['Success'] == false) {
     http_response_code(401);
-    $response['Success'] = false;
-    $response['Error'] = "Automatic login failed (token expired), please login manually!";
-} else {
-    if ($responseCode == 1) {
-        getAccountDetails($user, $userDetails);
-        $response['Success'] = true;
-        $response['User'] = $user;
-        $response['Token'] = $token;
-        $response['Score'] = $scoreOut;
-        $response['Messages'] = $messagesOut;
-        $response['Permissions'] = $userDetails['Permissions'];
-        $response['AccountType'] = PermissionsToString($userDetails['Permissions']);
-    } else {
-        http_response_code(401);
-        $response['Success'] = false;
-        $response['Error'] = "Invalid User/Password combination. Please try again";
-        // error_log("requestlogin failed $user");
-    }
 }
 
 echo json_encode($response);


### PR DESCRIPTION
Fixes #109 and #238 for the `dorequest?r=login` API.

The 0.79 DLL switched from using custom URLs to using rapi, which also caused it to switch from using the `login_app` endpoint to the `dorequest?r=login` API for logins. Because the two endpoints are out-of-sync, this resulted in #109 reappearing (see https://discord.com/channels/310192285306454017/310195854642249728/894042414132625438).

Retroarch has always used the `dorequest?r=login` API for logins, so it has never benefitted from the case-correcting, but I believe all that is affected there is the welcome message.

This ensures the two endpoints behave the same, though I don't believe anything is using the `login_app` endpoint any more.

Example test responses:
```
$ curl "localhost/dorequest.php?r=login&u=jamiras&p=Jamiras" && echo
{"Success":true,"User":"jamiras","Token":"bzKK1lDWEFHiFixo","Score":58874,"Messages":0}
$ curl -X POST "localhost/login_app.php" -d "u=jamiras&p=Jamiras" && echo
{"Success":true,"User":"Jamiras","Token":"bzKK1lDWEFHiFixo","Score":58874,"Messages":0,"Permissions":"4","AccountType":"Admin"}
```
Notice the `login_app` endpoint case-corrects the username and includes the Permissions information. With this PR, both functions now return the same data. The `login_app` endpoint does still return a 401 status code on failure, whereas the `dorequest?r=login` API returns 200 with the same payload indicating `"Success":false` with an `"Error":"[message]"`.