### PR TITLE
Add HTTP tests for Web & Connect APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ test*.php
 /public/tmp
 
 /resources/docker/nginx/logs/*
+/tests/http/http-client.private.env.json
 
 cronjobs/playersonline.log
 cronjobs/cronlog.log

--- a/public/API/API_GetAchievementOfTheWeek.php
+++ b/public/API/API_GetAchievementOfTheWeek.php
@@ -15,7 +15,7 @@ if (empty($achievementID)) {
         'Achievement' => ['ID' => null],
         'StartAt' => null,
     ]);
-    return;
+    exit;
 }
 
 $achievementData = GetAchievementMetadataJSON($achievementID);

--- a/public/API/API_GetAchievementUnlocks.php
+++ b/public/API/API_GetAchievementUnlocks.php
@@ -12,7 +12,7 @@ if (empty($achievementID)) {
     echo json_encode([
         'Achievement' => ['ID' => null],
     ]);
-    return;
+    exit;
 }
 
 $achievementData = GetAchievementMetadataJSON($achievementID);

--- a/public/API/API_GetFeed.php
+++ b/public/API/API_GetFeed.php
@@ -3,7 +3,7 @@
  * exit early - no more feeds in v1
  */
 echo json_encode(['success' => false]);
-return;
+exit;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../lib/bootstrap.php';

--- a/public/API/API_GetGameList.php
+++ b/public/API/API_GetGameList.php
@@ -8,7 +8,7 @@ runPublicApiMiddleware();
 $consoleID = requestInputQuery('i', null, 'integer');
 if ($consoleID < 0) {
     echo json_encode(['success' => false]);
-    return;
+    exit;
 }
 
 $officialFlag = requestInputQuery('f', false, 'boolean');

--- a/public/API/API_GetGameRankAndScore.php
+++ b/public/API/API_GetGameRankAndScore.php
@@ -8,7 +8,7 @@ runPublicApiMiddleware();
 $gameId = requestInputQuery('g', null, 'integer');
 if ($gameId <= 0) {
     echo json_encode(['success' => false]);
-    return;
+    exit;
 }
 
 $username = requestInputQuery('z');

--- a/public/API/API_GetTicketData.php
+++ b/public/API/API_GetTicketData.php
@@ -18,7 +18,7 @@ if ($ticketID > 0) {
     if ($ticketData == false) {
         http_response_code(404);
         echo json_encode(['error' => "Ticket ID $ticketID not found"]);
-        return;
+        exit;
     }
 
     $reportTypes = ['', "Triggered at a wrong time", "Doesn't trigger"];
@@ -29,7 +29,7 @@ if ($ticketID > 0) {
 
     $ticketData['URL'] = $baseUrl . "?i=$ticketID";
     echo json_encode($ticketData);
-    return;
+    exit;
 }
 
 // same logic used in ticketmanager.php
@@ -42,7 +42,7 @@ if ($gamesTableFlag == 1) {
     $ticketData['MostReportedGames'] = gamesSortedByOpenTickets($count);
     $ticketData['URL'] = $baseUrl . "?f=$gamesTableFlag";
     echo json_encode($ticketData);
-    return;
+    exit;
 }
 
 // getting ticket info for a specific user
@@ -77,7 +77,7 @@ if (isValidUsername($assignedToUser)) {
     }
     $ticketData['URL'] = $baseUrl . "?u=$assignedToUser";
     echo json_encode($ticketData);
-    return;
+    exit;
 }
 $assignedToUser = null;
 
@@ -97,11 +97,11 @@ if ($gameIDGiven > 0) {
         $ticketData['URL'] = $baseUrl . "?g=$gameIDGiven";
 
         echo json_encode($ticketData);
-        return;
+        exit;
     }
     http_response_code(404);
     echo json_encode(['error' => "Game ID $gameIDGiven not found"]);
-    return;
+    exit;
 }
 
 // getting data for a specific achievement
