### PR TITLE
allow admins to link hashes to unsupported consoles

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -1147,25 +1147,17 @@ function submitNewGameTitleJSON($user, $md5, $gameIDin, $titleIn, $consoleID)
     if (!isset($user)) {
         $retVal['Error'] = "User doesn't appear to be set or have permissions?";
         $retVal['Success'] = false;
+    } elseif ($permissions < Permissions::Developer) {
+        $retVal['Error'] = "You must be a developer to perform this action! Please drop a message in the forums to apply.";
+        $retVal['Success'] = false;
     } elseif (mb_strlen($md5) != 32) {
-        // error_log(__FUNCTION__ . " Md5 unready? Ignoring");
         $retVal['Error'] = "MD5 provided ($md5) doesn't appear to be exactly 32 characters, this request is invalid.";
         $retVal['Success'] = false;
     } elseif (mb_strlen($titleIn) < 2) {
-        // error_log(__FUNCTION__ . " $user provided a new md5 $md5 for console $consoleID, but provided the title $titleIn. Ignoring");
         $retVal['Error'] = "Cannot submit game title given as '$titleIn'";
         $retVal['Success'] = false;
-    } elseif (!isValidConsoleId($consoleID)) {
-        /**
-         * cannot submitGameTitle, $consoleID is 0! What console is this for?
-         */
-        $retVal['Error'] = "Cannot submit game title, ConsoleID is 0! What console is this for?";
-        $retVal['Success'] = false;
-    } elseif ($permissions < Permissions::Developer) {
-        /**
-         * Cannot submit *new* game title, not allowed! User level too low ($user, $permissions)
-         */
-        $retVal['Error'] = "The ROM you are trying to load is not in the database. Check official forum thread for details about versions of the game which are supported.";
+    } elseif ($consoleID < 1 || (!isValidConsoleId($consoleID) && $permissions < Permissions::Admin)) {
+        $retVal['Error'] = "Cannot submit game title for unknown ConsoleID $consoleID";
         $retVal['Success'] = false;
     } else {
         if (!empty($gameIDin)) {


### PR DESCRIPTION
Allows hashes to be linked during a rollout to simplify the development process.

Also changes the error message from `Cannot submit game title, ConsoleID is 0! What console is this for?` to `Cannot submit game title for unknown ConsoleID`, which seems to be leftover from this change: https://github.com/RetroAchievements/RAWeb/pull/468/files#diff-7c33f209aea8df531e4a87be81c561b821304c7ec6fa829cf70cb0fdd8fc33a7R1053

And changes the error message for non-devs from `The ROM you are trying to load is not in the database. Check official forum thread for details about versions of the game which are supported.` to `You must be a developer to perform this action! Please drop a message in the forums to apply.` to match the error they receive when they try to publish an achievement.