### PR TITLE
add Request ticket state

### DIFF
--- a/lib/database/activity.php
+++ b/lib/database/activity.php
@@ -662,7 +662,7 @@ function getArticleComments($articleTypeID, $articleID, $offset, $count, &$dataO
             SELECT c.ID, c.UserID, c.Payload, c.Submitted, c.Edited
             FROM Comment AS c
             WHERE c.ArticleType=$articleTypeID AND c.ArticleID=$articleID
-            ORDER BY c.Submitted DESC
+            ORDER BY c.Submitted DESC, c.ID DESC
             LIMIT $offset, $count
         ) AS LatestComments
         LEFT JOIN UserAccounts AS ua ON ua.ID = LatestComments.UserID";

--- a/lib/database/game.php
+++ b/lib/database/game.php
@@ -3,6 +3,7 @@
 use RA\ActivityType;
 use RA\ArticleType;
 use RA\Permissions;
+use RA\TicketState;
 
 function getGameData($gameID)
 {
@@ -293,7 +294,7 @@ function getGamesListByDev($dev, $consoleID, &$dataOut, $sortBy, $ticketsFlag = 
             LEFT JOIN
                 Achievements AS ach ON ach.ID = tick.AchievementID
             WHERE
-                tick.ReportState = 1
+                tick.ReportState IN (" . TicketState::Open . "," . TicketState::Request . ")
             GROUP BY
                 ach.GameID
         ) as ticks ON ticks.GameID = gd.ID ";

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -4,6 +4,7 @@ use RA\ActivityType;
 use RA\ArticleType;
 use RA\AwardThreshold;
 use RA\Permissions;
+use RA\TicketState;
 
 function generateEmailValidationString($user)
 {
@@ -1454,7 +1455,7 @@ function GetDeveloperStatsFull($count, $sortBy, $devFilter = 7)
     LEFT JOIN
         Achievements AS ach ON (ach.Author = ua.User AND ach.Flags IN (3, 5))
     LEFT JOIN
-        Ticket AS tick ON (tick.AchievementID = ach.ID AND tick.ReportState = 1)
+        Ticket AS tick ON (tick.AchievementID = ach.ID AND tick.ReportState IN (" . TicketState::Open . "," . TicketState::Request . "))
     WHERE
         ContribCount > 0 AND ContribYield > 0
         $stateCond

--- a/lib/render/layout.php
+++ b/lib/render/layout.php
@@ -1,6 +1,8 @@
 <?php
 
 use RA\Permissions;
+use RA\TicketFilters;
+use RA\TicketState;
 
 function RenderHtmlStart($isOpenGraphPage = false)
 {
@@ -158,13 +160,36 @@ function RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $error
         echo ")";
         echo "</a>";
 
+        $openTickets = 0;
+        $devRequestTickets = 0;
         if ($permissions >= Permissions::Developer) {
-            $openTickets = countOpenTicketsByDev($user);
-            if ($openTickets > 0) {
-                echo " - <a href='/ticketmanager.php?u=$user'>";
-                echo "<font color='red'>Tickets: <strong>$openTickets</strong></font>";
-                echo "</a>";
-            }
+            $openTicketsData = countOpenTicketsByDev($user);
+            $openTickets = $openTicketsData[TicketState::Open];
+            $devRequestTickets = $openTicketsData[TicketState::Request];
+        }
+
+        $requestTickets = countRequestTicketsByUser($user);
+
+        $prefix = 'Tickets: ';
+        $separator = '-';
+        if ($openTickets) {
+            $filter = TicketFilters::Default & ~TicketFilters::StateRequest;
+            echo " $separator <a href='/ticketmanager.php?u=$user&t=$filter'>";
+            echo "<font color='red'>$prefix<strong>$openTickets</strong></font>";
+            echo "</a>";
+            $prefix = '';
+            $separator = '/';
+        }
+
+        if ($devRequestTickets > 0) {
+            $filter = TicketFilters::Default & ~TicketFilters::StateOpen;
+            echo " $separator <a href='/ticketmanager.php?u=$user&t=$filter'>$prefix$devRequestTickets</a>";
+            $prefix = '';
+            $separator = '/';
+        }
+        if ($requestTickets > 0) {
+            $filter = TicketFilters::Default & ~TicketFilters::StateOpen;
+            echo " $separator <a href='/ticketmanager.php?p=$user&t=$filter'>$prefix$requestTickets</a>";
         }
 
         echo "</p>";

--- a/public/request/comment/create.php
+++ b/public/request/comment/create.php
@@ -1,6 +1,8 @@
 <?php
 
+use RA\ArticleType;
 use RA\Permissions;
+use RA\TicketState;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
@@ -22,6 +24,13 @@ $articleType = requestInputPost('t', null, 'integer');
 $commentPayload = requestInputPost('c');
 
 if (addArticleComment($user, $articleType, $articleID, $commentPayload)) {
+    if ($articleType == ArticleType::AchievementTicket) {
+        $ticketData = getTicket($articleID);
+        if ($ticketData['ReportState'] == TicketState::Request && $ticketData['ReportedBy'] == $user) {
+            updateTicket($user, $articleID, TicketState::Open);
+        }
+    }
+
     echo $articleID;
 } else {
     echo "FAILED!";

--- a/public/request/comment/create.php
+++ b/public/request/comment/create.php
@@ -25,6 +25,8 @@ $commentPayload = requestInputPost('c');
 
 if (addArticleComment($user, $articleType, $articleID, $commentPayload)) {
     if ($articleType == ArticleType::AchievementTicket) {
+        // if a user is responding to a ticket in the Request state,
+        // automatically change the state back to Open
         $ticketData = getTicket($articleID);
         if ($ticketData['ReportState'] == TicketState::Request && $ticketData['ReportedBy'] == $user) {
             updateTicket($user, $articleID, TicketState::Open);

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -95,6 +95,10 @@ if ($ticketID != 0) {
             }
             break;
 
+        case "request":
+            $ticketState = TicketState::Request;
+            break;
+
         case "reopen":
             $ticketState = TicketState::Open;
             break;
@@ -115,7 +119,7 @@ if ($ticketID != 0) {
         $ticketData = getTicket($ticketID);
     }
 
-    $numArticleComments = getArticleComments(7, $ticketID, 0, 20, $commentData);
+    $numArticleComments = getArticleComments(ArticleType::AchievementTicket, $ticketID, 0, 20, $commentData);
 
     // sets all filters enabled so we get closed/resolved tickets as well
     $altTicketData = getAllTickets(0, 99, null, null, null, null, $ticketData['AchievementID'], TicketFilters::All);
@@ -304,7 +308,6 @@ RenderHtmlHead($pageTitle);
                     Each filter is represented by a bit in the $ticketFilters variable.
                     This allows us to easily determine which filters are active as well as toggle them back and forth.
                  */
-                $openTickets = ($ticketFilters & TicketFilters::StateOpen);
                 $closedTickets = ($ticketFilters & TicketFilters::StateClosed);
                 $resolvedTickets = ($ticketFilters & TicketFilters::StateResolved);
 
@@ -347,6 +350,7 @@ RenderHtmlHead($pageTitle);
                 echo "<div>";
                 echo "<b>Ticket State:</b> ";
                 echo $linkFilter(TicketState::toString(TicketState::Open), TicketFilters::StateOpen) . ' | ';
+                echo $linkFilter(TicketState::toString(TicketState::Request), TicketFilters::StateRequest) . ' | ';
                 echo $linkFilter(TicketState::toString(TicketState::Closed), TicketFilters::StateClosed) . ' | ';
                 echo $linkFilter(TicketState::toString(TicketState::Resolved), TicketFilters::StateResolved);
                 echo "</div>";
@@ -773,19 +777,44 @@ RenderHtmlHead($pageTitle);
                     echo "<td>Reporter:</td>";
                     echo "<td colspan='7'>";
                     echo "<div class='smallicon'>";
-                    echo "<span>";
                     $msgPayload = "Hi [user=$reportedBy], I'm contacting you about ticket retroachievements.org/ticketmanager.php?i=$ticketID ";
                     $msgPayload = rawurlencode($msgPayload);
                     $msgTitle = rawurlencode("Bug Report ($gameTitle)");
                     echo "<a href='createmessage.php?t=$reportedBy&amp;s=$msgTitle&p=$msgPayload'>Contact the reporter - $reportedBy</a>";
-                    echo "</span>";
                     echo "</div>";
                     echo "</td>";
                     echo "</tr>";
+
+                    if ($reportState == TicketState::Open) {
+                        $lastComment = null;
+                        foreach ($commentData as $comment) {
+                            if ($comment['User'] != 'Server') {
+                                $lastComment = $comment;
+                            }
+                        }
+                        if ($lastComment != null && ($lastComment['User'] == $user || $lastComment['User'] == $achAuthor)) {
+                            echo "<tr><td/><td colspan='6'>";
+                            echo "<div class='smallicon'>";
+                            echo "<a href='ticketmanager.php?i=$ticketID&action=request'>Transfer to reporter - $reportedBy</a>";
+                            echo "</div>";
+                            echo "</td></tr>";
+                        }
+                    } elseif ($reportState == TicketState::Request) {
+                        echo "<tr><td/><td colspan='6'>";
+                        echo "<div class='smallicon'>";
+                        echo "<a href='ticketmanager.php?i=$ticketID&action=reopen'>Transfer to author - $achAuthor</a>";
+                        echo "</div>";
+                        echo "</td></tr>";
+                    }
                 }
 
                 echo "<tr>";
-                echo "<td></td><td colspan='7'>";
+                if ($permissions >= Permissions::Developer) {
+                    echo "<td></td>";
+                } else {
+                    echo "<td>Reporter:</td>";
+                }
+                echo "<td colspan='7'>";
 
                 $numAchievements = getUserUnlockDates($reportedBy, $gameID, $unlockData);
                 $unlockData[] = ['ID' => 0, 'Title' => 'Ticket Created', 'Date' => $reportedAt, 'HardcoreMode' => 0];
@@ -866,7 +895,7 @@ RenderHtmlHead($pageTitle);
                     echo "<select name='action' required>";
                     echo "<option value='' disabled selected hidden>Choose an action...</option>";
 
-                    if ($reportState == TicketState::Open) {
+                    if ($reportState == TicketState::Open || $reportState == TicketState::Request) {
                         if ($user == $reportedBy && $permissions < Permissions::Developer) {
                             echo "<option value='closed-mistaken'>Close - Mistaken report</option>";
                         } elseif ($permissions >= Permissions::Developer) {

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -293,7 +293,8 @@ RenderHtmlStart(true);
             echo "<a href='/gameList.php?d=$userPage'>View all achievements sets <b>$userPage</b> has worked on.</a><br>";
             echo "<a href='/individualdevstats.php?u=$userPage'>View  detailed stats for <b>$userPage</b>.</a><br>";
             if (isset($user) && $permissions >= Permissions::Registered) {
-                echo "<a href='/ticketmanager.php?u=$userPage'>Open Tickets: <b>" . countOpenTicketsByDev($userPage) . "</b></a><br>";
+                $openTicketsData = countOpenTicketsByDev($userPage);
+                echo "<a href='/ticketmanager.php?u=$userPage'>Open Tickets: <b>" . array_sum($openTicketsData) . "</b></a><br>";
             }
             echo "Achievements won by others: <b>$contribCount</b><br>";
             echo "Points awarded to others: <b>$contribYield</b><br><br>";

--- a/src/TicketFilters.php
+++ b/src/TicketFilters.php
@@ -40,8 +40,10 @@ abstract class TicketFilters
 
     public const ResolvedByNonAuthor = 1 << 17;
 
+    public const StateRequest = 1 << 18;
+
     // This should updated every time a new filter is added so it has all possible filter bits set
-    public const AllFilters = (1 << 18) - 1;
+    public const AllFilters = (1 << 19) - 1;
 
     // All filter is everything except Not Author (Not Author filter excludes items)
     public const All = self::AllFilters & ~self::ResolvedByNonAuthor;

--- a/src/TicketState.php
+++ b/src/TicketState.php
@@ -7,6 +7,7 @@ abstract class TicketState
     public const Closed = 0;
     public const Open = 1;
     public const Resolved = 2;
+    public const Request = 3;
 
     public static function toString(int $type): string
     {
@@ -14,6 +15,7 @@ abstract class TicketState
             TicketState::Closed => "Closed",
             TicketState::Open => "Open",
             TicketState::Resolved => "Resolved",
+            TicketState::Request => "Request",
             default => "Invalid state",
         };
     }


### PR DESCRIPTION
Adds a new state to tickets: **Request** (I'm open to a better name if anyone has any good suggestions).

A developer can use this state to put the ticket back in the hands of the reporter to collect additional information.

For example, I receive a ticket for an achievement and I get a bright red notification in my user summary area:
![image](https://user-images.githubusercontent.com/32680403/167322014-699ed76a-5eaf-4a21-b534-cfa4bfd5d7b1.png)

Upon viewing the ticket, I can contact the user asking for more information, but that happens through direct messages, which aren't captured in the ticket itself.
![image](https://user-images.githubusercontent.com/32680403/167322035-90893478-a2ec-4492-a39f-54ec7e762e3f.png)

Instead, I put a comment in the ticket, hoping the user sees it. 
![image](https://user-images.githubusercontent.com/32680403/167322067-fd993fe5-5d54-4211-b835-a2d20f7e6096.png)

At this point, there's not much more I can do with the ticket until the user responds (if they ever respond). The problem is the user may not have seen the email indicating the ticket was updated, so they won't know to respond.

If the last comment in a ticket is from me, I now have the option to transfer the ticket to the reporter.
![image](https://user-images.githubusercontent.com/32680403/167322147-4a667461-f9d5-4ad0-949c-096da7e3941b.png)

Clicking on that link changes the ticket status from "Open" to "Request", but more importantly, it gets rid of the big red text in my user area.
![image](https://user-images.githubusercontent.com/32680403/167322191-40f4e7d6-1879-48e3-b1f3-8e82b5014794.png)

I still see that I have tickets to work on, but since they're in the "Request" state, the text is a standard link instead of the "needs-your-attention-now" red. Looking back at the earlier image I provided, you can see I have one Open ticket (in red) and one Request ticket (in yellow).

The ticket itself captures the change, and the transfer link changes so I can reassign it back to myself (status back to Open)
![image](https://user-images.githubusercontent.com/32680403/167322322-9e6e6756-f046-4842-b454-95611fa864af.png)

More importantly, now the user also sees a yellow ticket indicator on their user area.
![image](https://user-images.githubusercontent.com/32680403/167322333-084506e2-fc79-41ae-8d8a-e8774bbeb982.png)

This will take them to the ticket list for tickets reported by them in the Request state
![image](https://user-images.githubusercontent.com/32680403/167322365-7da25c02-b0a6-42e5-ac5a-363999321109.png)

Where they can open the ticket and respond to the developer. They do not have the option to transfer the ticket.
![image](https://user-images.githubusercontent.com/32680403/167322392-6044e557-02f8-4ece-ada0-2057ef32a73e.png)

Instead, immediately upon adding a comment, it gets reassigned back to the developer (status changed back to Open) and the red text reappears on the developer's user area.
![image](https://user-images.githubusercontent.com/32680403/167322425-4ea983c1-a8a2-469f-acbe-2092910385cd.png)

The "transfer to reporter" link appears for any developer who has entered the last comment in the ticket. This allows other developers to pick up tickets for inactive developers. The user will still get their ticket notification, but the "in progress" indicator will appear for the achievement author, not the developer who is working the ticket.

The "transfer to author" link appears for any developer, allowing moderators to transfer tickets back to the developer if they feel things are not being handled appropriately.