### PR TITLE
return DateModified in API_GetGameList query

### DIFF
--- a/public/API/API_GetGameList.php
+++ b/public/API/API_GetGameList.php
@@ -16,6 +16,9 @@
  *    int        NumAchievements   number of core achievements for the game
  *    int        NumLeaderboards   number of leaderboards for the game
  *    int        Points            total number of points the game's achievements are worth
+ *    datetime   DateModified      when the last modification was made
+ *                                 NOTE: this only tracks modifications to the achievements of the game,
+ *                                       but is consistent with the data reported in the site game list.
  *    array      Hashes
  *     string     [value]          RetroAchievements hash associated to the game
  */
@@ -47,6 +50,7 @@ foreach ($dataOut as &$entry) {
         'NumAchievements' => $entry['NumAchievements'] ?? 0,
         'NumLeaderboards' => $entry['NumLBs'] ?? 0,
         'Points' => $entry['MaxPointsAvailable'] ?? 0,
+        'DateModified' => $entry['DateModified'],
     ];
     settype($responseEntry['NumAchievements'], 'integer');
     settype($responseEntry['NumLeaderboards'], 'integer');


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/645777658319208448/979739377007726613

Note: this value is actually `max(Achievements.DateModified)` and doesn't truly reflect the last modification to the Game record itself. However, it is consistent with the date shown on the games list as it's using the same query to build the data set.

Value will be null if the game has no achievements.

```
{"Title":"Donkey Kong","ID":"13354","ConsoleID":"51","ConsoleName":"Atari 7800","ImageIcon":"\/Images\/024839.png",
"NumAchievements":23,"NumLeaderboards":3,"Points":348,"DateModified":"2020-04-16 15:25:27"}
```
```
{"Title":"Impossible Mission","ID":"14264","ConsoleID":"51","ConsoleName":"Atari 7800","ImageIcon":"\/Images\/000001.png",
"NumAchievements":0,"NumLeaderboards":0,"Points":0,"DateModified":null}
```