### PR TITLE
remove pagination for per-console games with achievements lists

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -357,25 +357,44 @@ function getGamesListByDev($dev, $consoleID, &$dataOut, $sortBy, $ticketsFlag = 
         $sortBy = 1;
     }
 
-    $query .= match ($sortBy) {
-        11 => "ORDER BY gd.ConsoleID, Title DESC ",
-        2 => "ORDER BY gd.ConsoleID, NumAchievements DESC, Title ",
-        12 => "ORDER BY gd.ConsoleID, NumAchievements ASC, Title ",
-        3 => "ORDER BY gd.ConsoleID, MaxPointsAvailable DESC, Title ",
-        13 => "ORDER BY gd.ConsoleID, MaxPointsAvailable, Title ",
-        4 => "ORDER BY NumLBs DESC, gd.ConsoleID, MaxPointsAvailable, Title ",
-        14 => "ORDER BY NumLBs, gd.ConsoleID, MaxPointsAvailable, Title ",
+    $orderBy = match ($sortBy) {
+        1 => "Title",
+        11 => "Title DESC",
+        2 => "NumAchievements DESC, MaxPointsAvailable DESC",
+        12 => "NumAchievements, MaxPointsAvailable",
+        3 => "MaxPointsAvailable DESC, NumAchievements DESC",
+        13 => "MaxPointsAvailable, NumAchievements",
+        4 => "NumLBs DESC, MaxPointsAvailable DESC",
+        14 => "NumLBs, MaxPointsAvailable",
         5 => $ticketsFlag
-                ? "ORDER BY OpenTickets DESC, gd.ConsoleID, MaxPointsAvailable, Title "
-                : "ORDER BY gd.ConsoleID, Title ",
+                ? "OpenTickets DESC "
+                : "",
         15 => $ticketsFlag
-                ? "ORDER BY OpenTickets, gd.ConsoleID, MaxPointsAvailable, Title "
-                : "ORDER BY gd.ConsoleID, Title DESC ",
-        6 => "ORDER BY gd.ConsoleID, DateModified DESC, Title ",
-        16 => "ORDER BY gd.ConsoleID, DateModified ASC, Title DESC ",
-        // 1
-        default => "ORDER BY gd.ConsoleID, Title ",
+                ? "OpenTickets"
+                : "",
+        6 => "DateModified DESC",
+        16 => "DateModified",
+        default => "",
     };
+
+    if (!empty($orderBy)) {
+        if (!str_contains($orderBy, "Title")) {
+            if ($sortBy < 10) {
+                $orderBy .= ", Title";
+            } else {
+                $orderBy .= ", Title DESC";
+            }
+        }
+        if ($consoleID == 0) {
+            if (str_contains($orderBy, "Title DESC")) {
+                $orderBy .= ", ConsoleName DESC";
+            } else {
+                $orderBy .= ", ConsoleName";
+            }
+        }
+
+        $query .= "ORDER BY $orderBy ";
+    }
 
     if ($count > 0) {
         $query = substr_replace($query, "SQL_CALC_FOUND_ROWS ", 7, 0);

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -13,7 +13,7 @@ $sortBy = requestInputSanitized('s', 0, 'integer');
 $dev = requestInputSanitized('d');
 $filter = requestInputSanitized('f');
 
-if ($dev == null) {
+if ($dev == null && ($consoleIDInput == 0 || $filter != 0)) {
     $maxCount = 50;
     $offset = max(requestInputSanitized('o', 0, 'integer'), 0);
 } else {
@@ -34,7 +34,7 @@ $gamesCount = getGamesListByDev($dev, $consoleIDInput, $gamesList, $sortBy, $sho
 
 sanitize_outputs($requestedConsole);
 
-function ListGames($gamesList, $dev, $queryParams, $sortBy, $showTickets, $showConsole)
+function ListGames($gamesList, $dev, $queryParams, $sortBy, $showTickets, $showConsoleName, $showTotals)
 {
     echo "\n<div class='table-wrapper'><table><tbody>";
 
@@ -94,7 +94,7 @@ function ListGames($gamesList, $dev, $queryParams, $sortBy, $showTickets, $showC
         $numLBs = $gameEntry['NumLBs'];
         $gameIcon = $gameEntry['GameIcon'];
 
-        $consoleName = $showConsole ? $gameEntry['ConsoleName'] : null;
+        $consoleName = $showConsoleName ? $gameEntry['ConsoleName'] : null;
 
         sanitize_outputs($title);
 
@@ -146,7 +146,7 @@ function ListGames($gamesList, $dev, $queryParams, $sortBy, $showTickets, $showC
         $truePointsTally += $totalTrueRatio;
     }
 
-    if ($dev != null) {
+    if ($showTotals) {
         // Totals:
         echo "<tr>";
         echo "<td></td>";
@@ -193,7 +193,7 @@ RenderHtmlHead("Supported Games" . $requestedConsole);
                         sanitize_outputs($consoleName);
                         echo "<h2 class='longheader'>$consoleName</h2>";
 
-                        ListGames($consoleGames, $dev, '', $sortBy, $showTickets, false);
+                        ListGames($consoleGames, $dev, '', $sortBy, $showTickets, false, true);
 
                         echo "<br/>";
                     }
@@ -219,7 +219,7 @@ RenderHtmlHead("Supported Games" . $requestedConsole);
                     echo "<br/>";
 
                     $queryParams = "c=$consoleIDInput&f=$filter";
-                    ListGames($gamesList, null, $queryParams, $sortBy, $showTickets, $consoleIDInput == 0);
+                    ListGames($gamesList, null, $queryParams, $sortBy, $showTickets, $consoleIDInput == 0, $maxCount == 0);
 
                     // Add page traversal links
                     echo "\n<div class='rightalign row'>";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -34,11 +34,11 @@ $gamesCount = getGamesListByDev($dev, $consoleIDInput, $gamesList, $sortBy, $sho
 
 sanitize_outputs($requestedConsole);
 
-function ListGames($gamesList, $dev, $queryParams, $sortBy, $showTickets)
+function ListGames($gamesList, $dev, $queryParams, $sortBy, $showTickets, $showConsole)
 {
     echo "\n<div class='table-wrapper'><table><tbody>";
 
-    $sort1 = ($sortBy == 1) ? 11 : 1;
+    $sort1 = ($sortBy <= 1) ? 11 : 1;
     $sort2 = ($sortBy == 2) ? 12 : 2;
     $sort3 = ($sortBy == 3) ? 13 : 3;
     $sort4 = ($sortBy == 4) ? 14 : 4;
@@ -94,15 +94,17 @@ function ListGames($gamesList, $dev, $queryParams, $sortBy, $showTickets)
         $numLBs = $gameEntry['NumLBs'];
         $gameIcon = $gameEntry['GameIcon'];
 
+        $consoleName = $showConsole ? $gameEntry['ConsoleName'] : null;
+
         sanitize_outputs($title);
 
         echo "<tr>";
 
         echo "<td>";
-        echo GetGameAndTooltipDiv($gameID, $title, $gameIcon, null, true);
+        echo GetGameAndTooltipDiv($gameID, $title, $gameIcon, $consoleName, true);
         echo "</td>";
         echo "<td class='fullwidth'>";
-        echo GetGameAndTooltipDiv($gameID, $title, $gameIcon, null, false, null, true);
+        echo GetGameAndTooltipDiv($gameID, $title, $gameIcon, $consoleName, false, null, true);
         echo "</td>";
 
         if ($dev == null) {
@@ -191,7 +193,7 @@ RenderHtmlHead("Supported Games" . $requestedConsole);
                         sanitize_outputs($consoleName);
                         echo "<h2 class='longheader'>$consoleName</h2>";
 
-                        listGames($consoleGames, $dev, '', $sortBy, $showTickets);
+                        ListGames($consoleGames, $dev, '', $sortBy, $showTickets, false);
 
                         echo "<br/>";
                     }
@@ -217,7 +219,7 @@ RenderHtmlHead("Supported Games" . $requestedConsole);
                     echo "<br/>";
 
                     $queryParams = "c=$consoleIDInput&f=$filter";
-                    listGames($gamesList, null, $queryParams, $sortBy, $showTickets);
+                    ListGames($gamesList, null, $queryParams, $sortBy, $showTickets, $consoleIDInput == 0);
 
                     // Add page traversal links
                     echo "\n<div class='rightalign row'>";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -221,20 +221,28 @@ RenderHtmlHead("Supported Games" . $requestedConsole);
                     $queryParams = "c=$consoleIDInput&f=$filter";
                     ListGames($gamesList, null, $queryParams, $sortBy, $showTickets, $consoleIDInput == 0, $maxCount == 0);
 
-                    // Add page traversal links
-                    echo "\n<div class='rightalign row'>";
-                    if ($offset > 0) {
-                        $prevOffset = $offset - $maxCount;
-                        echo "<a href='/gameList.php?s=$sortBy&c=$consoleIDInput&f=$filter'>First</a> - ";
-                        echo "<a href='/gameList.php?s=$sortBy&c=$consoleIDInput&f=$filter&o=$prevOffset'>&lt; Previous $maxCount</a> - ";
+                    if ($maxCount != 0 && $gamesCount > $maxCount) {
+                        // Add page traversal links
+                        echo "\n<br/><div class='rightalign row'>";
+                        if ($offset > 0) {
+                            $prevOffset = $offset - $maxCount;
+                            echo "<a href='/gameList.php?s=$sortBy&c=$consoleIDInput&f=$filter&o=$prevOffset'>&lt;</a>&nbsp;";
+                        }
+
+                        echo "Page <select class='gameselector' onchange='window.location=\"/gameList.php?s=$sortBy&c=$consoleIDInput&f=$filter&o=\" + this.options[this.selectedIndex].value'>";
+                        $pages = floor(($gamesCount + $maxCount - 1) / $maxCount);
+                        for ($i = 1; $i <= $pages; $i++) {
+                            $pageOffset = ($i - 1) * $maxCount;
+                            echo "<option value='$pageOffset'" . (($offset == $pageOffset) ? " selected" : "") . ">$i</option>";
+                        }
+                        echo "</select> of $pages";
+
+                        $nextOffset = $offset + $maxCount;
+                        if ($nextOffset < $gamesCount) {
+                            echo "&nbsp;<a href='/gameList.php?s=$sortBy&c=$consoleIDInput&f=$filter&o=$nextOffset'>&gt;</a>";
+                        }
+                        echo "</div>";
                     }
-                    $nextOffset = $offset + $maxCount;
-                    if ($nextOffset < $gamesCount) {
-                        $lastOffset = $gamesCount - ($gamesCount % $maxCount);
-                        echo "<a href='/gameList.php?s=$sortBy&c=$consoleIDInput&f=$filter&o=$nextOffset'>Next $maxCount &gt;</a> - ";
-                        echo "<a href='/gameList.php?s=$sortBy&c=$consoleIDInput&f=$filter&o=$lastOffset'>Last</a>";
-                    }
-                    echo "</div>";
                 }
             ?>
             <br>


### PR DESCRIPTION
The All Games list and any list where "games without achievements" are present will still be paginated.

A page selector replaces the "first/prev/next/last" links.
![image](https://user-images.githubusercontent.com/32680403/163463969-3ffacc73-83a0-4bc8-a20d-2c33267aef42.png)

Also fixes the All Games list to not group items by console as the grouping was removed when the pagination was added.