### PR TITLE
Fix bbcode URL parsing for embeddable services

### DIFF
--- a/lib/util/bbcode.php
+++ b/lib/util/bbcode.php
@@ -28,18 +28,7 @@ function parseTopicCommentPHPBB($commentIn, $withImgur = false)
     //    Parse and format tags
     $comment = $commentIn;
 
-    //    [url]
-    //$comment = preg_replace( '/(\\[url=http:\\/\\/)(.*?)(\\])(.*?)(\\[\\/url\\])/i', '<a onmouseover=" Tip( \'${2}\' ) " onmouseout=\'UnTip()\' href=\'http://${2}\'>${4}</a>', $comment );
-    //$comment = preg_replace( '/(\\[url=)(.*?)(\\])(.*?)(\\[\\/url\\])/i', '<a onmouseover=" Tip( \'${2}\' ) " onmouseout=\'UnTip()\' href=\'http://${2}\'>${4}</a>', $comment );
-    //
-
-    $comment = linkifyYouTubeURLs($comment);
-    $comment = linkifyTwitchURLs($comment);
-    if ($withImgur) {
-        $comment = linkifyImgurURLs($comment);
-    }
-
-    // NOTE: using '~' instead of '/' to enclose the regex
+    // [url]
     $comment = preg_replace(
         '~\[url=(https?://[^\]]+)\](.*?)(\[/url\])~i',
         '<a onmouseover=" Tip( \'$1\' )" onmouseout=\'UnTip()\' href=\'$1\'>$2</a>',
@@ -51,36 +40,36 @@ function parseTopicCommentPHPBB($commentIn, $withImgur = false)
         $comment
     );
 
-    //    [b]
+    // [img]
+    $comment = preg_replace('/(\\[img=)(.*?)(\\])/i', '<img class=\'injectinlineimage\' src=\'${2}\' />', $comment);
+
+    if ($withImgur) {
+        $comment = linkifyImgurURLs($comment);
+    }
+    $comment = linkifyYouTubeURLs($comment);
+    $comment = linkifyTwitchURLs($comment);
+
+    // [b]
     $comment = preg_replace('/\\[b\\](.*?)\\[\\/b\\]/is', '<b>${1}</b>', $comment);
-    //    [i]
+    // [i]
     $comment = preg_replace('/\\[i\\](.*?)\\[\\/i\\]/is', '<i>${1}</i>', $comment);
-    //    [u]
+    // [u]
     $comment = preg_replace('/\\[u\\](.*?)\\[\\/u\\]/is', '<u>${1}</u>', $comment);
-    //    [s]
+    // [s]
     $comment = preg_replace('/\\[s\\](.*?)\\[\\/s\\]/is', '<s>${1}</s>', $comment);
-    //    [code]
+    // [code]
     $comment = preg_replace('/\\[code\\](?:<br.*?>)?(.*?)\\[\\/code\\]/is', '<pre class=\'codetags\'>${1}</pre>', $comment);
     $comment = preg_replace("/\r\n|\r|\n/", '', $comment);
-    //    [img]
-    $comment = preg_replace('/(\\[img=)(.*?)(\\])/i', '<img class=\'injectinlineimage\' src=\'${2}\' />', $comment);
-    //    [ach]
+    // [ach]
     $comment = preg_replace_callback('/(\\[ach=)(.*?)(\\])/i', 'cb_injectAchievementPHPBB', $comment);
-    //    [user]
+    // [user]
     $comment = preg_replace_callback('/(\\[user=)(.*?)(\\])/i', 'cb_injectUserPHPBB', $comment);
-    //    [game]
+    // [game]
     $comment = preg_replace_callback('/(\\[game=)(.*?)(\\])/i', 'cb_injectGamePHPBB', $comment);
-    //    [spoiler]
+    // [spoiler]
     $comment = preg_replace_callback('/\\[spoiler\\](?:<br.*?>)?(.*?)\\[\\/spoiler\\]/is', 'cb_injectSpoilerPHPBB', $comment);
-    //    [video]
-    //error_log( $comment );
 
     $comment = linkifyBasicURLs($comment);
