### PR TITLE
add admin comment block to user page

### DIFF
--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\ActivityType;
+use RA\ArticleType;
 use RA\Permissions;
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -24,7 +25,7 @@ function generateEmailValidationString($user)
     }
 
     //    Clear permissions til they validate their email.
-    SetAccountPermissionsJSON('Scott', Permissions::Admin, $user, Permissions::Unregistered);
+    SetAccountPermissionsJSON('Server', Permissions::Admin, $user, Permissions::Unregistered);
 
     return $emailCookie;
 }
@@ -34,7 +35,12 @@ function SetAccountPermissionsJSON($actingUser, $actingUserPermissions, $targetU
     sanitize_sql_inputs($actingUser, $targetUser, $targetUserNewPermissions);
     settype($targetUserNewPermissions, 'integer');
 
-    $targetUserCurrentPermissions = getUserPermissions($targetUser);
+    if (!getAccountDetails($targetUser, $targetUserData)) {
+        $retVal['Success'] = false;
+        $retVal['Error'] = "$targetUser not found";
+    }
+
+    $targetUserCurrentPermissions = $targetUserData['Permissions'];
 
     $retVal = [
         'DestUser' => $targetUser,
@@ -78,6 +84,9 @@ function SetAccountPermissionsJSON($actingUser, $actingUserPermissions, $targetU
     }
 
     $retVal['Success'] = true;
+
+    addArticleComment('Server', ArticleType::UserModeration, $targetUserData['ID'],
+        $actingUser . ' set account type to ' . PermissionsToString($targetUserNewPermissions));
 
     return $retVal;
 }
@@ -127,6 +136,11 @@ function setAccountForumPostAuth($sourceUser, $sourcePermissions, $user, $permis
         if ($dbResult !== false) {
             AuthoriseAllForumPosts($user);
 
+            if (getAccountDetails($user, $userData)) {
+                addArticleComment('Server', ArticleType::UserModeration, $userData['ID'],
+                    $sourceUser . ' authorized user\'s forum posts');
+            }
+
             // error_log(__FUNCTION__ . " SUCCESS! Upgraded $user to allow forum posts, authorised by $sourceUser ($sourcePermissions)");
             return true;
         } else {
@@ -161,7 +175,7 @@ function validateEmailValidationString($emailCookie, &$user)
             // log_sql($query);
             $dbResult = s_mysql_query($query);
             if ($dbResult !== false) {
-                $response = SetAccountPermissionsJSON('Scott', Permissions::Admin, $user, Permissions::Registered);
+                $response = SetAccountPermissionsJSON('Server', Permissions::Admin, $user, Permissions::Registered);
                 if ($response['Success']) {
                     static_addnewregistereduser($user);
                     generateAPIKey($user);
@@ -1793,6 +1807,12 @@ function cancelDeleteRequest($username): bool
 
     $query = "UPDATE UserAccounts u SET u.DeleteRequested = NULL WHERE u.User = '$username'";
     $dbResult = s_mysql_query($query);
+
+    if ($dbResult !== false) {
+        addArticleComment('Server', ArticleType::UserModeration, $user['ID'],
+            $username . ' canceled account deletion');
+    }
+
     return $dbResult !== false;
 }
 
@@ -1810,6 +1830,12 @@ function deleteRequest($username, $date = null): bool
     $date = $date ?? date('Y-m-d H:i:s');
     $query = "UPDATE UserAccounts u SET u.DeleteRequested = '$date', u.Permissions = $permission WHERE u.User = '$username'";
     $dbResult = s_mysql_query($query);
+
+    if ($dbResult !== false) {
+        addArticleComment('Server', ArticleType::UserModeration, $user['ID'],
+            $username . ' requested account deletion');
+    }
+
     return $dbResult !== false;
 }
 

--- a/lib/render/comment.php
+++ b/lib/render/comment.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\ArticleType;
 use RA\Permissions;
 use RA\SubscriptionSubjectType;
 
@@ -55,7 +56,7 @@ function RenderCommentsComponent(
             $lastID = $commentData[$i]['ID'];
         }
 
-        $canDeleteComments = ($articleTypeID == 3) && ($userID == $articleID) || $permissions >= Permissions::Admin;
+        $canDeleteComments = ($articleTypeID == ArticleType::User) && ($userID == $articleID) || $permissions >= Permissions::Admin;
 
         RenderArticleComment(
             $articleID,

--- a/public/request/user/update.php
+++ b/public/request/user/update.php
@@ -3,6 +3,8 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
+use RA\ArticleType;
+
 if (ValidatePOSTorGETChars("tpv")) {
     $targetUser = requestInput('t');
     $propertyType = requestInput('p', null, 'integer');
@@ -46,6 +48,12 @@ if ($propertyType == 1) {
 if ($propertyType == 2) {
     $hasBadge = HasPatreonBadge($targetUser);
     SetPatreonSupporter($targetUser, !$hasBadge);
+
+    if (getAccountDetails($targetUser, $targetUserData)) {
+        addArticleComment('Server', ArticleType::UserModeration, $targetUserData['ID'],
+            $user . ($hasBadge ? ' revoked' : ' awarded') . ' Patreon badge');
+    }
+
     // error_log("$user updated $targetUser to Patreon Status $hasBadge OK!!");
     header("Location: " . getenv('APP_URL') . "/user/$targetUser?e=OK");
 }
@@ -53,6 +61,12 @@ if ($propertyType == 2) {
 // Toggle 'Untracked' status
 if ($propertyType == 3) {
     SetUserTrackedStatus($targetUser, $value);
+
+    if (getAccountDetails($targetUser, $targetUserData)) {
+        addArticleComment('Server', ArticleType::UserModeration, $targetUserData['ID'],
+            $user . ' set status to ' . ($value ? 'Tracked' : 'Untracked'));
+    }
+
     // error_log("SetUserTrackedStatus, $targetUser => $value");
     header("Location: " . getenv('APP_URL') . "/user/$targetUser?e=OK");
 }

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -39,7 +39,7 @@ $userWallActive = $userMassData['UserWallActive'];
 $userIsUntracked = $userMassData['Untracked'];
 
 //    Get wall
-$numArticleComments = getArticleComments(3, $userPageID, 0, 100, $commentData);
+$numArticleComments = getArticleComments(ArticleType::User, $userPageID, 0, 100, $commentData);
 
 //    Get user's feed
 //$numFeedItems = getFeed( $userPage, 20, 0, $feedData, 0, 'individual' );
@@ -352,12 +352,16 @@ RenderHtmlStart(true);
             echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Admin (Click to show):</span><br>";
             echo "<div id='devboxcontent'>";
 
+            echo "<table cellspacing=8 border=1>";
+
             if ($permissions >= $userMassData['Permissions'] && ($user != $userPage)) {
-                echo "<li>Update Account Type:</li>";
+                echo "<tr>";
                 echo "<form method='post' action='/request/user/update.php' enctype='multipart/form-data'>";
                 echo "<input type='hidden' name='p' value='0' />";
                 echo "<input type='hidden' name='t' value='$userPage' />";
-
+                echo "<td>";
+                echo "<input type='submit' style='float: right;' value='Update Account Type' />";
+                echo "</td><td>";
                 echo "<select name='v' >";
                 $i = Permissions::Banned;
                 // Don't do this, looks weird when trying to change someone above you
@@ -372,42 +376,60 @@ RenderHtmlStart(true);
                 }
                 echo "</select>";
 
-                echo "&nbsp;<input type='submit' style='float: right;' value='Do it!' /><br><br>";
-                echo "<div style='clear:all;'></div>";
-                echo "</form><br>";
+                echo "</td></form></tr>";
             }
 
-            if ($permissions >= Permissions::Admin) {
-                echo "<form method='post' action='/request/user/update.php' enctype='multipart/form-data'>";
-                echo "<input type='hidden' name='p' value='2' />";
-                echo "<input type='hidden' name='t' value='$userPage' />";
-                echo "<input type='hidden' name='v' value='0' />";
-                echo "&nbsp;<input type='submit' style='float: right;' value='Toggle Patreon Supporter' /><br><br>";
-                echo "<div style='clear:all;'></div>";
-                echo "</form>";
+            $newValue = $userIsUntracked ? 0 : 1;
+            echo "<tr><td>";
+            echo "<form method='post' action='/request/user/update.php' enctype='multipart/form-data'>";
+            echo "<input TYPE='hidden' NAME='p' VALUE='3' />";
+            echo "<input TYPE='hidden' NAME='t' VALUE='$userPage' />";
+            echo "<input TYPE='hidden' NAME='v' VALUE='$newValue' />";
+            echo "<input type='submit' style='float: right;' value='Toggle Tracked Status' />";
+            echo "</form>";
+            echo "</td><td style='width: 100%'>";
+            echo ($userIsUntracked == 1) ? "Untracked User" : "Tracked User";
+            echo "</td></tr>";
 
-                echo "<form method='post' action='/request/user/recalculate-score.php' enctype='multipart/form-data'>";
-                echo "<input TYPE='hidden' NAME='u' VALUE='$userPage' />";
-                echo "&nbsp;<input type='submit' style='float: right;' value='Recalc Score Now' /><br><br>";
-                echo "<div style='clear:all;'></div>";
-                echo "</form>";
+            echo "<tr><td>";
+            echo "<form method='post' action='/request/user/update.php' enctype='multipart/form-data'>";
+            echo "<input type='hidden' name='p' value='2' />";
+            echo "<input type='hidden' name='t' value='$userPage' />";
+            echo "<input type='hidden' name='v' value='0' />";
+            echo "<input type='submit' style='float: right;' value='Toggle Patreon Supporter' />";
+            echo "</form>";
+            echo "</td><td>";
+            echo HasPatreonBadge($userPage) ? "Patreon Supporter" : "Not a Patreon Supporter";
+            echo "</td></tr>";
 
-                echo ($userIsUntracked == 1) ? "<b>Untracked User!</b>&nbsp;" : "Tracked User.&nbsp;";
-                $newValue = $userIsUntracked ? 0 : 1;
-                echo "<form method='post' action='/request/user/update.php' enctype='multipart/form-data'>";
-                echo "<input TYPE='hidden' NAME='p' VALUE='3' />";
-                echo "<input TYPE='hidden' NAME='t' VALUE='$userPage' />";
-                echo "<input TYPE='hidden' NAME='v' VALUE='$newValue' />";
-                echo "&nbsp;<input type='submit' style='float: right;' value='Toggle Tracked Status' /><br><br>";
-                echo "<div style='clear:all;'></div>";
-                echo "</form>";
+            echo "<tr><td>";
+            echo "<form method='post' action='/request/user/recalculate-score.php' enctype='multipart/form-data'>";
+            echo "<input TYPE='hidden' NAME='u' VALUE='$userPage' />";
+            echo "<input type='submit' style='float: right;' value='Recalc Score Now' />";
+            echo "</form>";
+            echo "</td></tr>";
 
-                echo "<form method='post' action='/request/user/remove-avatar.php' enctype='multipart/form-data' onsubmit='return confirm(\"Are you sure you want to permanently delete this avatar?\")'>";
-                echo "<input TYPE='hidden' NAME='u' VALUE='$userPage' />";
-                echo "&nbsp;<input type='submit' style='float: right;' value='Remove Avatar' /><br><br>";
-                echo "<div style='clear:all;'></div>";
-                echo "</form>";
-            }
+            echo "<tr><td>";
+            echo "<form method='post' action='/request/user/remove-avatar.php' enctype='multipart/form-data' onsubmit='return confirm(\"Are you sure you want to permanently delete this avatar?\")'>";
+            echo "<input TYPE='hidden' NAME='u' VALUE='$userPage' />";
+            echo "<input type='submit' style='float: right;' value='Remove Avatar' />";
+            echo "</form>";
+            echo "</td></tr>";
+
+            echo "<tr><td colspan=2>";
+            echo "<div class='commentscomponent left'>";
+            $numLogs = getArticleComments(ArticleType::UserModeration, $userPageID, 0, 1000, $logs);
+            RenderCommentsComponent($user,
+                $numLogs,
+                $logs,
+                $userPageID,
+                ArticleType::UserModeration,
+                $permissions
+            );
+            echo "</div>";
+            echo "</td></tr>";
+
+            echo "</table>";
 
             echo "</div>"; //devboxcontent
 

--- a/src/ArticleType.php
+++ b/src/ArticleType.php
@@ -20,6 +20,8 @@ abstract class ArticleType
 
     public const Forum = 8;
 
+    public const UserModeration = 9;
+
     private const VALUES = [
         self::Game,
         self::Achievement,
@@ -29,6 +31,7 @@ abstract class ArticleType
         self::Leaderboard,
         self::AchievementTicket,
         self::Forum,
+        self::UserModeration,
     ];
 
     public static function values(): array


### PR DESCRIPTION
Adds a new comment block within the admin tools on a user's page, allowing administrators to note things about the user, such as why they were untracked or banned. It also leverages the virtual audit functionality for tracking changes to settings managed by administrators.

![image](https://user-images.githubusercontent.com/32680403/155197803-5640724b-8895-43c7-b842-1f65c6269a77.png)
