### PR TITLE
Fix RR total players used for calc and remove softcore users from total

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -1099,7 +1099,9 @@ function recalculateTrueRatio($gameID)
     $query = "SELECT ach.ID, ach.Points, COUNT(*) AS NumAchieved
               FROM Achievements AS ach
               LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID
-              WHERE ach.GameID = $gameID AND ach.Flags = 3 AND aw.HardcoreMode = 1
+              LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
+              WHERE ach.GameID = $gameID AND ach.Flags = 3 AND aw.HardcoreMode = 1 
+              AND NOT ua.Untracked
               GROUP BY ach.ID";
 
     $dbResult = s_mysql_query($query);

--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -976,7 +976,7 @@ function getAchievementWonData(
     $numWinners = $data['NumEarned'];
     $gameID = $data['GameID'];   // Grab GameID at this point
 
-    $numPossibleWinners = getTotalUniquePlayers($gameID, $user);
+    $numPossibleWinners = getTotalUniquePlayers($gameID, $user, false);
 
     $numRecentWinners = 0;
 
@@ -1099,41 +1099,32 @@ function recalculateTrueRatio($gameID)
     $query = "SELECT ach.ID, ach.Points, COUNT(*) AS NumAchieved
               FROM Achievements AS ach
               LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID
-              WHERE ach.GameID = $gameID AND ach.Flags = 3 AND aw.HardcoreMode = 0
+              WHERE ach.GameID = $gameID AND ach.Flags = 3 AND aw.HardcoreMode = 1
               GROUP BY ach.ID";
 
     $dbResult = s_mysql_query($query);
     SQL_ASSERT($dbResult);
 
     if ($dbResult !== false) {
-        $achData = [];
-        $totalEarners = 0;
-        while ($nextData = mysqli_fetch_assoc($dbResult)) {
-            $achData[$nextData['ID']] = $nextData;
-            if ($nextData['NumAchieved'] > $totalEarners) {
-                $totalEarners = $nextData['NumAchieved'];
-            }
-        }
+        $numHardcoreWinners = getTotalUniquePlayers($gameID, null, true);
 
-        if ($totalEarners == 0) { // force all unachieved to be 1
-            $totalEarners = 1;
+        if ($numHardcoreWinners == 0) { // force all unachieved to be 1
+            $numHardcoreWinners = 1;
         }
 
         $ratioTotal = 0;
-
-        foreach ($achData as $nextAch) {
-            $achID = $nextAch['ID'];
-            $achPoints = (int) $nextAch['Points'];
-            $numAchieved = (int) $nextAch['NumAchieved'];
+        while ($nextData = mysqli_fetch_assoc($dbResult)) {
+            $achID = $nextData['ID'];
+            $achPoints = (int) $nextData['Points'];
+            $numAchieved = (int) $nextData['NumAchieved'];
 
             if ($numAchieved == 0) { // force all unachieved to be 1
                 $numAchieved = 1;
             }
 
             $ratioFactor = 0.4;
-            $newTrueRatio = ($achPoints * (1.0 - $ratioFactor)) + ($achPoints * (($totalEarners / $numAchieved) * $ratioFactor));
+            $newTrueRatio = ($achPoints * (1.0 - $ratioFactor)) + ($achPoints * (($numHardcoreWinners / $numAchieved) * $ratioFactor));
             $trueRatio = (int) $newTrueRatio;
-
             $ratioTotal += $trueRatio;
 
             $query = "UPDATE Achievements AS ach

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -860,7 +860,7 @@ function getGameListSearch($offset, $count, $method, $consoleID = null): array
 
 function getTotalUniquePlayers($gameID, $requestedBy, $hardcoreOnly = false)
 {
-    sanitize_sql_inputs($gameID, $requestedBy, $hardcoreOnly);
+    sanitize_sql_inputs($gameID, $requestedBy);
     settype($gameID, 'integer');
 
     $hardcoreJoin = "";

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -858,10 +858,15 @@ function getGameListSearch($offset, $count, $method, $consoleID = null): array
     return $retval;
 }
 
-function getTotalUniquePlayers($gameID, $requestedBy)
+function getTotalUniquePlayers($gameID, $requestedBy, $hardcoreOnly = false)
 {
-    sanitize_sql_inputs($gameID, $requestedBy);
+    sanitize_sql_inputs($gameID, $requestedBy, $hardcoreOnly);
     settype($gameID, 'integer');
+
+    $hardcoreJoin = "";
+    if ($hardcoreOnly) {
+        $hardcoreJoin = " AND aw.HardcoreMode = 1";
+    }
 
     $query = "
         SELECT COUNT(DISTINCT aw.User) As UniquePlayers
@@ -870,7 +875,8 @@ function getTotalUniquePlayers($gameID, $requestedBy)
         LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
         LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
         WHERE gd.ID = $gameID
-          AND (NOT ua.Untracked" . (isset($requestedBy) ? " OR ua.User = '$requestedBy'" : "") . ")
+        $hardcoreJoin
+        AND (NOT ua.Untracked" . (isset($requestedBy) ? " OR ua.User = '$requestedBy'" : "") . ")
     ";
 
     $dbResult = s_mysql_query($query);


### PR DESCRIPTION
Checking the RR calculation I noticed it was not calculating total users correctly and was instead using the total earners of the achievement with the most earns. You can see an example below

Current
1/2 and 2/2
![image](https://user-images.githubusercontent.com/4047771/164874749-88941a3e-41a2-4717-b432-4541adb0715e.png)

Fixed
1/10 and 2/10
![image](https://user-images.githubusercontent.com/4047771/164874773-7eb7bec2-bd24-4ba5-a795-a28d2d357ba2.png)

The other fix is removing softcore users from the calculation, it now counts the total hardcore users that earned the achievements as well as uses the total unique hardcore players for the total to check against. Example below with 34 hardcore users and 37 total

Current
26/37
![image](https://user-images.githubusercontent.com/4047771/164874842-d51b566f-fbe8-4adc-a40e-740f82fb77f1.png)


Fixed
1/34
![image](https://user-images.githubusercontent.com/4047771/164874849-8d471f2c-57fb-4aac-a05d-27c35be42022.png)
