### PR TITLE
split Site Awards into Game/Event/Site Awards

### DIFF
--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -140,126 +140,55 @@ function _GetUserAndTooltipDiv(
 
 function RenderSiteAwards($userAwards)
 {
-    echo "<div id='siteawards' class='component' >";
-    echo "<h3>Site Awards</h3>";
+    $gameAwards = array_values(array_filter($userAwards, function ($award) {
+        return $award['AwardType'] == AwardType::MASTERY && $award['ConsoleName'] != 'Events';
+    }));
+
+    $eventAwards = array_values(array_filter($userAwards, function ($award) {
+        return $award['AwardType'] == AwardType::MASTERY && $award['ConsoleName'] == 'Events';
+    }));
+
+    $siteAwards = array_values(array_filter($userAwards, function ($award) {
+        return $award['AwardType'] != AwardType::MASTERY && in_array((int) $award['AwardType'], AwardType::$active);
+    }));
+
+    if (!empty($gameAwards) || (empty($eventAwards) && empty($siteAwards))) {
+        RenderAwardGroup($gameAwards, "Game Awards");
+    }
+
+    if (!empty($eventAwards)) {
+        RenderAwardGroup($eventAwards, "Event Awards");
+    }
+
+    if (!empty($siteAwards)) {
+        RenderAwardGroup($siteAwards, "Site Awards");
+    }
+}
+
+function RenderAwardGroup($awards, $title)
+{
+    echo "<div id='" . strtolower(str_replace(' ', '', $title)) . "' class='component' >";
+    echo "<h3>$title</h3>";
     echo "<div class='siteawards'>";
     echo "<table class='siteawards'><tbody>";
 
-    $userAwards = array_values(array_filter($userAwards, function ($award) {
-        return in_array((int) $award['AwardType'], AwardType::$active);
-    }));
-
-    $numItems = count($userAwards);
+    $numItems = count($awards);
     $imageSize = 48;
     $numCols = 5;
-    for ($i = 0; $i < $numItems / 3; $i++) {
+    for ($i = 0; $i < ceil($numItems / $numCols); $i++) {
         echo "<tr>";
         for ($j = 0; $j < $numCols; $j++) {
             $nOffs = ($i * $numCols) + $j;
             if ($nOffs >= $numItems) {
+                echo "<td><div class='badgeimg'><div style='width:{$imageSize}px' /></div></td>";
                 continue;
             }
 
-            $elem = $userAwards[$nOffs];
-
-            //$awardedAt = $elem[ 'AwardedAt' ];
-            $awardType = $elem['AwardType'];
-            settype($awardType, 'integer');
-            $awardData = $elem['AwardData'];
-            $awardDataExtra = $elem['AwardDataExtra'];
-            $awardGameTitle = $elem['Title'];
-            $awardGameConsole = $elem['ConsoleName'];
-            $awardGameImage = $elem['ImageIcon'];
-            $awardDate = getNiceDate($elem['AwardedAt']);
-            //$awardGameFlags = $elem[ 'Flags' ];
-            $awardButGameIsIncomplete = (isset($elem['Incomplete']) && $elem['Incomplete'] == 1);
-            $imgclass = 'badgeimg siteawards';
-
-            if ($awardType == AwardType::MASTERY) {
-                if ($awardDataExtra == '1') {
-                    $tooltip = "MASTERED $awardGameTitle ($awardGameConsole)";
-                    $imgclass = 'goldimage';
-                } else {
-                    $tooltip = "Completed $awardGameTitle ($awardGameConsole)";
-                }
-
-                if ($awardButGameIsIncomplete) {
-                    $tooltip .= "...<br>but more achievements have been added!<br>Click here to find out what you're missing!";
-                }
-
-                $imagepath = $awardGameImage;
-                $linkdest = "/game/$awardData";
-            } elseif ($awardType == AwardType::ACHIEVEMENT_UNLOCKS_YIELD) {
-                // Developed a number of earned achievements
-                $tooltip = "Awarded for being a hard-working developer and producing achievements that have been earned over " . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . " times!";
-
-                $imagepath = "/Images/_Trophy" . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . ".png";
-
-                $linkdest = ''; //    TBD: referrals page?
-            } elseif ($awardType == AwardType::ACHIEVEMENT_POINTS_YIELD) {
-                // Yielded an amount of points earned by players
-                $tooltip = "Awarded for producing many valuable achievements, providing over " . RA\AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$awardData] . " points to the community!";
-
-                if ($awardData == 0) {
-                    $imagepath = "/Images/trophy-green.png";
-                } elseif ($awardData == 1) {
-                    $imagepath = "/Images/trophy-bronze.png";
-                } elseif ($awardData == 2) {
-                    $imagepath = "/Images/trophy-platinum.png";
-                } elseif ($awardData == 3) {
-                    $imagepath = "/Images/trophy-silver.png";
-                } elseif ($awardData == 4) {
-                    $imagepath = "/Images/trophy-gold.png";
-                } else {
-                    $imagepath = "/Images/trophy-gold.png";
-                }
-
-                $linkdest = ''; //    TBD: referrals page?
-            } elseif ($awardType == AwardType::REFERRALS) {
-                $tooltip = "Referred $awardData members";
-
-                if ($awardData < 2) {
-                    $imagepath = "/Badge/00083.png";
-                } elseif ($awardData < 3) {
-                    $imagepath = "/Badge/00083.png";
-                } elseif ($awardData < 5) {
-                    $imagepath = "/Badge/00083.png";
-                } elseif ($awardData < 10) {
-                    $imagepath = "/Badge/00083.png";
-                } elseif ($awardData < 15) {
-                    $imagepath = "/Badge/00083.png";
-                } else {
-                    $imagepath = "/Badge/00083.png";
-                }
-
-                $linkdest = ''; //    TBD: referrals page?
-            } elseif ($awardType == AwardType::PATREON_SUPPORTER) {
-                $tooltip = 'Awarded for being a Patreon supporter! Thank-you so much for your support!';
-
-                $imagepath = '/Images/PatreonBadge.png';
-                $linkdest = 'https://www.patreon.com/retroachievements';
-            } else {
-                // Unknown or inactive award type
-                continue;
-            }
-
-            $tooltip .= "\r\nAwarded on $awardDate";
-            $tooltip = attributeEscape($tooltip);
-            $displayable = "<a href=\"$linkdest\"><img class=\"$imgclass\" alt=\"$tooltip\" title=\"$tooltip\" src=\"$imagepath\" width=\"$imageSize\" height=\"$imageSize\" /></a>";
-            $tooltipImagePath = "$imagepath";
-            $tooltipImageSize = 96; //64;    //    screw that, lets make it big!
-            $tooltipTitle = "Site Award";
-
-            // $textWithTooltip = WrapWithTooltip($displayable, $tooltipImagePath, $tooltipImageSize, $tooltipTitle, $tooltip);
-            $textWithTooltip = $displayable;
-
-            $newOverlayDiv = '';
-            // if ($awardButGameIsIncomplete) {
-            //     $newOverlayDiv = WrapWithTooltip("<a href=\"$linkdest\"><div class=\"trophyimageincomplete\"></div></a>", $tooltipImagePath, $tooltipImageSize, $tooltipTitle, $tooltip);
-            // }
-
-            echo "<td><div class='trophycontainer'><div class='trophyimage'>$textWithTooltip</div>$newOverlayDiv</div></td>";
+            echo "<td>";
+            RenderAward($awards[$nOffs], $imageSize);
+            echo "</td>";
         }
+
         echo "</tr>";
     }
     echo "</tbody></table>";
@@ -269,6 +198,109 @@ function RenderSiteAwards($userAwards)
     //echo "<br>";
 
     echo "</div>";
+}
+
+function RenderAward($award, $imageSize, $clickable = true)
+{
+    $awardType = $award['AwardType'];
+    settype($awardType, 'integer');
+    $awardData = $award['AwardData'];
+    $awardDataExtra = $award['AwardDataExtra'];
+    $awardGameTitle = $award['Title'];
+    $awardGameConsole = $award['ConsoleName'];
+    $awardGameImage = $award['ImageIcon'];
+    $awardDate = getNiceDate($award['AwardedAt']);
+    $awardButGameIsIncomplete = (isset($award['Incomplete']) && $award['Incomplete'] == 1);
+    $imgclass = 'badgeimg siteawards';
+
+    if ($awardType == AwardType::MASTERY) {
+        if ($awardDataExtra == '1') {
+            $tooltip = "MASTERED $awardGameTitle ($awardGameConsole)";
+            $imgclass = 'goldimage';
+        } else {
+            $tooltip = "Completed $awardGameTitle ($awardGameConsole)";
+        }
+
+        if ($awardButGameIsIncomplete) {
+            $tooltip .= "...<br>but more achievements have been added!<br>Click here to find out what you're missing!";
+        }
+
+        $imagepath = $awardGameImage;
+        $linkdest = "/game/$awardData";
+    } elseif ($awardType == AwardType::ACHIEVEMENT_UNLOCKS_YIELD) {
+        // Developed a number of earned achievements
+        $tooltip = "Awarded for being a hard-working developer and producing achievements that have been earned over " . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . " times!";
+
+        $imagepath = "/Images/_Trophy" . RA\AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . ".png";
+
+        $linkdest = ''; //    TBD: referrals page?
+    } elseif ($awardType == AwardType::ACHIEVEMENT_POINTS_YIELD) {
+        // Yielded an amount of points earned by players
+        $tooltip = "Awarded for producing many valuable achievements, providing over " . RA\AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$awardData] . " points to the community!";
+
+        if ($awardData == 0) {
+            $imagepath = "/Images/trophy-green.png";
+        } elseif ($awardData == 1) {
+            $imagepath = "/Images/trophy-bronze.png";
+        } elseif ($awardData == 2) {
+            $imagepath = "/Images/trophy-platinum.png";
+        } elseif ($awardData == 3) {
+            $imagepath = "/Images/trophy-silver.png";
+        } elseif ($awardData == 4) {
+            $imagepath = "/Images/trophy-gold.png";
+        } else {
+            $imagepath = "/Images/trophy-gold.png";
+        }
+
+        $linkdest = ''; //    TBD: referrals page?
+    } elseif ($awardType == AwardType::REFERRALS) {
+        $tooltip = "Referred $awardData members";
+
+        if ($awardData < 2) {
+            $imagepath = "/Badge/00083.png";
+        } elseif ($awardData < 3) {
+            $imagepath = "/Badge/00083.png";
+        } elseif ($awardData < 5) {
+            $imagepath = "/Badge/00083.png";
+        } elseif ($awardData < 10) {
+            $imagepath = "/Badge/00083.png";
+        } elseif ($awardData < 15) {
+            $imagepath = "/Badge/00083.png";
+        } else {
+            $imagepath = "/Badge/00083.png";
+        }
+
+        $linkdest = ''; //    TBD: referrals page?
+    } elseif ($awardType == AwardType::PATREON_SUPPORTER) {
+        $tooltip = 'Awarded for being a Patreon supporter! Thank-you so much for your support!';
+
+        $imagepath = '/Images/PatreonBadge.png';
+        $linkdest = 'https://www.patreon.com/retroachievements';
+    } else {
+        // Unknown or inactive award type
+        return;
+    }
+
+    $tooltip .= "\r\nAwarded on $awardDate";
+    $tooltip = attributeEscape($tooltip);
+
+    $displayable = "<img class=\"$imgclass\" alt=\"$tooltip\" title=\"$tooltip\" src=\"$imagepath\" width=\"$imageSize\" height=\"$imageSize\" />";
+    $newOverlayDiv = '';
+
+    if ($clickable && !empty($linkdest)) {
+        $displayable = "<a href=\"$linkdest\">$displayable</a>";
+        $tooltipImagePath = "$imagepath";
+        $tooltipImageSize = 96; //64;    //    screw that, lets make it big!
+        $tooltipTitle = "Site Award";
+
+        // $textWithTooltip = WrapWithTooltip($displayable, $tooltipImagePath, $tooltipImageSize, $tooltipTitle, $tooltip);
+
+        // if ($awardButGameIsIncomplete) {
+        //     $newOverlayDiv = WrapWithTooltip("<a href=\"$linkdest\"><div class=\"trophyimageincomplete\"></div></a>", $tooltipImagePath, $tooltipImageSize, $tooltipTitle, $tooltip);
+        // }
+    }
+
+    echo "<div><div>$displayable</div>$newOverlayDiv</div>";
 }
 
 function RenderCompletedGamesList($user, $userCompletedGamesList)


### PR DESCRIPTION
If any section would be empty it's not displayed. 

![image](https://user-images.githubusercontent.com/32680403/161657978-31cdb82b-0824-4289-a413-13d89a52b069.png)

![image](https://user-images.githubusercontent.com/32680403/161658006-92c15201-2f58-45db-a9dd-944cf42fb071.png)

The only caveat is if all three sections would be empty, an empty Game Awards section is displayed.

![image](https://user-images.githubusercontent.com/32680403/161658022-317626df-0803-447b-bfdf-7103b0ed83f8.png)

The reorder site awards page is similarly split up:

![image](https://user-images.githubusercontent.com/32680403/161658345-120efb18-4727-4cf0-bd43-902f008dff3b.png)

