### PR TITLE
don't hide forum topics if last post is from an unverified user

### DIFF
--- a/lib/database/forum.php
+++ b/lib/database/forum.php
@@ -90,8 +90,8 @@ function getForumTopics($forumID, $offset, $count, &$maxCountOut)
                 FROM ForumTopic AS ft
                 LEFT JOIN ForumTopicComment AS ftc ON ftc.ID = ft.LatestCommentID
                 LEFT JOIN Forum AS f ON f.ID = ft.ForumID
-                LEFT JOIN ForumTopicComment AS ftc2 ON ftc2.ForumTopicID = ft.ID
-                WHERE ft.ForumID = $forumID AND ftc.Authorised = 1
+                LEFT JOIN ForumTopicComment AS ftc2 ON ftc2.ForumTopicID = ft.ID AND ftc2.Authorised = 1
+                WHERE ft.ForumID = $forumID
                 GROUP BY ft.ID, LatestCommentPostedDate
                 ORDER BY LatestCommentPostedDate DESC
                 LIMIT $offset, $count";
@@ -102,8 +102,10 @@ function getForumTopics($forumID, $offset, $count, &$maxCountOut)
 
         $numResults = 0;
         while ($db_entry = mysqli_fetch_assoc($dbResult)) {
-            $dataOut[$numResults] = $db_entry;
-            $numResults++;
+            if ($db_entry['NumTopicReplies'] != -1) {
+                $dataOut[$numResults] = $db_entry;
+                $numResults++;
+            }
         }
         return $dataOut;
     } else {

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -252,7 +252,7 @@ RenderHtmlStart();
 
             if ($nextCommentAuthorised == 0) {
                 // Allow, only if this is MY comment (disclaimer: unofficial), or if I'm admin (disclaimer: unofficial, verify user?)
-                if ($permissions >= Permissions::Developer) {
+                if ($permissions >= Permissions::Admin) {
                     // Allow with disclaimer
                     $showDisclaimer = true;
                     $showAuthoriseTools = true;


### PR DESCRIPTION
Instead of filtering on forum topics where the last post is unauthorized, this modifies the query to count the number of authorized posts in a forum topic and ignores anything without any authorized posts.

The list will still show the unauthorized user as the user for the last post, but upon opening the topic, the unauthorized posts will remain hidden.
![image](https://user-images.githubusercontent.com/32680403/137637609-04c8e04d-4b0e-4ea7-be2f-8395a2bb123e.png)

The unauthorized links page still shows the full post count:
![image](https://user-images.githubusercontent.com/32680403/137637718-982055f2-ed6a-4947-93e3-f97595a4a002.png)

The unauthorized post also does not appear in the Forum Activity list on the main page, or the Forum Post History. No change was necessary for that behavior.