### PR TITLE
PHP 8 compatibility

### DIFF
--- a/.hooks/post-merge
+++ b/.hooks/post-merge
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-composer.phar install
+php composer.phar install
 
 printf "\n✅ post-merge hook\n\n"

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ It is a "flat" PHP project; individual php files within the `public` folder hand
 ## Requirements
 
 - Local web server
-- [PHP 7.4](http://php.net/manual/en/)
+- [PHP 8.0](http://php.net/manual/en/)
 - [Composer v2](https://getcomposer.org/) PHP dependency manager
 - [MySQL 8](https://dev.mysql.com/doc/refman/8.0/en/)
 - [Node.js 12](https://nodejs.org/)
 
 **[XAMPP](https://www.apachefriends.org/download.html)** provides an easy way to run an Apache web server, MySQL/MariaDB, and PHP on your system.
 
-Note: Install the XAMPP version packaged with PHP 7.4.
+Note: Install the XAMPP version packaged with PHP 8.0.
 
 You might have to enable some extensions in `php.ini`:
 ```

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -27,7 +27,7 @@ function GetGameAndTooltipDiv(
     $gameIcon = $gameIcon != null ? $gameIcon : "/Images/PlayingIcon32.png";
 
     $tooltip = "<div id='objtooltip' style='display:flex;max-width:400px'>";
-    $tooltip .= "<img style='margin-right:5px' src='$gameIcon' width='$tooltipIconSize' height='$tooltipIconSize' />";
+    $tooltip .= "<img style='margin-right:5px' src='" . getenv('ASSET_URL') . "$gameIcon' width='$tooltipIconSize' height='$tooltipIconSize' />";
     $tooltip .= "<div>";
     $tooltip .= "<b>$gameName</b><br>";
     $tooltip .= $consoleStr;

--- a/public/awardedList.php
+++ b/public/awardedList.php
@@ -153,11 +153,7 @@ RenderHtmlHead("Achievement List" . $requestedConsole);
                 $consoleName
             );
 
-            if ($achCount++ % 2 == 0) {
-                echo "<tr>";
-            } else {
-                echo "<tr>";
-            }
+            echo "<tr>";
 
             echo "<td style='min-width:25%'>";
             echo GetAchievementAndTooltipDiv($achID, $achTitle, $achDesc, $achPoints, $gameTitle, $achBadgeName, true);

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -58,6 +58,8 @@ RenderHtmlHead("Forum Recent Posts");
                 $postTime = $topicPostData['PostedAt'];
                 $nicePostTime = getNiceDate(strtotime($postTime));
 
+                sanitize_outputs($forumTopicTitle, $postMessage);
+
                 echo "<tr>";
 
                 echo "<td>";

--- a/public/history.php
+++ b/public/history.php
@@ -34,37 +34,6 @@ $userPagePoints = getScore($userPage);
 
 getUserActivityRange($userPage, $userSignedUp, $userLastLogin);
 
-$userCompletedGamesList = getUsersCompletedGamesAndMax($userPage);
-
-$userCompletedGames = [];
-
-//	Merge all elements of $userCompletedGamesList into one unique list
-for ($i = 0; $i < count($userCompletedGamesList); $i++) {
-    $gameID = $userCompletedGamesList[$i]['GameID'];
-
-    if ($userCompletedGamesList[$i]['HardcoreMode'] == 0) {
-        $userCompletedGames[$gameID] = $userCompletedGamesList[$i];
-    }
-
-    $userCompletedGames[$gameID]['NumAwardedHC'] = 0; //	Update this later, but fill in for now
-}
-
-for ($i = 0; $i < count($userCompletedGamesList); $i++) {
-    $gameID = $userCompletedGamesList[$i]['GameID'];
-    if ($userCompletedGamesList[$i]['HardcoreMode'] == 1) {
-        $userCompletedGames[$gameID]['NumAwardedHC'] = $userCompletedGamesList[$i]['NumAwarded'];
-    }
-}
-
-function scorePctCompare($a, $b)
-{
-    return $a['PctWon'] < $b['PctWon'];
-}
-
-usort($userCompletedGames, "scorePctCompare");
-
-$userCompletedGamesList = $userCompletedGames;
-
 //	the past week
 $userScoreData = getAwardedList($userPage, 0, 1000);
 
@@ -297,16 +266,10 @@ RenderHtmlHead("$userPage's Legacy");
             $dateUnix = strtotime("$nextDay-$nextMonth-$nextYear");
             $dateStr = getNiceDate($dateUnix, true);
 
-            if ($dayCount++ % 2 == 0) {
-                echo "<tr>";
-            } else {
-                echo "<tr>";
-            }
-
+            echo "<tr>";
             echo "<td>$dateStr</td>";
             echo "<td><a href='historyexamine.php?d=$dateUnix&u=$userPage'>$nextNumAwarded</a></td>";
             echo "<td><a href='historyexamine.php?d=$dateUnix&u=$userPage'>$nextTotalPointsEarned</a></td>";
-
             echo "</tr>";
         }
 

--- a/public/historyexamine.php
+++ b/public/historyexamine.php
@@ -107,12 +107,7 @@ RenderHtmlHead("$userPage's Legacy - $dateStr");
             }
         }
 
-        function dateCompare($a, $b)
-        {
-            return $a['Date'] > $b['Date'];
-        }
-
-        usort($achEarnedLib, "dateCompare");
+        usort($achEarnedLib, fn ($a, $b) => $a['Date'] <=> $b['Date']);
 
         foreach ($achEarnedLib as $achEarned) {
             $achAwardedAt = $achEarned['Date'];
@@ -128,6 +123,8 @@ RenderHtmlHead("$userPage's Legacy - $dateStr");
             $achConsoleName = $achEarned['ConsoleName'];
             $achBadgeName = $achEarned['BadgeName'];
             $hardcoreMode = $achEarned['HardcoreMode'];
+
+            sanitize_outputs($achTitle, $achDesc);
 
             //$pointsCount 	+= $achPoints;
 

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -332,11 +332,7 @@ RenderHtmlHead($pageTitle);
 
             echo "</tr>";
 
-            if ($listCount++ % 2 == 0) {
-                echo "<tr>";
-            } else {
-                echo "<tr>";
-            }
+            echo "<tr>";
 
             echo "<td>";
             //echo "Memory:";

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -71,18 +71,9 @@ for ($i = 0; $i < count($userCompletedGamesList); $i++) {
         $userCompletedGames[$gameID]['NumAwardedHC'] = $userCompletedGamesList[$i]['NumAwarded'];
     }
 }
-//var_dump( $userCompletedGames );
-//    Custom sort, then overwrite $userCompletedGamesList
 
-function scorePctCompare($a, $b)
-{
-    if (empty($a['PctWon']) || empty($b['PctWon'])) {
-        return 0;
-    }
-    return $a['PctWon'] < $b['PctWon'];
-}
-
-usort($userCompletedGames, "scorePctCompare");
+// Custom sort, then overwrite $userCompletedGamesList
+usort($userCompletedGames, fn ($a, $b) => ($b['PctWon'] ?? 0) <=> ($a['PctWon'] ?? 0));
 
 $userCompletedGamesList = $userCompletedGames;
 

--- a/resources/docker/php/Dockerfile
+++ b/resources/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm
+FROM php:8.0-fpm
 
 RUN apt-get update
 


### PR DESCRIPTION
Run PHP 7.4 code without any errors or warning in PHP 8.

Will be followed up with full PHP 8 upgrade (using rector, see https://github.com/RetroAchievements/RAWeb/pull/911) as soon as server has been configured accordingly (php-fpm pool, socket).