### PR TITLE
fix edits not being logged for leaderboards with an unknown author

### DIFF
--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -865,7 +865,7 @@ function UploadNewLeaderboard(
         if ($dbResult !== false && mysqli_num_rows($dbResult) == 1) {
             $data = mysqli_fetch_assoc($dbResult);
             $displayOrder = $data['DisplayOrder'];
-            $originalAuthor = $data['Author'];
+            $originalAuthor = $data['Author'] ?? "Unknown";
             settype($displayOrder, 'integer');
         }
     }


### PR DESCRIPTION
The logic to prevent adding an "edit" comment when first uploading a new leaderboard was also not adding an "edit" comment when modifying a leaderboard whose author has been NULLed out for whatever reason.