### PR TITLE
show recent players on game page

### DIFF
--- a/lib/constants.php
+++ b/lib/constants.php
@@ -1,4 +1,4 @@
 <?php
 
-define('VERSION', '1.74.2');
+define('VERSION', '1.75.0');
 define('MIN_POINTS', 500);

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -420,10 +420,10 @@ function getGamesListByDev($dev, $consoleID, &$dataOut, $sortBy, $ticketsFlag = 
             break;
 
         case 6:
-            $query .= "ORDER BY gd.ConsoleID, MAX(ach.DateModified) DESC, Title ";
+            $query .= "ORDER BY gd.ConsoleID, DateModified DESC, Title ";
             break;
         case 16:
-            $query .= "ORDER BY gd.ConsoleID, MAX(ach.DateModified) ASC, Title DESC ";
+            $query .= "ORDER BY gd.ConsoleID, DateModified ASC, Title DESC ";
             break;
     }
 

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -902,6 +902,34 @@ function getTotalUniquePlayers($gameID, $requestedBy)
     return $data['UniquePlayers'];
 }
 
+function getGameRecentPlayers($gameID, $maximum_results = 0)
+{
+    sanitize_sql_inputs($gameID, $maximum_results);
+    settype($gameID, 'integer');
+
+    $retval = [];
+
+    $query = "SELECT ua.ID as UserID, ua.User, ua.RichPresenceMsgDate AS Date, ua.RichPresenceMsg AS Activity
+              FROM UserAccounts AS ua
+              WHERE ua.LastGameID = $gameID
+              ORDER BY ua.RichPresenceMsgDate DESC";
+
+    if ($maximum_results > 0) {
+        $query .= " LIMIT $maximum_results";
+    }
+
+    $dbResult = s_mysql_query($query);
+    SQL_ASSERT($dbResult);
+
+    if ($dbResult !== false) {
+        while ($data = mysqli_fetch_assoc($dbResult)) {
+            $retval[] = $data;
+        }
+    }
+
+    return $retval;
+}
+
 /**
  * Gets a game's high scorers or latest masters.
  *

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -177,3 +177,35 @@ function RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions 
         }
     }
 }
+
+function RenderRecentGamePlayers($recentPlayerData)
+{
+    echo "<div class='component'>Recent Players:";
+    echo "<table class='smalltable'><tbody>";
+    echo "<tr><th>User</th><th>When</th><th>Activity</th>";
+
+    foreach ($recentPlayerData as $recentPlayer) {
+        echo "<tr>";
+
+        $userName = $recentPlayer['User'];
+        $date = $recentPlayer['Date'];
+        $activity = $recentPlayer['Activity'];
+
+        sanitize_outputs(
+            $userName,
+            $activity
+        );
+
+        echo "<td nowrap>";
+        echo GetUserAndTooltipDiv($userName, true);
+        echo GetUserAndTooltipDiv($userName, false);
+        echo "</td>";
+
+        echo "<td>$date</td>";
+        echo "<td>$activity</td>";
+        echo "</tr>";
+    }
+
+    echo "</tbody></table>";
+    echo "</div>";
+}

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1070,9 +1070,14 @@ RenderHtmlStart(true);
             }
 
             RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions);
-            echo "<br><br>";
+            echo "<br>";
 
             if ($isFullyFeaturedGame) {
+                $recentPlayerData = getGameRecentPlayers($gameID, 10);
+                if (count($recentPlayerData) > 0) {
+                    RenderRecentGamePlayers($recentPlayerData);
+                }
+
                 RenderCommentsComponent($user, $numArticleComments, $commentData, $gameID, \RA\ArticleType::Game, $permissions >= Permissions::Admin);
             }
             ?>


### PR DESCRIPTION
Adds a "Recent Players" section at the bottom of the game page (just above the comments). It's populated with the 10 most recent "Last Seen In" entries matching the game. If there are no recent "Last Seen In" entries, the section is not shown.

![image](https://user-images.githubusercontent.com/32680403/143624289-33d0958d-6082-4d28-9afc-1f03ab17ee88.png)

Implements #730, but only shows the 10 most recent and does not automatically refresh.

Does 10 seem like a reasonable number? It could be unbounded, but in my dump from 2018 there's nearly 1400 entries for Super Mario World.

Would the header be better as "Recent Players" (as pictured), "Recent Activity", "Recent Player Activity", "Recently Seen Players", or something else?