### PR TITLE
add disclaimer to linked hashes page

### DIFF
--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -16,12 +16,14 @@ $consoleName = null;
 $gameIcon = null;
 $gameTitle = null;
 $hashes = null;
+$forumTopicID = 0;
 if ($gameIDSpecified) {
     getGameMetadata($gameID, $user, $achievementData, $gameData);
     $consoleName = $gameData['ConsoleName'];
     $consoleID = $gameData['ConsoleID'];
     $gameTitle = $gameData['Title'];
     $gameIcon = $gameData['ImageIcon'];
+    $forumTopicID = $gameData['ForumTopicID'];
     $hashes = getHashListByGameID($gameID, true);
 } else {
     //	Immediate redirect: this is pointless otherwise!
@@ -43,13 +45,19 @@ RenderHtmlHead("Linked Hashes");
         echo GetGameAndTooltipDiv($gameID, $gameTitle, $gameIcon, $consoleName, false, 96);
         echo "<br><br>";
 
-        echo "<p><b>Hashes are used to confirm if two copies of a file are identical. We use it to ensure the player is using the same ROM as the achievement developer, or a compatible one.</b></p>";
-        echo "Currently this game has <b>" . count($hashes) . "</b> unique ROM(s) registered for it with the following hashes:<br><br>";
+        echo "<p><b>Hashes are used to confirm if two copies of a file are identical. " .
+             "We use it to ensure the player is using the same ROM as the achievement developer, or a compatible one." .
+             "<br/><br/>RetroAchievements only hashes portions of larger games to minimize load times, and strips " .
+             "headers on smaller ones. Details on how the hash is generated for each system can be found " .
+             "<a href='https://docs.retroachievements.org/Game-Identification/'>here</a>." .
+             "</b></p>";
+
+        echo "Currently this game has <b>" . count($hashes) . "</b> unique hashes registered for it:<br><br>";
 
         echo "<ul>";
         foreach ($hashes as $hash) {
             echo "<li>";
-            echo "<code>" . $hash['hash'] . "</code>";
+            echo "<code>  " . $hash['hash'] . "</code>";
             if (!empty($hash['User'])) {
                 echo " linked by " . GetUserAndTooltipDiv($hash['User']);
             }
@@ -58,6 +66,10 @@ RenderHtmlHead("Linked Hashes");
         echo "</ul>";
 
         echo "<br>";
+
+        if ($forumTopicID > 0) {
+            echo "Descriptions for these hashes may be listed on the <a href='viewtopic.php?t=$forumTopicID'>official forum topic</a>.<br/>";
+        }
 
         ?>
         <br>


### PR DESCRIPTION
Adds a disclaimer that RetroAchievements hashes are not whole file, and links to the doc page describing the per-system hashes.

Also adds a link to the official forum topic (if available) which might help identify the individual hashes.

![image](https://user-images.githubusercontent.com/32680403/146569103-720e7785-7794-4fd1-9282-cca6934d212a.png)
