### PR TITLE
add ability to view sent messages if they haven't been deleted by the recipient

### DIFF
--- a/lib/database/message.php
+++ b/lib/database/message.php
@@ -85,6 +85,36 @@ function GetMessageCount($user, &$totalMessageCount)
     }
 }
 
+function GetSentMessageCount($user)
+{
+    sanitize_sql_inputs($user);
+
+    if (!isset($user)) {
+        return 0;
+    }
+
+    $messageCount = 0;
+
+    $query = "
+        SELECT COUNT(*) AS NumFound
+        FROM Messages AS msg
+        WHERE msg.UserFrom = '$user'
+    ";
+
+    $dbResult = s_mysql_query($query);
+    SQL_ASSERT($dbResult);
+
+    if ($dbResult !== false) {
+        while ($data = mysqli_fetch_assoc($dbResult)) {
+            $messageCount = $data['NumFound'];
+        }
+
+        settype($messageCount, 'integer');
+    }
+
+    return $messageCount;
+}
+
 function GetTotalMessageCount($user)
 {
     sanitize_sql_inputs($user);

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -26,7 +26,7 @@ RenderHtmlStart();
 if ($outbox) {
     $unreadMessageCount = 0;
     $totalMessageCount = GetSentMessageCount($user);
-    $allMessages = GetSentMessages($user, $offset, $count, $unreadOnly);
+    $allMessages = GetSentMessages($user, $offset, $count);
     RenderHtmlHead('Outbox');
 } else {
     $unreadMessageCount = GetMessageCount($user, $totalMessageCount);
@@ -114,16 +114,14 @@ if ($outbox) {
             <?php
             if ($outbox) {
                 echo "<h2>Outbox</h2>";
-            } else {
-                echo "<h2>Inbox</h2>";
-            }
 
-            if ($outbox) {
                 echo "<div id='messagecounttext'>";
                 echo "<big>You have $totalMessageCount sent messages.</big>";
                 echo "</div>";
                 echo "<a href='/inbox.php'>Inbox</a>";
             } else {
+                echo "<h2>Inbox</h2>";
+
                 echo "<div id='messagecounttext'>";
                 echo "<span id='messagecountcontainer'>";
                 echo "<big>You have <b>$unreadMessageCount</b> unread messages</big>";

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -54,8 +54,9 @@ if ($outbox) {
     if (data.substr(0, 3) == 'OK:') {
       var msgID = data.substr(3);
       var titleID = '#msgInlineTitle' + msgID;
-      if ($(titleID).find('span').contents().length) {
-        $(titleID).find('span').contents().unwrap();
+
+      if ($(titleID).find('span').hasClass('unreadmsgtitle')) {
+        $(titleID).find('span').removeClass('unreadmsgtitle');
 
         //	Reduce the number of unread messages by 1
         var numUnread = parseInt($('#messagecounttext').find('b').html());
@@ -83,8 +84,8 @@ if ($outbox) {
       $('#msgInline' + msgID).toggle();
       var titleID = '#msgInlineTitle' + msgID;
 
-      if ($(titleID).find('span').contents().length == false) {
-        $(titleID).contents().wrap('<span class=\'unreadmsgtitle\'>');
+      if (!$(titleID).find('span').hasClass('unreadmsgtitle')) {
+        $(titleID).find('span').addClass('unreadmsgtitle');
 
         //	Increase the number of unread messages by 1
         var numUnread = parseInt($('#messagecounttext').find('b').html());
@@ -196,13 +197,11 @@ if ($outbox) {
                 //echo "<td>" . $msgTo . "</td>";
 
                 echo "<td class='pointer' id='msgInlineTitle$msgID' onclick=\"MarkAsRead( $msgID ); return false;\">";
-                echo "<span>";
                 if ($msgUnread) {
                     echo "<span class='unreadmsgtitle'>$msgTitle</span>";
                 } else {
-                    echo "$msgTitle";
+                    echo "<span>$msgTitle</span>";
                 }
-                echo "</span>";
                 echo "</td>";
 
                 echo "</tr>";


### PR DESCRIPTION
Adds an 'Outbox' link to the user's Inbox:
![image](https://user-images.githubusercontent.com/32680403/154982605-7fb1609f-7944-4e3d-98ba-0ee1faca417c.png)

Clicking on that changes the view to messages sent by the user (instead of messages received by the user). In this mode, the ability to mark messages as read or unread, and the ability to create and delete messages are removed. Only the recipient of a message can mark it as read or delete it.
![image](https://user-images.githubusercontent.com/32680403/154982238-0bf1eb59-60be-4d64-8ff5-da0e453d7c3f.png)

Because of the way the database is currently structured, if the recipient deletes the message, it also disappears from the sender's outbox. Additionally, there's no automatic correlation between messages and their responses.

Also fixes an issue where marking a previously read message as unread would not update the visual state of the message.