### PR TITLE
add warnings for account deletion

### DIFF
--- a/lib/database/auth.php
+++ b/lib/database/auth.php
@@ -89,12 +89,6 @@ function validateUser_app(&$user, $token, &$fbUser, $permissionRequired): bool
     );
 }
 
-function getCookie(&$userOut, &$cookieOut)
-{
-    $userOut = RA_ReadCookie('RA_User');
-    $cookieOut = RA_ReadCookie('RA_Cookie');
-}
-
 function RA_ValidateCookie(
     &$userOut,
     &$permissionsOut,

--- a/lib/database/auth.php
+++ b/lib/database/auth.php
@@ -89,42 +89,6 @@ function validateUser_app(&$user, $token, &$fbUser, $permissionRequired): bool
     );
 }
 
-function validateUser_cookie(&$user, $cookie, $permissionRequired, &$permissions = 0): bool
-{
-    return validateFromCookie($user, $points, $permissions, $permissionRequired);
-}
-
-function validateFromCookie(&$userOut, &$pointsOut, &$permissionsOut, $permissionRequired = 0): bool
-{
-    $userOut = RA_ReadCookie("RA_User");
-    $cookie = RA_ReadCookie("RA_Cookie");
-
-    sanitize_sql_inputs($userOut);
-
-    if (mb_strlen($userOut) < 2 || mb_strlen($cookie) < 2 || !isValidUsername($userOut)) {
-        // There is no cookie
-        return false;
-    } else {
-        // Cookie maybe stale: check it!
-        $query = "SELECT User, cookie, RAPoints, Permissions FROM UserAccounts WHERE User='$userOut'";
-        $dbResult = s_mysql_query($query);
-        if ($dbResult == false) {
-            return false;
-        } else {
-            $data = mysqli_fetch_array($dbResult);
-            if ($data['cookie'] == $cookie) {
-                $pointsOut = $data['RAPoints'];
-                $userOut = $data['User']; // Case correction
-                $permissionsOut = $data['Permissions'];
-
-                return $permissionsOut >= $permissionRequired;
-            } else {
-                return false;
-            }
-        }
-    }
-}
-
 function getCookie(&$userOut, &$cookieOut)
 {
     $userOut = RA_ReadCookie('RA_User');

--- a/lib/database/auth.php
+++ b/lib/database/auth.php
@@ -89,7 +89,7 @@ function validateUser_app(&$user, $token, &$fbUser, $permissionRequired): bool
     );
 }
 
-function RA_ValidateCookie(
+function authenticateFromCookie(
     &$userOut,
     &$permissionsOut,
     &$userDetailsOut,

--- a/lib/database/auth.php
+++ b/lib/database/auth.php
@@ -169,25 +169,6 @@ function RA_ValidateCookie(
     return false;
 }
 
-function RA_ReadCookieCredentials(
-    &$userOut,
-    &$pointsOut,
-    &$truePointsOut,
-    &$unreadMessagesOut,
-    &$permissionOut,
-    $minPermissions = null,
-    &$userIDOut = null
-): bool {
-    $result = RA_ValidateCookie($userOut, $permissionOut, $userDetails, $minPermissions);
-
-    $pointsOut = $userDetails['RAPoints'] ?? 0;
-    $unreadMessagesOut = $userDetails['UnreadMessageCount'] ?? 0;
-    $truePointsOut = $userDetails['TrueRAPoints'] ?? 0;
-    $userIDOut = $userDetails['ID'] ?? 0;
-
-    return $result;
-}
-
 function RA_ReadTokenCredentials(
     &$userOut,
     $token,

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1694,7 +1694,7 @@ function getMostAwardedGames($gameIDs)
     return $retVal;
 }
 
-function getDeleteTime($deleteRequested): string
+function getDeleteDate($deleteRequested): string
 {
     if (empty($deleteRequested)) {
         return null;
@@ -1726,8 +1726,8 @@ function deleteRequest($username, $date = null): bool
         return false;
     }
 
-    // Cap permissions to 1
-    $permission = min($user['Permissions'], 1);
+    // Cap permissions
+    $permission = min($user['Permissions'], Permissions::Registered);
 
     $date ??= date('Y-m-d H:i:s');
     $query = "UPDATE UserAccounts u SET u.DeleteRequested = '$date', u.Permissions = $permission WHERE u.User = '$username'";
@@ -1736,6 +1736,8 @@ function deleteRequest($username, $date = null): bool
     if ($dbResult !== false) {
         addArticleComment('Server', ArticleType::UserModeration, $user['ID'],
             $username . ' requested account deletion');
+
+        SendDeleteRequestEmail($username, $user['EmailAddress'], $date);
     }
 
     return $dbResult !== false;

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1697,7 +1697,7 @@ function getMostAwardedGames($gameIDs)
 function getDeleteDate($deleteRequested): string
 {
     if (empty($deleteRequested)) {
-        return null;
+        return '';
     }
 
     return date('Y-m-d', strtotime($deleteRequested) + 60 * 60 * 24 * 14);

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -360,7 +360,7 @@ function getAccountDetails(&$user, &$dataOut)
 
     $query = "SELECT ID, User, EmailAddress, Permissions, RAPoints, TrueRAPoints,
                      cookie, websitePrefs, UnreadMessageCount, Motto, UserWallActive,
-                     fbUser, fbPrefs, ApiKey, ContribCount, ContribYield,
+                     fbUser, fbPrefs, APIKey, ContribCount, ContribYield,
                      RichPresenceMsg, LastGameID, LastLogin, LastActivityID,
                      Created, DeleteRequested, Untracked
                 FROM UserAccounts

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -358,7 +358,11 @@ function getAccountDetails(&$user, &$dataOut)
 
     sanitize_sql_inputs($user);
 
-    $query = "SELECT ID, cookie, User, EmailAddress, Permissions, RAPoints, TrueRAPoints, fbUser, fbPrefs, websitePrefs, LastActivityID, Motto, ContribCount, ContribYield, APIKey, UserWallActive, Untracked, RichPresenceMsg, LastGameID, LastLogin, Created, DeleteRequested, Deleted
+    $query = "SELECT ID, User, EmailAddress, Permissions, RAPoints, TrueRAPoints,
+                     cookie, websitePrefs, UnreadMessageCount, Motto, UserWallActive,
+                     fbUser, fbPrefs, ApiKey, ContribCount, ContribYield,
+                     RichPresenceMsg, LastGameID, LastLogin, LastActivityID,
+                     Created, DeleteRequested, Untracked
                 FROM UserAccounts
                 WHERE User='$user'
                 AND Deleted IS NULL";
@@ -1688,6 +1692,14 @@ function getMostAwardedGames($gameIDs)
         }
     }
     return $retVal;
+}
+
+function getDeleteTime($deleteRequested): string
+{
+    if (empty($deleteRequested))
+        return null;
+
+    return date('Y-m-d', strtotime($deleteRequested) + 60 * 60 * 24 * 14);
 }
 
 function cancelDeleteRequest($username): bool

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1696,8 +1696,9 @@ function getMostAwardedGames($gameIDs)
 
 function getDeleteTime($deleteRequested): string
 {
-    if (empty($deleteRequested))
+    if (empty($deleteRequested)) {
         return null;
+    }
 
     return date('Y-m-d', strtotime($deleteRequested) + 60 * 60 * 24 * 14);
 }

--- a/lib/render/layout.php
+++ b/lib/render/layout.php
@@ -111,12 +111,12 @@ function RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $error
     echo "<div id='logocontainer'><a id='logo' href='/'><img src='/Images/RA_Logo10.png' alt='Retro Achievements logo'></a>";
 
     if (!empty($deleteRequested)) {
-        echo "<div style='text-align: center; font-size:14px; color:#dd0000'>Your account is marked to be deleted on " . 
+        echo "<div style='text-align: center; font-size:14px; color:#dd0000'>Your account is marked to be deleted on " .
             getDeleteTime($deleteRequested) . "</div>";
     }
 
     echo "</div>";
-    
+
     echo "<div class='login'>";
 
     if ($user == false) {

--- a/lib/render/layout.php
+++ b/lib/render/layout.php
@@ -96,7 +96,7 @@ function RenderTitleTag($title = null)
     // </script>";
 }
 
-function RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions = 0)
+function RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions = 0, $deleteRequested = null)
 {
     settype($unreadMessageCount, "integer");
     settype($truePoints, 'integer');
@@ -110,9 +110,9 @@ function RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $error
 
     echo "<div id='logocontainer'><a id='logo' href='/'><img src='/Images/RA_Logo10.png' alt='Retro Achievements logo'></a>";
 
-    if (getAccountDetails($user, $userDetails) && $userDetails['DeleteRequested']) {
+    if (!empty($deleteRequested)) {
         echo "<div style='text-align: center; font-size:14px; color:#dd0000'>Your account is marked to be deleted on " . 
-             date('Y-m-d', strtotime($userDetails['DeleteRequested']) + 60 * 60 * 24 * 14) . "</div>";
+            getDeleteTime($deleteRequested) . "</div>";
     }
 
     echo "</div>";
@@ -359,6 +359,22 @@ function RenderToolbar($user, $permissions = 0)
 
     echo "</ul>";
     echo "</div>";
+}
+
+function RenderHeader($userDetails)
+{
+    $errorCode = requestInputSanitized('e');
+
+    if ($userDetails) {
+        RenderTitleBar($userDetails['User'], $userDetails['RAPoints'],
+            $userDetails['TrueRAPoints'], $userDetails['UnreadMessageCount'],
+            $errorCode, $userDetails['Permissions'],
+            $userDetails['DeleteRequested']);
+        RenderToolbar($userDetails['User'], $userDetails['Permissions']);
+    } else {
+        RenderTitleBar(null, 0, 0, 0, $errorCode);
+        RenderToolbar(null, 0);
+    }
 }
 
 function RenderFooter()

--- a/lib/render/layout.php
+++ b/lib/render/layout.php
@@ -112,7 +112,7 @@ function RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $error
 
     if (!empty($deleteRequested)) {
         echo "<div style='text-align: center; font-size:14px; color:#dd0000'>Your account is marked to be deleted on " .
-            getDeleteTime($deleteRequested) . "</div>";
+            getDeleteDate($deleteRequested) . "</div>";
     }
 
     echo "</div>";

--- a/lib/render/layout.php
+++ b/lib/render/layout.php
@@ -108,8 +108,15 @@ function RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $error
 
     echo "<div id='title'>";
 
-    echo "<div id='logocontainer'><a id='logo' href='/'><img src='/Images/RA_Logo10.png' alt='Retro Achievements logo'></a></div>";
+    echo "<div id='logocontainer'><a id='logo' href='/'><img src='/Images/RA_Logo10.png' alt='Retro Achievements logo'></a>";
 
+    if (getAccountDetails($user, $userDetails) && $userDetails['DeleteRequested']) {
+        echo "<div style='text-align: center; font-size:14px; color:#dd0000'>Your account is marked to be deleted on " . 
+             date('Y-m-d', strtotime($userDetails['DeleteRequested']) + 60 * 60 * 24 * 14) . "</div>";
+    }
+
+    echo "</div>";
+    
     echo "<div class='login'>";
 
     if ($user == false) {

--- a/lib/util/mail.php
+++ b/lib/util/mail.php
@@ -333,7 +333,7 @@ function SendDeleteRequestEmail($user, $email, $deleteRequested): bool
 
     $msg = "Hello $user,<br>" .
         "Your account has been marked for deletion.<br>" .
-        "If you do not cancel this request before " . getDeleteDate($deleteRequested) . "," .
+        "If you do not cancel this request before " . getDeleteDate($deleteRequested) . ", " .
         "you will no longer be able to access your account.<br>" .
         "Thanks!<br>" .
         "-- Your friends at RetroAchievements.org<br>";

--- a/lib/util/mail.php
+++ b/lib/util/mail.php
@@ -326,3 +326,17 @@ function SendPasswordResetEmail($user, $email, $token): bool
 
     return mail_utf8($email, $emailTitle, $msg);
 }
+
+function SendDeleteRequestEmail($user, $email, $deleteRequested): bool
+{
+    $emailTitle = "Account Deletion Request";
+
+    $msg = "Hello $user,<br>" .
+        "Your account has been marked for deletion.<br>" .
+        "If you do not cancel this request before " . getDeleteDate($deleteRequested) . "," .
+        "you will no longer be able to access your account.<br>" .
+        "Thanks!<br>" .
+        "-- Your friends at RetroAchievements.org<br>";
+
+    return mail_utf8($email, $emailTitle, $msg);
+}

--- a/public/APIDemo.php
+++ b/public/APIDemo.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 require_once __DIR__ . "/../src/RetroAchievementsWebApiClient.php";
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 

--- a/public/APIDemo.php
+++ b/public/APIDemo.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 require_once __DIR__ . "/../src/RetroAchievementsWebApiClient.php";
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 
@@ -15,8 +15,7 @@ RenderHtmlStart();
 RenderHtmlHead("RetroAchievements API Demo (PHP)");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id='mainpage'>
     <div id='fullcontainer'>
         <?php

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -7,7 +7,7 @@ use RA\Shortcode\Shortcode;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $achievementID = requestInputSanitized('ID', 0, 'integer');
 
@@ -83,8 +83,7 @@ RenderHtmlStart(true);
 </head>
 
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <?php if ($permissions >= Permissions::Developer): ?>
     <script>
         function PostEmbedUpdate() {

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -7,7 +7,7 @@ use RA\Shortcode\Shortcode;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $achievementID = requestInputSanitized('ID', 0, 'integer');
 

--- a/public/achievementList.php
+++ b/public/achievementList.php
@@ -7,7 +7,7 @@ $consoleList = getConsoleList();
 $consoleIDInput = requestInputSanitized('z', 0, 'integer');
 $mobileBrowser = IsMobileBrowser();
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
 
@@ -42,8 +42,7 @@ RenderHtmlStart();
 RenderHtmlHead("Achievement List" . $requestedConsole);
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id='mainpage'>
     <div id='fullcontainer'>
         <?php

--- a/public/achievementList.php
+++ b/public/achievementList.php
@@ -7,7 +7,7 @@ $consoleList = getConsoleList();
 $consoleIDInput = requestInputSanitized('z', 0, 'integer');
 $mobileBrowser = IsMobileBrowser();
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
 

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     exit;
 }
 

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     exit;
 }
 
