### PR TITLE
feat(api): add API_GetAchievementDistribution.php

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -749,7 +749,7 @@ function getAchievementDistribution($gameID, $hardcore, $requestedBy, $flags)
     settype($flags, 'integer');
     $retval = [];
 
-    //    Returns an array of the number of players who have achieved each total, up to the max.
+    // Returns an array of the number of players who have achieved each total, up to the max.
     $query = "
         SELECT InnerTable.AwardedCount, COUNT(*) AS NumUniquePlayers
         FROM (
@@ -776,6 +776,15 @@ function getAchievementDistribution($gameID, $hardcore, $requestedBy, $flags)
             settype($numUnique, 'integer');
             $retval[$awardedCount] = $numUnique;
         }
+
+        // fill the gaps and sort
+        $numAchievements = getGameMetadataByFlags($gameID, $requestedBy, $achievementData, $gameData, 1, null, $flags);
+        for ($i = 1; $i <= $numAchievements; $i++) {
+            if (!array_key_exists($i, $retval)) {
+                $retval[$i] = 0;
+            }
+        }
+        ksort($retval);
     }
 
     return $retval;

--- a/public/API/API_GetAchievementDistribution.php
+++ b/public/API/API_GetAchievementDistribution.php
@@ -10,4 +10,4 @@ $hardcore = requestInputQuery('h', 0, 'integer');
 $requestedBy = requestInputQuery('z');
 $flags = requestInputQuery('f', 3, 'integer');
 
-echo json_encode(getAchievementDistribution($gameId, $hardcore, $requestedBy, $flags));
+echo json_encode(getAchievementDistribution($gameID, $hardcore, $requestedBy, $flags));

--- a/public/API/API_GetAchievementDistribution.php
+++ b/public/API/API_GetAchievementDistribution.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../lib/bootstrap.php';
+
+runPublicApiMiddleware();
+
+$gameID = requestInputQuery('i');
+$hardcore = requestInputQuery('h', 0, 'integer');
+$requestedBy = requestInputQuery('z');
+$flags = requestInputQuery('f', 3, 'integer');
+
+echo json_encode(getAchievementDistribution($gameId, $hardcore, $requestedBy, $flags));

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -95,13 +95,6 @@ if ($isFullyFeaturedGame) {
     }
 
     $achDist = getAchievementDistribution($gameID, 0, $user, $flags); // for now, only retrieve casual!
-    for ($i = 1; $i <= $numAchievements; $i++) {
-        if (!array_key_exists($i, $achDist)) {
-            $achDist[$i] = 0;
-        }
-    }
-
-    ksort($achDist);
 
     $numArticleComments = getArticleComments(1, $gameID, 0, 20, $commentData);
 


### PR DESCRIPTION
Hi! I am the author of https://github.com/achievements-app/retroachievements-js and https://github.com/achievements-app/psn-api. I'm in the process of building a dashboard for my own portfolio site that is connected to all the gaming platforms I play on, and I've hit a snag during the development process.

Currently there is no good way for a RetroAchievements API user to calculate what the mastery % of a game is without manually scraping the site.

This PR:
* Adds an endpoint to retrieve the achievement distribution data from a given game ID.

On the current V1 site, this is represented via this graph:
<img width="313" alt="Screen Shot 2021-12-15 at 7 58 05 PM" src="https://user-images.githubusercontent.com/3984985/146288471-d20da832-8764-4a9f-92c5-02d0a25eb268.png">

After this PR is merged, this data can be retrieved via the _/API/API_GetAchievementDistribution.php_ public route.