### PR TITLE
return failure messages when provided with an invalid file

### DIFF
--- a/lib/util/upload.php
+++ b/lib/util/upload.php
@@ -4,7 +4,7 @@ use Aws\S3\S3Client;
 
 function UploadToS3($filenameSrc, $filenameDest)
 {
-    if (!getenv('AWS_ACCESS_KEY_ID') && !in_array(getenv('APP_ENV'), ['local'])) {
+    if (!getenv('AWS_ACCESS_KEY_ID') || in_array(getenv('APP_ENV'), ['local'])) {
         // nothing to do here
         return;
     }

--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -228,8 +228,14 @@ function RenderUserPref($websitePrefs, $userPref, $setIfTrue, $state = null)
 
   function onUploadImageComplete(data) {
     $('#loadingiconavatar').fadeTo(100, 0.0);
-    var d = new Date();
-    $('.userpic').attr('src', '/UserPic/<?php echo $user; ?>' + '.png?' + d.getTime());
+
+    var result = $.parseJSON(data);
+    if (result.Success) {
+      var d = new Date();
+      $('.userpic').attr('src', '/UserPic/<?php echo $user; ?>' + '.png?' + d.getTime());
+    } else {
+      alert('Upload failed!\n' + result.Error);
+    }
   }
 
   function validateEmail() {

--- a/public/doupload.php
+++ b/public/doupload.php
@@ -25,7 +25,16 @@ if (isset($_FILES["file"]) && isset($_FILES["file"]["name"])) {
 
 switch ($requestType) {
     case "uploadbadgeimage":
-        $response['Response'] = UploadBadgeImage($_FILES["file"]);
+        $uploadResponse = UploadBadgeImage($_FILES["file"]);
+        $response['Success'] = $uploadResponse['Success'];
+        unset($uploadResponse['Success']);
+
+        if ($uploadResponse['Error']) {
+            $response['Error'] = $uploadResponse['Error'];
+            unset($uploadResponse['Error']);
+        }
+
+        $response['Response'] = $uploadResponse;
         break;
 
     default:

--- a/public/request/user/update-avatar.php
+++ b/public/request/user/update-avatar.php
@@ -17,7 +17,16 @@ if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, 
     exit;
 }
 
-$response['Response'] = UploadUserPic($user, $filename, $rawImage);
-
+$uploadResponse = UploadUserPic($user, $filename, $rawImage);
+$response['Success'] = $uploadResponse['Success'];
+unset($uploadResponse['Success']);
 settype($response['Success'], 'boolean');
+
+if ($uploadResponse['Error']) {
+    $response['Error'] = $uploadResponse['Error'];
+    unset($uploadResponse['Error']);
+}
+
+$response['Response'] = $uploadResponse;
+
 echo json_encode($response, JSON_THROW_ON_ERROR);

--- a/public/request/user/update-avatar.php
+++ b/public/request/user/update-avatar.php
@@ -17,16 +17,6 @@ if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, 
     exit;
 }
 
-$uploadResponse = UploadUserPic($user, $filename, $rawImage);
-$response['Success'] = $uploadResponse['Success'];
-unset($uploadResponse['Success']);
-settype($response['Success'], 'boolean');
-
-if ($uploadResponse['Error']) {
-    $response['Error'] = $uploadResponse['Error'];
-    unset($uploadResponse['Error']);
-}
-
-$response['Response'] = $uploadResponse;
+$response = UploadUserPic($user, $filename, $rawImage);
 
 echo json_encode($response, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
Fixes an issue when uploading a file where the extension (implied mime type) didn't match the contents. When uploading game badges, it would return a 500 Internal Error error. On the user profile, it would silently fail (it was probably still 500ing in the ajax request).