### PR TITLE
allow code notes to be accessed by registered users

### DIFF
--- a/lib/render/codenote.php
+++ b/lib/render/codenote.php
@@ -1,14 +1,22 @@
 <?php
 
-function RenderCodeNotes($codeNotes)
+function RenderCodeNotes($codeNotes, $showDisclaimer = false)
 {
     echo "<h3>Code Notes</h3>";
+
+    if ($showDisclaimer) {
+        echo "The RetroAchievements addressing scheme for most systems is to access the system memory " .
+             "at address $00000000, immediately followed by the cartridge memory. As such, the addresses " .
+             "displayed below may not directly correspond to the addresses on the real hardware.";
+        echo "<br/><br/>";
+    }
+
     echo "<table class='smalltable xsmall'><tbody>";
 
     echo "<tr><th style='font-size:100%;'>Mem</th><th style='font-size:100%;'>Note</th><th style='font-size:100%;'>Author</th></tr>";
 
     foreach ($codeNotes as $nextCodeNote) {
-        if (empty(trim($nextCodeNote['Note']))) {
+        if (empty(trim($nextCodeNote['Note'])) || $nextCodeNote['Note'] == "''") {
             continue;
         }
 

--- a/public/codenotes.php
+++ b/public/codenotes.php
@@ -28,8 +28,8 @@ RenderHtmlHead('Code Notes');
     <div id="fullcontainer">
         <?php echo "Game: " . GetGameAndTooltipDiv($gameData['ID'], $gameData['Title'], $gameData['ImageIcon'], $gameData['ConsoleName']); ?>
         <?php
-        if (isset($gameData) && isset($user) && $permissions >= Permissions::JuniorDeveloper) {
-            RenderCodeNotes($codeNotes);
+        if (isset($gameData) && isset($user) && $permissions >= Permissions::Registered) {
+            RenderCodeNotes($codeNotes, true);
         }
         ?>
     </div>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1092,16 +1092,16 @@ RenderHtmlStart(true);
             echo "</li>";
 
             if (isset($user)) {
-                echo "<li><a class='info-button' href='/linkedhashes.php?g=$gameID'><span>🔗</span>Linked Hashes</a></li>";
-                $numOpenTickets = countOpenTickets(
-                    requestInputSanitized('f') == $unofficialFlag,
-                    requestInputSanitized('t', 2041),
-                    null,
-                    $gameID
-                );
                 if ($permissions >= Permissions::Registered) {
+                    echo "<li><a class='info-button' href='/linkedhashes.php?g=$gameID'><span>🔗</span>Linked Hashes</a></li>";
                     echo "<li><a class='info-button' href='/codenotes.php?g=$gameID'><span>📑</span>Code Notes</a></li>";
 
+                    $numOpenTickets = countOpenTickets(
+                        requestInputSanitized('f') == $unofficialFlag,
+                        requestInputSanitized('t', 2041),
+                        null,
+                        $gameID
+                    );
                     if ($flags == $unofficialFlag) {
                         echo "<li><a class='info-button' href='/ticketmanager.php?g=$gameID&f=$flags'><span>🎫</span>Open Unofficial Tickets ($numOpenTickets)</a></li>";
                     } else {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1092,7 +1092,7 @@ RenderHtmlStart(true);
             echo "</li>";
 
             if (isset($user)) {
-                echo "<li><a class='info-button' href='/linkedhashes.php?g=$gameID'><span>🔗</span>Hashes linked to this game</a></li>";
+                echo "<li><a class='info-button' href='/linkedhashes.php?g=$gameID'><span>🔗</span>Linked Hashes</a></li>";
                 $numOpenTickets = countOpenTickets(
                     requestInputSanitized('f') == $unofficialFlag,
                     requestInputSanitized('t', 2041),
@@ -1100,14 +1100,16 @@ RenderHtmlStart(true);
                     $gameID
                 );
                 if ($permissions >= Permissions::Registered) {
+                    echo "<li><a class='info-button' href='/codenotes.php?g=$gameID'><span>📑</span>Code Notes</a></li>";
+
                     if ($flags == $unofficialFlag) {
-                        echo "<li><a class='info-button' href='/ticketmanager.php?g=$gameID&f=$flags'><span>🎫</span>($numOpenTickets) Open Unofficial Tickets for this game</a></li>";
+                        echo "<li><a class='info-button' href='/ticketmanager.php?g=$gameID&f=$flags'><span>🎫</span>Open Unofficial Tickets ($numOpenTickets)</a></li>";
                     } else {
-                        echo "<li><a class='info-button' href='/ticketmanager.php?g=$gameID'><span>🎫</span>($numOpenTickets) Open Tickets for this game</a></li>";
+                        echo "<li><a class='info-button' href='/ticketmanager.php?g=$gameID'><span>🎫</span>Open Tickets ($numOpenTickets)</a></li>";
                     }
                 }
                 if ($numAchievements == 0) {
-                    echo "<li><a class='info-button' href='/setRequestors.php?g=$gameID'><span>📜</span>Set Requestors for this game</a></li>";
+                    echo "<li><a class='info-button' href='/setRequestors.php?g=$gameID'><span>📜</span>Set Requestors</a></li>";
                 }
                 //if( $flags == $unofficialFlag )
                 //echo "<li><a class='info-button' href='/game/$gameID'><span>🏆</span>View Core Achievements</a></li>";


### PR DESCRIPTION
Adds a "Code Notes" link to the "More Info" section of the game page. It is visible for users with Registered or higher permissions.

![image](https://user-images.githubusercontent.com/32680403/146478202-71d1e64a-87dd-4363-960e-ff8fc316f99a.png)

The link under "Dev (click to show)" is still present for people's muscle memory. Previously, it was the only way to access the page. The page also did not display notes for anyone with permissions below Junior Developer.

I've also added a disclaimer to the Code Notes page indicating that our addresses may not map directly to hardware addresses, as the desire behind making these pages more accessible was for sharing the information with the preservation and modding communities.

![image](https://user-images.githubusercontent.com/32680403/146478442-5ed2f6dc-ec19-4885-8c54-4051ec7c6a51.png)

The disclaimer does not show up on other pages that list the Code Notes (like the leaderboard editor).