### PR TITLE
TicketManager Hotfix

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -1100,8 +1100,8 @@ function recalculateTrueRatio($gameID)
               FROM Achievements AS ach
               LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID
               LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
-              WHERE ach.GameID = $gameID AND ach.Flags = 3 AND aw.HardcoreMode = 1 
-              AND NOT ua.Untracked
+              WHERE ach.GameID = $gameID AND ach.Flags = 3 AND (aw.HardcoreMode = 1 OR aw.HardcoreMode IS NULL)
+              AND (NOT ua.Untracked OR ua.Untracked IS NULL)
               GROUP BY ach.ID";
 
     $dbResult = s_mysql_query($query);

--- a/lib/database/rom.php
+++ b/lib/database/rom.php
@@ -83,7 +83,7 @@ function getHashList($offset, $count, $searchedHash): array
     sanitize_sql_inputs($offset, $count, $searchedHash);
 
     $searchQuery = "";
-    if ($searchedHash !== null || $searchedHash != "") {
+    if ($searchedHash !== null && $searchedHash != "") {
         $offset = 0;
         $count = 1;
         $searchQuery = " WHERE h.MD5='" . $searchedHash . "'";

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -408,10 +408,8 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
     // Set the date names if we are choosing anything but All Time
     $whereDateAchievement = "";
     $whereDateAward = "";
-    if (mb_strlen($whereCond) > 0) {
-        $whereDateAchievement = "AND aw.Date";
-        $whereDateAward = "AND sa.AwardDate";
-    }
+    $whereDateAchievement = "AND aw.Date";
+    $whereDateAward = "AND sa.AwardDate";
 
     // Determine ascending or descending order
     settype($sort, 'integer');

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1184,7 +1184,9 @@ RenderHtmlStart(true);
 
                     $numOpenTickets = countOpenTickets(
                         requestInputSanitized('f') == $unofficialFlag,
-                        requestInputSanitized('t', 16377),
+                        requestInputSanitized('t', 131065),
+                        null,
+                        null,
                         null,
                         $gameID
                     );

--- a/public/request/uploadpic.php
+++ b/public/request/uploadpic.php
@@ -39,7 +39,7 @@ if ($_FILES["file"]["size"] > 1_048_576) {
     echo "Error: image too big! Must be smaller than 1mb!";
     exit;
 }
-if ($extension == null || mb_strlen($extension) < 1) {
+if ($extension == null) {
     echo "Error: no file detected. Did you pick a file for upload?";
     exit;
 }

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -117,7 +117,7 @@ if ($ticketID != 0) {
     $numArticleComments = getArticleComments(7, $ticketID, 0, 20, $commentData);
 
     // sets all filters enabled so we get closed/resolved tickets as well
-    $altTicketData = getAllTickets(0, 99, null, null, null, null, null, $ticketData['AchievementID'], $allTicketsFilter);
+    $altTicketData = getAllTickets(0, 99, null, null, null, null, $ticketData['AchievementID'], $allTicketsFilter);
     // var_dump($altTicketData);
     $numOpenTickets = 0;
     foreach ($altTicketData as $pastTicket) {


### PR DESCRIPTION
Fix:
Game Page - Open Ticket count (Was showing 0)
Ticket Manager - Related tickets (Was linking to all kinds of random other related tickets)

rom.php - phpstan error (Changed from || to &&)
leaderboard.php - phpstan error (Assuming phpstan is true there is no need for checking so removed if case, since match has a default value I believe this is true)
uploadpic.php - phpstan error (Assuming phpstan is true there is no need to check this condition so removed it)

Not super confident to the removals for leaderboard.php and uploadpic.php so if someone can review those that would be great. Here are the errors I was getting
![image](https://user-images.githubusercontent.com/4047771/166185637-5acef3ea-6b1e-4e6d-99e0-432cdc8956b2.png)


Add:
Calculate RR for 0 earn achievements (value is that of 1 earn)