### PR TITLE
Allow Multiple Similar Games To Be Removed at Once

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -759,7 +759,7 @@ RenderHtmlStart(true);
                         }
 
                         echo "</select>";
-                        echo "<input type='submit' style='float: right;' value='Remove' size='37'>";
+                        echo "<input type='submit' style='float: right;' value='Remove' size='37' onclick='return confirm(\"Are you sure you want to remove the selected relations?\")'>";
                         echo "</form>";
                         echo "</td></tr>";
                     }

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -744,7 +744,6 @@ RenderHtmlStart(true);
 
                         echo "To remove:";
                         echo "<select name='m[]' style='resize:auto' multiple>";
-                        echo "<option value='0' selected>-</option>";
 
                         foreach ($relatedGames as $gameAlt) {
                             $gameAltID = $gameAlt['gameIDAlt'];

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -743,7 +743,7 @@ RenderHtmlStart(true);
                         echo "<input type='hidden' name='i' value='$gameID'>";
 
                         echo "To remove:";
-                        echo "<select name='m'>";
+                        echo "<select name='m[]' style='resize:auto' multiple>";
                         echo "<option value='0' selected>-</option>";
 
                         foreach ($relatedGames as $gameAlt) {

--- a/public/request/game/update.php
+++ b/public/request/game/update.php
@@ -35,7 +35,13 @@ if (RA_ReadCookieCredentials($user, $points, $truePoints, $unreadMessageCount, $
     } else {
         if (isset($newGameAlt) || isset($removeGameAlt)) {
             // new alt provided/alt to be removed
-            requestModifyGameAlt($gameID, $newGameAlt, $removeGameAlt);
+            if (is_array($removeGameAlt)) {
+                foreach ($removeGameAlt as &$gameAlt) {
+                    requestModifyGameAlt($gameID, $newGameAlt, $gameAlt);
+                }
+            } else {
+                requestModifyGameAlt($gameID, $newGameAlt, $removeGameAlt);
+            }
             header("location: " . getenv('APP_URL') . "/game/$gameID?e=ok");
             exit;
         } else {


### PR DESCRIPTION
Updates the Remove Similar Games dropdown to be multiselect and resizable. Allowing for easy removal of multiple entries at once.
![](https://user-images.githubusercontent.com/16140035/168451804-39185e13-5f12-4c54-946f-3b6e4c6867cc.gif)