### PR TITLE
Fix history graph total points to only count core achievements

### DIFF
--- a/lib/database/history.php
+++ b/lib/database/history.php
@@ -126,7 +126,7 @@ function getAwardedList($user, $listOffset, $maxToFetch, $dateFrom = null, $date
     $query = "SELECT YEAR(aw.Date) AS Year, MONTH(aw.Date) AS Month, DAY(aw.Date) AS Day, aw.Date, SUM(ach.Points) AS Points FROM Awarded AS aw ";
     $query .= "LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID ";
     $query .= "LEFT JOIN GameData AS gd ON gd.ID = ach.GameID ";
-    $query .= "WHERE aw.user = '$user' ";    //AND ach.Flags = 3
+    $query .= "WHERE aw.user = '$user' AND ach.Flags = 3";
 
     if (isset($dateFrom) && isset($dateTo)) {
         $dateFromFormatted = $dateFrom; //2013-07-01


### PR DESCRIPTION
A user pointed out the total points are higher in the graph than what the user actually has, turns out it counts unofficial achievements in this total so adding a check to only count core achievements (which was already there just commented out).
![image](https://user-images.githubusercontent.com/4047771/146683220-87994613-1255-4f9f-a9fa-d95d3842683b.png)
