### PR TITLE
Remove Locked Topic Information

### DIFF
--- a/lib/database/forum.php
+++ b/lib/database/forum.php
@@ -3,7 +3,7 @@
 use RA\ModifyTopicField;
 use RA\Permissions;
 
-function getForumList($categoryID = 0)
+function getForumList($permissions, $categoryID = 0)
 {
     sanitize_sql_inputs($categoryID);
     settype($categoryID, 'integer');
@@ -63,7 +63,7 @@ function getForumDetails($forumID, &$forumDataOut)
     }
 }
 
-function getForumTopics($forumID, $offset, $count, &$maxCountOut)
+function getForumTopics($forumID, $offset, $count, $permissions, &$maxCountOut)
 {
     sanitize_sql_inputs($forumID, $offset, $count);
     settype($forumID, "integer");
@@ -84,6 +84,7 @@ function getForumTopics($forumID, $offset, $count, &$maxCountOut)
                 LEFT JOIN Forum AS f ON f.ID = ft.ForumID
                 LEFT JOIN ForumTopicComment AS ftc2 ON ftc2.ForumTopicID = ft.ID AND ftc2.Authorised = 1
                 WHERE ft.ForumID = $forumID
+                AND ft.RequiredPermissions <= $permissions
                 GROUP BY ft.ID, LatestCommentPostedDate
                 ORDER BY LatestCommentPostedDate DESC
                 LIMIT $offset, $count";
@@ -493,7 +494,7 @@ function generateGameForumTopic($user, $gameID, &$forumTopicID)
     }
 }
 
