### PR TITLE
ignore achievements with no retro ratio when determining easiest achievements

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -148,6 +148,9 @@ function getAchievementsListByDev(
         if (isset($dev)) {
             $query .= "AND ach.Author = '$dev' ";
         }
+        if ($sortBy == 4) {
+            $query .= "AND ach.TrueRatio > 0 ";
+        }
     } elseif (isset($dev)) {
         $query .= "WHERE ach.Author = '$dev' ";
     }
@@ -168,7 +171,7 @@ function getAchievementsListByDev(
             $query .= "ORDER BY ach.Points, GameTitle ";
             break;
         case 4:
-            $query .= "ORDER BY ach.TrueRatio, GameTitle ";
+            $query .= "ORDER BY ach.TrueRatio, ach.Points DESC, GameTitle ";
             break;
         case 5:
             $query .= "ORDER BY ach.Author ";
@@ -192,7 +195,7 @@ function getAchievementsListByDev(
             $query .= "ORDER BY ach.Points DESC, GameTitle ";
             break;
         case 14:
-            $query .= "ORDER BY ach.TrueRatio DESC, GameTitle ";
+            $query .= "ORDER BY ach.TrueRatio DESC, ach.Points, GameTitle ";
             break;
         case 15:
             $query .= "ORDER BY ach.Author DESC ";


### PR DESCRIPTION
Newly created achievements have a retro ratio of 0. As such, they appear "easier" than all other achievements. There are currently around 5300 achievements with a retro ratio of 0. This filters those out so actual easy achievements appear in the "Easy Achievements" page. Unfortunately, there are around 7000 achievements with a retro ratio of 1, so identifying the "easiest" achievements is still far from perfect.

A secondary sort was also added to subclassify items within the same retro ratio by their point value. i.e. a 1 point achievement with a retro ratio of 2 is harder than a 2 point achievement with a retro ratio of 2.