### PR TITLE
Fix shortcode parsed auto-link URLs including trailing sentence-punctuation characters

### DIFF
--- a/public/test/shortcode.php
+++ b/public/test/shortcode.php
@@ -88,10 +88,12 @@ https://example.com/?test=test,test.test%20test+test(test)&test-test"
 https://example.com/?test=test,test.test%20test+test(test)&test-test'
 https://example.com/?test=test,test.test%20test+test(test)&test-test)
 https://example.com/?test=test,test.test%20test+test(test)&test-test(
-https://example.com/?test=test,test.test%20test+test(test)&test-test-
 https://example.com/?test=https://example.com/?test=test,test.test%20test+test(test)&test-test
 [url="https://example.com/?test=test,test.test%20test+test(test)&test-test"]
 [url=https://example.com/?test=test,test.test%20test+test(test)&test-test]https://example.com/?test=test,test.test%20test+test(test)&test-test[/url]
+
+Trailing hyphens ARE part of URL (matches most markdown parsers):
+https://example.com/?test=test,test.test%20test+test(test)&test-test-
 
 [url="retroachievements.org#1"] | [url="retroachievements.org#2"]
 [url="https://retroachievements.org#1"] | [url="https://retroachievements.org#2"]

--- a/public/test/shortcode.php
+++ b/public/test/shortcode.php
@@ -73,6 +73,23 @@ https://youtu.be/dMH0bHeiRNg
 example.org (no link)
 www.example.org (no link)
 
+Trailing sentence-punctuation characters are NOT part of URL:
+https://example.com/?test=test,test.test%20test+test(test)&test-test!
+https://example.com/?test=test,test.test%20test+test(test)&test-test,
+https://example.com/?test=test,test.test%20test+test(test)&test-test.
+https://example.com/?test=test,test.test%20test+test(test)&test-test. continue
+https://example.com/?test=test,test.test%20test+test(test)&test-test?
+https://example.com/?test=test,test.test%20test+test(test)&test-test;
+https://example.com/?test=test,test.test%20test+test(test)&test-test:
+https://example.com/?test=test,test.test%20test+test(test)&test-test"
+https://example.com/?test=test,test.test%20test+test(test)&test-test'
+https://example.com/?test=test,test.test%20test+test(test)&test-test)
+https://example.com/?test=test,test.test%20test+test(test)&test-test(
+https://example.com/?test=test,test.test%20test+test(test)&test-test-
+https://example.com/?test=https://example.com/?test=test,test.test%20test+test(test)&test-test
+[url="https://example.com/?test=test,test.test%20test+test(test)&test-test"]
+[url=https://example.com/?test=test,test.test%20test+test(test)&test-test]https://example.com/?test=test,test.test%20test+test(test)&test-test[/url]
+
 [url="retroachievements.org#1"] | [url="retroachievements.org#2"]
 [url="https://retroachievements.org#1"] | [url="https://retroachievements.org#2"]
 [url=http://retroachievements.org#1] | [url=http://retroachievements.org#2]
@@ -146,7 +163,7 @@ RenderSharedHeader();
 ?>
 <body>
 <script src='/vendor/wz_tooltip.js'></script>
-<div style="width:560px">
+<div style="width:560px;margin:10px;">
     <h1>Shortcode</h1>
     <?php echo Shortcode::render($payload, ['imgur' => true]) ?>
 </div>

--- a/public/test/shortcode.php
+++ b/public/test/shortcode.php
@@ -74,6 +74,9 @@ example.org (no link)
 www.example.org (no link)
 
 Trailing sentence-punctuation characters are NOT part of URL:
+https://example.com.
+https://example.com?
+https://example.com?test
 https://example.com/?test=test,test.test%20test+test(test)&test-test!
 https://example.com/?test=test,test.test%20test+test(test)&test-test,
 https://example.com/?test=test,test.test%20test+test(test)&test-test.

--- a/src/Shortcode/Shortcode.php
+++ b/src/Shortcode/Shortcode.php
@@ -182,19 +182,19 @@ final class Shortcode
 
     private function linkifyBasicURLs($text)
     {
+        // see https://stackoverflow.com/a/2271552/580651:
+        // [...] it's probably safe to assume a semicolon at the end of a URL is meant as sentence punctuation.
+        // The same goes for other sentence-punctuation characters like periods, question marks, quotes, etc..
+        // lookahead: (?<![!,.?;:"\'()-])
         $text = preg_replace(
             '~
-            (https?://[a-z0-9_./?=&#%:+(),-]+)
+            (https?://[\w!#$%&\'()*+,./:;=?@\[\]-]+(?<![!,.?;:"\'()-]))
             (?!                 # Assert URL is not pre-linked.
-              [?=&+%\w.-]*      # Allow URL (query) remainder.
-              (?:               # Group pre-linked alternatives.
-                [^<>]*>         # Either inside a start tag,
-                | [^<>]*</a>   # or inside <a> element text contents.
-              )                 # End recognized pre-linked alts.
+              [^<>]*>           # Either inside a start tag,
+              | [^<>]*</a>      # End recognized pre-linked alts.
             )                   # End negative lookahead assertion.
-            ([?=&+%\w.-]*)      # Consume any URL (query) remainder.
             ~ix',
-            ' <a href="$1" target="_blank" rel="noopener">$1</a> ',
+            '<a href="$1" target="_blank" rel="noopener">$1</a>',
             $text
         );
 

--- a/src/Shortcode/Shortcode.php
+++ b/src/Shortcode/Shortcode.php
@@ -188,7 +188,7 @@ final class Shortcode
         // lookahead: (?<![!,.?;:"\'()-])
         $text = preg_replace(
             '~
-            (https?://[\w!#$%&\'()*+,./:;=?@\[\]-]+(?<![!,.?;:"\'()-]))
+            (https?://[\w!#$%&\'()*+,./:;=?@\[\]-]+(?<![!,.?;:"\'()]))
             (?!                 # Assert URL is not pre-linked.
               [^<>]*>           # Either inside a start tag,
               | [^<>]*</a>      # End recognized pre-linked alts.


### PR DESCRIPTION
**Before**
![Screenshot 2022-04-16 at 00 39 06](https://user-images.githubusercontent.com/1280590/163650026-ffcd7056-265f-4a0d-9175-d4414196aa3a.png)

**After**
![Screenshot 2022-04-16 at 00 32 29](https://user-images.githubusercontent.com/1280590/163650057-19e2ae01-065d-4a3c-ae2d-ecd659eee35e.png)

_Discord Markdown_
![Screenshot 2022-04-16 at 00 35 56](https://user-images.githubusercontent.com/1280590/163650101-5b8892f3-29a0-45fd-8a7f-df840c0467dd.png)

_JetBrains Markdown_
![Screenshot 2022-04-16 at 00 37 07](https://user-images.githubusercontent.com/1280590/163650118-c8c842b0-0f02-460d-8fbf-90cbd55292ab.png)

