### PR TITLE
start with collapsible sections collapsed

### DIFF
--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -181,7 +181,7 @@ RenderHtmlStart(true);
         if ($achievedLocal) {
             echo "<div class='devbox'>";
             echo "<span onclick=\"$('#resetboxcontent').toggle(); return false;\">Reset Progress</span><br>";
-            echo "<div id='resetboxcontent'>";
+            echo "<div id='resetboxcontent' style='display: none'>";
             echo "<form id='resetform' action='/request/user/reset-achievements.php' method='post'>";
             echo "<input type='hidden' name='u' value='$user'>";
             echo "<input type='hidden' name='a' value='$achievementID'>";
@@ -194,7 +194,7 @@ RenderHtmlStart(true);
         if (isset($user) && $permissions >= Permissions::JuniorDeveloper) {
             echo "<div class='devbox mb-3'>";
             echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Dev (Click to show):</span><br>";
-            echo "<div id='devboxcontent'>";
+            echo "<div id='devboxcontent' style='display: none'>";
 
             if ($permissions >= Permissions::Developer) {
                 echo "<li>Set embedded video URL:</li>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -592,7 +592,7 @@ RenderHtmlStart(true);
             if (isset($user) && ($permissions >= Permissions::Developer || ($isFullyFeaturedGame && $permissions >= Permissions::JuniorDeveloper))) {
                 echo "<div class='devbox'>";
                 echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Dev (Click to show):</span><br>";
-                echo "<div id='devboxcontent'>";
+                echo "<div id='devboxcontent' style='display: none'>";
 
                 // Display the option to switch between viewing core/unofficial for non-hub page
                 if ($isFullyFeaturedGame) {
@@ -862,7 +862,7 @@ RenderHtmlStart(true);
                     if ($numEarnedCasual > 0 || $numEarnedHardcore > 0) {
                         echo "<div class='devbox'>";
                         echo "<span onclick=\"$('#resetboxcontent').toggle(); return false;\">Reset Progress</span><br>";
-                        echo "<div id='resetboxcontent'>";
+                        echo "<div id='resetboxcontent' style='display: none'>";
                         echo "<form id='resetform' action='/request/user/reset-achievements.php' method='post'>";
                         echo "<input type='hidden' name='u' value='$user'>";
                         echo "<input type='hidden' name='g' value='$gameID'>";

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -324,10 +324,7 @@ function reloadTwitchContainer(videoID) {
 }
 
 jQuery(document).ready(function onReady($) {
-  $('#devboxcontent').hide();
-  $('#resetboxcontent').hide();
   $('.msgPayload').hide();
-  $('#managevids').hide();
 
   var $searchBoxInput = $('.searchboxinput');
   $searchBoxInput.autocomplete({ source: '/request/search.php', minLength: 2 });

--- a/public/largechat.php
+++ b/public/largechat.php
@@ -65,7 +65,7 @@ RenderHtmlHead("RA Cinema");
         if ($permissions >= Permissions::Developer) {
             echo "<div>";
             echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Extra (click to show):</span>";
-            echo "<div id='devboxcontent'>";
+            echo "<div id='devboxcontent' style='display: none'>";
 
             $vidTitle = "";
             $vidLink = "";

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -138,7 +138,7 @@ RenderHtmlHead($pageTitle);
 
         echo "<div class='devbox'>";
         echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Dev (Click to show):</span><br>";
-        echo "<div id='devboxcontent'>";
+        echo "<div id='devboxcontent' style='display: none'>";
 
         echo "<ul>";
         if (isset($gameID)) {

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -105,7 +105,7 @@ RenderHtmlStart(true);
             if (isset($user) && $permissions >= Permissions::JuniorDeveloper) {
                 echo "<div class='devbox'>";
                 echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Dev (Click to show):</span><br>";
-                echo "<div id='devboxcontent'>";
+                echo "<div id='devboxcontent' style='display: none'>";
 
                 echo "<ul>";
                 echo "<a href='/leaderboardList.php?g=$gameID'>Leaderboard Management for $gameTitle</a>";

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -339,7 +339,7 @@ RenderHtmlStart(true);
         if (isset($user) && $permissions >= Permissions::Admin) {
             echo "<div class='devbox'>";
             echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Admin (Click to show):</span><br>";
-            echo "<div id='devboxcontent'>";
+            echo "<div id='devboxcontent' style='display: none'>";
 
             echo "<table cellspacing=8 border=1>";
 

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -110,7 +110,7 @@ RenderHtmlStart();
         if (isset($user) && ($thisTopicAuthor == $user || $permissions >= Permissions::Admin)) {
             echo "<div class='devbox'>";
             echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Options (Click to show):</span><br>";
-            echo "<div id='devboxcontent'>";
+            echo "<div id='devboxcontent' style='display: none'>";
 
             echo "<div>Change Topic Title:</div>";
             echo "<form action='/request/forum-topic/modify.php' method='post' >";


### PR DESCRIPTION
Instead of relying on onready javascript to hide them by name.

Prevents collapsible sections from being rendered/visible/open while the page is loading. For most pages, this just causes the section to flash as briefly visible, but for larger pages (games with lots of achievements, user pages), the collapsible sections remain open for a second or more while the rest of the page loads.