### PR TITLE
use secondary query to calculate unique players in getGameMetadata

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -201,8 +201,6 @@ function getGameMetadataByFlags(
     //echo $query;
 
     $numAchievements = 0;
-    $numDistinctPlayersCasual = 0;
-    $numDistinctPlayersHardcore = 0;
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {
@@ -210,17 +208,6 @@ function getGameMetadataByFlags(
             $nextID = $data['ID'];
             settype($nextID, 'integer');
             $achievementDataOut[$nextID] = $data;
-
-            $numHC = $data['NumAwardedHardcore'];
-            $numCas = $data['NumAwarded'];
-
-            if ($numCas > $numDistinctPlayersCasual) {
-                $numDistinctPlayersCasual = $numCas;
-            }
-            if ($numHC > $numDistinctPlayersHardcore) {
-                $numDistinctPlayersHardcore = $numHC;
-            }
-
             $numAchievements++;
         }
     } else {
@@ -253,7 +240,7 @@ function getGameMetadataByFlags(
         $query = "SELECT ach.ID, aw.Date, aw.HardcoreMode
                   FROM Awarded AS aw
                   LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
-                  WHERE ach.GameID = $gameID AND aw.User = '$user2'";
+                  WHERE ach.GameID = $gameID AND ach.Flags = $flags AND aw.User = '$user2'";
 
         $dbResult = s_mysql_query($query);
         if ($dbResult !== false) {
@@ -265,6 +252,28 @@ function getGameMetadataByFlags(
                 } else {
                     $achievementDataOut[$nextID]['DateEarnedFriend'] = $data['Date'];
                 }
+            }
+        }
+    }
+
+    $numDistinctPlayersCasual = 0;
+    $numDistinctPlayersHardcore = 0;
+
+    $query = "SELECT aw.HardcoreMode, COUNT(DISTINCT aw.User) as Users
+              FROM Awarded AS aw
+              LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
+              LEFT JOIN UserAccounts as ua ON ua.User = aw.User
+              WHERE ach.GameID = $gameID
+              AND (NOT ua.Untracked" . (isset($user) ? " OR ua.User = '$user'" : "") . ")
+              GROUP BY aw.HardcoreMode";
+    $dbResult = s_mysql_query($query);
+    if ($dbResult !== false) {
+        while ($data = mysqli_fetch_assoc($dbResult)) {
+            print_r($data);
+            if ($data['HardcoreMode'] == 1) {
+                $numDistinctPlayersHardcore = $data['Users'];
+            } else {
+                $numDistinctPlayersCasual = $data['Users'];
             }
         }
     }

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -269,7 +269,6 @@ function getGameMetadataByFlags(
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {
         while ($data = mysqli_fetch_assoc($dbResult)) {
-            print_r($data);
             if ($data['HardcoreMode'] == 1) {
                 $numDistinctPlayersHardcore = $data['Users'];
             } else {
@@ -753,7 +752,7 @@ function requestModifyGameForumTopic($gameID, $newForumTopic)
  *
  * @return array of achievement distribution information to plot on the game page
  */
-function getAchievementDistribution($gameID, $hardcore, $requestedBy, $flags)
+function getAchievementDistribution($gameID, $hardcore, $requestedBy, $flags, $numAchievements = null)
 {
     sanitize_sql_inputs($gameID, $hardcore, $requestedBy, $flags);
     settype($gameID, 'integer');
@@ -790,7 +789,10 @@ function getAchievementDistribution($gameID, $hardcore, $requestedBy, $flags)
         }
 
         // fill the gaps and sort
-        $numAchievements = getGameMetadataByFlags($gameID, $requestedBy, $achievementData, $gameData, 1, null, $flags);
+        if ($numAchievements === null) {
+            $numAchievements = getGameMetadataByFlags($gameID, $requestedBy, $achievementData, $gameData, 1, null, $flags);
+        }
+
         for ($i = 1; $i <= $numAchievements; $i++) {
             if (!array_key_exists($i, $retval)) {
                 $retval[$i] = 0;

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -140,7 +140,7 @@ if ($isFullyFeaturedGame) {
     $numDistinctPlayersCasual = $gameData['NumDistinctPlayersCasual'];
     $numDistinctPlayersHardcore = $gameData['NumDistinctPlayersHardcore'];
 
-    $achDist = getAchievementDistribution($gameID, 0, $user, $flags); // for now, only retrieve casual!
+    $achDist = getAchievementDistribution($gameID, 0, $user, $flags, $numAchievements); // for now, only retrieve casual!
 
     $numArticleComments = getArticleComments(1, $gameID, 0, 20, $commentData);
 

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -139,20 +139,6 @@ $isSoleAuthor = false;
 if ($isFullyFeaturedGame) {
     $numDistinctPlayersCasual = $gameData['NumDistinctPlayersCasual'];
     $numDistinctPlayersHardcore = $gameData['NumDistinctPlayersHardcore'];
-    if ($numDistinctPlayersCasual == 0) {
-        $numDistinctPlayersCasual = 1;
-    }
-    if ($numDistinctPlayersHardcore == 0) {
-        $numDistinctPlayersHardcore = 1; //??
-    }
-
-    $totalUniquePlayers = getTotalUniquePlayers($gameID, $user);
-    if ($numDistinctPlayersCasual < $totalUniquePlayers) {
-        $numDistinctPlayersCasual = $totalUniquePlayers;
-    }
-    if ($numDistinctPlayersHardcore < $totalUniquePlayers) {
-        $numDistinctPlayersHardcore = $totalUniquePlayers;
-    }
 
     $achDist = getAchievementDistribution($gameID, 0, $user, $flags); // for now, only retrieve casual!
 
@@ -1015,9 +1001,14 @@ RenderHtmlStart(true);
                             $tooltipText = $earnedOnHardcore ? '<br clear=all>Unlocked: ' . getNiceDate(strtotime($nextAch['DateEarnedHardcore'])) . '<br>-=HARDCORE=-' : '';
 
                             $wonBy = $nextAch['NumAwarded'];
-                            $completionPctCasual = sprintf("%01.2f", ($wonBy / $numDistinctPlayersCasual) * 100);
                             $wonByHardcore = $nextAch['NumAwardedHardcore'];
-                            $completionPctHardcore = sprintf("%01.2f", ($wonByHardcore / $numDistinctPlayersCasual) * 100);
+                            if ($numDistinctPlayersCasual == 0) {
+                                $completionPctCasual = "0";
+                                $completionPctHardcore = "0";
+                            } else {
+                                $completionPctCasual = sprintf("%01.2f", ($wonBy / $numDistinctPlayersCasual) * 100);
+                                $completionPctHardcore = sprintf("%01.2f", ($wonByHardcore / $numDistinctPlayersCasual) * 100);
+                            }
 
                             if ($user == "" || !$achieved) {
                                 $achBadgeName .= "_lock";


### PR DESCRIPTION
Fixes an issue reported by Kinglink.
https://discord.com/channels/310192285306454017/453242743292952578/957568137761550388

Within `getGameMetadata`, the `NumDistinctPlayersCasual` and `NumDistinctPlayersHardcore` values were being derived as the maximum value for any given achievement within the set. The `gameInfo.php` page made a separate call to `getTotalUniquePlayers` to get the actual value.

I've modified `getGameMetadata` to make a separate query to fetch the correct values so they can be used in other places (like `API_GetGameExtended.php`), and removed the separate call to `getTotalUniquePlayers` in `gameInfo.php`.

I've also modified `getAchievementDistribution` to accept an optional parameter that is the number of achievements to prevent an extra call to `getGameMetadata` just to fill in any gaps in the distribution chart.