### PR TITLE
use different escaping function for Tip()

### DIFF
--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -582,6 +582,8 @@ function getFeed($user, $maxMessages, $offset, &$dataOut, $latestFeedID = 0, $ty
         $i = 0;
         while ($db_entry = mysqli_fetch_assoc($dbResult)) {
             $dataOut[$i] = $db_entry;
+            $dataOut[$i]['timestamp'] = strtotime($dataOut[$i]['timestamp']);
+            $dataOut[$i]['CommentPostedAt'] = strtotime($dataOut[$i]['CommentPostedAt']);
             $i++;
         }
 

--- a/lib/render/achievement.php
+++ b/lib/render/achievement.php
@@ -38,7 +38,7 @@ function GetAchievementAndTooltipDiv(
     $tooltip .= "</div>";
     $tooltip .= "</div>";
 
-    $tooltip = attributeEscape($tooltip);
+    $tooltip = tipEscape($tooltip);
 
     $smallBadge = '';
     $displayable = "$achName";

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -13,11 +13,6 @@ function GetGameAndTooltipDiv(
 ): string {
     $tooltipIconSize = 64; //96;
 
-    sanitize_outputs(
-        $gameName,
-        $consoleName
-    );
-
     $consoleStr = '';
     if ($consoleName !== null && mb_strlen($consoleName) > 2) {
         $consoleStr = "($consoleName)";
@@ -32,7 +27,7 @@ function GetGameAndTooltipDiv(
     $tooltip .= $consoleStr;
     $tooltip .= "</div>";
     $tooltip .= "</div>";
-    $tooltip = attributeEscape($tooltip);
+    $tooltip = tipEscape($tooltip);
 
     $gameNameEscaped = attributeEscape($gameName);
 

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -4,20 +4,16 @@ function GetLeaderboardAndTooltipDiv($lbID, $lbName, $lbDesc, $gameName, $gameIc
 {
     $tooltipIconSize = 64; //96;
 
-    $lbNameStr = str_replace("'", "\'", $lbName);
-    $lbDescStr = str_replace("'", "\'", $lbDesc);
-    $gameNameStr = str_replace("'", "\'", $gameName);
+    $tooltip = "<div id='objtooltip' style='display:flex;max-width:400px'>";
+    $tooltip .= "<img style='margin-right:5px' src='$gameIcon' width='$tooltipIconSize' height='$tooltipIconSize' />";
+    $tooltip .= "<div>";
+    $tooltip .= "<b>$lbName</b>";
+    $tooltip .= "<br>$lbDesc";
+    $tooltip .= "<br><br><i>$gameName</i>";
+    $tooltip .= "</div>";
+    $tooltip .= "</div>";
 
-    $tooltip = "<div id=\'objtooltip\'>" .
-        "<img src=\'$gameIcon\' width=\'$tooltipIconSize\' height=\'$tooltipIconSize\ />" .
-        "<b>$lbNameStr</b><br>" .
-        "<i>($gameNameStr)</i><br>" .
-        "<br>" .
-        "$lbDescStr<br>" .
-        "</div>";
-
-    $tooltip = str_replace('<', '&lt;', $tooltip);
-    $tooltip = str_replace('>', '&gt;', $tooltip);
+    $tooltip = tipEscape($tooltip);
 
     return "<div class='bb_inline' onmouseover=\"Tip('$tooltip')\" onmouseout=\"UnTip()\" >" .
         "<a href='/leaderboardinfo.php?i=$lbID'>" .

--- a/lib/render/ticket.php
+++ b/lib/render/ticket.php
@@ -34,11 +34,9 @@ function GetTicketAndTooltipDiv(TicketModel $ticket): string
         "<div class='ticket-tooltip-state'>" . TicketStates::renderState($ticket->ticketState) . "</div>" .
     "</div>";
 
-    $tooltip = str_replace("'", "\'", $tooltip);
+    $tooltip = tipEscape($tooltip);
 
-    sanitize_outputs($tooltip);
-
-    $achNameAttr = htmlspecialchars($ticket->achievementTitle, ENT_QUOTES);
+    $achNameAttr = attributeEscape($ticket->achievementTitle);
     $smallBadgePath = "/Badge/" . $ticket->badgeName . ".png";
 
     return "<a class='ticket-block bb_inline $ticketStateClass' href='/ticketmanager.php?i=" . $ticket->ticketId

--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -38,64 +38,63 @@ function GetUserAndTooltipDiv(
     $lastLogin = $userCardInfo['LastActivity'] ? getNiceDate(strtotime($userCardInfo['LastActivity'])) : null;
     $memberSince = $userCardInfo['MemberSince'] ? getNiceDate(strtotime($userCardInfo['MemberSince']), true) : null;
 
-    $tooltip = "<div id=\'objtooltip\' class=\'usercard\'>";
+    $tooltip = "<div id='objtooltip' class='usercard'>";
     $tooltip .= "<table><tbody>";
     $tooltip .= "<tr>";
-    $tooltip .= "<td class=\'usercardavatar\'><img src=\'/UserPic/" . $user . ".png\'/>";
-    $tooltip .= "<td class=\'usercard\'>";
+    $tooltip .= "<td class='usercardavatar'><img src='/UserPic/" . $user . ".png'/>";
+    $tooltip .= "<td class='usercard'>";
     $tooltip .= "<table><tbody>";
     $tooltip .= "<tr>";
-    $tooltip .= "<td class=\'usercardusername\'>$user</td>";
-    $tooltip .= "<td class=\'usercardaccounttype\'>$userAccountType</td>";
+    $tooltip .= "<td class='usercardusername'>$user</td>";
+    $tooltip .= "<td class='usercardaccounttype'>$userAccountType</td>";
     $tooltip .= "</tr>";
 
     //Add the user motto if it's set
     if ($userMotto !== null && mb_strlen($userMotto) > 2) {
-        $userMotto = str_replace('\'', '\\\'', $userMotto);
-        $userMotto = str_replace('"', '\\\'\\\'', $userMotto);
+        sanitize_outputs($userMotto);
         $tooltip .= "<tr>";
-        $tooltip .= "<td colspan=\'2\' height=\'32px\'><span class=\'usermotto tooltip\'>$userMotto</span></td>";
+        $tooltip .= "<td colspan='2' height='32px'><span class='usermotto tooltip'>$userMotto</span></td>";
         $tooltip .= "</tr>";
     } else {
         //Insert blank row to add whitespace where motto would be
         $tooltip .= "<tr>";
-        $tooltip .= "<td height=\'24px\'></td>";
+        $tooltip .= "<td height='24px'></td>";
         $tooltip .= "</tr>";
     }
 
     //Add the user points if there are any
     if ($userPoints !== null) {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class=\'usercardbasictext\'><b>Points:</b> $userPoints ($userTruePoints)</td>";
+        $tooltip .= "<td class='usercardbasictext'><b>Points:</b> $userPoints ($userTruePoints)</td>";
         $tooltip .= "</tr>";
     } else {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class=\'usercardbasictext\'><b>Points:</b> 0</td>";
+        $tooltip .= "<td class='usercardbasictext'><b>Points:</b> 0</td>";
         $tooltip .= "</tr>";
     }
 
     //Add the other user informaiton
     if ($userUntracked) {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Untracked</td>";
+        $tooltip .= "<td class='usercardbasictext'><b>Site Rank:</b> Untracked</td>";
         $tooltip .= "</tr>";
     } elseif ($userPoints < MIN_POINTS) {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> Needs at least " . MIN_POINTS . " points </td>";
+        $tooltip .= "<td class='usercardbasictext'><b>Site Rank:</b> Needs at least " . MIN_POINTS . " points </td>";
         $tooltip .= "</tr>";
     } else {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class=\'usercardbasictext\'><b>Site Rank:</b> $userRank</td>";
+        $tooltip .= "<td class='usercardbasictext'><b>Site Rank:</b> $userRank</td>";
         $tooltip .= "</tr>";
     }
     if ($lastLogin) {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class=\'usercardbasictext\'><b>Last Activity:</b> $lastLogin</td>";
+        $tooltip .= "<td class='usercardbasictext'><b>Last Activity:</b> $lastLogin</td>";
         $tooltip .= "</tr>";
     }
     if ($memberSince) {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class=\'usercardbasictext\'><b>Member Since:</b> $memberSince</td>";
+        $tooltip .= "<td class='usercardbasictext'><b>Member Since:</b> $memberSince</td>";
         $tooltip .= "</tr>";
     }
     $tooltip .= "</tbody></table>";
@@ -104,7 +103,7 @@ function GetUserAndTooltipDiv(
     $tooltip .= "</tbody></table>";
     $tooltip .= "</div>";
 
-    $tooltip = htmlspecialchars($tooltip);
+    $tooltip = tipEscape($tooltip);
 
     $linkURL = "/user/$user";
     if (!empty($customLink)) {
@@ -159,11 +158,6 @@ function RenderSiteAwards($userAwards)
             //$awardGameFlags = $elem[ 'Flags' ];
             $awardButGameIsIncomplete = (isset($elem['Incomplete']) && $elem['Incomplete'] == 1);
             $imgclass = 'badgeimg siteawards';
-
-            sanitize_outputs(
-                $awardGameTitle,
-                $awardGameConsole,
-            );
 
             if ($awardType == AwardType::MASTERY) {
                 if ($awardDataExtra == '1') {

--- a/lib/util/string.php
+++ b/lib/util/string.php
@@ -14,8 +14,18 @@ function attributeEscape($input)
     // htmlspecialchars escapes a bunch of stuff that the tooltip can't handle
     // (like &rsquo; $frac12; and &deg;). when placed in title or alt fields.
     // just do the bare minimum.
-    $input = str_replace("'", "\'", $input);
+    $input = str_replace("'", "&#39;", $input);
     $input = str_replace('"', "&quot;", $input);
+    return $input;
+}
+
+function tipEscape($input)
+{
+    // the Tip() function expects single quotes to be escaped, and other html reserved
+    // characters to be converted to entities.
+    $input = htmlentities($input, ENT_COMPAT | ENT_HTML401);
+    // ENT_COMPAT will not convert single quotes. do so ourself.
+    $input = str_replace("'", "\'", $input);
     return $input;
 }
 


### PR DESCRIPTION
Addendum to #882 

For simple tooltips (i.e. for mastery badges), a different set of escaping rules needs to be applied. #882 caused apostrophes in game titles to appear escaped in the non-fancy tooltip: i.e. `Kirby\'s Dream Land`

This separates the logic for escaping fancy tooltips and basic tooltips and updates each of the pieces of code generating fancy tooltips to use the fancy tooltip escaping function.