### PR TITLE
Ticket-Manager | RR hotfix

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -1100,8 +1100,8 @@ function recalculateTrueRatio($gameID)
               FROM Achievements AS ach
               LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID
               LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
-              WHERE ach.GameID = $gameID AND ach.Flags = 3 AND aw.HardcoreMode = 1 
-              AND NOT ua.Untracked
+              WHERE ach.GameID = $gameID AND ach.Flags = 3 AND (aw.HardcoreMode = 1 OR aw.HardcoreMode IS NULL)
+              AND (NOT ua.Untracked OR ua.Untracked IS NULL)
               GROUP BY ach.ID";
 
     $dbResult = s_mysql_query($query);

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1184,7 +1184,9 @@ RenderHtmlStart(true);
 
                     $numOpenTickets = countOpenTickets(
                         requestInputSanitized('f') == $unofficialFlag,
-                        requestInputSanitized('t', 16377),
+                        requestInputSanitized('t', 131065),
+                        null,
+                        null,
                         null,
                         $gameID
                     );

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -117,7 +117,7 @@ if ($ticketID != 0) {
     $numArticleComments = getArticleComments(7, $ticketID, 0, 20, $commentData);
 
     // sets all filters enabled so we get closed/resolved tickets as well
-    $altTicketData = getAllTickets(0, 99, null, null, null, null, null, $ticketData['AchievementID'], $allTicketsFilter);
+    $altTicketData = getAllTickets(0, 99, null, null, null, null, $ticketData['AchievementID'], $allTicketsFilter);
     // var_dump($altTicketData);
     $numOpenTickets = 0;
     foreach ($altTicketData as $pastTicket) {


### PR DESCRIPTION
Fix related achievements referencing tickets from other games as seen below
![image](https://user-images.githubusercontent.com/4047771/166236105-f55590e2-5efb-4a49-9b21-5baa80ad900b.png)

As well as game page displaying 0 open tickets when there are some
![image](https://user-images.githubusercontent.com/4047771/166236193-2423ef99-b7a0-4e7e-8603-f93b12ab6513.png)

Also tweaking RR calculation to include games with 0 earns
![image](https://user-images.githubusercontent.com/4047771/166236274-a305cbd3-f9bb-4587-8509-971880abc492.png)
