### PR TITLE
Don't show mature warning for hubs

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -58,7 +58,7 @@ $pageTitle = "$gameTitle ($consoleName)";
 $gameAlts = getGameAlternatives($gameID);
 
 $v = requestInputSanitized('v', 0, 'integer');
-if ($v != 1) {
+if ($v != 1 && $isFullyFeaturedGame) {
     foreach ($gameAlts as $gameAlt) {
         if ($gameAlt['Title'] == '[Theme - Mature]') {
             if (getAccountDetails($user, $accountDetails) &&


### PR DESCRIPTION
Followup to #904 

Prevents showing the mature content warning on hub pages. In particular, the `[Central -Themes]` hub, although it will also prevent it from showing on the `[Theme - Mature]` hub as well.

Since the hub is just a collection of links to games, and the links can be posted in forums without flagging the warning, I believe this to be acceptable.

It's also reinforced by the warning itself: "This **GAME** may contain content not appropriate for all ages"