### PR TITLE
ignore all non-scaling operands for scalable flags

### DIFF
--- a/lib/util/trigger.php
+++ b/lib/util/trigger.php
@@ -133,6 +133,19 @@ function parseOperand($mem)
     return [$type, $size, $address, $mem];
 }
 
+function isScalerOperator($cmp)
+{
+    switch ($cmp) {
+        case '*':
+        case '/':
+        case '&':
+            return true;
+
+        default:
+            return false;
+    }
+}
+
 function parseCondition($mem)
 {
     $flag = '';
@@ -170,9 +183,11 @@ function parseCondition($mem)
 
     [$lType, $lSize, $lMemory, $mem] = parseOperand($mem);
 
-    if ($scalable && $mem == '=0') {
-        $mem = ''; // AddSource X=0 should just be AddSource X
-    } elseif (strlen($mem) > 0) {
+    if (strlen($mem) == 0) {
+        // no operator
+    } elseif ($scalable && !isScalerOperator($mem[0])) {
+        $mem = ''; // non-scaler operator ignored for scalable operations
+    } else {
         $cmp = $mem[0];
         $cmplen = 1;
         switch ($mem[0]) {


### PR DESCRIPTION
Ensures operator and operand are not shown for all comparisons on conditions with scalable flags (AddSource, SubSource, AddAddress). Previously, it only handled "=0".

See https://discord.com/channels/310192285306454017/310195377993416714/953351104660373594