### PR TITLE
allow award groups to be ordered

### DIFF
--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -43,11 +43,7 @@ RenderHtmlHead("Reorder Site Awards");
 
         $userAwards = getUsersSiteAwards($user, true);
 
-        $gameAwards = array_values(array_filter($userAwards, fn ($award) => $award['AwardType'] == AwardType::MASTERY && $award['ConsoleName'] != 'Events'));
-
-        $eventAwards = array_values(array_filter($userAwards, fn ($award) => $award['AwardType'] == AwardType::MASTERY && $award['ConsoleName'] == 'Events'));
-
-        $siteAwards = array_values(array_filter($userAwards, fn ($award) => $award['AwardType'] != AwardType::MASTERY && in_array((int) $award['AwardType'], AwardType::$active)));
+        [$gameAwards, $eventAwards, $siteAwards] = SeparateAwards($userAwards);
 
         function RenderAwardOrderTable($title, $awards, &$counter)
         {


### PR DESCRIPTION
Leverages the Display Order property of the first item in each group to determine which order to display the groups on a user's profile page.

i.e. If your first Game Award Display Order is lower than your first Event Award display order, the Game Award section will be displayed first. If the first Event Award Display Order is lower, it will be displayed first. Only the first item in each group matters for intergroup interactions. Items within a group will be ordered by their display order within the group.

The reorder page still has a fixed order of: Game Awards, Event Awards, and Site Awards.

This also moves any Event Awards in the "[Central - Developer Events]" or "[Dev Events - *]" hubs into the Site Awards group.