### PR TITLE
add NumAchievements,NumLeaderboards,Points, and Hashes to API_GetGameList

### DIFF
--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -4,27 +4,6 @@ use RA\ActivityType;
 use RA\ArticleType;
 use RA\Permissions;
 
-function getGameFromHash($md5Hash, &$gameIDOut, &$gameTitleOut)
-{
-    sanitize_sql_inputs($md5Hash);
-
-    $query = "SELECT ID, GameName FROM GameData WHERE GameMD5='$md5Hash'";
-    $dbResult = s_mysql_query($query);
-
-    if ($dbResult !== null) {
-        $data = mysqli_fetch_assoc($dbResult);
-        if ($data !== null) {
-            $gameIDOut = $data['ID'];
-            $gameTitleOut = $data['GameName'];
-            return true;
-        } else {
-            return false;
-        }
-    } else {
-        return false;
-    }
-}
-
 function getGameData($gameID)
 {
     sanitize_sql_inputs($gameID);

--- a/public/API/API_GetGameList.php
+++ b/public/API/API_GetGameList.php
@@ -11,8 +11,43 @@ if ($consoleID < 0) {
     exit;
 }
 
-$officialFlag = requestInputQuery('f', false, 'boolean');
+$withAchievements = requestInputQuery('f', false, 'boolean');
+$withHashes = requestInputQuery('h', false, 'boolean');
 
-getGamesList($consoleID, $dataOut, $officialFlag);
+getGamesListByDev(null, $consoleID, $dataOut, 1, false, $withAchievements ? 0 : 2);
 
-echo utf8_encode(json_encode($dataOut, JSON_THROW_ON_ERROR));
+$response = [];
+foreach ($dataOut as &$entry) {
+    $responseEntry = [
+        'Title' => $entry['Title'],
+        'ID' => $entry['ID'],
+        'ConsoleID' => $entry['ConsoleID'],
+        'ConsoleName' => $entry['ConsoleName'],
+        'ImageIcon' => $entry['GameIcon'],
+        'NumAchievements' => $entry['NumAchievements'] ?? 0,
+        'NumLeaderboards' => $entry['NumLBs'] ?? 0,
+        'Points' => $entry['MaxPointsAvailable'] ?? 0,
+    ];
+    settype($responseEntry['NumAchievements'], 'integer');
+    settype($responseEntry['NumLeaderboards'], 'integer');
+    settype($responseEntry['Points'], 'integer');
+
+    if ($withHashes) {
+        $responseEntry['Hashes'] = [];
+    }
+
+    $response[] = $responseEntry;
+}
+
+if ($withHashes) {
+    foreach (getMD5List($consoleID) as $hash => $gameID) {
+        foreach ($response as &$entry) {
+            if ($entry['ID'] == $gameID) {
+                $entry['Hashes'][] = $hash;
+                break;
+            }
+        }
+    }
+}
+
+echo json_encode($response, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
Previous response:
```
{
  "Title":"Ninja Golf",
  "ID":"13352",
  "ConsoleID":"51",
  "ImageIcon":"\/Images\/019885.png",
  "ConsoleName":"Atari 7800"
}
```

New response:
```
{
  "Title":"Ninja Golf",
  "ID":"13352",
  "ConsoleID":"51",
  "ConsoleName":"Atari 7800",
  "ImageIcon":"\/Images\/019885.png",
  "NumAchievements":31,
  "NumLeaderboards":0,
  "Points":485,
  "Hashes":["bb551483d114dcc5bae7aaa892ee856a","220121f771fc4b98cef97dc040e8d378"]
}
```

Note that the `"Hashes"` subdata is only available if `h=1` is passed to the API. `f=1` will limit the response to games with achievements (existing behavior).

The new fields are returns as integers where appropriate. I did not "fix" the previous fields that should have been returned as integers as that's a potentially breaking change.