-
-    //global $autolink;
-    //$comment = $autolink->convert( $comment );
-    //    Debug:
-    //$comment = $commentIn . "<br>" . $comment;
 
     return $comment;
 }
@@ -121,8 +110,10 @@ function cb_injectUserPHPBB($matches)
 {
     if (count($matches) > 1) {
         $user = $matches[2];
+
         return GetUserAndTooltipDiv($user, false);
     }
+
     return "";
 }
 
@@ -135,6 +126,7 @@ function cb_injectGamePHPBB($matches)
 
         return GetGameAndTooltipDiv($gameID, $gameName, $gameData['GameIcon'], $consoleName);
     }
+
     return "";
 }
 
@@ -148,8 +140,10 @@ function cb_injectSpoilerPHPBB($matches)
         $spoilerBox .= $matches[1];
         $spoilerBox .= "</div>";
         $spoilerBox .= "</div>";
+
         return $spoilerBox;
     }
+
     return "";
 }
 
@@ -172,29 +166,30 @@ function linkifyYouTubeURLs($text)
     // https://www.youtube.com/watch?v=1YiNYWpwn7o
     // www.youtube.com/watch?v=Yjba9rvs4iU
 
-    $pattern = '~
-        # Match non-linked youtube URL in the wild. (Rev:20130823)
-        (?:https?://)?    # Optional scheme. Either http or https.
-        (?:[0-9A-Z-]+\.)? # Optional subdomain.
-        (?:               # Group host alternatives.
-          youtu\.be/      # Either youtu.be,
-        | youtube\.com    # or youtube.com followed by
-          \S*             # Allow anything up to VIDEO_ID,
-          [^\w\-\s]       # but char before ID is non-ID char.
-        )                 # End host alternatives.
-        ([\w\-]{11})      # $1: VIDEO_ID is exactly 11 chars.
-        (?=[^\w\-]|$)     # Assert next char is non-ID or EOS.
-        (?!               # Assert URL is not pre-linked.
-          [?=&+%\w.-]*    # Allow URL (query) remainder.
-          (?:             # Group pre-linked alternatives.
-            [\'"][^<>]*>  # Either inside a start tag,
-          | </a>          # or inside <a> element text contents.
-          )               # End recognized pre-linked alts.
-        )                 # End negative lookahead assertion.
-        ([?=&+%\w.-]*)        # Consume any URL (query) remainder.
-        ~ix';
-
-    $text = preg_replace($pattern, makeEmbeddedVideo('//www.youtube-nocookie.com/embed/$1$2'), $text);
+    $text = preg_replace(
+        '~
+            (?:https?://)?      # Optional scheme. Either http or https.
+            (?:[0-9A-Z-]+\.)?   # Optional subdomain.
+            (?:                 # Group host alternatives.
+              youtu\.be\/       # Either youtu.be (trailing slash required),
+            | youtube\.com      # or youtube.com followed by
+              \S*               # Allow anything up to VIDEO_ID,
+              [^\w\-\s]         # but char before ID is non-ID char.
+            )                   # End host alternatives.
+            ([\w\-]{11})        # $1: VIDEO_ID is exactly 11 chars.
+            (?=[^\w\-]|$)       # Assert next char is non-ID or EOS.
+            (?!                 # Assert URL is not pre-linked.
+              [?=&+%\w.-]*      # Allow URL (query) remainder.
+              (?:               # Group pre-linked alternatives.
+                [^<>]*>         # Either inside a start tag,
+                | [^<>]*<\/a>   # or inside <a> element text contents.
+              )                 # End recognized pre-linked alts.
+            )                   # End negative lookahead assertion.
+            ([?=&+%\w.-]*)      # Consume any URL (query) remainder.
+        ~ix',
+        makeEmbeddedVideo('//www.youtube-nocookie.com/embed/$1$2'),
+        $text
+    );
 
     return $text;
 }
@@ -209,15 +204,30 @@ function linkifyTwitchURLs($text)
 
     // https://www.twitch.tv/videos/270709956
     // https://www.twitch.tv/gamingwithmist/v/40482810
+
     $text = preg_replace(
-        '~(?:https?://)?(?:www.)?twitch.tv/(?:videos|[^/]+/v)/([0-9]+)~i',
+        '~
+            (?:https?:\/\/)?    # Optional scheme. Either http or https.
+            (?:www.)?           # Optional subdomain.
+            (?:twitch.tv\/.*)   # Host.
+            (?:videos|[^\/]+\/v)# See path examples above.
+            \/([0-9]+)          # $1
+            (?!                 # Assert URL is not pre-linked.
+              [?=&+%\w.-]*      # Allow URL (query) remainder.
+              (?:               # Group pre-linked alternatives.
+                [^<>]*>         # Either inside a start tag,
+                | [^<>]*<\/a>   # or inside <a> element text contents.
+              )                 # End recognized pre-linked alts.
+            )                   # End negative lookahead assertion.
+            ([?=&+%\w.-]*)      # Consume any URL (query) remainder.
+        ~ix',
         makeEmbeddedVideo('//player.twitch.tv/?video=$1&parent=' . $parent . '&autoplay=false'),
         $text
     );
 
     // https://www.twitch.tv/collections/cWHCMbAY1xQVDA
     $text = preg_replace(
-        '~(?:https?://)?(?:www.)?twitch.tv/collections/([a-z0-9]+)~i',
+        '~(?:https?://)?(?:www.)?twitch.tv/collections/([a-z0-9]+)~ix',
         makeEmbeddedVideo('//player.twitch.tv/?collection=$1&parent=' . $parent . '&autoplay=false'),
         $text
     );
@@ -248,8 +258,22 @@ function linkifyImgurURLs($text)
     // https://imgur.com/a/bciLIYm.gif -> replaced by gifv - potentially broken if it's a static image
     // https://imgur.com/a/bciLIYm.jpg -> downloads as gif if original is a gif, potentially large :/ can't do much about that
 
-    $pattern = '~(?:https?://)?(?:[0-9a-z-]+\.)?imgur\.com(?:[\w/]*/)?(\w+)(\.\w+)?~ix';
-    // $text = 'https://i.imgur.com/bciLIYm https://i.imgur.com/bciLIYm.mp4 https://imgur.com/a/bciLIYm.gif';
+    $pattern = '~
+        (?:https?://)?
+        (?:[0-9a-z-]+\.)?
+        imgur\.com
+        (?:[\w/]*/)?
+        (\w+)(\.\w+)?
+        (?!                 # Assert URL is not pre-linked.
+          [?=&+%\w.-]*      # Allow URL (query) remainder.
+          (?:               # Group pre-linked alternatives.
+            [^<>]*>         # Either inside a start tag,
+            | [^<>]*<\/a>   # or inside <a> element text contents.
+          )                 # End recognized pre-linked alts.
+        )                   # End negative lookahead assertion.
+        ([?=&+%\w.-]*)      # Consume any URL (query) remainder.
+    ~ix';
+
     preg_match_all($pattern, $text, $matches);
     if (!count($matches[0])) {
         return $text;
@@ -263,72 +287,44 @@ function linkifyImgurURLs($text)
         if (in_array($extension, ['.gifv', '.mp4', '.webm'])) {
             $replacements[$i] = '<a href="//imgur.com/' . $id . '" target="_blank" rel="noopener"><div class="embed-responsive embed-responsive-16by9"><video controls class="embed-responsive-item"><source src="//i.imgur.com/' . $id . '.mp4" type="video/mp4"></video></div><div class="text-right mb-3"><small>view on imgur</small></div></a>';
         } elseif (in_array($extension, ['.jpg', '.png', '.jpeg'])) {
-            $replacements[$i] = '<a href="//imgur.com/' . $id . '" target="_blank" rel="noopener"><img class="img-fluid" src="//i.imgur.com/' . $id . '.jpg"><div class="text-right mb-3"><small>view on imgur</small></div></a>';
+            $replacements[$i] = '<a href="//imgur.com/' . $id . '" target="_blank" rel="noopener"><img class="injectinlineimage" src="//i.imgur.com/' . $id . '.jpg"><div class="text-right mb-3"><small>view on imgur</small></div></a>';
         }
     }
     $text = preg_replace_array($pattern, $replacements, $text);
+
     return $text;
-}
-
-function cb_linkifySelective($matches)
-{
-    //error_log( count( $matches ) );
-    //error_log( $matches[ 0 ] );
-    //error_log( $matches[ 1 ] );
-    //error_log( $matches[ 2 ] );
-    //error_log( $matches[ 3 ] );
-    //error_log( $matches[ 4 ] );
-    //error_log( $matches[ 5 ] );
-
-    $url = $matches[0];
-
-    if (mb_stripos($url, 'youtube-nocookie') !== false) {
-        return $url; //    Ignore: these have been replaced above
-    } elseif (mb_stripos($url, 'www.twitch.tv') !== false) {
-        return $url; //    Ignore: these have been replaced above
-    } elseif (substr_compare($url, '.png', -4) === 0 || substr_compare($url, '.jpg', -4) === 0 || substr_compare(
-        $url,
-        '.jpeg',
-        -5
-    ) === 0) {
-        return $url; //    Ignore: this is an image!
-    } else {
-        $actualURL = $url;
-        //if( strpos( $url, 'www' ) === 0 )
-        //    $actualURL = "http://" . $url; //    Prepend http://
-
-        if (mb_strpos($url, 'http://') === false && mb_strpos($url, 'https://') === false) {
-            $actualURL = "https://" . $url; //    Prepend http://
-        }
-
-        return '<a onmouseover=" Tip( \'' . $url . '\' ) " onmouseout=\'UnTip()\' href=\'' . $actualURL . '\'>' . $url . '</a>';
-    }
 }
 
 function linkifyBasicURLs($text)
 {
-    //$pattern = '@((https?://)?([-\w]+\.[-\w\.]+)+\w(:\d+)?(/([-\w/_\.]*(\?\S+)?)?)*)@';
-    //$pattern = "/(?i)\b((?:https?:\/\/|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'\".,<>?«»“”‘’]))/";
-    //$pattern = '@((?<=[^\"\'])https?://([-\w\.]+[-\w])+(:\d+)?(/([\w/_\.#-]*(\?\S+)?[^\.\s])?)?)@';     //    NOT preceded by ' or "
-    //$pattern = '@([^\'\"]https?://([-\w\.]+[-\w])+(:\d+)?(/([\w/_\.#-]*(\?\S+)?[^\.\s])?)?)@';     //    NOT preceded by ' or " - 22:33 22/02/2014
-    //    http://stackoverflow.com/questions/833469/regular-expression-for-url
-    //$pattern = "(\s)((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)";
-    //$pattern = '((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)';
-
-    // meleu: commented this in 31-May-2018
-    //$pattern = '(([\w]+:)?\/\/)?(([\d\w]|%[a-fA-f\d]{2,2})+(:([\d\w]|%[a-fA-f\d]{2,2})+)?@)?([\d\w][-\d\w]{0,253}[\d\w]\.)+[\w]{2,63}(:[\d]+)?(\/([-+_~.\d\w]|%[a-fA-f\d]{2,2})*)*(\?(&?([-+_~.\d\w]|%[a-fA-f\d]{2,2})=?)*)?(#([-+_~.\d\w]|%[a-fA-f\d]{2,2})*)?';
-    //$text = preg_replace_callback( '/' . $pattern . '/', 'cb_linkifySelective', $text );
-
-    // meleu: applying some tricks I learned in
-    // https://stackoverflow.com/questions/12538358/
-    // NOTE: using '~' instead of '/' to enclose the regex
     $text = preg_replace(
-        '~(https?://[a-z0-9_./?=&#%:+(),-]+)(?![^<>]*>)~i',
+        '~
+            (https?://[a-z0-9_./?=&#%:+(),-]+)
+            (?!                 # Assert URL is not pre-linked.
+              [?=&+%\w.-]*      # Allow URL (query) remainder.
+              (?:               # Group pre-linked alternatives.
+                [^<>]*>         # Either inside a start tag,
+                | [^<>]*<\/a>   # or inside <a> element text contents.
+              )                 # End recognized pre-linked alts.
+            )                   # End negative lookahead assertion.
+            ([?=&+%\w.-]*)      # Consume any URL (query) remainder.
+            ~ix',
         ' <a href="$1" target="_blank" rel="noopener">$1</a> ',
         $text
     );
     $text = preg_replace(
-        '~(\s|^)(www\.[a-z0-9_./?=&#%:+(),-]+)(?![^<>]*>)~i',
+        '~
+            (\s|^)
+            (www\.[a-z0-9_./?=&#%:+(),-]+)
+            (?!                 # Assert URL is not pre-linked.
+              [?=&+%\w.-]*      # Allow URL (query) remainder.
+              (?:               # Group pre-linked alternatives.
+                [^<>]*>         # Either inside a start tag,
+                | [^<>]*<\/a>   # or inside <a> element text contents.
+              )                 # End recognized pre-linked alts.
+            )                   # End negative lookahead assertion.
+            ([?=&+%\w.-]*)      # Consume any URL (query) remainder.
+        ~ix',
         ' <a target="_blank" href="https://$2" rel="noopener">$2</a> ',
         $text
     );

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1157,6 +1157,10 @@ pre, code, .code {
   border-radius: 10px;
 }
 
+#WzBoDy tr {
+  background: none;
+}
+
 #carouselpages {
   width: 240px;
 }

--- a/public/test/bbcode.php
+++ b/public/test/bbcode.php
@@ -2,10 +2,15 @@
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../lib/bootstrap.php';
 
-$username = 'luchaos';
+$username = 'Scott';
 $user = GetUserData($username);
 
 $payload = <<<EOF
+
+[b]BBCode / Shortcode Tests[/b]
+
+[b][i]Code Blocks[/i][/b]
+
 [code]inline code[/code]
 
 [code]
@@ -25,32 +30,85 @@ Text in-between without leading or trailing extra lines
 [code]
 [b]formatting works in code?[/b]
 [/code]
+
+[b][i]Spoiler[/i][/b]
+
 [spoiler]test
 test
 test
 [b]test[/b]
-[/spoiler]
-twitch.tv
-twitch.tv/retroachievements
-www.twitch.tv/rcheevos
-https://www.twitch.tv/rcheevos
+[code]Code within spoiler[/code]
 
-example.org
-https://www.twitch.tv/videos/12826295
+[b]Embeds in spoiler[/b]
+[img=https://retroachievements.org/Images/043749.png] 
+https://www.youtube.com/watch?v=r1BVvs_sxrw
+https://youtu.be/dMH0bHeiRNg
+
+[/spoiler]
+
+[b][i]Links[/i][/b]
+
 [user=$username]
-www.example.org
+example.org (no link)
+www.example.org (no link)
+[url=https://retroachievements.org]URL Shortcode[/url]
+<a href="http://www.retroachievements.org">HTML</a>
+https://retroachievements.org/user/$username
+
+[b][i]Images[/i][/b]
+
+https://retroachievements.org/Images/043749.png
+[img=https://retroachievements.org/Images/043749.png] 
+
+[b][i]YouTube[/i][/b]
+
+[url=https://www.youtube.com/watch?v=r1BVvs_sxrw]Shortcode[/url]
+[url=https://www.youtube.com/watch?v=r1BVvs_sxrw  ] Shortcode https://www.youtube.com/watch?v=r1BVvs_sxrw [/url]
+<a href="https://www.youtube.com/watch?v=r1BVvs_sxrw">Link</a>
+<a href=" https://www.youtube.com/watch?v=r1BVvs_sxrw  "> Link https://www.youtube.com/watch?v=r1BVvs_sxrw </a>
 
 https://www.youtube.com/watch?v=r1BVvs_sxrw
 
-<a href="http://www.retroachievements.org">test</a>
+[b][i]youtu.be[/i][/b]
 
-http://retroachievements.org/user/$username
+[url=https://www.youtu.be/dMH0bHeiRNg]Shortcode[/url]
+[url=https://www.youtu.be/dMH0bHeiRNg  ] Shortcode https://www.youtu.be/dMH0bHeiRNg [/url]
+<a href="https://www.youtu.be/dMH0bHeiRNg">Link</a>
+<a href=" https://www.youtu.be/dMH0bHeiRNg "> Link https://www.youtu.be/dMH0bHeiRNg </a>
 
-https://www.youtube.com/watch?v=Eldywk__eag
+https://www.youtu.be/dMH0bHeiRNg
 
-[url=http://retroachievements.org]http://retroachievements.org[/url]
+[b][i]Twitch[/i][/b]
 
-www.example.org
+[url=https://www.twitch.tv/videos/12826295]Shortcode[/url]
+[url=https://www.youtu.be/dMH0bHeiRNg  ] Shortcode https://www.youtu.be/dMH0bHeiRNg [/url]
+<a href="https://www.twitch.tv/videos/12826295">Link</a>
+<a href=" https://www.twitch.tv/videos/12826295 "> Link https://www.twitch.tv/videos/12826295 </a>
+https://www.twitch.tv/rcheevos
+
+https://www.twitch.tv/videos/12826295
+
+[b][i]Imgur[/i][/b]
+
+[url=https://www.twitch.tv/videos/12826295]Shortcode[/url]
+[url=https://www.youtu.be/dMH0bHeiRNg  ] Shortcode https://www.youtu.be/dMH0bHeiRNg [/url]
+<a href="https://i.imgur.com/MaYu3L8.mp4">Link</a>
+<a href=" https://i.imgur.com/MaYu3L8.mp4 "> Link https://imgur.com/a/MaYu3L8.jpg </a>
+
+[img=https://imgur.com/a/MaYu3L8.png]  (CORS error)
+
+https://imgur.com/gallery/MaYu3L8 (no extension -&gt; link)
+
+https://imgur.com/gallery/MaYu3L8.gifv
+https://imgur.com/a/MaYu3L8.gifv
+https://i.imgur.com/MaYu3L8.gifv
+https://i.imgur.com/MaYu3L8.webm
+https://i.imgur.com/MaYu3L8.mp4
+https://imgur.com/a/MaYu3L8.gif
+https://imgur.com/a/MaYu3L8.jpg
+https://imgur.com/a/MaYu3L8.png
+https://imgur.com/a/MaYu3L8.jpeg
+
 EOF;
 
 RenderHtmlStart();
@@ -59,7 +117,7 @@ RenderSharedHeader();
 <body>
 <script src='/vendor/wz_tooltip.js'></script>
 <div style="width: 360px; margin: auto">
-    <?php RenderTopicCommentPayload($payload) ?>
+    <?php echo parseTopicCommentPHPBB(nl2br($payload), true) ?>
 </div>
 </body>
 


### PR DESCRIPTION
Allows to add URLs as links for services that are embeddable (YouTube,
Twitch, Imgur). Fix link tooltip background color and clean up bbcode
util while at it.

Fixes #818

Verify via `/test/bbcode.php` in browser:

![Screenshot 2021-12-05 at 04 16 51](https://user-images.githubusercontent.com/1280590/144732079-862e11ca-ada3-4195-8ff5-682eb23d4055.png)

![Screenshot 2021-12-05 at 04 17 03](https://user-images.githubusercontent.com/1280590/144732080-6f9a63cb-053c-41c2-9703-ad85c7735273.png)

![Screenshot 2021-12-05 at 04 17 13](https://user-images.githubusercontent.com/1280590/144732082-d7833a9b-0bb5-4c84-b6a4-1b452163102f.png)

![Screenshot 2021-12-05 at 04 17 20](https://user-images.githubusercontent.com/1280590/144732085-909e1af5-51a3-40f3-92fa-a715e763ec33.png)

![Screenshot 2021-12-05 at 04 17 31](https://user-images.githubusercontent.com/1280590/144732087-a785cbea-6180-4d82-b233-18e0c31a7dd1.png)

