### PR TITLE
separate hubs from similar games

### DIFF
--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -111,7 +111,8 @@ function RenderGameAlts($gameAlts, $showTitle = true)
 {
     echo "<div class='component gamealts'>";
     if ($showTitle) {
-        echo "<h3>Related</h3>";
+        echo "<h3>Similar Games</h3>";
+        echo "Have you tried:<br>";
     }
     echo "<table><tbody>";
     foreach ($gameAlts as $nextGame) {

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -155,6 +155,36 @@ function RenderGameAlts($gameAlts, $headerText = null)
     echo "</div>";
 }
 
+function RenderMetadataTableRow($label, $gameDataValue, $gameHubs)
+{
+    $values = [];
+
+    if ($gameHubs) {
+        $hubPrefix = "[$label - ";
+        foreach ($gameHubs as $hub) {
+            if (substr($hub['Title'], 0, strlen($hubPrefix)) == $hubPrefix) {
+                $value = substr($hub['Title'], strlen($hubPrefix), -1);
+                $values[] = "<a href=/game/" . $hub['gameIDAlt'] . ">$value</a>";
+
+                if ($value == $gameDataValue) {
+                    $gameDataValue = null;
+                }
+            }
+        }
+    }
+
+    if ($gameDataValue) {
+        $values[] = $gameDataValue;
+    }
+
+    if ($values) {
+        echo "<tr>";
+        echo "<td style='white-space: nowrap'>$label:</td>";
+        echo "<td><b>" . implode(', ', $values) . "</b></td>";
+        echo "</tr>";
+    }
+}
+
 function RenderLinkToGameForum($gameTitle, $gameID, $forumTopicID, $permissions = 0)
 {
     sanitize_outputs(

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -107,12 +107,11 @@ function RenderBoxArt($imagePath)
     echo "</div>";
 }
 
-function RenderGameAlts($gameAlts, $showTitle = true)
+function RenderGameAlts($gameAlts, $headerText = null)
 {
     echo "<div class='component gamealts'>";
-    if ($showTitle) {
-        echo "<h3>Similar Games</h3>";
-        echo "Have you tried:<br>";
+    if ($headerText) {
+        echo "<h3>$headerText</h3>";
     }
     echo "<table><tbody>";
     foreach ($gameAlts as $nextGame) {
@@ -132,18 +131,21 @@ function RenderGameAlts($gameAlts, $showTitle = true)
         );
 
         $isFullyFeaturedGame = !in_array($consoleName, ['Hubs']);
+        if (!$isFullyFeaturedGame) {
+            $consoleName = null;
+        }
 
         echo "<td>";
         echo GetGameAndTooltipDiv($gameID, $gameTitle, $gameIcon, $consoleName, true);
         echo "</td>";
 
-        echo "<td " . ($isFullyFeaturedGame ? '' : 'colspan="2"') . ">";
+        echo "<td style='width: 100%' " . ($isFullyFeaturedGame ? '' : 'colspan="2"') . ">";
         echo GetGameAndTooltipDiv($gameID, $gameTitle, $gameIcon, $consoleName, false, 32, true);
         echo "</td>";
 
         if ($isFullyFeaturedGame) {
             echo "<td>";
-            echo "$points points<span class='TrueRatio'> ($totalTP)</span>";
+            echo "<span style='white-space: nowrap'>$points points</span><span class='TrueRatio'> ($totalTP)</span>";
             echo "</td>";
         }
 

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -569,57 +569,16 @@ RenderHtmlStart(true);
             $imageIngame = $gameData['ImageIngame'];
             $pageTitleAttr = attributeEscape($pageTitle);
 
-            function addMetadata($label, $gameDataValue, $gameHubs)
-            {
-                $output = '';
-
-                $first = true;
-                if ($gameHubs) {
-                    $hubPrefix = "[$label - ";
-                    foreach ($gameHubs as $hub) {
-                        if (substr($hub['Title'], 0, strlen($hubPrefix)) == $hubPrefix) {
-                            if ($first) {
-                                $first = false;
-                            } else {
-                                $output .= ", ";
-                            }
-
-                            $value = substr($hub['Title'], strlen($hubPrefix), -1);
-                            $output .= "<a href=/game/" . $hub['gameIDAlt'] . ">$value</a>";
-
-                            if ($value == $gameDataValue) {
-                                $gameDataValue = null;
-                            }
-                        }
-                    }
-                }
-
-                if ($gameDataValue) {
-                    if (!$first) {
-                        $output .= ", ";
-                    }
-
-                    $output .= $gameDataValue;
-                }
-
-                if ($output) {
-                    echo "<tr>";
-                    echo "<td style='white-space: nowrap'>$label:</td>";
-                    echo "<td><b>$output</b></td>";
-                    echo "</tr>";
-                }
-            }
-
             echo "<h3 class='longheader'>$pageTitle</h3>";
             echo "<table><tbody>";
             echo "<tr>";
             echo "<td style='width:110px; padding: 7px; vertical-align: top' ><img src='$imageIcon' title='$pageTitleAttr' width='96' height='96'></td>";
             echo "<td>";
             echo "<table class='gameinfo'><tbody>";
-            addMetadata('Developer', $developer, $gameHubs);
-            addMetadata('Publisher', $publisher, $gameHubs);
-            addMetadata('Genre', $genre, $gameHubs);
-            addMetadata('Released', $released, null);
+            RenderMetadataTableRow('Developer', $developer, $gameHubs);
+            RenderMetadataTableRow('Publisher', $publisher, $gameHubs);
+            RenderMetadataTableRow('Genre', $genre, $gameHubs);
+            RenderMetadataTableRow('Released', $released, null);
             echo "</tbody></table>";
             echo "</tr>";
             echo "</tbody></table>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -560,6 +560,10 @@ RenderHtmlStart(true);
                 echo "</div>";
             }
 
+            $developer = $gameData['Developer'] ?? null;
+            $publisher = $gameData['Publisher'] ?? null;
+            $genre = $gameData['Genre'] ?? null;
+            $released = $gameData['Released'] ?? null;
             $imageIcon = $gameData['ImageIcon'];
             $imageTitle = $gameData['ImageTitle'];
             $imageIngame = $gameData['ImageIngame'];
@@ -612,10 +616,10 @@ RenderHtmlStart(true);
             echo "<td style='width:110px; padding: 7px; vertical-align: top' ><img src='$imageIcon' title='$pageTitleAttr' width='96' height='96'></td>";
             echo "<td>";
             echo "<table class='gameinfo'><tbody>";
-            addMetadata('Developer', $gameData['Developer'] ?? null, $gameHubs);
-            addMetadata('Publisher', $gameData['Publisher'] ?? null, $gameHubs);
-            addMetadata('Genre', $gameData['Genre'] ?? null, $gameHubs);
-            addMetadata('Released', $gameData['Released'] ?? null, null);
+            addMetadata('Developer', $developer, $gameHubs);
+            addMetadata('Publisher', $publisher, $gameHubs);
+            addMetadata('Genre', $genre, $gameHubs);
+            addMetadata('Released', $released, null);
             echo "</tbody></table>";
             echo "</tr>";
             echo "</tbody></table>";


### PR DESCRIPTION
Extracts Hubs from the Related list and turns them into metadata which will be displayed below the game screenshots.

![image](https://user-images.githubusercontent.com/32680403/155168470-8d65272a-cf4e-4ade-bff4-d444a6bacdb8.png) ![image](https://user-images.githubusercontent.com/32680403/155168516-9f6ffd58-7fcf-41a8-b22a-c8dd3411fa53.png)

If a Hub name starts with Meta, that's discarded. The remaining Hub name is split on the last hyphen, creating a label and value. Multiple items sharing a label are grouped together, otherwise labels are ordered as they would have been in the Related list.

The metadata items appearing above the screenshots are still populated from the game details (editable in the Dev section), but matching Hub items will be merged. If the label/values are not exact, they will be appended instead of merged:

![image](https://user-images.githubusercontent.com/32680403/155169480-bc7c5999-2658-4a38-a567-72910ce8b73a.png)
