### PR TITLE
Fix total players displayed and used in RR calc from using Unofficial

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -981,7 +981,7 @@ function getAchievementWonData(
     $numWinners = $data['NumEarned'];
     $gameID = $data['GameID'];   // Grab GameID at this point
 
-    $numPossibleWinners = getTotalUniquePlayers($gameID, $user, false);
+    $numPossibleWinners = getTotalUniquePlayers($gameID, $user, false, null);
 
     // Get recent winners, and their most recent activity:
     $query = "SELECT ua.User, ua.RAPoints,
@@ -1092,7 +1092,7 @@ function recalculateTrueRatio($gameID)
     SQL_ASSERT($dbResult);
 
     if ($dbResult !== false) {
-        $numHardcoreWinners = getTotalUniquePlayers($gameID, null, true);
+        $numHardcoreWinners = getTotalUniquePlayers($gameID, null, true, 3);
 
         if ($numHardcoreWinners == 0) { // force all unachieved to be 1
             $numHardcoreWinners = 1;

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -213,7 +213,7 @@ function getGameMetadataByFlags(
               FROM Awarded AS aw
               LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
               LEFT JOIN UserAccounts as ua ON ua.User = aw.User
-              WHERE ach.GameID = $gameID
+              WHERE ach.GameID = $gameID AND ach.Flags = $flags
               AND (NOT ua.Untracked" . (isset($user) ? " OR ua.User = '$user'" : "") . ")
               GROUP BY aw.HardcoreMode";
     $dbResult = s_mysql_query($query);

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -837,14 +837,19 @@ function getGameListSearch($offset, $count, $method, $consoleID = null): array
     return $retval;
 }
 
-function getTotalUniquePlayers($gameID, $requestedBy, $hardcoreOnly = false)
+function getTotalUniquePlayers($gameID, $requestedBy, $hardcoreOnly = false, $flags = null)
 {
     sanitize_sql_inputs($gameID, $requestedBy);
     settype($gameID, 'integer');
 
-    $hardcoreJoin = "";
+    $hardcoreCond = "";
     if ($hardcoreOnly) {
-        $hardcoreJoin = " AND aw.HardcoreMode = 1";
+        $hardcoreCond = " AND aw.HardcoreMode = 1";
+    }
+
+    $achievementStateCond = "";
+    if ($flags !== null) {
+        $achievementStateCond = "AND ach.Flags = $flags";
     }
 
     $query = "
@@ -854,7 +859,7 @@ function getTotalUniquePlayers($gameID, $requestedBy, $hardcoreOnly = false)
         LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
         LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
         WHERE gd.ID = $gameID
-        $hardcoreJoin
+        $hardcoreCond $achievementStateCond
         AND (NOT ua.Untracked" . (isset($requestedBy) ? " OR ua.User = '$requestedBy'" : "") . ")
     ";
 


### PR DESCRIPTION
Noticed that the displayed won by total users was also counting unique users from unofficial which in cases of re-authoring can cause weird affects like seen in https://retroachievements.org/game/7015 which has 6 total users from the new achievements.
![image](https://user-images.githubusercontent.com/4047771/167275032-ed332e18-ebef-42d6-92f1-3ab7b99a6ab6.png)

This shouldn't make much difference for most games but the few that get re-authored completely and do not do any transferring of earns are currently showing overinflated user totals as well as inflated RR. Has a very minor impact on some popular games with unofficial achievements from the samples I've checked.