### PR TITLE
Display error on failed password resets from reset url

### DIFF
--- a/public/request/auth/update-password.php
+++ b/public/request/auth/update-password.php
@@ -15,17 +15,19 @@ $newpass1 = requestInputPost('x');
 $newpass2 = requestInputPost('y');
 
 if ($newpass1 !== $newpass2) {
-    header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=passinequal");
+    if (!isset($passResetToken)) {
+        header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=passinequal");
+    } elseif (isValidPasswordResetToken($user, $passResetToken)) {
+        header("Location: " . getenv('APP_URL') . "/resetPassword.php?u=$user&t=$passResetToken&e=passinequal");
+    }
     exit;
 }
-
-if (mb_strlen($newpass1) < 8) {
-    header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=badnewpass");
-    exit;
-}
-
-if ($newpass1 == $user) {
-    header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=badnewpass");
+if (mb_strlen($newpass1) < 8 || $newpass1 == $user) {
+    if (!isset($passResetToken)) {
+        header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=badnewpass");
+    } elseif (isValidPasswordResetToken($user, $passResetToken)) {
+        header("Location: " . getenv('APP_URL') . "/resetPassword.php?u=$user&t=$passResetToken&e=badnewpass");
+    }
     exit;
 }
 
@@ -37,9 +39,9 @@ if (isset($passResetToken) && isValidPasswordResetToken($user, $passResetToken))
         RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
         generateAppToken($user, $tokenInOut);
 
-        header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=changepassok");
+        header("Location: " . getenv('APP_URL') . "/resetPassword.php?e=changepassok");
     } else {
-        header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=generalerror");
+        header("Location: " . getenv('APP_URL') . "/resetPassword.php?e=generalerror");
     }
     exit;
 }

--- a/public/request/auth/update-password.php
+++ b/public/request/auth/update-password.php
@@ -15,22 +15,21 @@ $newpass1 = requestInputPost('x');
 $newpass2 = requestInputPost('y');
 
 if ($newpass1 !== $newpass2) {
-    if (!isset($passResetToken)) {
-        header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=passinequal");
-    } elseif (isValidPasswordResetToken($user, $passResetToken)) {
+    if (isset($passResetToken) && isValidPasswordResetToken($user, $passResetToken)) {
         header("Location: " . getenv('APP_URL') . "/resetPassword.php?u=$user&t=$passResetToken&e=passinequal");
+    } else {
+        header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=passinequal");
     }
     exit;
 }
 if (mb_strlen($newpass1) < 8 || $newpass1 == $user) {
-    if (!isset($passResetToken)) {
-        header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=badnewpass");
-    } elseif (isValidPasswordResetToken($user, $passResetToken)) {
+    if (isset($passResetToken) && isValidPasswordResetToken($user, $passResetToken)) {
         header("Location: " . getenv('APP_URL') . "/resetPassword.php?u=$user&t=$passResetToken&e=badnewpass");
+    } else {
+        header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=badnewpass");
     }
     exit;
 }
-
 if (isset($passResetToken) && isValidPasswordResetToken($user, $passResetToken)) {
     RemovePasswordResetToken($user);
     if (changePassword($user, $newpass1)) {

--- a/public/resetPassword.php
+++ b/public/resetPassword.php
@@ -24,6 +24,14 @@ RenderHtmlHead("Password Reset");
 <div id="mainpage">
     <div id="fullcontainer">
         <?php
+        if ($errorCode == 'badnewpass') {
+            echo "<div id=\"warning\">Info: Errors changing your password, passwords too short!</div>";
+        } elseif ($errorCode == 'passinequal') {
+            echo "<div id=\"warning\">Info: Errors changing your password, new passwords were not identical!</div>";
+        } elseif ($errorCode == 'changepassok') {
+            echo "<div id=\"warning\">Info: Password changed OK!</div>";
+        }
+
         echo "<h2 class='longheader'>Password Reset</h2>";
 
         if ($allowNewPasswordEntry == null) {


### PR DESCRIPTION
Fixes #845 by redirecting to the `resetPassword.php` with the same `$user` and `$passResetToken` parameters along with an error message to indicate it failed.

![image](https://user-images.githubusercontent.com/4047771/164994584-d01d771a-e3fc-4935-8e5c-440447727162.png)

Also displays a message when changed successfully and changed the redirect to `resetPassword.php` for now since the auto-login portion of the code doesn't seem to be working properly anyways.

![image](https://user-images.githubusercontent.com/4047771/164994625-dbdc6125-da45-4b20-adce-b982867c5e6a.png)

Old behavior was redirecting to the homepage on success and failure with this message
![image](https://user-images.githubusercontent.com/4047771/164994677-63ba5ddd-59c3-4773-bedc-eb841ee048da.png)

