### PR TITLE
Prevent blocked users from sending private messages

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -1052,7 +1052,7 @@ function getAchievementRecentWinnersData($achID, $offset, $count, $user = null, 
 
     $extraWhere = "";
     if (isset($friendsOnly) && $friendsOnly && isset($user) && $user) {
-        $extraWhere = " AND aw.User IN ( SELECT Friend FROM Friends WHERE User = '$user' ) ";
+        $extraWhere = " AND aw.User IN ( SELECT Friend FROM Friends WHERE User = '$user' AND Friendship = 1 ) ";
     }
 
     //    Get recent winners, and their most recent activity:

--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -534,7 +534,7 @@ function getFeed($user, $maxMessages, $offset, &$dataOut, $latestFeedID = 0, $ty
     if ($type == 'activity') {      //    Find just this activity, ONLY!
         $subquery = "act.ID = $latestFeedID ";
     } elseif ($type == 'friends') {     //    User has been provided: find my friends!
-        $subquery = "act.ID > $latestFeedID AND ( act.user = '$user' OR act.user IN ( SELECT f.Friend FROM Friends AS f WHERE f.User = '$user' ) )";
+        $subquery = "act.ID > $latestFeedID AND ( act.user = '$user' OR act.user IN ( SELECT f.Friend FROM Friends AS f WHERE f.User = '$user' AND f.Friendship = 1 ) )";
     } elseif ($type == 'individual') {    //    User and 'individual', just this user's feed!
         $subquery = "act.ID > $latestFeedID AND ( act.user = '$user' )";
     } else { //if( $type == 'global' )                    //    Otherwise, global feed

--- a/lib/database/friend.php
+++ b/lib/database/friend.php
@@ -308,6 +308,7 @@ function getAllFriendsProgress($user, $gameID, &$friendScoresOut)
                 SELECT f.Friend 
                 FROM Friends AS f 
                 WHERE f.User = '$user'
+                AND f.Friendship = 1
             ) AS _FriendList 
             LEFT JOIN UserAccounts AS ua ON ua.User = aw.User 
             LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID 
@@ -351,6 +352,7 @@ function GetFriendList($user)
               FROM Friends AS f
               LEFT JOIN UserAccounts AS ua ON ua.User = f.Friend
               WHERE f.User='$user'
+              AND f.Friendship = 1
               AND ua.ID IS NOT NULL
               ORDER BY ua.LastActivityID DESC";
 

--- a/lib/database/friend.php
+++ b/lib/database/friend.php
@@ -247,6 +247,24 @@ function isFriendsWith($user, $friend)
     return $data['Friendship'] == '1';
 }
 
+function isUserBlocking($user, $possibly_blocked_user)
+{
+    sanitize_sql_inputs($user, $possibly_blocked_user);
+
+    $query = "SELECT * FROM Friends WHERE User='$user' AND Friend='$possibly_blocked_user'";
+    $dbResult = s_mysql_query($query);
+    if ($dbResult == false) {
+        return false;
+    }
+
+    $data = mysqli_fetch_assoc($dbResult);
+    if ($data == false) {
+        return false;
+    }
+
+    return $data['Friendship'] == '-1';
+}
+
 function getAllFriendsProgress($user, $gameID, &$friendScoresOut)
 {
     sanitize_sql_inputs($user, $gameID);

--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -374,7 +374,7 @@ function GetLeaderboardEntriesDataJSON($lbID, $user, $numToFetch, $offset, $frie
     $retVal = [];
 
     //    'Me or my friends'
-    $friendQuery = $friendsOnly ? "( ( ua.User IN ( SELECT Friend FROM Friends WHERE User='$user' ) ) OR ua.User='$user' )" : "TRUE";
+    $friendQuery = $friendsOnly ? "( ( ua.User IN ( SELECT Friend FROM Friends WHERE User='$user' AND Friendship = 1 ) ) OR ua.User='$user' )" : "TRUE";
 
     //    Get entries:
     $query = "SELECT ua.User, le.Score, UNIX_TIMESTAMP( le.DateSubmitted ) AS DateSubmitted

--- a/lib/render/error.php
+++ b/lib/render/error.php
@@ -26,6 +26,7 @@ function RenderErrorCodeWarning(?string $errorCode)
         'issue_submitted' => "Your issue ticket has been successfully submitted.",
         'merge_failed' => "Problems encountered while performing merge. These errors have been reported and will be fixed soon... sorry!",
         'merge_success' => "Game merge successful!",
+        'messageblocked' => "Message was not delivered - blocked by recipient.",
         'modify_game_ok' => "Game modify successful!",
         'modify_ok' => "Info: Modified OK!",
         'newadded' => "Friend request sent.",

--- a/lib/render/error.php
+++ b/lib/render/error.php
@@ -26,7 +26,6 @@ function RenderErrorCodeWarning(?string $errorCode)
         'issue_submitted' => "Your issue ticket has been successfully submitted.",
         'merge_failed' => "Problems encountered while performing merge. These errors have been reported and will be fixed soon... sorry!",
         'merge_success' => "Game merge successful!",
-        'messageblocked' => "Message was not delivered - blocked by recipient.",
         'modify_game_ok' => "Game modify successful!",
         'modify_ok' => "Info: Modified OK!",
         'newadded' => "Friend request sent.",

--- a/public/request/message/send.php
+++ b/public/request/message/send.php
@@ -17,7 +17,7 @@ $payload = requestInputPost('m');
 
 if (validateUser_cookie($user, $cookie, 0) == true) {
     if (isUserBlocking($recipient, $user)) {
-        header("Location: " . getenv('APP_URL') . "/inbox.php?e=messageblocked");
+        header("Location: " . getenv('APP_URL') . "/inbox.php?e=sentok");
         exit;
     }
 

--- a/public/request/message/send.php
+++ b/public/request/message/send.php
@@ -16,6 +16,11 @@ $title = requestInputPost('t');
 $payload = requestInputPost('m');
 
 if (validateUser_cookie($user, $cookie, 0) == true) {
+    if (isUserBlocking($recipient, $user)) {
+        header("Location: " . getenv('APP_URL') . "/inbox.php?e=messageblocked");
+        exit;
+    }
+
     if (CreateNewMessage($user, $recipient, $title, $payload)) {
         header("Location: " . getenv('APP_URL') . "/inbox.php?e=sentok");
         exit;

--- a/public/request/message/send.php
+++ b/public/request/message/send.php
@@ -17,6 +17,7 @@ $payload = requestInputPost('m');
 
 if (validateUser_cookie($user, $cookie, 0) == true) {
     if (isUserBlocking($recipient, $user)) {
+        // recipient has blocked the user. just pretend the message was sent
         header("Location: " . getenv('APP_URL') . "/inbox.php?e=sentok");
         exit;
     }

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -342,9 +342,7 @@ RenderHtmlStart(true);
                 echo "<span class='clickablebutton'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$userPage&amp;a=0'>Unblock user</a></span>";
             }
 
-            if ($userMassData['FriendReciprocation'] !== -1) {
-                echo "<span class='clickablebutton'><a href='/createmessage.php?t=$userPage'>Send Private Message</a></span>";
-            }
+            echo "<span class='clickablebutton'><a href='/createmessage.php?t=$userPage'>Send Private Message</a></span>";
 
             echo "</div>"; //    buttoncollection
             echo "</div>"; //    friendbox

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -342,7 +342,9 @@ RenderHtmlStart(true);
                 echo "<span class='clickablebutton'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$userPage&amp;a=0'>Unblock user</a></span>";
             }
 
-            echo "<span class='clickablebutton'><a href='/createmessage.php?t=$userPage'>Send Private Message</a></span>";
+            if ($userMassData['FriendReciprocation'] !== -1) {
+                echo "<span class='clickablebutton'><a href='/createmessage.php?t=$userPage'>Send Private Message</a></span>";
+            }
 
             echo "</div>"; //    buttoncollection
             echo "</div>"; //    friendbox
@@ -547,8 +549,10 @@ RenderHtmlStart(true);
 
         if ($userWallActive) {
             echo "<h4>User Wall</h4>";
+
+            // passing 'null' for $user disables the ability to add comments
             RenderCommentsComponent(
-                $user,
+                ($userMassData['FriendReciprocation'] !== -1) ? $user : null,
                 $numArticleComments,
                 $commentData,
                 $userPageID,


### PR DESCRIPTION
Removes the "Send Private Message" link from a user's page when that user has blocked the logged in user. Also removes the ability to post comments on that user's page.

Additionally, removes blocked users from the "compare with friends" lists on the game page and a couple of API calls.

Fixes #813. Closes #691