@@ -44,8 +44,7 @@ RenderHtmlHead("Manage Achievements");
 ?>
 <body>
 
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 
 
 <script>

--- a/public/admin.php
+++ b/public/admin.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Admin)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Admin)) {
     // Immediate redirect if we cannot validate user!
     header("Location: " . getenv('APP_URL'));
     exit;

--- a/public/admin.php
+++ b/public/admin.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Admin)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Admin)) {
     // Immediate redirect if we cannot validate user!
     header("Location: " . getenv('APP_URL'));
     exit;
@@ -422,8 +422,7 @@ RenderHtmlStart();
 RenderHtmlHead('Admin Tools');
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <script src="/vendor/jquery.datetimepicker.full.min.js"></script>
 <link rel="stylesheet" href="/vendor/jquery.datetimepicker.min.css">
 <div id="mainpage">

--- a/public/attemptmerge.php
+++ b/public/attemptmerge.php
@@ -7,7 +7,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie(
+if (!authenticateFromCookie(
     $user,
     $permissions,
     $userDataOut,

--- a/public/attemptmerge.php
+++ b/public/attemptmerge.php
@@ -7,12 +7,10 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials(
+if (!RA_ValidateCookie(
     $user,
-    $points,
-    $truePoints,
-    $unreadMessageCount,
     $permissions,
+    $userDataOut,
     Permissions::Developer
 )) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
@@ -48,8 +46,7 @@ RenderHtmlStart();
 RenderHtmlHead("Merge Game Entry ($consoleName)");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDataOut); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <h2>Merging Game Entry</h2>

--- a/public/attemptrename.php
+++ b/public/attemptrename.php
@@ -5,12 +5,10 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials(
+if (!RA_ValidateCookie(
     $user,
-    $points,
-    $truePoints,
-    $unreadMessageCount,
     $permissions,
+    $userDetails,
     Permissions::Developer
 )) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
@@ -50,8 +48,7 @@ RenderHtmlStart();
 RenderHtmlHead("Rename Game Entry ($consoleName)");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <h2>Rename Game Entry</h2>

--- a/public/attemptrename.php
+++ b/public/attemptrename.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie(
+if (!authenticateFromCookie(
     $user,
     $permissions,
     $userDetails,

--- a/public/awardedList.php
+++ b/public/awardedList.php
@@ -9,7 +9,7 @@ exit;
 $consoleList = getConsoleList();
 $consoleIDInput = requestInputSanitized('i', 0, 'integer');
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
 
@@ -36,8 +36,7 @@ RenderHtmlStart();
 RenderHtmlHead("Achievement List" . $requestedConsole);
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id='fullcontainer'>
         <?php

--- a/public/awardedList.php
+++ b/public/awardedList.php
@@ -9,7 +9,7 @@ exit;
 $consoleList = getConsoleList();
 $consoleIDInput = requestInputSanitized('i', 0, 'integer');
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
 

--- a/public/codenotes.php
+++ b/public/codenotes.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $gameID = requestInputSanitized('g', 1, 'integer');
 $gameData = getGameData($gameID);
@@ -23,8 +23,7 @@ RenderHtmlStart();
 RenderHtmlHead('Code Notes');
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id='mainpage'>
     <div id="fullcontainer">
         <?php echo "Game: " . GetGameAndTooltipDiv($gameData['ID'], $gameData['Title'], $gameData['ImageIcon'], $gameData['ConsoleName']); ?>

--- a/public/codenotes.php
+++ b/public/codenotes.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $gameID = requestInputSanitized('g', 1, 'integer');
 $gameData = getGameData($gameID);

--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -280,8 +280,6 @@ function RenderUserPref($websitePrefs, $userPref, $setIfTrue, $state = null)
                 echo "<td>";
                 echo "<form method='POST' action='/request/user/update-motto.php'>";
                 echo "<input class='fullwidth' name='m' value=\"$userMottoString\" maxlength='49' id='usermottoinput' placeholder='Add your motto here! (No profanity please!)' />";
-                echo "<input type='hidden' name='u' VALUE='$user'>";
-                echo "<input type='hidden' name='c' VALUE='$cookie'>";
                 echo "<input value='Set Motto' name='submit' type='submit' size='37' />";
                 echo "</form>";
                 echo "</td>";
@@ -294,8 +292,6 @@ function RenderUserPref($websitePrefs, $userPref, $setIfTrue, $state = null)
                 echo "<form method='POST' action='/request/user/update-wall.php'>";
                 $checkedStr = ($userWallActive == 1) ? "checked" : "";
                 echo "<input type='checkbox' name='v' value='1' id='userwallactive' $checkedStr/>";
-                echo "<input type='hidden' name='u' value='$user'>";
-                echo "<input type='hidden' name='c' value='$cookie'>";
                 echo "<input type='hidden' name='t' value='wall'>";
                 echo "<input value='Save' name='submit' type='submit' size='37' />";
                 echo "</form>";
@@ -510,8 +506,6 @@ function RenderUserPref($websitePrefs, $userPref, $setIfTrue, $state = null)
                     </tr>
                     </tbody>
                 </table>
-                <input TYPE="hidden" NAME="u" VALUE="<?php echo $user; ?>">
-                <input TYPE="hidden" NAME="c" VALUE="<?php echo $cookie; ?>">
             </form>
         </div>
         <div class='component'>

--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -6,7 +6,7 @@ use RA\UserPref;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;

--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -557,7 +557,7 @@ function RenderUserPref($websitePrefs, $userPref, $setIfTrue, $state = null)
             <?php if ($userDetails['DeleteRequested']): ?>
                 <p>
                     You requested to have your account deleted on <?= $userDetails['DeleteRequested'] ?> (UTC).<br>
-                    Your account will be permanently deleted on <?= date('Y-m-d', strtotime($userDetails['DeleteRequested']) + 60 * 60 * 24 * 14) ?>.
+                    Your account will be permanently deleted on <?= getDeleteTime($userDetails['DeleteRequested']) ?>.
                 </p>
                 <form method="post" action="/request/auth/delete-account-cancel.php" onsubmit="return confirm('Are you sure you want to cancel your account deletion request?');">
                     <input type="submit" value="Cancel account deletion request">

--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -551,7 +551,7 @@ function RenderUserPref($websitePrefs, $userPref, $setIfTrue, $state = null)
             <?php if ($userDetails['DeleteRequested']): ?>
                 <p>
                     You requested to have your account deleted on <?= $userDetails['DeleteRequested'] ?> (UTC).<br>
-                    Your account will be permanently deleted on <?= getDeleteTime($userDetails['DeleteRequested']) ?>.
+                    Your account will be permanently deleted on <?= getDeleteDate($userDetails['DeleteRequested']) ?>.
                 </p>
                 <form method="post" action="/request/auth/delete-account-cancel.php" onsubmit="return confirm('Are you sure you want to cancel your account deletion request?');">
                     <input type="submit" value="Cancel account deletion request">

--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -6,13 +6,7 @@ use RA\UserPref;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
-    if (getAccountDetails($user, $userDetails) == false) {
-        // Immediate redirect if we cannot validate user!
-        header("Location: " . getenv('APP_URL') . "?e=accountissue");
-        exit;
-    }
-} else {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;
@@ -259,8 +253,7 @@ function RenderUserPref($websitePrefs, $userPref, $setIfTrue, $state = null)
 
   GetAllResettableGamesList();
 </script>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="leftcontainer">
         <?php RenderErrorCodeWarning($errorCode); ?>

--- a/public/createaccount.php
+++ b/public/createaccount.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 

--- a/public/createaccount.php
+++ b/public/createaccount.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 
@@ -12,8 +12,7 @@ RenderHtmlHead("Create Account");
 ?>
 <body>
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <h3>Create Account</h3>

--- a/public/createmessage.php
+++ b/public/createmessage.php
@@ -9,13 +9,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 $user = RA_ReadCookie('RA_User');
 $cookieRaw = RA_ReadCookie('RA_Cookie');
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
-    if (getAccountDetails($user, $userDetails) == false) {
-        // Immediate redirect if we cannot validate user!
-        header("Location: " . getenv('APP_URL') . "?e=accountissue");
-        exit;
-    }
-} else {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;
@@ -72,8 +66,7 @@ RenderHtmlHead("Send Message");
 
   $(document).ready(onUserChange);
 </script>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 
 <div id="mainpage">
     <div id='fullcontainer'>

--- a/public/createmessage.php
+++ b/public/createmessage.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 $user = RA_ReadCookie('RA_User');
 $cookieRaw = RA_ReadCookie('RA_Cookie');
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;

--- a/public/createmessage.php
+++ b/public/createmessage.php
@@ -91,8 +91,6 @@ RenderHtmlHead("Send Message");
             echo "<tbody>";
 
             echo "<form class='messageform' action='/request/message/send.php' method='post'>";
-            echo "<input type='hidden' value='$user' name='u'>";
-            echo "<input type='hidden' value='$cookieRaw' name='c'>";
             $destUser = mb_strlen($messageTo) > 2 ? $messageTo : '_User';
             echo "<tr>";
             echo "<td>User:</td>";

--- a/public/createtopic.php
+++ b/public/createtopic.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate cookie!	//TBD: pass args?
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;

--- a/public/createtopic.php
+++ b/public/createtopic.php
@@ -29,7 +29,6 @@ $thisForumDescription = $forumData['ForumDescription'];
 $thisCategoryID = $forumData['CategoryID'];
 $thisCategoryName = $forumData['CategoryName'];
 
-getCookie($user, $cookieRaw);
 $errorCode = requestInputSanitized('e');
 
 RenderHtmlStart();
@@ -54,10 +53,9 @@ RenderHtmlHead("Create topic: $thisForumTitle");
             echo "<tbody>";
 
             echo "<form action='/request/forum-topic/create.php' method='post'>";
-            echo "<input type='hidden' value='$cookieRaw' name='c'>";
             echo "<input type='hidden' value='$requestedForumID' name='f'>";
             echo "<tr>" . "<td>Forum:</td><td><input type='text' readonly value='$thisForumTitle'></td></tr>";
-            echo "<tr>" . "<td>Author:</td><td><input type='text' readonly value='$user' name='u'></td></tr>";
+            echo "<tr>" . "<td>Author:</td><td><input type='text' readonly value='$user'></td></tr>";
             echo "<tr>" . "<td>Title:</td><td><input class='fullwidth' type='text' value='' name='t'></td></tr>";
             echo "<tr>" . "<td>Message:</td><td>";
 

--- a/public/createtopic.php
+++ b/public/createtopic.php
@@ -5,13 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
-    if (getAccountDetails($user, $userDetails) == false) {
-        // Immediate redirect if we cannot validate user!	//TBD: pass args?
-        header("Location: " . getenv('APP_URL') . "?e=accountissue");
-        exit;
-    }
-} else {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate cookie!	//TBD: pass args?
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;
@@ -42,8 +36,7 @@ RenderHtmlStart();
 RenderHtmlHead("Create topic: $thisForumTitle");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="leftcontainer">
         <div id="forums">

--- a/public/developerstats.php
+++ b/public/developerstats.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 $type = requestInputSanitized('t', 0, 'integer');
@@ -17,8 +17,7 @@ RenderHtmlHead("Developer Stats");
 ?>
 <body>
 <?php
-RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions);
-RenderToolbar($user, $permissions);
+RenderHeader($userDetails);
 ?>
 <div id='mainpage'>
     <div id='fullcontainer'>

--- a/public/developerstats.php
+++ b/public/developerstats.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 $type = requestInputSanitized('t', 0, 'integer');

--- a/public/download.php
+++ b/public/download.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 $emulators = getActiveEmulatorReleases();
 $consoles = getConsoleList();
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 $staticData = getStaticData();
@@ -15,8 +15,7 @@ RenderHtmlStart();
 RenderHtmlHead("Download a client");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id='fullcontainer'>
 

--- a/public/download.php
+++ b/public/download.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 $emulators = getActiveEmulatorReleases();
 $consoles = getConsoleList();
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 $staticData = getStaticData();

--- a/public/editpost.php
+++ b/public/editpost.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     // Immediate redirect if we cannot validate cookie!	//TBD: pass args?
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;

--- a/public/editpost.php
+++ b/public/editpost.php
@@ -37,7 +37,6 @@ $thisAuthor = $commentData['Author'];
 // $thisCategoryID = $topicData['CategoryID'];
 // $thisCategoryName = $topicData['CategoryName'];
 
-getCookie($user, $cookieRaw);
 $errorCode = requestInputSanitized('e');
 
 RenderHtmlStart();
@@ -58,10 +57,8 @@ RenderHtmlHead("Edit post");
         echo "<tbody>";
 
         echo "<form action='/request/forum-topic/update.php' method='post'>";
-        echo "<input type='hidden' value='$cookieRaw' name='c'>";
         echo "<input type='hidden' value='$requestedComment' name='i'>";
         echo "<input type='hidden' value='$thisTopicID' name='t'>";
-        echo "<input type='hidden' value='$user' name='u'>";
         // echo "<input type='hidden' value='$requestedForumID' name='f'>";
         echo "<tr>" . "<td>Forum:</td><td><input type='text' readonly value='$thisForumTitle'></td></tr>";
         echo "<tr>" . "<td>Topic:</td><td><input type='text' readonly class='fullwidth' value='$thisTopicTitle'></td></tr>";

--- a/public/editpost.php
+++ b/public/editpost.php
@@ -5,13 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
-    if (getAccountDetails($user, $userDetails) == false) {
-        // Immediate redirect if we cannot validate user!	//TBD: pass args?
-        header("Location: " . getenv('APP_URL') . "?e=accountissue");
-        exit;
-    }
-} else {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     // Immediate redirect if we cannot validate cookie!	//TBD: pass args?
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;
@@ -50,8 +44,7 @@ RenderHtmlStart();
 RenderHtmlHead("Edit post");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <?php

--- a/public/faq.php
+++ b/public/faq.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 RenderHtmlStart();

--- a/public/faq.php
+++ b/public/faq.php
@@ -3,15 +3,14 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 RenderHtmlStart();
 RenderHtmlHead("FAQ");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <?php
     $yOffs = 0;

--- a/public/feed.php
+++ b/public/feed.php
@@ -12,7 +12,7 @@ $global = requestInputSanitized('g', null, 'integer');
 $activityID = requestInputSanitized('a', null, 'integer');
 $individual = requestInputSanitized('i', null, 'integer');
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 // Max: last 50 messages:
 $maxMessages = 50;
@@ -55,8 +55,7 @@ RenderHtmlHead($pageTitle);
   });
 </script>
 
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 
 <div id="mainpage">
     <div id="leftcontainer">

--- a/public/feed.php
+++ b/public/feed.php
@@ -12,7 +12,7 @@ $global = requestInputSanitized('g', null, 'integer');
 $activityID = requestInputSanitized('a', null, 'integer');
 $individual = requestInputSanitized('i', null, 'integer');
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 // Max: last 50 messages:
 $maxMessages = 50;

--- a/public/forum.php
+++ b/public/forum.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 
 $requestedCategoryID = requestInputSanitized('c', null, 'integer');
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $forumList = getForumList($permissions, $requestedCategoryID);
 
@@ -32,8 +32,7 @@ RenderHtmlStart();
 RenderHtmlHead($pageTitle);
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="leftcontainer">
         <?php RenderErrorCodeWarning($errorCode); ?>

--- a/public/forum.php
+++ b/public/forum.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 
 $requestedCategoryID = requestInputSanitized('c', null, 'integer');
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $forumList = getForumList($permissions, $requestedCategoryID);
 

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -8,7 +8,7 @@ $maxCount = 25;
 $offset = requestInputSanitized('o', 0, 'integer');
 $count = $maxCount;
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $numPostsFound = getRecentForumPosts($offset, $count, 90, $permissions, $recentPostsData);
 

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -8,7 +8,7 @@ $maxCount = 25;
 $offset = requestInputSanitized('o', 0, 'integer');
 $count = $maxCount;
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $numPostsFound = getRecentForumPosts($offset, $count, 90, $permissions, $recentPostsData);
 
@@ -18,8 +18,7 @@ RenderHtmlStart();
 RenderHtmlHead("Forum Recent Posts");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id='fullcontainer'>
         <div id="forums">

--- a/public/friends.php
+++ b/public/friends.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;

--- a/public/friends.php
+++ b/public/friends.php
@@ -57,8 +57,8 @@ RenderHtmlHead("Friends");
                 echo "<td style='vertical-align:middle;'>";
                 echo "<div class='buttoncollection'>";
                 echo "<span style='display:block;'><a href='/createmessage.php?t=$user'>Send&nbsp;Message</a></span>";
-                echo "<span style='display:block;'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$nextFriendName&amp;a=0'>Remove&nbsp;Friend</a></span>";
-                echo "<span style='display:block;'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$nextFriendName&amp;a=-1'>Block&nbsp;User</a></span>";
+                echo "<span style='display:block;'><a href='/request/friend/update.php?f=$nextFriendName&amp;a=0'>Remove&nbsp;Friend</a></span>";
+                echo "<span style='display:block;'><a href='/request/friend/update.php?f=$nextFriendName&amp;a=-1'>Block&nbsp;User</a></span>";
                 echo "</div>";
                 echo "</td>";
 

--- a/public/friends.php
+++ b/public/friends.php
@@ -5,13 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Unregistered)) {
-    if (getAccountDetails($user, $userDetails) == false) {
-        // Immediate redirect if we cannot validate user!
-        header("Location: " . getenv('APP_URL') . "?e=accountissue");
-        exit;
-    }
-} else {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;
@@ -27,8 +21,7 @@ RenderHtmlStart();
 RenderHtmlHead("Friends");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <h2>Friends</h2>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -130,7 +130,6 @@ if ($v != 1 && $isFullyFeaturedGame) {
 $achDist = null;
 $authorInfo = [];
 $commentData = null;
-$cookie = null;
 $gameTopAchievers = null;
 $lbData = null;
 $numArticleComments = null;
@@ -154,8 +153,6 @@ if ($isFullyFeaturedGame) {
     $achDist = getAchievementDistribution($gameID, 0, $user, $flags, $numAchievements); // for now, only retrieve casual!
 
     $numArticleComments = getArticleComments(1, $gameID, 0, 20, $commentData);
-
-    getCookie($user, $cookie);
 
     $numLeaderboards = getLeaderboardsForGame($gameID, $lbData, $user);
 

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -22,9 +22,10 @@ if ($gameID == null || $gameID == 0) {
 }
 
 $friendScores = [];
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, null, $userID)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails)) {
     getAllFriendsProgress($user, $gameID, $friendScores);
 }
+$userID = $userDetails['ID'] ?? 0;
 
 $errorCode = requestInputSanitized('e');
 
@@ -92,8 +93,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
     <?php RenderTitleTag($pageTitle); ?>
 </head>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions);
+<?php RenderHeader($userDetails);
             echo "<div id='mainpage'>";
             echo "<div id='leftcontainer'>";
             echo "<div class='navpath'>";
@@ -233,8 +233,7 @@ RenderHtmlStart(true);
     <?php RenderTitleTag($pageTitle); ?>
 </head>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <?php if ($isFullyFeaturedGame): ?>
     <script src="https://www.gstatic.com/charts/loader.js"></script>
     <script>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -82,8 +82,7 @@ $v = requestInputSanitized('v', 0, 'integer');
 if ($v != 1 && $isFullyFeaturedGame) {
     foreach ($gameHubs as $hub) {
         if ($hub['Title'] == '[Theme - Mature]') {
-            if (getAccountDetails($user, $accountDetails) &&
-                BitSet($accountDetails['websitePrefs'], UserPref::SiteMsgOff_MatureContent)) {
+            if (BitSet($userDetails['websitePrefs'], UserPref::SiteMsgOff_MatureContent)) {
                 break;
             }
 

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -624,7 +624,7 @@ RenderHtmlStart(true);
 
                 // Display leaderboard management options depending on the current number of leaderboards
                 if ($numLeaderboards == 0) {
-                    echo "<div><a href='/request/leaderboard/create.php?u=$user&c=$cookie&g=$gameID'>Create First Leaderboard</a></div>";
+                    echo "<div><a href='/request/leaderboard/create.php?g=$gameID'>Create First Leaderboard</a></div>";
                 } else {
                     echo "<div><a href='/leaderboardList.php?g=$gameID'>Manage Leaderboards</a></div>";
                 }

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -22,7 +22,7 @@ if ($gameID == null || $gameID == 0) {
 }
 
 $friendScores = [];
-if (RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (authenticateFromCookie($user, $permissions, $userDetails)) {
     getAllFriendsProgress($user, $gameID, $friendScores);
 }
 $userID = $userDetails['ID'] ?? 0;

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -26,7 +26,7 @@ if ($consoleIDInput !== 0) {
     $requestedConsole = " (" . $consoleList[$consoleIDInput] . ")";
 }
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $showTickets = (isset($user) && $permissions >= Permissions::Developer);
 $gamesList = [];
@@ -169,8 +169,7 @@ RenderHtmlStart();
 RenderHtmlHead("Supported Games" . $requestedConsole);
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <div class="largelist">

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -26,7 +26,7 @@ if ($consoleIDInput !== 0) {
     $requestedConsole = " (" . $consoleList[$consoleIDInput] . ")";
 }
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $showTickets = (isset($user) && $permissions >= Permissions::Developer);
 $gamesList = [];

--- a/public/gameSearch.php
+++ b/public/gameSearch.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $maxCount = 50;
 

--- a/public/gameSearch.php
+++ b/public/gameSearch.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $maxCount = 50;
 
@@ -23,8 +23,7 @@ RenderHtmlStart();
 RenderHtmlHead("Game Search");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <?php

--- a/public/gamecompare.php
+++ b/public/gamecompare.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 $gameID = requestInputSanitized('ID', null, 'integer');
 $user2 = requestInputSanitized('f');
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Unregistered)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;
 }
@@ -62,8 +62,7 @@ RenderHtmlStart();
 RenderHtmlHead("Game Compare");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="leftcontainer">
         <div id="gamecompare">

--- a/public/gamecompare.php
+++ b/public/gamecompare.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 $gameID = requestInputSanitized('ID', null, 'integer');
 $user2 = requestInputSanitized('f');
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;
 }

--- a/public/globalRanking.php
+++ b/public/globalRanking.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
 
@@ -56,8 +56,7 @@ RenderHtmlHead($lbUsers . " Ranking - " . $lbType);
 ?>
 <body>
 <?php
-RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions);
-RenderToolbar($user, $permissions);
+RenderHeader($userDetails);
 ?>
 <div id='mainpage'>
     <div id='fullcontainer'>

--- a/public/globalRanking.php
+++ b/public/globalRanking.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
 

--- a/public/history.php
+++ b/public/history.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $userPage = requestInputSanitized('u', $user);
 

--- a/public/history.php
+++ b/public/history.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $userPage = requestInputSanitized('u', $user);
 
@@ -42,8 +42,7 @@ RenderHtmlStart(true);
 RenderHtmlHead("$userPage's Legacy");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 <script>
   google.load('visualization', '1.0', { 'packages': ['corechart'] });

--- a/public/historyexamine.php
+++ b/public/historyexamine.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $userPage = requestInputSanitized('u', $user);
 if (!isset($userPage)) {

--- a/public/historyexamine.php
+++ b/public/historyexamine.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $userPage = requestInputSanitized('u', $user);
 if (!isset($userPage)) {
@@ -40,8 +40,7 @@ RenderHtmlHead("$userPage's Legacy - $dateStr");
     return true;
  }
 </script>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id='fullcontainer'>
         <?php

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -13,7 +13,7 @@ $count = requestInputSanitized('c', $maxCount, 'integer');
 $unreadOnly = requestInputSanitized('u', 0, 'integer');
 $outbox = requestInputSanitized('s', 0, 'integer');
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     // Trying to visit someone's inbox while not being logged in :S
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;
@@ -36,8 +36,7 @@ if ($outbox) {
 
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <script>
   function MarkAsRead(msgID) {
     $('#msgInline' + msgID).toggle();

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -19,8 +19,6 @@ if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     exit;
 }
 
-getCookie($user, $cookieRaw);
-
 RenderHtmlStart();
 
 if ($outbox) {
@@ -211,7 +209,7 @@ if ($outbox) {
                     echo "<div class='buttoncollection rightfloat'>";
                     echo "<span class='rightalign clickablebutton'><a href='#' onclick=\"MarkAsUnread( $msgID ); return false;\" >Mark as unread</a></span>";
                     echo "<span class='rightalign clickablebutton'><a href='/createmessage.php?t=$msgUser&amp;i=$msgID'>Reply</a></span>";
-                    echo "<span class='rightalign clickablebutton'><a href='/request/message/delete.php?u=$user&amp;c=$cookieRaw&amp;m=$msgID' onclick='return confirm(\"Are you sure you want to permanently delete this message?\")'>Delete</a></span>";
+                    echo "<span class='rightalign clickablebutton'><a href='/request/message/delete.php?m=$msgID' onclick='return confirm(\"Are you sure you want to permanently delete this message?\")'>Delete</a></span>";
                     echo "</div>";
                 }
 

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -13,7 +13,7 @@ $count = requestInputSanitized('c', $maxCount, 'integer');
 $unreadOnly = requestInputSanitized('u', 0, 'integer');
 $outbox = requestInputSanitized('s', 0, 'integer');
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     // Trying to visit someone's inbox while not being logged in :S
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;

--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,8 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+$userDetails = null;
+RA_ValidateCookie($userDetails);
 
 $playersOnlineArray = [];
 
@@ -32,8 +33,7 @@ RenderHtmlHead();
 ?>
 <body>
 <?php
-RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions);
-RenderToolbar($user, $permissions);
+RenderHeader($userDetails);
 ?>
 <link type='text/css' rel='stylesheet' href='/rcarousel/widget/css/rcarousel.css'/>
 <link type='text/css' rel='stylesheet' href='/rcarousel/rcarousel-ra.css'/>

--- a/public/index.php
+++ b/public/index.php
@@ -3,8 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-$userDetails = null;
-RA_ValidateCookie($userDetails);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $playersOnlineArray = [];
 

--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $playersOnlineArray = [];
 

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 
 use RA\TicketState;
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $dev = requestInputSanitized('u');
 $errorCode = requestInputSanitized('e');
@@ -524,8 +524,7 @@ RenderHtmlStart();
 RenderHtmlHead("$dev's Developer Stats");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 <script>

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 
 use RA\TicketState;
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $dev = requestInputSanitized('u');
 $errorCode = requestInputSanitized('e');

--- a/public/largechat.php
+++ b/public/largechat.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 $vidID = requestInputSanitized('v', 0, 'integer');
@@ -15,8 +15,7 @@ RenderHtmlStart();
 RenderHtmlHead("RA Cinema");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <script>
   var archiveURLs = [];
   var archiveTitles = [];

--- a/public/largechat.php
+++ b/public/largechat.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 $vidID = requestInputSanitized('v', 0, 'integer');

--- a/public/latesthasheslinked.php
+++ b/public/latesthasheslinked.php
@@ -1,9 +1,14 @@
 <?php
 
+use RA\Permissions;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+    header("Location: " . getenv('APP_URL'));
+    exit;
+}
 
 $maxCount = 50;
 
@@ -23,8 +28,7 @@ RenderHtmlHead("Hash List");
 ?>
 <body>
 <?php
-RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions);
-RenderToolbar($user, $permissions);
+RenderHeader($userDetails);
 ?>
 <div id='mainpage'>
     <div id='fullcontainer'>

--- a/public/latesthasheslinked.php
+++ b/public/latesthasheslinked.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     header("Location: " . getenv('APP_URL'));
     exit;
 }

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -145,10 +145,8 @@ RenderHtmlHead($pageTitle);
         echo "<ul>";
         if (isset($gameID)) {
             echo "<li>";
-            echo "<a href='/request/leaderboard/create.php?u=$user&c=$cookie&g=$gameID'>Add New Leaderboard to " . $gameData['Title'] . "</a></br>";
+            echo "<a href='/request/leaderboard/create.php?g=$gameID'>Add New Leaderboard to " . $gameData['Title'] . "</a></br>";
             echo "<form method='post' action='/request/leaderboard/create.php'> ";
-            echo "<input type='hidden' name='u' value='$user' />";
-            echo "<input type='hidden' name='c' value='$cookie' />";
             echo "<input type='hidden' name='g' value='$gameID' />";
             echo "Duplicate leaderboard ID: ";
             echo "<input style='width: 10%;' type='number' min=1 value=1 name='l' /> ";
@@ -161,8 +159,6 @@ RenderHtmlHead($pageTitle);
         } else {
             echo "<li>Add new leaderboard<br>";
             echo "<form method='post' action='/request/leaderboard/create.php' >";
-            echo "<input type='hidden' name='u' value='$user' />";
-            echo "<input type='hidden' name='c' value='$cookie' />";
             echo "<select name='g'>";
             foreach ($gamesList as $nextGame) {
                 $nextGameID = $nextGame['ID'];

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -8,7 +8,10 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 $consoleList = getConsoleList();
 $consoleIDInput = requestInputSanitized('c', 0, 'integer');
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+    header("Location: " . getenv('APP_URL'));
+    exit;
+}
 
 getCookie($user, $cookie);
 
@@ -58,8 +61,7 @@ RenderHtmlStart();
 RenderHtmlHead($pageTitle);
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <script>
   function ReloadLBPageByConsole() {
     var ID = $('#consoleselector').val();
@@ -180,7 +182,7 @@ RenderHtmlHead($pageTitle);
     }
 
     if (isset($gameData) && isset($user) && $permissions >= Permissions::JuniorDeveloper) {
-        echo "<div id='warning'>Status: OK!</div>";
+        echo "<div id='warning'></div>";
     }
 
     if (!isset($gameData)) {

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 $consoleList = getConsoleList();
 $consoleIDInput = requestInputSanitized('c', 0, 'integer');
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     header("Location: " . getenv('APP_URL'));
     exit;
 }

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -13,8 +13,6 @@ if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer
     exit;
 }
 
-getCookie($user, $cookie);
-
 $permissions = 0;
 if (isset($user)) {
     $permissions = getUserPermissions($user);

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -6,7 +6,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $lbID = requestInputSanitized('i', null, 'integer');
 if (empty($lbID)) {

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -40,7 +40,6 @@ $consoleName = $lbData['ConsoleName'];
 $forumTopicID = $lbData['ForumTopicID'];
 
 $pageTitle = "Leaderboard: $lbTitle ($gameTitle)";
-getCookie($user, $cookie);
 
 $numLeaderboards = getLeaderboardsForGame($gameID, $allGameLBData, $user);
 $numArticleComments = getArticleComments(6, $lbID, 0, 20, $commentData);

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -6,7 +6,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $lbID = requestInputSanitized('i', null, 'integer');
 if (empty($lbID)) {
@@ -61,8 +61,7 @@ RenderHtmlStart(true);
     <?php RenderTitleTag($pageTitle); ?>
 </head>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 
 <div id="mainpage">
     <div id="leftcontainer">

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;
@@ -37,8 +37,7 @@ RenderHtmlStart();
 RenderHtmlHead("Linked Hashes");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id='fullcontainer'>
 

--- a/public/managehashes.php
+++ b/public/managehashes.php
@@ -6,7 +6,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;
@@ -42,8 +42,7 @@ RenderHtmlStart();
 RenderHtmlHead("Manage Game Hashes");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <script>
 function UpdateHashDetails(user, hash) {
     var $warning = $('#warning');

--- a/public/managehashes.php
+++ b/public/managehashes.php
@@ -6,7 +6,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;

--- a/public/popularGames.php
+++ b/public/popularGames.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 header("Location: " . getenv('APP_URL'));
 exit;
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $maxCount = 50;
 

--- a/public/popularGames.php
+++ b/public/popularGames.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../lib/bootstrap.php';
 header("Location: " . getenv('APP_URL'));
 exit;
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $maxCount = 50;
 
@@ -22,8 +22,7 @@ RenderHtmlStart();
 RenderHtmlHead("Most Popular Games");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id='fullcontainer'>
         <?php

--- a/public/recentMastery.php
+++ b/public/recentMastery.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
 // First day with Game Awards

--- a/public/recentMastery.php
+++ b/public/recentMastery.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
 // First day with Game Awards
@@ -27,8 +27,7 @@ RenderHtmlHead("Recent " . $lbUsers . " Masteries");
 ?>
 <body>
 <?php
-RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions);
-RenderToolbar($user, $permissions);
+RenderHeader($userDetails);
 ?>
 <div id='mainpage'>
     <div id='fullcontainer'>

--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -6,7 +6,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;

--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -6,13 +6,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
-    if (getAccountDetails($user, $userDetails) == false) {
-        // Immediate redirect if we cannot validate user!
-        header("Location: " . getenv('APP_URL') . "?e=accountissue");
-        exit;
-    }
-} else {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;
@@ -24,12 +18,11 @@ RenderHtmlStart();
 RenderHtmlHead("Reorder Site Awards");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="leftcontainer">
         <?php
-        echo "<div id='warning' class='rightfloat'>Status: OK!</div>";
+        echo "<div id='warning' class='rightfloat'></div>";
 
         echo "<h2 class='longheader'>Reorder Site Awards</h2>";
         echo "<span class='clickablebutton'><a href='/reorderSiteAwards.php'>Refresh Page</a></span><br>";

--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -62,8 +62,6 @@ RenderHtmlHead("Report Broken Achievement");
         <h3 class="longheader">Report Broken Achievement</h3>
 
         <form action="/request/ticket/create.php" method="post">
-            <input type="hidden" value="<?php echo $user ?>" name="u">
-            <input type="hidden" value="<?php echo $cookieRaw ?>" name="c">
             <input type="hidden" value="<?php echo $achievementID ?>" name="i">
             <table>
                 <tbody>

--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 $cookieRaw = RA_ReadCookie('RA_Cookie');
 
 $achievementID = requestInputSanitized('i', 0, 'integer');

--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 $cookieRaw = RA_ReadCookie('RA_Cookie');
 
 $achievementID = requestInputSanitized('i', 0, 'integer');
@@ -39,8 +39,7 @@ RenderHtmlStart(true);
 RenderHtmlHead("Report Broken Achievement");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <script>
   function displayCore() {
     if (['RetroArch', 'RALibRetro'].indexOf(document.getElementById('emulator').value) > -1) {

--- a/public/request/achievement/update.php
+++ b/public/request/achievement/update.php
@@ -23,7 +23,7 @@ if (ValidatePOSTChars("uafv")) {
     }
 }
 
-if (!validateFromCookie($user, $points, $permissions, Permissions::JuniorDeveloper)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     echo "FAILED! Unauthenticaed";
     exit;
 }

--- a/public/request/achievement/update.php
+++ b/public/request/achievement/update.php
@@ -23,7 +23,7 @@ if (ValidatePOSTChars("uafv")) {
     }
 }
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     echo "FAILED! Unauthenticaed";
     exit;
 }

--- a/public/request/auth/delete-account-cancel.php
+++ b/public/request/auth/delete-account-cancel.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=error");
     exit;
 }

--- a/public/request/auth/delete-account-cancel.php
+++ b/public/request/auth/delete-account-cancel.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=error");
     exit;
 }

--- a/public/request/auth/delete-account.php
+++ b/public/request/auth/delete-account.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=error");
     exit;
 }

--- a/public/request/auth/delete-account.php
+++ b/public/request/auth/delete-account.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=error");
     exit;
 }

