### PR TITLE
Add an empty cell under the Last Updated column

### DIFF
--- a/public/gameList.php
+++ b/public/gameList.php
@@ -199,11 +199,11 @@ RenderHtmlHead("Supported Games" . $requestedConsole);
                 echo "<td><b>Totals: $gameCount games</b></td>";
                 echo "<td><b>$achievementsTally</b></td>";
                 echo "<td><b>$pointsTally</b><span class='TrueRatio'> ($truePointsTally)</span></td>";
+                echo "<td></td>";
                 echo "<td><b>$lbCount</b></td>";
                 if ($showTickets) {
                     echo "<td><b>$ticketsCount</b></td>";
                 }
-                echo "<td></td>";
                 echo "</tr>";
                 echo "</tbody></table></div>";
             }


### PR DESCRIPTION
Also removes an empty cell that doesn't correspond to any column.

This fixes leaderboard and ticket totals displaying under the incorrect columns.
![gamelist](https://user-images.githubusercontent.com/94993132/143310767-938dc623-7497-4c82-a352-a6c22b366e09.png)
![gamelist-fix](https://user-images.githubusercontent.com/94993132/143311318-ed308ebf-2467-48e5-9eea-5c68a4ad2cf1.png)
