### PR TITLE
ensure variable type is specified for match clauses

### DIFF
--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -395,6 +395,7 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
 {
     $pointRequirement = "";
 
+    settype($lbType, 'integer');
     $whereCond = match ($lbType) {
         // Daily
         0 => "BETWEEN TIMESTAMP('$date') AND DATE_ADD('$date', INTERVAL 24 * 60 * 60 - 1 SECOND)",
@@ -475,6 +476,7 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
             break;
     }
 
+    settype($untracked, 'integer');
     $untrackedCond = match ($untracked) {
         0 => "AND Untracked = 0",
         1 => "AND Untracked = 1",

--- a/public/request/user/update-subscription.php
+++ b/public/request/user/update-subscription.php
@@ -8,9 +8,9 @@ require_once __DIR__ . '/../../../lib/bootstrap.php';
 
 // what is being (un-)subscribed? and where should we go back to at the end?
 
-$returnUrl = requestInputPost("return_url");
-$subjectType = requestInputPost("subject_type");
-$subjectID = requestInputPost("subject_id");
+$returnUrl = requestInputPost('return_url', null, 'string');
+$subjectType = requestInputPost('subject_type', null, 'string');
+$subjectID = requestInputPost('subject_id', 0, 'integer');
 
 if ($subjectType === null || $subjectID === null || $returnUrl === null) {
     exit;

--- a/src/SubscriptionSubjectType.php
+++ b/src/SubscriptionSubjectType.php
@@ -16,7 +16,7 @@ abstract class SubscriptionSubjectType
 
     public const GameAchievements = "GameAchievements";
 
-    public static function fromArticleType($articleType)
+    public static function fromArticleType(int $articleType)
     {
         return match ($articleType) {
             ArticleType::Game => SubscriptionSubjectType::GameWall,


### PR DESCRIPTION
This fixes the issue where the `(subscribe)` link was not changing to `(unsubcribe)` after subscribing.

#911 changed several `switch` statements to `match` expressions. It turns out that `switch` will coerce the data type, but `match` will not. This led to a situation where a variable that was sanitized for SQL got converted to a string and was no longer being matched by the `match` clauses.

I went through and audited all of the `match` clauses added in #911 and made sure the variable type was well known at the point where the `match` is evaluated. It turns out there was only a couple questionable cases, which I have addressed in this PR.