--- a/public/request/auth/reset-api-key.php
+++ b/public/request/auth/reset-api-key.php
@@ -10,7 +10,7 @@ if (!ValidatePOSTChars("cu")) {
     exit;
 }
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     http_response_code(401);
     echo json_encode(['Success' => false]);
     exit;

--- a/public/request/auth/reset-api-key.php
+++ b/public/request/auth/reset-api-key.php
@@ -10,7 +10,7 @@ if (!ValidatePOSTChars("cu")) {
     exit;
 }
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     http_response_code(401);
     echo json_encode(['Success' => false]);
     exit;

--- a/public/request/auth/reset-connect-key.php
+++ b/public/request/auth/reset-connect-key.php
@@ -10,7 +10,7 @@ if (!ValidatePOSTChars("cu")) {
     exit;
 }
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     http_response_code(401);
     echo json_encode(['Success' => false]);
     exit;

--- a/public/request/auth/reset-connect-key.php
+++ b/public/request/auth/reset-connect-key.php
@@ -10,7 +10,7 @@ if (!ValidatePOSTChars("cu")) {
     exit;
 }
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     http_response_code(401);
     echo json_encode(['Success' => false]);
     exit;

--- a/public/request/auth/update-password.php
+++ b/public/request/auth/update-password.php
@@ -35,7 +35,7 @@ if (isset($passResetToken) && isValidPasswordResetToken($user, $passResetToken))
     if (changePassword($user, $newpass1)) {
         // Perform auto-login:
         generateCookie($user, $newCookie);
-        RA_ValidateCookie($user, $permissions, $userDetails);
+        authenticateFromCookie($user, $permissions, $userDetails);
         generateAppToken($user, $tokenInOut);
 
         header("Location: " . getenv('APP_URL') . "/resetPassword.php?e=changepassok");

--- a/public/request/auth/update-password.php
+++ b/public/request/auth/update-password.php
@@ -35,7 +35,7 @@ if (isset($passResetToken) && isValidPasswordResetToken($user, $passResetToken))
     if (changePassword($user, $newpass1)) {
         // Perform auto-login:
         generateCookie($user, $newCookie);
-        RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+        RA_ValidateCookie($user, $permissions, $userDetails);
         generateAppToken($user, $tokenInOut);
 
         header("Location: " . getenv('APP_URL') . "/resetPassword.php?e=changepassok");

--- a/public/request/comment/create.php
+++ b/public/request/comment/create.php
@@ -11,7 +11,7 @@ if (!ValidatePOSTChars("act")) {
     exit;
 }
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     echo "FAILED!";
     exit;
 }

--- a/public/request/comment/create.php
+++ b/public/request/comment/create.php
@@ -11,7 +11,7 @@ if (!ValidatePOSTChars("act")) {
     exit;
 }
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     echo "FAILED!";
     exit;
 }

