### PR TITLE
allow official forum topic sidebar link when not logged in

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1083,12 +1083,13 @@ RenderHtmlStart(true);
             <?php
             RenderBoxArt($gameData['ImageBoxArt']);
 
+            echo "<h3>More Info</h3>";
+            echo "<ul>";
+            echo "<li>";
+            RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions);
+            echo "</li>";
+
             if (isset($user)) {
-                echo "<h3>More Info</h3>";
-                echo "<ul>";
-                echo "<li>";
-                RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions);
-                echo "</li>";
                 echo "<li><a class='info-button' href='/linkedhashes.php?g=$gameID'><span>🔗</span>Hashes linked to this game</a></li>";
                 $numOpenTickets = countOpenTickets(
                     requestInputSanitized('f') == $unofficialFlag,


### PR DESCRIPTION
The "Official Forum Topic" link always appears after the achievements. It only appears in the sidebar when logged in. This just makes it visible in the sidebar when not logged in.

It does have the unintended side effect of showing an empty "More Info" sidebar section if not logged in and the game does not have an official forum topic.