### PR TITLE
Fix broken dev page when first achievement is 0 pointer

### DIFF
--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -351,7 +351,7 @@ foreach ($userArchInfo as $achievement) {
         $firstAchievement = $achievement;
         $lastAchievement = $achievement;
     } else {
-        if ($hardestAchievement['Points'] && $achievement['Points'] && ($hardestAchievement['TrueRatio'] / $hardestAchievement['Points']) < ($achievement['TrueRatio'] / $achievement['Points'])) {
+        if ($hardestAchievement['Points'] == 0 || $hardestAchievement['Points'] && $achievement['Points'] && ($hardestAchievement['TrueRatio'] / $hardestAchievement['Points']) < ($achievement['TrueRatio'] / $achievement['Points'])) {
             $hardestAchievement = $achievement;
         }
         if ($easiestAchievement['TrueRatio'] == 0 || ($achievement['TrueRatio'] > 0 && (($easiestAchievement['TrueRatio'] / $easiestAchievement['Points']) > ($achievement['TrueRatio'] / $achievement['Points'])))) {


### PR DESCRIPTION
Fixes cases of developer stat page breaking at the hardest achievement which prevents it from displaying the rest of the info when the developers first achievement (in core) is a 0 pointer.