### PR TITLE
fix display of 'fancy' tooltips

### DIFF
--- a/lib/render/achievement.php
+++ b/lib/render/achievement.php
@@ -38,9 +38,7 @@ function GetAchievementAndTooltipDiv(
     $tooltip .= "</div>";
     $tooltip .= "</div>";
 
-    $tooltip = str_replace("'", "\'", $tooltip);
-
-    sanitize_outputs($tooltip);
+    $tooltip = attributeEscape($tooltip);
 
     $smallBadge = '';
     $displayable = "$achName";

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -38,10 +38,6 @@ function GetGameAndTooltipDiv(
 
     $displayable = "";
 
-    sanitize_outputs(
-        $tooltip,
-    );
-
     if ($justText == false) {
         $displayable = "<img loading='lazy' alt='' title=\"$gameNameEscaped\" src='" . getenv('ASSET_URL') . "$gameIcon' width='$imgSizeOverride' height='$imgSizeOverride' class='badgeimg' />";
     }

--- a/lib/util/string.php
+++ b/lib/util/string.php
@@ -14,7 +14,7 @@ function attributeEscape($input)
     // htmlspecialchars escapes a bunch of stuff that the tooltip can't handle
     // (like &rsquo; $frac12; and &deg;). when placed in title or alt fields.
     // just do the bare minimum.
-    $input = str_replace("'", "&#39;", $input);
+    $input = str_replace("'", "\'", $input);
     $input = str_replace('"', "&quot;", $input);
     return $input;
 }


### PR DESCRIPTION
#874 made it so apostrophes could appear in tooltips, but broke the "fancy" tooltips in the process.

current:
![image](https://user-images.githubusercontent.com/32680403/146278233-d0e54ca2-6128-45b7-b5f7-cd975478d37a.png)

intended:
![image](https://user-images.githubusercontent.com/32680403/146278267-0d8372eb-a750-4ceb-b636-11c2b6ef0bba.png)
