### PR TITLE
prevent negative offset in lbinfo query

### DIFF
--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -459,10 +459,11 @@ function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly, $n
                 if ($offset <= 0) {
                     $offset = 0;
                 } elseif ($retVal['TotalEntries'] - $userPosition + 1 < $numToFetch) {
-                    $offset = $retVal['TotalEntries'] - $numToFetch;
+                    $offset = max(0, $retVal['TotalEntries'] - $numToFetch);
                 }
             }
         }
+
         //    Now get entries:
         $query = "SELECT ua.User, le.Score, le.DateSubmitted, 
                   CASE WHEN !lbd.LowerIsBetter 


### PR DESCRIPTION
When asking for the N leaderboard entries near a user, we do some math to calculate the actual offset to use in the query. It turns out that if N is larger than the number of items in the leaderboard and the user's rank is greater than N/2, then the calculated offset will be negative and no results will be returned.

See https://discord.com/channels/310192285306454017/645777658319208448/928763424039657532

The solution is simply to adjust the value to 0 if it ends up being less than 0.