### PR TITLE
add lazy loading attribute to profile and game images outputted by JS

### DIFF
--- a/lib/constants.php
+++ b/lib/constants.php
@@ -1,4 +1,4 @@
 <?php
 
-const VERSION = '1.78.0';
+const VERSION = '1.78.1';
 const MIN_POINTS = 500;

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -341,7 +341,7 @@ function GetGameAndTooltipDiv(gameID, gameTitle, gameIcon, consoleName, imageIns
   if (imageInstead) {
     displayable = '<img alt="started playing ' + gameTitle
       + '" title="Started playing ' + gameTitle + '" src=\'' + gameIcon
-      + '\' width=\'32\' height=\'32\' class=\'badgeimg\' />';
+      + '\' width=\'32\' height=\'32\' class=\'badgeimg\' loading=\'lazy\' />';
   }
   return '<div class=\'bb_inline\' onmouseover="Tip(\'' + tooltip
     + '\')" onmouseout="UnTip()" >'
@@ -386,7 +386,7 @@ function GetUserAndTooltipDiv(user, points, motto, imageInstead, extraText) {
   if (imageInstead) {
     displayable = '<img src=\'/UserPic/' + user
       + '.png\' width=\'32\' height=\'32\' alt=\'' + user + '\' title=\'' + user
-      + '\' class=\'badgeimg\' />';
+      + '\' class=\'badgeimg\' loading=\'lazy\' />';
   }
   return '<div class=\'bb_inline\' onmouseover="Tip(\'' + tooltip
     + '\')" onmouseout="UnTip()" >'


### PR DESCRIPTION
This is a small change in JS code to include "loading" attribute, which will greately decrease transfer, when visiting homepage. Active players widget includes a lot of images, and more players are active in games, the more data user needs to download to see main page (and, I guess, that's first contact with RA for a lot of new users).

Implementing this change will let browsers to not load those images, until user explicitly show the need for them (by scrolling down in active players list).