### PR TITLE
add tooltip to game rating

### DIFF
--- a/lib/database/rating.php
+++ b/lib/database/rating.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\ObjectType;
+
 function getGameRating($gameID)
 {
     sanitize_sql_inputs($gameID);
@@ -16,6 +18,15 @@ function getGameRating($gameID)
     $retVal = [];
     while ($nextRow = mysqli_fetch_array($dbResult)) {
         $retVal[$nextRow['RatingObjectType']] = $nextRow;
+    }
+
+    if (!isset($retVal[ObjectType::Game])) {
+        $retVal[ObjectType::Game]['AvgPct'] = 0.0;
+        $retVal[ObjectType::Game]['NumVotes'] = 0;
+    }
+    if (!isset($retVal[ObjectType::Achievement])) {
+        $retVal[ObjectType::Achievement]['AvgPct'] = 0.0;
+        $retVal[ObjectType::Achievement]['NumVotes'] = 0;
     }
 
     return $retVal;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1244,7 +1244,8 @@ span.hardcore {
 div.rating {
   cursor: pointer;
   display: block;
-  float: right;
+  float: left;
+  clear: left;
 }
 
 div.rating a {

--- a/public/request/game/rating.php
+++ b/public/request/game/rating.php
@@ -11,9 +11,9 @@ $gameRating = getGameRating($gameID);
 
 $gameData = [];
 $gameData['GameID'] = $gameID;
-$gameData['Ratings']['Game'] = $gameRating[ObjectType::Game]['AvgPct'];
-$gameData['Ratings']['Achievements'] = $gameRating[ObjectType::Achievement]['AvgPct'];
-$gameData['Ratings']['GameNumVotes'] = $gameRating[ObjectType::Game]['NumVotes'];
-$gameData['Ratings']['AchievementsNumVotes'] = $gameRating[ObjectType::Achievement]['NumVotes'];
+$gameData['Ratings']['Game'] = $gameRating[ObjectType::Game]['AverageRating'];
+$gameData['Ratings']['Achievements'] = $gameRating[ObjectType::Achievement]['AverageRating'];
+$gameData['Ratings']['GameNumVotes'] = $gameRating[ObjectType::Game]['RatingCount'];
+$gameData['Ratings']['AchievementsNumVotes'] = $gameRating[ObjectType::Achievement]['RatingCount'];
 
 echo json_encode($gameData, JSON_THROW_ON_ERROR);

--- a/public/request/game/rating.php
+++ b/public/request/game/rating.php
@@ -9,15 +9,6 @@ $gameID = requestInputQuery('i');
 
 $gameRating = getGameRating($gameID);
 
-if (!isset($gameRating[ObjectType::Game])) {
-    $gameRating[ObjectType::Game]['AvgPct'] = 0.0;
-    $gameRating[ObjectType::Game]['NumVotes'] = 0;
-}
-if (!isset($gameRating[ObjectType::Achievement])) {
-    $gameRating[ObjectType::Achievement]['AvgPct'] = 0.0;
-    $gameRating[ObjectType::Achievement]['NumVotes'] = 0;
-}
-
 $gameData = [];
 $gameData['GameID'] = $gameID;
 $gameData['Ratings']['Game'] = $gameRating[ObjectType::Game]['AvgPct'];


### PR DESCRIPTION
Adds a tooltip to the game rating widget showing a distribution of the user-submitted ratings, and highlighting the user's rating.
![image](https://user-images.githubusercontent.com/32680403/164327444-70232fec-ad86-4fed-abf7-3eda06904fcb.png)

When the user changes their rating, the user's rating portion of the tooltip is updated, but the distribution is not.
![image](https://user-images.githubusercontent.com/32680403/164329145-cf054fb0-e480-4843-9701-ae90cb5bce83.png)

The rating will be hidden until there are at least five ratings submitted:
![image](https://user-images.githubusercontent.com/32680403/164327949-10834962-14fc-4d3a-916d-b9687dde13aa.png)
![image](https://user-images.githubusercontent.com/32680403/164328739-382dcc22-43a9-4614-8b62-18ee72a0a13f.png)
![image](https://user-images.githubusercontent.com/32680403/164328595-7d2a5556-bf8d-4ac0-9964-61a6dc95b750.png)

When a game has no ratings:
![image](https://user-images.githubusercontent.com/32680403/164327252-e44ca5c4-eeb7-4276-b35b-e723dd58e21e.png)
