### PR TITLE
lazy load images for completion list

### DIFF
--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -355,7 +355,7 @@ function RenderCompletedGamesList($user, $userCompletedGamesList)
         $tooltip = "Progress: $nextNumAwarded achievements won out of a possible $nextMaxPossible";
         $tooltip = sprintf("%s (%01.1f%%)", $tooltip, ($nextTotalAwarded / $nextMaxPossible) * 100);
 
-        $displayable = "<a href=\"/game/$nextGameID\"><img alt=\"$tooltipTitle ($nextConsoleName)\" title=\"$tooltipTitle\" src=\"$nextImageIcon\" width=\"32\" height=\"32\" />";
+        $displayable = "<a href=\"/game/$nextGameID\"><img alt=\"$tooltipTitle ($nextConsoleName)\" title=\"$tooltipTitle\" src=\"$nextImageIcon\" width=\"32\" height=\"32\" loading=\"lazy\" />";
         // $textWithTooltip = WrapWithTooltip($displayable, $tooltipImagePath, $tooltipImageSize, $tooltipTitle, $tooltip);
         $textWithTooltip = $displayable;
 


### PR DESCRIPTION
Avoids greedily downloading images for the 90% of the games in the Completion List that are not visible unless the user scrolls

![image](https://user-images.githubusercontent.com/32680403/162786481-c316265a-3eaf-46c1-87f2-ca93264c716a.png)
