### PR TITLE
rewrite trigger parser to support mixed case markers

### DIFF
--- a/lib/util/string.php
+++ b/lib/util/string.php
@@ -44,10 +44,3 @@ function rand_string($length)
 
     return $str;
 }
-
-function multiexplode($delimiters, $string)
-{
-    $ready = str_replace($delimiters, $delimiters[0], $string);
-    $launch = explode($delimiters[0], $ready);
-    return $launch;
-}

--- a/lib/util/trigger.php
+++ b/lib/util/trigger.php
@@ -113,9 +113,13 @@ function parseOperand($mem)
             }
         }
 
-        $value = '0x' . str_pad(dechex(substr($mem, 0, $count)), 6, '0', STR_PAD_LEFT);
+        $value = '0x' . str_pad(dechex((int) substr($mem, 0, $count)), 6, '0', STR_PAD_LEFT);
         $mem = substr($mem, $count);
         return [$type, $size, $value, $mem];
+    }
+
+    if (!$type) {
+        $type = 'Mem';
     }
 
     $count = 0;


### PR DESCRIPTION
Fixes case where lowercase markers somehow get into achievement definition.
![image](https://user-images.githubusercontent.com/32680403/146682650-9f574199-ebc8-48ca-8b6d-196309ced731.png)

Previously the first condition was incorrect:
![image](https://user-images.githubusercontent.com/32680403/146682577-1b221ba6-1ea9-4ac5-91a4-7a2a3914a782.png)

Also adds support for 0.80 features (i.e. floats and big endian values):
![image](https://user-images.githubusercontent.com/32680403/146682684-9e193a7b-c31b-4361-bdba-41a1a6cc5865.png)