@@ -111,7 +111,7 @@ if ($achievementIDGiven > 0) {
     if (!$achievementData) {
         http_response_code(404);
         echo json_encode(['error' => "Achievement ID $achievementIDGiven not found"]);
-        return;
+        exit;
     }
     $ticketData['AchievementID'] = $achievementIDGiven;
     $ticketData['AchievementTitle'] = $achievementData['Title'];
@@ -119,7 +119,7 @@ if ($achievementIDGiven > 0) {
     $ticketData['URL'] = $baseUrl . "?a=$achievementIDGiven";
     $ticketData['OpenTickets'] = countOpenTicketsByAchievement($achievementIDGiven);
     echo json_encode($ticketData);
-    return;
+    exit;
 }
 
 // getting the 10 most recent tickets

--- a/tests/http/api-connect.http
+++ b/tests/http/api-connect.http
@@ -1,3 +1,5 @@
+# To be used with a JetBrains IDE HTTP Client
+
 ### Latest client
 # curl -X POST --location "http://{{host}}/dorequest.php" \
 #    -H "Content-Type: application/x-www-form-urlencoded" \

--- a/tests/http/api-connect.http
+++ b/tests/http/api-connect.http
@@ -1,0 +1,39 @@
+### Latest client
+# curl -X POST --location "http://{{host}}/dorequest.php" \
+#    -H "Content-Type: application/x-www-form-urlencoded" \
+#    -d "r=latestclient&e={{emulator}}"
+POST {{host}}/dorequest.php
+Content-Type: application/x-www-form-urlencoded
+
+r=latestclient&e={{emulator}}
+
+### Latest integration
+# curl -X POST --location "http://{{host}}/dorequest.php" \
+#    -H "Content-Type: application/x-www-form-urlencoded" \
+#    -d "r=latestintegration"
+POST {{host}}/dorequest.php
+Content-Type: application/x-www-form-urlencoded
+
+r=latestintegration
+
+### Login. Retrieve and save token.
+# curl -X POST --location "http://{{host}}/dorequest.php" \
+#    -H "Content-Type: application/x-www-form-urlencoded" \
+#    -d "u={{apiUser}}&p={{password}}&r=login"
+POST {{host}}/dorequest.php
+Content-Type: application/x-www-form-urlencoded
+
+u={{apiUser}}&p={{password}}&r=login
+
+> {% client.global.set("token", response.body.json.Token); %}
+
+### Game ID
+# curl -X POST --location "http://{{host}}/dorequest.php" \
+#    -H "Content-Type: application/x-www-form-urlencoded" \
+#    -d "u={{apiUser}}&t={{token}}&r=gameid&m={{gameHash}}"
+POST {{host}}/dorequest.php
+Content-Type: application/x-www-form-urlencoded
+
+u={{apiUser}}&t={{token}}&r=gameid&m={{gameHash}}
+
+###

--- a/tests/http/api-web.http
+++ b/tests/http/api-web.http
@@ -1,3 +1,5 @@
+# To be used with a JetBrains IDE HTTP Client
+
 ### GetAchievementCount
 # curl -X GET --location "http://{{host}}/API/API_GetAchievementCount.php?y={{apiToken}}&z={{apiUser}}&i={{game}}" -H "Accept: application/json"
 GET {{host}}/API/API_GetAchievementCount.php?y={{apiToken}}&z={{apiUser}}&i={{game}}

--- a/tests/http/api-web.http
+++ b/tests/http/api-web.http
@@ -1,0 +1,109 @@
+### GetAchievementCount
+# curl -X GET --location "http://{{host}}/API/API_GetAchievementCount.php?y={{apiToken}}&z={{apiUser}}&i={{game}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetAchievementCount.php?y={{apiToken}}&z={{apiUser}}&i={{game}}
+Accept: application/json
+
+### GetAchievementDistribution
+# curl -X GET --location "http://{{host}}/API/API_GetAchievementDistribution.php?y={{apiToken}}&z={{apiUser}}&i={{game}}&h=1&f=3" -H "Accept: application/json"
+GET {{host}}/API/API_GetAchievementDistribution.php?y={{apiToken}}&z={{apiUser}}&i={{game}}&h=1&f=3
+Accept: application/json
+
+### GetAchievementOfTheWeek
+# curl -X GET --location "http://{{host}}/API/API_GetAchievementOfTheWeek.php?y={{apiToken}}&z={{apiUser}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetAchievementOfTheWeek.php?y={{apiToken}}&z={{apiUser}}
+Accept: application/json
+
+### GetAchievementsEarnedBetween
+# curl -X GET --location "http://{{host}}/API/API_GetAchievementsEarnedBetween.php?y={{apiToken}}&z={{apiUser}}&u={{user}}&f=1550000000&t=1610000000" -H "Accept: application/json"
+GET {{host}}/API/API_GetAchievementsEarnedBetween.php?y={{apiToken}}&z={{apiUser}}&u={{user}}&f=1550000000&t=1610000000
+Accept: application/json
+
+### GetAchievementsEarnedOnDay
+# curl -X GET --location "http://{{host}}/API/API_GetAchievementsEarnedOnDay.php?y={{apiToken}}&z={{apiUser}}&u={{user}}&d=2019-02-12" -H "Accept: application/json"
+GET {{host}}/API/API_GetAchievementsEarnedOnDay.php?y={{apiToken}}&z={{apiUser}}&u={{user}}&d=2019-02-12
+Accept: application/json
+
+### GetAchievementUnlocks
+# curl -X GET --location "http://{{host}}/API/API_GetAchievementUnlocks.php?y={{apiToken}}&z={{apiUser}}&a={{achievement}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetAchievementUnlocks.php?y={{apiToken}}&z={{apiUser}}&a={{achievement}}
+Accept: application/json
+
+### GetConsoleIDs
+# curl -X GET --location "http://{{host}}/API/API_GetConsoleIDs.php?y={{apiToken}}&z={{apiUser}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetConsoleIDs.php?y={{apiToken}}&z={{apiUser}}
+Accept: application/json
+
+### GetFeed
+# curl -X GET --location "http://{{host}}/API/API_GetFeed.php?y={{apiToken}}&z={{apiUser}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetFeed.php?y={{apiToken}}&z={{apiUser}}
+Accept: application/json
+
+### GetGame
+# curl -X GET --location "http://{{host}}/API/API_GetGame.php?y={{apiToken}}&z={{apiUser}}&i={{game}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetGame.php?y={{apiToken}}&z={{apiUser}}&i={{game}}
+Accept: application/json
+
+### GetGameExtended
+# curl -X GET --location "http://{{host}}/API/API_GetGameExtended.php?y={{apiToken}}&z={{apiUser}}&i={{game}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetGameExtended.php?y={{apiToken}}&z={{apiUser}}&i={{game}}
+Accept: application/json
+
+### GetGameInfoAndUserProgress
+# curl -X GET --location "http://{{host}}/API/API_GetGameInfoAndUserProgress.php?y={{apiToken}}&z={{apiUser}}&u={{user}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetGameInfoAndUserProgress.php?y={{apiToken}}&z={{apiUser}}&u={{user}}
+Accept: application/json
+
+### GetGameList
+# curl -X GET --location "http://{{host}}/API/API_GetGameList.php?y={{apiToken}}&z={{apiUser}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetGameList.php?y={{apiToken}}&z={{apiUser}}&i={{console}}
+Accept: application/json
+
+### GetGameRankAndScore
+# curl -X GET --location "http://{{host}}/API/API_GetGameRankAndScore.php?y={{apiToken}}&z={{apiUser}}&g={{game}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetGameRankAndScore.php?y={{apiToken}}&z={{apiUser}}&g={{game}}
+Accept: application/json
+
+### GetGameRating
+# curl -X GET --location "http://{{host}}/API/API_GetGameRating.php?y={{apiToken}}&z={{apiUser}}&i={{game}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetGameRating.php?y={{apiToken}}&z={{apiUser}}&i={{game}}
+Accept: application/json
+
+### GetTicketData
+# curl -X GET --location "http://{{host}}/API/API_GetTicketData.php?y={{apiToken}}&z={{apiUser}}&i={{ticket}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetTicketData.php?y={{apiToken}}&z={{apiUser}}&i={{ticket}}
+Accept: application/json
+
+### GetTopTenUsers
+# curl -X GET --location "http://{{host}}/API/API_GetTopTenUsers.php?y={{apiToken}}&z={{apiUser}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetTopTenUsers.php?y={{apiToken}}&z={{apiUser}}
+Accept: application/json
+
+### GetUserCompletedGames
+# curl -X GET --location "http://{{host}}/API/API_GetUserCompletedGames.php?y={{apiToken}}&z={{apiUser}}&u={{user}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetUserCompletedGames.php?y={{apiToken}}&z={{apiUser}}&u={{user}}
+Accept: application/json
+
+### GetUserGameRankAndScore
+# curl -X GET --location "http://{{host}}/API/API_GetUserGameRankAndScore.php?y={{apiToken}}&z={{apiUser}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetUserGameRankAndScore.php?y={{apiToken}}&z={{apiUser}}&g={{game}}&u={{user}}
+Accept: application/json
+
+### GetUserProgress
+# curl -X GET --location "http://{{host}}/API/API_GetUserProgress.php?y={{apiToken}}&z={{apiUser}}&i={{game}}&u={{user}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetUserProgress.php?y={{apiToken}}&z={{apiUser}}&i={{game}}&u={{user}}
+Accept: application/json
+
+### GetUserRankAndScore
+# curl -X GET --location "http://{{host}}/API/API_GetUserRankAndScore.php?y={{apiToken}}&z={{apiUser}}&u={{user}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetUserRankAndScore.php?y={{apiToken}}&z={{apiUser}}&u={{user}}
+Accept: application/json
+
+### GetUserRecentlyPlayedGames
+# curl -X GET --location "http://{{host}}/API/API_GetUserRecentlyPlayedGames.php?y={{apiToken}}&z={{apiUser}}&u={{user}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetUserRecentlyPlayedGames.php?y={{apiToken}}&z={{apiUser}}&u={{user}}
+Accept: application/json
+
+### GetUserSummary
+# curl -X GET --location "http://{{host}}/API/API_GetUserSummary.php?y={{apiToken}}&z={{apiUser}}&u={{user}}" -H "Accept: application/json"
+GET {{host}}/API/API_GetUserSummary.php?y={{apiToken}}&z={{apiUser}}&u={{user}}
+Accept: application/json

--- a/tests/http/http-client.env.json
+++ b/tests/http/http-client.env.json
@@ -1,0 +1,16 @@
+{
+  "dev": {
+    // Override these in http-client.private.env.json
+    "host": "http://localhost:64100",
+    "achievement": "1",
+    "console": "1",
+    "emulator": "7",
+    "game": "1",
+    "gameHash": "1bc674be034e43c96b86487ac69d9293",
+    "ticket": "1",
+    "user": "Scott",
+    "password": "",
+    "apiUser": "",
+    "apiToken": ""
+  }
+}


### PR DESCRIPTION
... to quickly test for PHP 8 compatibility.
I think those are for JetBrains IDEs only, at least I could not find any reference as to whether those can be run by another HTTP client. Added curl notations for reference.

Includes all of Web API but only a few Connect API requests as the latter was acceptance tested with an actual client (latest RALibretro).