-function getRecentForumPosts($offset, $count, $numMessageChars, &$dataOut)
+function getRecentForumPosts($offset, $count, $numMessageChars, $permissions, &$dataOut)
 {
     sanitize_sql_inputs($offset, $count, $numMessageChars);
     //    02:08 21/02/2014 - cater for 20 spam messages
@@ -519,6 +520,7 @@ function getRecentForumPosts($offset, $count, $numMessageChars, &$dataOut)
         INNER JOIN ForumTopic AS ft ON ft.ID = LatestComments.ForumTopicID
         LEFT JOIN Forum AS f ON f.ID = ft.ForumID
         LEFT JOIN UserAccounts AS ua ON ua.User = LatestComments.Author
+        WHERE ft.RequiredPermissions <= '$permissions'
         ORDER BY LatestComments.DateCreated DESC
         LIMIT 0, $count";
 

--- a/lib/database/search.php
+++ b/lib/database/search.php
@@ -1,6 +1,6 @@
 <?php
 
-function performSearch($searchQuery, $offset, $count, &$searchResultsOut)
+function performSearch($searchQuery, $offset, $count, $permissions, &$searchResultsOut)
 {
     global $db;
 
@@ -38,7 +38,9 @@ function performSearch($searchQuery, $offset, $count, &$searchResultsOut)
         CONCAT( '...', MID( ftc.Payload, GREATEST( LOCATE('$searchQuery', ftc.Payload)-25, 1), 60 ), '...' ) AS Title
         FROM ForumTopicComment AS ftc
         LEFT JOIN UserAccounts AS ua ON ua.ID = ftc.AuthorID
+        LEFT JOIN ForumTopic AS ft ON ft.ID = ftc.ForumTopicID
         WHERE ftc.Payload LIKE '%$searchQuery%'
+        AND ft.RequiredPermissions <= '$permissions'
         GROUP BY ID, ftc.ID
     )
     UNION

--- a/lib/render/forum.php
+++ b/lib/render/forum.php
@@ -1,11 +1,11 @@
 <?php
 
-function RenderRecentForumPostsComponent($numToFetch = 4)
+function RenderRecentForumPostsComponent($permissions, $numToFetch = 4)
 {
     echo "<div class='component'>";
     echo "<h3>Forum Activity</h3>";
 
-    if (getRecentForumPosts(0, $numToFetch, 100, $recentPostData) != 0) {
+    if (getRecentForumPosts(0, $numToFetch, 100, $permissions, $recentPostData) != 0) {
         foreach ($recentPostData as $nextData) {
             $timestamp = strtotime($nextData['PostedAt']);
             $datePosted = date("d M", $timestamp);

--- a/public/createtopic.php
+++ b/public/createtopic.php
@@ -79,7 +79,7 @@ RenderHtmlHead("Create topic: $thisForumTitle");
         </div>
     </div>
     <div id="rightcontainer">
-        <?php RenderRecentForumPostsComponent(4); ?>
+        <?php RenderRecentForumPostsComponent($permissions, 4); ?>
     </div>
 </div>
 <?php RenderFooter(); ?>

--- a/public/forum.php
+++ b/public/forum.php
@@ -4,9 +4,9 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 
 $requestedCategoryID = requestInputSanitized('c', null, 'integer');
 
-$forumList = getForumList($requestedCategoryID);
-
 RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+
+$forumList = getForumList($permissions, $requestedCategoryID);
 
 $numUnofficialLinks = 0;
 if ($permissions >= \RA\Permissions::Developer) {
@@ -144,7 +144,7 @@ RenderHtmlHead($pageTitle);
     </div>
     <div id="rightcontainer">
         <?php
-        RenderRecentForumPostsComponent(8);
+        RenderRecentForumPostsComponent($permissions, 8);
         ?>
     </div>
 </div>

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -9,7 +9,7 @@ $count = $maxCount;
 
 RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
 
-$numPostsFound = getRecentForumPosts($offset, $count, 90, $recentPostsData);
+$numPostsFound = getRecentForumPosts($offset, $count, 90, $permissions, $recentPostsData);
 
 $errorCode = requestInputSanitized('e');
 

--- a/public/index.php
+++ b/public/index.php
@@ -210,7 +210,7 @@ RenderToolbar($user, $permissions);
         RenderActivePlayersComponent();
         RenderCurrentlyOnlineComponent();
         echo "<div style='min-height: 160px;' id='chart_usersonline'></div>";
-        RenderRecentForumPostsComponent(4);
+        RenderRecentForumPostsComponent($permissions, 4);
         ?>
     </div>
     <div id="rightcontainer" style="padding-top: 20px">

--- a/public/rss-forum.xml.php
+++ b/public/rss-forum.xml.php
@@ -3,6 +3,8 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
+use RA\Permissions;
+
 $site = getenv('APP_URL');
 
 $dom = new DOMDocument('1.0', 'UTF-8');
@@ -25,7 +27,7 @@ $xmlRoot->appendChild($dom->createElement('title', 'RetroAchievements.org Forum 
 $xmlRoot->appendChild($dom->createElement('description', 'RetroAchievements.org, your home for achievements in classic games'));
 $xmlRoot->appendChild($dom->createElement('link', getenv('APP_URL')));
 
-$numPostsFound = getRecentForumPosts(0, 30, 120, 1, $recentPostsData);
+$numPostsFound = getRecentForumPosts(0, 30, 120, Permissions::Registered, $recentPostsData);
 //$feedData = array_reverse( $recentPostsData );
 
 $lastID = 0;

--- a/public/rss-forum.xml.php
+++ b/public/rss-forum.xml.php
@@ -25,7 +25,7 @@ $xmlRoot->appendChild($dom->createElement('title', 'RetroAchievements.org Forum 
 $xmlRoot->appendChild($dom->createElement('description', 'RetroAchievements.org, your home for achievements in classic games'));
 $xmlRoot->appendChild($dom->createElement('link', getenv('APP_URL')));
 
-$numPostsFound = getRecentForumPosts(0, 30, 120, $recentPostsData);
+$numPostsFound = getRecentForumPosts(0, 30, 120, 1, $recentPostsData);
 //$feedData = array_reverse( $recentPostsData );
 
 $lastID = 0;

--- a/public/searchresults.php
+++ b/public/searchresults.php
@@ -11,7 +11,7 @@ $maxCount = requestInputSanitized('c', 50, 'integer');
 $searchResults = null;
 $resultsCount = 0;
 if ($searchQuery !== null) {
-    $resultsCount = performSearch($searchQuery, $offset, $maxCount, $searchResults);
+    $resultsCount = performSearch($searchQuery, $offset, $maxCount, $permissions, $searchResults);
 }
 
 $errorCode = requestInputSanitized('e');

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -46,7 +46,7 @@ if ($requestedForumID == 0) {
     $thisCategoryID = $forumDataOut['CategoryID'];
     $thisCategoryName = $forumDataOut['CategoryName'];
 
-    $topicList = getForumTopics($requestedForumID, $offset, $count, $numTotalTopics);
+    $topicList = getForumTopics($requestedForumID, $offset, $count, $permissions, $numTotalTopics);
 
     $requestedForum = $thisForumTitle;
 }
@@ -220,7 +220,7 @@ RenderHtmlHead("View forum: $thisForumTitle");
     </div>
     <div id="rightcontainer">
         <?php
-        RenderRecentForumPostsComponent(8);
+        RenderRecentForumPostsComponent($permissions, 8);
         ?>
     </div>
 </div>


### PR DESCRIPTION
This removes information on topic information that the user does not have permission to access from Forum Activity, Forum Post History, Search results, and RSS feed.

It does not remove the Last Post info from this section below (my latest comment is in a locked Chat topic):
![image](https://user-images.githubusercontent.com/16140035/156279161-cb719dac-f6ea-4261-919a-b7cb0e15204e.png)
The Last Post (`LatestCommentID`) for each individual forum is stored in the `Forum` table, the query below uses that ID specifically when rendering this section. I'm not sure the best way to fix this without completely rewriting that query. It's an edge case given how infrequent a locked topic has the latest post of a given forum. This section also does not show what the topic or comment actual was. I can work on rewriting the query if that is preferred.

https://github.com/RetroAchievements/RAWeb/blob/c969d683c304d810f20e50b3d559ab5e693df733/lib/database/forum.php#L13-L26