### PR TITLE
exclude ResolvedByNonAuthor from All filter

### DIFF
--- a/src/TicketFilters.php
+++ b/src/TicketFilters.php
@@ -40,10 +40,14 @@ abstract class TicketFilters
 
     public const ResolvedByNonAuthor = 1 << 17;
 
-    public const All = (1 << 18) - 1;
+    // This should updated every time a new filter is added so it has all possible filter bits set
+    public const AllFilters = (1 << 18) - 1;
+
+    // All filter is everything except Not Author (Not Author filter excludes items)
+    public const All = self::AllFilters & ~self::ResolvedByNonAuthor;
 
     // Default filter is everything except Closed, Resolved, and Not Author
-    public const Default = self::All & ~self::StateClosed
-                                     & ~self::StateResolved
-                                     & ~self::ResolvedByNonAuthor;
+    public const Default = self::AllFilters & ~self::StateClosed
+                                            & ~self::StateResolved
+                                            & ~self::ResolvedByNonAuthor;
 }


### PR DESCRIPTION
Fixes an issue introduced by #970 where other tickets for this achievement would not show up when viewing a ticket.