--- a/public/request/comment/delete.php
+++ b/public/request/comment/delete.php
@@ -11,7 +11,7 @@ $commentID = requestInput('c', 0, 'integer');
 $response = [];
 $response['ArtID'] = $articleID;
 $response['CommentID'] = $commentID;
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     $response['Success'] = RemoveComment($articleID, $commentID, $userDetails['ID'], $permissions);
 } else {
     $response['Success'] = false;

--- a/public/request/comment/delete.php
+++ b/public/request/comment/delete.php
@@ -11,8 +11,8 @@ $commentID = requestInput('c', 0, 'integer');
 $response = [];
 $response['ArtID'] = $articleID;
 $response['CommentID'] = $commentID;
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered, $userID)) {
-    $response['Success'] = RemoveComment($articleID, $commentID, $userID, $permissions);
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+    $response['Success'] = RemoveComment($articleID, $commentID, $userDetails['ID'], $permissions);
 } else {
     $response['Success'] = false;
 }

--- a/public/request/forum-topic-comment/create.php
+++ b/public/request/forum-topic-comment/create.php
@@ -14,7 +14,7 @@ if (!ValidatePOSTChars("tp")) {
     exit;
 }
 
-if (validateFromCookie($user, $unused, $permissions, Permissions::Registered)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     if (submitTopicComment($user, $topicID, null, $commentPayload, $newCommentID)) {
         // Good!
         header("Location: " . getenv('APP_URL') . "/viewtopic.php?t=$topicID&c=$newCommentID");

--- a/public/request/forum-topic-comment/create.php
+++ b/public/request/forum-topic-comment/create.php
@@ -14,7 +14,7 @@ if (!ValidatePOSTChars("tp")) {
     exit;
 }
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     if (submitTopicComment($user, $topicID, null, $commentPayload, $newCommentID)) {
         // Good!
         header("Location: " . getenv('APP_URL') . "/viewtopic.php?t=$topicID&c=$newCommentID");

--- a/public/request/forum-topic/create.php
+++ b/public/request/forum-topic/create.php
@@ -43,7 +43,7 @@ foreach ($bannedTitles as $nextWord) {
     }
 }
 
-if (validateFromCookie($user, $points, $permissions, Permissions::Registered)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     $topicID = null;
     if (submitNewTopic($user, $forumID, $topicTitle, $topicPayload, $topicID)) {
         // Good!

--- a/public/request/forum-topic/create.php
+++ b/public/request/forum-topic/create.php
@@ -43,7 +43,7 @@ foreach ($bannedTitles as $nextWord) {
     }
 }
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     $topicID = null;
     if (submitNewTopic($user, $forumID, $topicTitle, $topicPayload, $topicID)) {
         // Good!

--- a/public/request/forum-topic/modify.php
+++ b/public/request/forum-topic/modify.php
@@ -15,7 +15,7 @@ $topicID = requestInputPost('t');
 $field = requestInputPost('f');
 $value = requestInputPost('v');
 
-if (validateFromCookie($user, $unused, $permissions, Permissions::Registered)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     if (requestModifyTopic($user, $permissions, $topicID, $field, $value)) {
         if ($field == ModifyTopicField::DeleteTopic) {
             header("location: " . getenv('APP_URL') . "/forum.php?e=delete_ok");

--- a/public/request/forum-topic/modify.php
+++ b/public/request/forum-topic/modify.php
@@ -15,7 +15,7 @@ $topicID = requestInputPost('t');
 $field = requestInputPost('f');
 $value = requestInputPost('v');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     if (requestModifyTopic($user, $permissions, $topicID, $field, $value)) {
         if ($field == ModifyTopicField::DeleteTopic) {
             header("location: " . getenv('APP_URL') . "/forum.php?e=delete_ok");

--- a/public/request/forum-topic/update.php
+++ b/public/request/forum-topic/update.php
@@ -16,7 +16,7 @@ if (!ValidatePOSTChars("uctpi")) {
     exit;
 }
 
-if (validateUser_cookie($user, $cookie, 1, $permissions)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     if (getSingleTopicComment($commentID, $commentData) == false) {
         header("location: " . getenv('APP_URL') . "/forum.php?e=unknowncomment");
         exit;

--- a/public/request/forum-topic/update.php
+++ b/public/request/forum-topic/update.php
@@ -16,7 +16,7 @@ if (!ValidatePOSTChars("uctpi")) {
     exit;
 }
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     if (getSingleTopicComment($commentID, $commentData) == false) {
         header("location: " . getenv('APP_URL') . "/forum.php?e=unknowncomment");
         exit;

--- a/public/request/friend/update.php
+++ b/public/request/friend/update.php
@@ -3,17 +3,15 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!ValidateGETChars("ucfa")) {
+if (!ValidateGETChars("fa")) {
     echo "FAILED";
     exit;
 }
 
-$user = requestInputQuery('u');
-$cookie = requestInputQuery('c');
 $friend = requestInputQuery('f');
 $action = requestInputQuery('a');
 
-if (validateUser_cookie($user, $cookie, 0) == true) {
+if (RA_ValidateCookie($user, $permissions, $userDetail)) {
     $returnVal = changeFriendStatus($user, $friend, $action);
     header("Location: " . getenv('APP_URL') . "/user/$friend?e=$returnVal");
 } else {

--- a/public/request/friend/update.php
+++ b/public/request/friend/update.php
@@ -11,7 +11,7 @@ if (!ValidateGETChars("fa")) {
 $friend = requestInputQuery('f');
 $action = requestInputQuery('a');
 
-if (RA_ValidateCookie($user, $permissions, $userDetail)) {
+if (authenticateFromCookie($user, $permissions, $userDetail)) {
     $returnVal = changeFriendStatus($user, $friend, $action);
     header("Location: " . getenv('APP_URL') . "/user/$friend?e=$returnVal");
 } else {

--- a/public/request/game/generate-forum-topic.php
+++ b/public/request/game/generate-forum-topic.php
@@ -12,7 +12,7 @@ if (!ValidateGETChars("g")) {
 
 $gameID = requestInputQuery('g');
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     header("Location: " . getenv('APP_URL') . "/forum.php?e=badcredentials");
     exit;
 }

--- a/public/request/game/generate-forum-topic.php
+++ b/public/request/game/generate-forum-topic.php
@@ -12,7 +12,7 @@ if (!ValidateGETChars("g")) {
 
 $gameID = requestInputQuery('g');
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     header("Location: " . getenv('APP_URL') . "/forum.php?e=badcredentials");
     exit;
 }

--- a/public/request/game/modify.php
+++ b/public/request/game/modify.php
@@ -16,7 +16,7 @@ $gameID = requestInputPost('g');
 $field = requestInputPost('f');
 $value = requestInputPost('v');
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     if ($field == 4) {
         $name = requestInputPost('n');
         $labels = requestInputPost('l');

--- a/public/request/game/modify.php
+++ b/public/request/game/modify.php
@@ -16,7 +16,7 @@ $gameID = requestInputPost('g');
 $field = requestInputPost('f');
 $value = requestInputPost('v');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     if ($field == 4) {
         $name = requestInputPost('n');
         $labels = requestInputPost('l');

--- a/public/request/game/recalculate-points-ratio.php
+++ b/public/request/game/recalculate-points-ratio.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../lib/bootstrap.php';
 
 $gameID = requestInputQuery('g');
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     if (recalculateTrueRatio($gameID)) {
         header("location: " . getenv('APP_URL') . "/game/$gameID?e=recalc_points_ratio_ok");
         exit;

--- a/public/request/game/recalculate-points-ratio.php
+++ b/public/request/game/recalculate-points-ratio.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../lib/bootstrap.php';
 
 $gameID = requestInputQuery('g');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     if (recalculateTrueRatio($gameID)) {
         header("location: " . getenv('APP_URL') . "/game/$gameID?e=recalc_points_ratio_ok");
         exit;

--- a/public/request/game/update-rating.php
+++ b/public/request/game/update-rating.php
@@ -12,7 +12,7 @@ $ratingValue = requestInputQuery('v', null, 'integer');
 $validRating = ($ratingType == 1 || $ratingType == 3) && ($ratingValue >= 1 && $ratingValue <= 5);
 
 if ($validRating
-      && RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
+      && RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     $success = submitGameRating($user, $ratingType, $ratingID, $ratingValue);
 } else {
     $success = false;

--- a/public/request/game/update-rating.php
+++ b/public/request/game/update-rating.php
@@ -12,7 +12,7 @@ $ratingValue = requestInputQuery('v', null, 'integer');
 $validRating = ($ratingType == 1 || $ratingType == 3) && ($ratingValue >= 1 && $ratingValue <= 5);
 
 if ($validRating
-      && RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+      && authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     $success = submitGameRating($user, $ratingType, $ratingID, $ratingValue);
 } else {
     $success = false;

--- a/public/request/game/update.php
+++ b/public/request/game/update.php
@@ -19,7 +19,7 @@ $removeGameAlt = requestInputPost('m');
 
 $newForumTopic = requestInputPost('f', null, 'integer');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     // Only allow jr. devs if they are the sole author of the set
     if ($permissions == Permissions::JuniorDeveloper) {
         if (!checkIfSoleDeveloper($user, $gameID)) {

--- a/public/request/game/update.php
+++ b/public/request/game/update.php
@@ -19,7 +19,7 @@ $removeGameAlt = requestInputPost('m');
 
 $newForumTopic = requestInputPost('f', null, 'integer');
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::JuniorDeveloper)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     // Only allow jr. devs if they are the sole author of the set
     if ($permissions == Permissions::JuniorDeveloper) {
         if (!checkIfSoleDeveloper($user, $gameID)) {

--- a/public/request/leaderboard/create.php
+++ b/public/request/leaderboard/create.php
@@ -9,7 +9,7 @@ $gameID = requestInput('g');
 $leaderboardID = requestInput('l');
 $duplicateNumber = requestInput('n');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     if (isset($leaderboardID) && isset($duplicateNumber)) {
         if (duplicateLeaderboard($gameID, $leaderboardID, $duplicateNumber, $user)) {
             header("Location: " . getenv('APP_URL') . "/leaderboardList.php?g=$gameID&e=ok");

--- a/public/request/leaderboard/create.php
+++ b/public/request/leaderboard/create.php
@@ -5,20 +5,11 @@ use RA\Permissions;
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-$user = requestInputPost('u');
-$cookie = requestInputPost('c');
-$gameID = requestInputPost('g');
-$leaderboardID = requestInputPost('l');
-$duplicateNumber = requestInputPost('n');
-if (!isset($user)) {
-    $user = requestInputQuery('u');
-    $cookie = requestInputQuery('c');
-    $gameID = requestInputQuery('g');
-    $leaderboardID = requestInputQuery('l');
-    $duplicateNumber = requestInputQuery('n');
-}
+$gameID = requestInput('g');
+$leaderboardID = requestInput('l');
+$duplicateNumber = requestInput('n');
 
-if (validateUser_cookie($user, $cookie, Permissions::JuniorDeveloper)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     if (isset($leaderboardID) && isset($duplicateNumber)) {
         if (duplicateLeaderboard($gameID, $leaderboardID, $duplicateNumber, $user)) {
             header("Location: " . getenv('APP_URL') . "/leaderboardList.php?g=$gameID&e=ok");

--- a/public/request/leaderboard/delete.php
+++ b/public/request/leaderboard/delete.php
@@ -16,7 +16,7 @@ $gameID = requestInputQuery('g');
 
 getCookie($user, $cookie);
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer) &&
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer) &&
     $source == $user &&
     validateUser_cookie($user, $cookie, 2)) {
     if (requestDeleteLB($lbID)) {

--- a/public/request/leaderboard/delete.php
+++ b/public/request/leaderboard/delete.php
@@ -14,7 +14,7 @@ $source = requestInputQuery('u');
 $lbID = requestInputQuery('i');
 $gameID = requestInputQuery('g');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer) &&
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer) &&
     $source == $user) {
     if (requestDeleteLB($lbID)) {
         header("Location: " . getenv('APP_URL') . "/leaderboardList.php?e=deleteok&g=$gameID");

--- a/public/request/leaderboard/delete.php
+++ b/public/request/leaderboard/delete.php
@@ -14,11 +14,8 @@ $source = requestInputQuery('u');
 $lbID = requestInputQuery('i');
 $gameID = requestInputQuery('g');
 
-getCookie($user, $cookie);
-
 if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer) &&
-    $source == $user &&
-    validateUser_cookie($user, $cookie, 2)) {
+    $source == $user) {
     if (requestDeleteLB($lbID)) {
         header("Location: " . getenv('APP_URL') . "/leaderboardList.php?e=deleteok&g=$gameID");
         exit;

--- a/public/request/leaderboard/remove-entry.php
+++ b/public/request/leaderboard/remove-entry.php
@@ -11,7 +11,7 @@ $targetUser = requestInput('t');
 $reason = requestInputPost('r');
 $returnUrl = getenv('APP_URL') . '/leaderboardinfo.php?i=' . $leaderboardId;
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     header('Location: ' . $returnUrl . '&success=false');
     exit;
 }

--- a/public/request/leaderboard/remove-entry.php
+++ b/public/request/leaderboard/remove-entry.php
@@ -11,7 +11,7 @@ $targetUser = requestInput('t');
 $reason = requestInputPost('r');
 $returnUrl = getenv('APP_URL') . '/leaderboardinfo.php?i=' . $leaderboardId;
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::JuniorDeveloper)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     header('Location: ' . $returnUrl . '&success=false');
     exit;
 }

--- a/public/request/leaderboard/reset.php
+++ b/public/request/leaderboard/reset.php
@@ -16,7 +16,7 @@ $lbid = requestInputQuery('i');
 
 // Double check cookie as well
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer) &&
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer) &&
     ($source == $user)) {
     requestResetLB($lbid);
 

--- a/public/request/leaderboard/reset.php
+++ b/public/request/leaderboard/reset.php
@@ -16,7 +16,7 @@ $lbid = requestInputQuery('i');
 
 // Double check cookie as well
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer) &&
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer) &&
     ($source == $user)) {
     requestResetLB($lbid);
 

--- a/public/request/leaderboard/update.php
+++ b/public/request/leaderboard/update.php
@@ -20,8 +20,6 @@ $lbFormat = requestInputPost('f');
 $lbLowerIsBetter = requestInputPost('l');
 $lbDisplayOrder = requestInputPost('o');
 
-getCookie($user, $cookie);
-
 if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)
     && $source == $user) {
     $prevData = GetLeaderboardData($lbID, $user, 1, 0, false);

--- a/public/request/leaderboard/update.php
+++ b/public/request/leaderboard/update.php
@@ -22,7 +22,7 @@ $lbDisplayOrder = requestInputPost('o');
 
 getCookie($user, $cookie);
 
-if (validateFromCookie($user, $points, $permissions, Permissions::JuniorDeveloper)
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)
     && $source == $user) {
     $prevData = GetLeaderboardData($lbID, $user, 1, 0, false);
     $prevUpdated = strtotime($prevData["LBUpdated"]);

--- a/public/request/leaderboard/update.php
+++ b/public/request/leaderboard/update.php
@@ -20,7 +20,7 @@ $lbFormat = requestInputPost('f');
 $lbLowerIsBetter = requestInputPost('l');
 $lbDisplayOrder = requestInputPost('o');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)
     && $source == $user) {
     $prevData = GetLeaderboardData($lbID, $user, 1, 0, false);
     $prevUpdated = strtotime($prevData["LBUpdated"]);

--- a/public/request/message/delete.php
+++ b/public/request/message/delete.php
@@ -10,7 +10,7 @@ if (!ValidateGETChars("m")) {
 
 $messageID = requestInputQuery('m');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (authenticateFromCookie($user, $permissions, $userDetails)) {
     if (DeleteMessage($user, $messageID)) {
         header("Location: " . getenv('APP_URL') . "/inbox.php?e=deleteok");
         exit;

--- a/public/request/message/delete.php
+++ b/public/request/message/delete.php
@@ -3,16 +3,14 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!ValidateGETChars("ucm")) {
+if (!ValidateGETChars("m")) {
     echo "FAILED";
     exit;
 }
 
-$user = requestInputQuery('u');
-$cookie = requestInputQuery('c');
 $messageID = requestInputQuery('m');
 
-if (validateUser_cookie($user, $cookie, 0) == true) {
+if (RA_ValidateCookie($user, $permissions, $userDetails)) {
     if (DeleteMessage($user, $messageID)) {
         header("Location: " . getenv('APP_URL') . "/inbox.php?e=deleteok");
         exit;

--- a/public/request/message/send.php
+++ b/public/request/message/send.php
@@ -3,19 +3,16 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!ValidatePOSTChars("ucdtm")) {
+if (!ValidatePOSTChars("dtm")) {
     echo "FAILED";
     exit;
 }
-
-$user = requestInputPost('u');
-$cookie = requestInputPost('c');
 
 $recipient = requestInputPost('d');
 $title = requestInputPost('t');
 $payload = requestInputPost('m');
 
-if (validateUser_cookie($user, $cookie, 0) == true) {
+if (RA_ValidateCookie($user, $permissions, $userDetail)) {
     if (isUserBlocking($recipient, $user)) {
         // recipient has blocked the user. just pretend the message was sent
         header("Location: " . getenv('APP_URL') . "/inbox.php?e=sentok");

--- a/public/request/message/send.php
+++ b/public/request/message/send.php
@@ -12,7 +12,7 @@ $recipient = requestInputPost('d');
 $title = requestInputPost('t');
 $payload = requestInputPost('m');
 
-if (RA_ValidateCookie($user, $permissions, $userDetail)) {
+if (authenticateFromCookie($user, $permissions, $userDetail)) {
     if (isUserBlocking($recipient, $user)) {
         // recipient has blocked the user. just pretend the message was sent
         header("Location: " . getenv('APP_URL') . "/inbox.php?e=sentok");

--- a/public/request/news/image-upload.php
+++ b/public/request/news/image-upload.php
@@ -3,13 +3,7 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
-    if (getAccountDetails($user, $userDetails) == false) {
-        // Immediate redirect if we cannot validate user!
-        header("Location: " . getenv('APP_URL') . "?e=accountissue");
-        exit;
-    }
-} else {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;

--- a/public/request/news/image-upload.php
+++ b/public/request/news/image-upload.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=notloggedin");
     exit;

--- a/public/request/news/update.php
+++ b/public/request/news/update.php
@@ -22,7 +22,7 @@ $title = str_replace("_http_", "http", $title);
 $link = str_replace("_http_", "http", $link);
 $image = str_replace("_http_", "http", $image);
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     requestModifyNews($author, $id, $title, $payload, $link, $image);
 
     echo "OK";

--- a/public/request/news/update.php
+++ b/public/request/news/update.php
@@ -22,7 +22,7 @@ $title = str_replace("_http_", "http", $title);
 $link = str_replace("_http_", "http", $link);
 $image = str_replace("_http_", "http", $image);
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     requestModifyNews($author, $id, $title, $payload, $link, $image);
 
     echo "OK";

--- a/public/request/playlist/update.php
+++ b/public/request/playlist/update.php
@@ -15,7 +15,7 @@ $title = requestInputPost('t');
 $link = requestInputPost('l');
 $id = requestInputPost('i', null, 'integer');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer) &&
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer) &&
     ($author == $user)) {
     $link = str_replace("_http_", "http", $link);
 

--- a/public/request/playlist/update.php
+++ b/public/request/playlist/update.php
@@ -15,7 +15,7 @@ $title = requestInputPost('t');
 $link = requestInputPost('l');
 $id = requestInputPost('i', null, 'integer');
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer) &&
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer) &&
     ($author == $user)) {
     $link = str_replace("_http_", "http", $link);
 

--- a/public/request/set-request/update.php
+++ b/public/request/set-request/update.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../lib/bootstrap.php';
 
 $gameID = requestInputQuery('i', null, 'integer');
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     $setRequestList = getUserRequestList($user);
     $totalRequests = getUserRequestsInformation($user, $setRequestList, $gameID);
     $totalRequests['gameRequests'] = getSetRequestCount($gameID);

--- a/public/request/set-request/update.php
+++ b/public/request/set-request/update.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../lib/bootstrap.php';
 
 $gameID = requestInputQuery('i', null, 'integer');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     $setRequestList = getUserRequestList($user);
     $totalRequests = getUserRequestsInformation($user, $setRequestList, $gameID);
     $totalRequests['gameRequests'] = getSetRequestCount($gameID);

--- a/public/request/ticket/create.php
+++ b/public/request/ticket/create.php
@@ -36,7 +36,7 @@ if (isset($_POST['note'])) {
     $note = $appendNote;
 }
 
-if (RA_ValidateCookie($user, $permissions, $userDetail)) {
+if (authenticateFromCookie($user, $permissions, $userDetail)) {
     $success = submitNewTickets($user, $achievementID, $problemType, $hardcore, $note, $msgOut);
     if ($msgOut == "FAILED!") {
         header("Location: " . getenv('APP_URL') . "/achievement/$achievementID?e=issue_failed");

--- a/public/request/ticket/create.php
+++ b/public/request/ticket/create.php
@@ -3,13 +3,11 @@
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!ValidatePOSTChars("ucipm")) {
+if (!ValidatePOSTChars("ipm")) {
     echo "FAILED";
     exit;
 }
 
-$user = requestInputPost('u');
-$cookie = requestInputPost('c');
 $achievementID = requestInputPost('i');
 $problemType = requestInputPost('p');
 $modeS = requestInputPost('m');
@@ -38,7 +36,7 @@ if (isset($_POST['note'])) {
     $note = $appendNote;
 }
 
-if (validateUser_cookie($user, $cookie, 0) == true) {
+if (RA_ValidateCookie($user, $permissions, $userDetail)) {
     $success = submitNewTickets($user, $achievementID, $problemType, $hardcore, $note, $msgOut);
     if ($msgOut == "FAILED!") {
         header("Location: " . getenv('APP_URL') . "/achievement/$achievementID?e=issue_failed");

--- a/public/request/uploadpic.php
+++ b/public/request/uploadpic.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../lib/bootstrap.php';
 
 $imageIterFilename = __DIR__ . "/../ImageIter.txt";
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=badcredentials");
     exit;

--- a/public/request/uploadpic.php
+++ b/public/request/uploadpic.php
@@ -7,13 +7,7 @@ require_once __DIR__ . '/../../lib/bootstrap.php';
 
 $imageIterFilename = __DIR__ . "/../ImageIter.txt";
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::JuniorDeveloper)) {
-    if (getAccountDetails($user, $userDetails) == false) {
-        // Immediate redirect if we cannot validate user!
-        header("Location: " . getenv('APP_URL') . "?e=accountissue");
-        exit;
-    }
-} else {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     // Immediate redirect if we cannot validate cookie!
     header("Location: " . getenv('APP_URL') . "?e=badcredentials");
     exit;

--- a/public/request/user/list-games.php
+++ b/public/request/user/list-games.php
@@ -10,7 +10,7 @@ if (!ValidatePOSTChars("u")) {
 
 $userIn = requestInputPost('u');
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails) || $user != $userIn) {
+if (!authenticateFromCookie($user, $permissions, $userDetails) || $user != $userIn) {
     echo "ERROR2";
     exit;
 }

--- a/public/request/user/list-games.php
+++ b/public/request/user/list-games.php
@@ -8,10 +8,9 @@ if (!ValidatePOSTChars("u")) {
     exit;
 }
 
-$user = requestInputPost('u');
+$userIn = requestInputPost('u');
 
-getcookie($userIn, $cookie);
-if ($user == $userIn && validateUser_cookie($user, $cookie, 0) == false) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails) || $user != $userIn) {
     echo "ERROR2";
     exit;
 }

--- a/public/request/user/list-unlocks.php
+++ b/public/request/user/list-unlocks.php
@@ -12,7 +12,7 @@ if (!ValidatePOSTChars('g')) {
 
 $gameID = requestInputPost('g', null, 'integer');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
     echo "OK:";
 
     $numUnlocks = getUserUnlocksDetailed($user, $gameID, $dataOut);

--- a/public/request/user/list-unlocks.php
+++ b/public/request/user/list-unlocks.php
@@ -12,7 +12,7 @@ if (!ValidatePOSTChars('g')) {
 
 $gameID = requestInputPost('g', null, 'integer');
 
-if (validateFromCookie($user, $points, $permissions, Permissions::Unregistered)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
     echo "OK:";
 
     $numUnlocks = getUserUnlocksDetailed($user, $gameID, $dataOut);

--- a/public/request/user/recalculate-score.php
+++ b/public/request/user/recalculate-score.php
@@ -12,7 +12,7 @@ if (!ValidatePOSTChars("u")) {
 
 $userIn = requestInputPost('u');
 
-$permOk = RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)
+$permOk = authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)
           && ($user == $userIn
               || $permissions >= Permissions::Admin);
 if (!$permOk) {

--- a/public/request/user/recalculate-score.php
+++ b/public/request/user/recalculate-score.php
@@ -12,7 +12,7 @@ if (!ValidatePOSTChars("u")) {
 
 $userIn = requestInputPost('u');
 
-$permOk = RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)
+$permOk = RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)
           && ($user == $userIn
               || $permissions >= Permissions::Admin);
 if (!$permOk) {

--- a/public/request/user/remove-avatar.php
+++ b/public/request/user/remove-avatar.php
@@ -12,8 +12,9 @@ if (!ValidatePOSTChars("u")) {
 
 $user = requestInputPost('u');
 
-if (validateUser_cookie($actingUser, null, Permissions::Registered)) {
-    if ($user !== $actingUser && !validateUser_cookie($actingUser, null, Permissions::Admin)) {
+if (RA_ValidateCookie($actingUser, $permissions, $actingUserDetails, Permissions::Registered)) {
+    if ($user !== $actingUser && $permissions < Permissions::Admin) {
+        header("Location: " . getenv('APP_URL') . "/user/" . $user);
         return false;
     }
     removeAvatar($user);

--- a/public/request/user/remove-avatar.php
+++ b/public/request/user/remove-avatar.php
@@ -12,7 +12,7 @@ if (!ValidatePOSTChars("u")) {
 
 $user = requestInputPost('u');
 
-if (RA_ValidateCookie($actingUser, $permissions, $actingUserDetails, Permissions::Registered)) {
+if (authenticateFromCookie($actingUser, $permissions, $actingUserDetails, Permissions::Registered)) {
     if ($user !== $actingUser && $permissions < Permissions::Admin) {
         header("Location: " . getenv('APP_URL') . "/user/" . $user);
         return false;

--- a/public/request/user/reset-achievements.php
+++ b/public/request/user/reset-achievements.php
@@ -12,7 +12,7 @@ $user = requestInputPost('u', null);
 $gameID = requestInputPost('g', null, 'integer');
 $achID = requestInputPost('a', null, 'integer');
 
-if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails)) {
     if (!empty($achID) && resetSingleAchievement($user, $achID)) {
         echo "OK";
     } elseif (!empty($gameID) && resetAchievements($user, $gameID) > 0) {

--- a/public/request/user/reset-achievements.php
+++ b/public/request/user/reset-achievements.php
@@ -12,7 +12,7 @@ $user = requestInputPost('u', null);
 $gameID = requestInputPost('g', null, 'integer');
 $achID = requestInputPost('a', null, 'integer');
 
-if (RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (authenticateFromCookie($user, $permissions, $userDetails)) {
     if (!empty($achID) && resetSingleAchievement($user, $achID)) {
         echo "OK";
     } elseif (!empty($gameID) && resetAchievements($user, $gameID) > 0) {

--- a/public/request/user/update-avatar.php
+++ b/public/request/user/update-avatar.php
@@ -11,7 +11,7 @@ $user = requestInput('u');
 $filename = requestInput('f');
 $rawImage = requestInput('i');
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     http_response_code(401);
     echo json_encode(['Success' => false]);
     exit;

--- a/public/request/user/update-avatar.php
+++ b/public/request/user/update-avatar.php
@@ -11,7 +11,7 @@ $user = requestInput('u');
 $filename = requestInput('f');
 $rawImage = requestInput('i');
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     http_response_code(401);
     echo json_encode(['Success' => false]);
     exit;

--- a/public/request/user/update-email.php
+++ b/public/request/user/update-email.php
@@ -19,7 +19,7 @@ if ($email !== $email2) {
     if (filter_var($email, FILTER_VALIDATE_EMAIL) == false) {
         header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=e_badnewemail");
     } else {
-        if (RA_ValidateCookie($user, $permissions, $userDetail)) {
+        if (authenticateFromCookie($user, $permissions, $userDetail)) {
             $query = "UPDATE UserAccounts SET EmailAddress='$email', Permissions=0, Updated=NOW() WHERE User='$user'";
             $dbResult = s_mysql_query($query);
             if ($dbResult) {

--- a/public/request/user/update-email.php
+++ b/public/request/user/update-email.php
@@ -5,15 +5,13 @@ use RA\ArticleType;
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!ValidatePOSTChars("efcu")) {
+if (!ValidatePOSTChars("ef")) {
     header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=e_baddata");
     exit;
 }
 
 $email = requestInputPost('e');
 $email2 = requestInputPost('f');
-$user = requestInputPost('u');
-$cookie = requestInputPost('c');
 
 if ($email !== $email2) {
     header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=e_notmatch");
@@ -21,7 +19,7 @@ if ($email !== $email2) {
     if (filter_var($email, FILTER_VALIDATE_EMAIL) == false) {
         header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=e_badnewemail");
     } else {
-        if (validateUser_cookie($user, $cookie, 0) == true) {
+        if (RA_ValidateCookie($user, $permissions, $userDetail)) {
             $query = "UPDATE UserAccounts SET EmailAddress='$email', Permissions=0, Updated=NOW() WHERE User='$user'";
             $dbResult = s_mysql_query($query);
             if ($dbResult) {

--- a/public/request/user/update-email.php
+++ b/public/request/user/update-email.php
@@ -25,10 +25,8 @@ if ($email !== $email2) {
             if ($dbResult) {
                 sendValidationEmail($user, $email);
 
-                if (getAccountDetails($user, $userData)) {
-                    addArticleComment('Server', ArticleType::UserModeration, $userData['ID'],
-                        $user . ' changed their email address');
-                }
+                addArticleComment('Server', ArticleType::UserModeration, $userDetail['ID'],
+                    $user . ' changed their email address');
 
                 header("Location: " . getenv('APP_URL') . "/controlpanel.php?e=e_changeok");
             } else {

--- a/public/request/user/update-motto.php
+++ b/public/request/user/update-motto.php
@@ -1,20 +1,20 @@
 <?php
 
+use RA\Permissions;
+
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!ValidatePOSTChars("ucm")) {
+if (!ValidatePOSTChars("m")) {
     header("Location: " . getenv('APP_URL') . "?e=invalidparams");
     exit;
 }
 
-$user = requestInputPost('u');
-$cookie = requestInputPost('c');
 $newMotto = requestInputPost('m');
 
 sanitize_sql_inputs($user, $cookie, $newMotto);
 
-if (validateUser_cookie($user, $cookie, 1)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     $query = "
 			UPDATE UserAccounts
 			SET Motto='$newMotto', Updated=NOW()

--- a/public/request/user/update-motto.php
+++ b/public/request/user/update-motto.php
@@ -14,7 +14,7 @@ $newMotto = requestInputPost('m');
 
 sanitize_sql_inputs($user, $cookie, $newMotto);
 
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     $query = "
 			UPDATE UserAccounts
 			SET Motto='$newMotto', Updated=NOW()

--- a/public/request/user/update-notification.php
+++ b/public/request/user/update-notification.php
@@ -9,10 +9,9 @@ if (!ValidatePOSTChars("pu")) {
 }
 
 $prefs = requestInputPost('p');
-$user = requestInputPost('u');
-getcookie($userIn, $cookie);
+$userIn = requestInputPost('u');
 
-if ($user == $userIn && validateUser_cookie($user, $cookie, 0) == false) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails) || $user != $userIn) {
     echo "ERROR2";
     exit;
 }

--- a/public/request/user/update-notification.php
+++ b/public/request/user/update-notification.php
@@ -11,7 +11,7 @@ if (!ValidatePOSTChars("pu")) {
 $prefs = requestInputPost('p');
 $userIn = requestInputPost('u');
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails) || $user != $userIn) {
+if (!authenticateFromCookie($user, $permissions, $userDetails) || $user != $userIn) {
     echo "ERROR2";
     exit;
 }

--- a/public/request/user/update-site-award.php
+++ b/public/request/user/update-site-award.php
@@ -20,7 +20,7 @@ if (ValidatePOSTChars("tdev")) {
     }
 }
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     echo "FAILED!";
     exit;
 }

--- a/public/request/user/update-site-award.php
+++ b/public/request/user/update-site-award.php
@@ -20,7 +20,7 @@ if (ValidatePOSTChars("tdev")) {
     }
 }
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     echo "FAILED!";
     exit;
 }

--- a/public/request/user/update-subscription.php
+++ b/public/request/user/update-subscription.php
@@ -21,12 +21,12 @@ $requiredPermissions = match ($subjectType) {
     default => Permissions::Registered,
 };
 
-if (!validateFromCookie($user, $unused, $permissions, $requiredPermissions)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, $requiredPermissions)) {
     header("Location: " . getenv("APP_URL") . $returnUrl . "&e=badcredentials");
     exit;
 }
 
-$userID = getUserIDFromUser($user);
+$userID = $userDetails['ID'];
 if ($userID == 0) {
     header("Location: " . getenv("APP_URL") . $returnUrl . "&e=badcredentials");
     exit;

--- a/public/request/user/update-subscription.php
+++ b/public/request/user/update-subscription.php
@@ -21,7 +21,7 @@ $requiredPermissions = match ($subjectType) {
     default => Permissions::Registered,
 };
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, $requiredPermissions)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, $requiredPermissions)) {
     header("Location: " . getenv("APP_URL") . $returnUrl . "&e=badcredentials");
     exit;
 }

--- a/public/request/user/update-wall.php
+++ b/public/request/user/update-wall.php
@@ -1,23 +1,22 @@
 <?php
 
 use RA\ArticleType;
+use RA\Permissions;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
 
-if (!ValidatePOSTChars("uct")) {
+if (!ValidatePOSTChars("t")) {
     header("Location: " . getenv('APP_URL') . "?e=invalidparams");
     exit;
 }
 
-$user = requestInputPost('u');
-$cookie = requestInputPost('c');
 $prefType = requestInputPost('t');
 $value = requestInputPost('v', 0, 'integer');
 
 global $db;
 $changeErrorCode = null;
-if (validateUser_cookie($user, $cookie, 1)) {
+if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     if ($prefType == 'wall') {
         $query = "UPDATE UserAccounts
                 SET UserWallActive=$value, Updated=NOW()

--- a/public/request/user/update-wall.php
+++ b/public/request/user/update-wall.php
@@ -16,7 +16,7 @@ $value = requestInputPost('v', 0, 'integer');
 
 global $db;
 $changeErrorCode = null;
-if (RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     if ($prefType == 'wall') {
         $query = "UPDATE UserAccounts
                 SET UserWallActive=$value, Updated=NOW()

--- a/public/request/user/update.php
+++ b/public/request/user/update.php
@@ -15,7 +15,7 @@ if (ValidatePOSTorGETChars("tpv")) {
     exit;
 }
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Admin)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Admin)) {
     echo "FAILED!";
     exit;
 }

--- a/public/request/user/update.php
+++ b/public/request/user/update.php
@@ -15,7 +15,7 @@ if (ValidatePOSTorGETChars("tpv")) {
     exit;
 }
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Admin)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Admin)) {
     echo "FAILED!";
     exit;
 }

--- a/public/resetPassword.php
+++ b/public/resetPassword.php
@@ -18,8 +18,7 @@ RenderHtmlStart();
 RenderHtmlHead("Password Reset");
 ?>
 <body>
-<?php RenderTitleBar(null, 0, 0, 0, $errorCode); ?>
-<?php RenderToolbar(null, 0); ?>
+<?php RenderHeader(null); ?>
 
 <div id="mainpage">
     <div id="fullcontainer">

--- a/public/rss.php
+++ b/public/rss.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 RenderHtmlStart();

--- a/public/rss.php
+++ b/public/rss.php
@@ -3,15 +3,14 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $errorCode = requestInputSanitized('e');
 RenderHtmlStart();
 RenderHtmlHead("RSS Feeds");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <?php
     $yOffs = 0;

--- a/public/searchresults.php
+++ b/public/searchresults.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $searchQuery = requestInputSanitized('s', null);
 $offset = requestInputSanitized('o', 0, 'integer');

--- a/public/searchresults.php
+++ b/public/searchresults.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $searchQuery = requestInputSanitized('s', null);
 $offset = requestInputSanitized('o', 0, 'integer');
@@ -20,8 +20,7 @@ RenderHtmlStart();
 RenderHtmlHead("Search");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <?php

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     header("Location: " . getenv('APP_URL'));
     exit;
 }

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     header("Location: " . getenv('APP_URL'));
     exit;
 }
@@ -54,8 +54,7 @@ RenderHtmlHead("Set Requests");
 ?>
 <body>
 <?php
-RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions);
-RenderToolbar($user, $permissions);
+RenderHeader($userDetails);
 ?>
 <div id='mainpage'>
     <div id='fullcontainer'>

--- a/public/setRequestors.php
+++ b/public/setRequestors.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;

--- a/public/setRequestors.php
+++ b/public/setRequestors.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Registered)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;
@@ -34,8 +34,7 @@ RenderHtmlStart();
 RenderHtmlHead("Set Requests");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id='fullcontainer'>
         <h2>List of Set Requests</h2>

--- a/public/submitnews.php
+++ b/public/submitnews.php
@@ -12,7 +12,7 @@ $newsArticleID = requestInputSanitized('n', 0, 'integer');
 $newsCount = getLatestNewsHeaders(0, 999, $newsData);
 $activeNewsArticle = null;
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;
@@ -22,8 +22,7 @@ RenderHtmlStart();
 RenderHtmlHead("Manage News");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <script>
   function onSubmitNews() {
     var title = $('#NewsTitle').val();

--- a/public/submitnews.php
+++ b/public/submitnews.php
@@ -12,7 +12,7 @@ $newsArticleID = requestInputSanitized('n', 0, 'integer');
 $newsCount = getLatestNewsHeaders(0, 999, $newsData);
 $activeNewsArticle = null;
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;

--- a/public/submitvidurl.php
+++ b/public/submitvidurl.php
@@ -11,7 +11,7 @@ $newsArticleID = requestInputSanitized('n', null, 'integer');
 
 $newsCount = getLatestNewsHeaders(0, 999, $newsData);
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;

--- a/public/submitvidurl.php
+++ b/public/submitvidurl.php
@@ -11,7 +11,7 @@ $newsArticleID = requestInputSanitized('n', null, 'integer');
 
 $newsCount = getLatestNewsHeaders(0, 999, $newsData);
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, Permissions::Developer)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails, Permissions::Developer)) {
     // Immediate redirect if we cannot validate user!	//TBD: pass args?
     header("Location: " . getenv('APP_URL'));
     exit;
@@ -21,8 +21,7 @@ RenderHtmlStart();
 RenderHtmlHead("Manage News");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <?php

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -9,7 +9,7 @@ use RA\TicketType;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions)) {
+if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
     header("Location: " . getenv('APP_URL'));
     exit;
 }
@@ -190,8 +190,7 @@ RenderHtmlStart();
 RenderHtmlHead($pageTitle);
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <?php RenderErrorCodeWarning($errorCode); ?>
     <div id="fullcontainer">

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -9,7 +9,7 @@ use RA\TicketType;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-if (!RA_ValidateCookie($user, $permissions, $userDetails)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     header("Location: " . getenv('APP_URL'));
     exit;
 }

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -105,8 +105,6 @@ sanitize_outputs(
 
 $errorCode = requestInputSanitized('e');
 
-getCookie($user, $cookie);
-
 $pageTitle = "$userPage";
 
 $userPagePoints = getScore($userPage);

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -18,7 +18,7 @@ if (ctype_alnum($userPage) == false) {
     exit;
 }
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $maxNumGamesToFetch = requestInputSanitized('g', 5, 'integer');
 

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -18,7 +18,7 @@ if (ctype_alnum($userPage) == false) {
     exit;
 }
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $maxNumGamesToFetch = requestInputSanitized('g', 5, 'integer');
 
@@ -153,8 +153,7 @@ RenderHtmlStart(true);
     <?php RenderTitleTag($pageTitle); ?>
 </head>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 <script>
   google.load('visualization', '1.0', { 'packages': ['corechart'] });

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -307,26 +307,26 @@ RenderHtmlStart(true);
 
             if ($userMassData['Friendship'] == 1) {
                 if ($userMassData['FriendReciprocation'] == 1) {
-                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$userPage&amp;a=0'>Remove friend</a></span>";
+                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?f=$userPage&amp;a=0'>Remove friend</a></span>";
                 } elseif ($userMassData['FriendReciprocation'] == 0) {
                     // They haven't accepted yet
-                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$userPage&amp;a=0'>Cancel friend request</a></span>";
+                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?f=$userPage&amp;a=0'>Cancel friend request</a></span>";
                 } elseif ($userMassData['FriendReciprocation'] == -1) {
                     // They blocked us
-                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$userPage&amp;a=0'>Remove friend</a></span>";
+                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?f=$userPage&amp;a=0'>Remove friend</a></span>";
                 }
             } elseif ($userMassData['Friendship'] == 0) {
                 if ($userMassData['FriendReciprocation'] == 1) {
-                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$userPage&amp;a=1'>Confirm friend request</a></span>";
+                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?f=$userPage&amp;a=1'>Confirm friend request</a></span>";
                 } elseif ($userMassData['FriendReciprocation'] == 0) {
-                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$userPage&amp;a=1'>Add friend</a></span>";
+                    echo "<span class='clickablebutton'><a href='/request/friend/update.php?f=$userPage&amp;a=1'>Add friend</a></span>";
                 }
             }
 
             if ($userMassData['Friendship'] !== -1) {
-                echo "<span class='clickablebutton'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$userPage&amp;a=-1'>Block user</a></span>";
+                echo "<span class='clickablebutton'><a href='/request/friend/update.php?f=$userPage&amp;a=-1'>Block user</a></span>";
             } else {
-                echo "<span class='clickablebutton'><a href='/request/friend/update.php?u=$user&amp;c=$cookie&amp;f=$userPage&amp;a=0'>Unblock user</a></span>";
+                echo "<span class='clickablebutton'><a href='/request/friend/update.php?f=$userPage&amp;a=0'>Unblock user</a></span>";
             }
 
             echo "<span class='clickablebutton'><a href='/createmessage.php?t=$userPage'>Send Private Message</a></span>";

--- a/public/userList.php
+++ b/public/userList.php
@@ -11,7 +11,7 @@ $maxCount = 25;
 
 $perms = requestInputQuery('p', 1, 'integer');
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $showUntracked = false;
 if (isset($user) && $permissions >= Permissions::Admin) {

--- a/public/userList.php
+++ b/public/userList.php
@@ -11,7 +11,7 @@ $maxCount = 25;
 
 $perms = requestInputQuery('p', 1, 'integer');
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $showUntracked = false;
 if (isset($user) && $permissions >= Permissions::Admin) {
@@ -35,8 +35,7 @@ RenderHtmlStart();
 RenderHtmlHead("Users");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="fullcontainer">
         <?php

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions);
+RA_ValidateCookie($user, $permissions, $userDetails);
 
 $requestedForumID = requestInputSanitized('f', null, 'integer');
 $offset = requestInputSanitized('o', 0, 'integer');
@@ -68,8 +68,7 @@ RenderHtmlStart();
 RenderHtmlHead("View forum: $thisForumTitle");
 ?>
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 <div id="mainpage">
     <div id="leftcontainer">
         <div id="forums">

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -5,7 +5,7 @@ use RA\Permissions;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 
 $requestedForumID = requestInputSanitized('f', null, 'integer');
 $offset = requestInputSanitized('o', 0, 'integer');

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -8,7 +8,8 @@ use RA\SubscriptionSubjectType;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $permissions, null, $userID);
+RA_ValidateCookie($user, $permissions, $userDetails);
+$userID = $userDetails['ID'] ?? 0;
 
 // Fetch topic ID
 $requestedTopicID = requestInputSanitized('t', 0, 'integer');
@@ -78,8 +79,7 @@ RenderHtmlStart();
 </head>
 
 <body>
-<?php RenderTitleBar($user, $points, $truePoints, $unreadMessageCount, $errorCode, $permissions); ?>
-<?php RenderToolbar($user, $permissions); ?>
+<?php RenderHeader($userDetails); ?>
 
 <div id="mainpage">
     <?php RenderErrorCodeWarning($errorCode); ?>

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -380,7 +380,7 @@ RenderHtmlStart();
             echo "</tbody></table></div>";
         } else {
             echo "</tbody></table></div>";
-            RenderLoginComponent($user, $points, $errorCode, true);
+            echo "<br/>You must log in before you can join this conversation.<br/>";
         }
         ?>
         <br>

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -8,7 +8,7 @@ use RA\SubscriptionSubjectType;
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
-RA_ValidateCookie($user, $permissions, $userDetails);
+authenticateFromCookie($user, $permissions, $userDetails);
 $userID = $userDetails['ID'] ?? 0;
 
 // Fetch topic ID


### PR DESCRIPTION
Adds a banner on all pages of the website, and an email when the action is first taken. This should make it obvious to a user when their account is marked for deletion, whether intentional, accidental, or malicious.

![image](https://user-images.githubusercontent.com/32680403/167747283-3a426fd3-8e9e-44f9-94c3-82418291c163.png)

> Hello TestUser1,
> Your account has been marked for deletion.
> If you do not cancel this request before 2022-05-25, you will no longer be able to access your account.
> Thanks!
> -- Your friends at RetroAchievements.org

With these changes (and the logging added in #914), we should be able to re-enable the cron job that actually does the deleting.

We should probably wait a few days after publishing these changes so users can see the banner (which will report a time in the past) in case they aren't aware there's a pending deletion request and want to cancel it.