### PR TITLE
eliminate second call to expensive query

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -906,25 +906,26 @@ function getTotalUniquePlayers($gameID, $requestedBy)
  * Gets a game's high scorers or latest masters.
  *
  * @param int $gameID game ID to get high score information for
- * @param int $offset query offset value
- * @param int $count query number of returned rows
  * @param string $requestedBy user requesting the information
- * @param int $type The type of data to return.
- *          0 - High Scores
- *          1 - Latest Masters
  *
  * @return array of user information to display on the High Scores section of a game page
  */
-function getGameTopAchievers($gameID, $offset, $count, $requestedBy, $type = 0)
+function getGameTopAchievers($gameID, $requestedBy)
 {
     sanitize_sql_inputs($gameID, $offset, $count, $requestedBy);
 
-    $retval = [];
-    $havingQuery = "";
-    $order = "ASC";
-    if ($type == 1) {
-        $havingQuery = "HAVING TotalScore = (SELECT SUM(Points * 2) AS Points FROM Achievements WHERE GameID = $gameID AND Flags = 3)";
-        $order = "DESC";
+    $high_scores = [];
+    $masters = [];
+    $mastery_score = 0;
+
+    $query = "SELECT SUM(Points * 2) AS Points FROM Achievements WHERE GameID = $gameID AND Flags = 3";
+    $dbResult = s_mysql_query($query);
+    SQL_ASSERT($dbResult);
+
+    if ($dbResult !== false) {
+        if ($data = mysqli_fetch_assoc($dbResult)) {
+            $mastery_score = $data['Points'];
+        }
     }
 
     $query = "SELECT aw.User, SUM(ach.points) AS TotalScore, MAX(aw.Date) AS LastAward
@@ -936,19 +937,31 @@ function getGameTopAchievers($gameID, $offset, $count, $requestedBy, $type = 0)
                   AND ach.Flags = 3 
                   AND gd.ID = $gameID
                 GROUP BY aw.User
-                $havingQuery
-                ORDER BY TotalScore DESC, LastAward $order
-                LIMIT $offset, $count";
+                ORDER BY TotalScore DESC, LastAward ASC";
 
     $dbResult = s_mysql_query($query);
     SQL_ASSERT($dbResult);
 
     if ($dbResult !== false) {
         while ($data = mysqli_fetch_assoc($dbResult)) {
-            $retval[] = $data;
+            if (count($high_scores) < 10) {
+                array_push($high_scores, $data);
+            }
+
+            if ($data['TotalScore'] == $mastery_score) {
+                if (count($masters) == 10) {
+                    array_shift($masters);
+                }
+                array_push($masters, $data);
+            } elseif (count($high_scores) == 10) {
+                break;
+            }
         }
     }
 
+    $retval = [];
+    $retval['Masters'] = array_reverse($masters);
+    $retval['HighScores'] = $high_scores;
     return $retval;
 }
 

--- a/public/API/API_GetGameRankAndScore.php
+++ b/public/API/API_GetGameRankAndScore.php
@@ -14,6 +14,10 @@ if ($gameId <= 0) {
 $username = requestInputQuery('z');
 $type = requestInputQuery('t', 0, 'integer');
 
-$gameTopAchievers = getGameTopAchievers($gameId, 0, 10, $username, $type);
+$gameTopAchievers = getGameTopAchievers($gameId, $username);
 
-echo json_encode($gameTopAchievers);
+if ($type == 1) {
+    echo json_encode($gameTopAchievers['Masters']);
+} else {
+    echo json_encode($gameTopAchievers['HighScores']);
+}

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -60,7 +60,6 @@ $achDist = null;
 $authorInfo = null;
 $commentData = null;
 $cookie = null;
-$gameLatestMasters = null;
 $gameTopAchievers = null;
 $lbData = null;
 $numArticleComments = null;
@@ -155,8 +154,7 @@ if ($isFullyFeaturedGame) {
     }
 
     //Get the top ten players at this game:
-    $gameTopAchievers = getGameTopAchievers($gameID, 0, 10, $user, 0);
-    $gameLatestMasters = getGameTopAchievers($gameID, 0, 10, $user, 1);
+    $gameTopAchievers = getGameTopAchievers($gameID, $user);
 
     // Determine if the logged in user is the sole author of the set
     if (isset($user)) {
@@ -1128,7 +1126,7 @@ RenderHtmlStart(true);
             echo "<div id='chart_distribution'></div>";
             echo "</div>";
 
-            RenderTopAchieversComponent($user, $gameTopAchievers, $gameLatestMasters);
+            RenderTopAchieversComponent($user, $gameTopAchievers['HighScores'], $gameTopAchievers['Masters']);
             RenderGameLeaderboardsComponent($gameID, $lbData);
             ?>
         </div>


### PR DESCRIPTION
The query used to determine the latest masters of a set and highest scorers for a set is very intensive when a set has a lot of users as it has to calculate every user's score for the set and the datetime of the last achievement earned by the user from the set.

The current implementation runs the query twice, once for High Scores, and once for Latest Masters. This PR runs it once to determine both.

In my dev env, this eliminated 25% of the time spent generating the game page for Super Mario Bros. (6.6s down from 8.8s), which has 5186 unique users for which those values had to be calculated.

I'm not sure if this will translate directly to the live site. The live Super Mario Bros. set has over 17k users, and Super Mario World has over 27k users. Both of these pages took me more than 15 seconds to load. Even shaving 4 seconds (~25%) off those times would be beneficial.