### PR TITLE
Cleanup namespaces

### DIFF
--- a/lib/database/achievement-creator.php
+++ b/lib/database/achievement-creator.php
@@ -15,7 +15,7 @@ function getUserAchievementsPerConsole(string $user): array
               LEFT JOIN GameData AS gd ON gd.ID = a.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               WHERE a.Author = '$user'
-              AND a.Flags = " . AchievementType::OFFICIAL_CORE . "
+              AND a.Flags = " . AchievementType::OfficialCore . "
               AND gd.ConsoleID NOT IN (100, 101)
               GROUP BY ConsoleName
               ORDER BY AchievementCount DESC, ConsoleName";
@@ -42,7 +42,7 @@ function getUserSetsPerConsole(string $user): array
               LEFT JOIN GameData AS gd ON gd.ID = a.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               WHERE a.Author = '$user'
-              AND a.Flags = " . AchievementType::OFFICIAL_CORE . "
+              AND a.Flags = " . AchievementType::OfficialCore . "
               AND gd.ConsoleID NOT IN (100, 101)
               GROUP BY ConsoleName
               ORDER BY SetCount DESC, ConsoleName";
@@ -70,7 +70,7 @@ function getUserAchievementInformation(string $user): array
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               LEFT JOIN UserAccounts AS ua ON ua.User = '$user'
               WHERE Author LIKE '$user'
-              AND a.Flags = " . AchievementType::OFFICIAL_CORE . "
+              AND a.Flags = " . AchievementType::OfficialCore . "
               AND gd.ConsoleID NOT IN (100, 101)
               ORDER BY a.DateCreated";
 
@@ -99,7 +99,7 @@ function getOwnAchievementsObtained(string $user): bool|array|null
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               WHERE a.Author LIKE '$user'
               AND aw.User LIKE '$user'
-              AND a.Flags = " . AchievementType::OFFICIAL_CORE . "
+              AND a.Flags = " . AchievementType::OfficialCore . "
               AND gd.ConsoleID NOT IN (100, 101)";
 
     $dbResult = s_mysql_query($query);
@@ -128,7 +128,7 @@ function getObtainersOfSpecificUser(string $user): array
               LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
               WHERE a.Author LIKE '$user'
               AND aw.User NOT LIKE '$user'
-              AND a.Flags = " . AchievementType::OFFICIAL_CORE . "
+              AND a.Flags = " . AchievementType::OfficialCore . "
               AND gd.ConsoleID NOT IN (100, 101)
               AND Untracked = 0
               GROUP BY aw.User
@@ -155,7 +155,7 @@ function checkIfSoleDeveloper(string $user, int $gameID): bool
         SELECT distinct(Author) AS Author FROM Achievements AS ach
         LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
         WHERE ach.GameID = $gameID
-        AND ach.Flags = " . AchievementType::OFFICIAL_CORE . "";
+        AND ach.Flags = " . AchievementType::OfficialCore . "";
 
     $dbResult = s_mysql_query($query);
 

--- a/lib/database/achievement-points.php
+++ b/lib/database/achievement-points.php
@@ -17,7 +17,7 @@ function recalculateTrueRatio($gameID): bool
     $dbResult = s_mysql_query($query);
 
     if ($dbResult !== false) {
-        $numHardcoreWinners = getTotalUniquePlayers($gameID, null, true, AchievementType::OFFICIAL_CORE);
+        $numHardcoreWinners = getTotalUniquePlayers($gameID, null, true, AchievementType::OfficialCore);
 
         if ($numHardcoreWinners == 0) { // force all unachieved to be 1
             $numHardcoreWinners = 1;

--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -237,7 +237,7 @@ function UploadNewAchievement(
         return false;
     }
 
-    if ($type === AchievementType::OFFICIAL_CORE && !isValidConsoleId(getGameData($gameID)['ConsoleID'])) {
+    if ($type === AchievementType::OfficialCore && !isValidConsoleId(getGameData($gameID)['ConsoleID'])) {
         $errorOut = "You cannot promote achievements for a game from an unsupported console (console ID: " . getGameData($gameID)['ConsoleID'] . ").";
         return false;
     }
@@ -302,7 +302,7 @@ function UploadNewAchievement(
             $changingLogic = ($data['MemAddr'] != $mem);
 
             $userPermissions = getUserPermissions($author);
-            if ($type === AchievementType::OFFICIAL_CORE || $changingAchSet) { // If modifying core or changing achievement state
+            if ($type === AchievementType::OfficialCore || $changingAchSet) { // If modifying core or changing achievement state
                 // changing ach set detected; user is $author, permissions is $userPermissions, target set is $type
                 if ($userPermissions < Permissions::Developer) {
                     // Must be developer to modify core!
@@ -311,7 +311,7 @@ function UploadNewAchievement(
                 }
             }
 
-            if ($type === AchievementType::UNOFFICIAL) { // If modifying unofficial
+            if ($type === AchievementType::Unofficial) { // If modifying unofficial
                 // Only allow jr. devs to modify unofficial if they are the author
                 if ($userPermissions == Permissions::JuniorDeveloper && $data['Author'] != $author) {
                     $errorOut = "You must be a developer to perform this action! Please drop a message in the forums to apply.";
@@ -343,7 +343,7 @@ function UploadNewAchievement(
                 postActivity($author, ActivityType::EditAchievement, $idInOut);
 
                 if ($changingAchSet) {
-                    if ($type === AchievementType::OFFICIAL_CORE) {
+                    if ($type === AchievementType::OfficialCore) {
                         addArticleComment(
                             "Server",
                             ArticleType::Achievement,
@@ -351,7 +351,7 @@ function UploadNewAchievement(
                             "$author promoted this achievement to the Core set.",
                             $author
                         );
-                    } elseif ($type === AchievementType::UNOFFICIAL) {
+                    } elseif ($type === AchievementType::Unofficial) {
                         addArticleComment(
                             "Server",
                             ArticleType::Achievement,

--- a/lib/database/forum.php
+++ b/lib/database/forum.php
@@ -1,7 +1,7 @@
 <?php
 
 use RA\ArticleType;
-use RA\ModifyTopicField;
+use RA\ForumTopicAction;
 use RA\Permissions;
 use RA\SubscriptionSubjectType;
 
@@ -529,7 +529,7 @@ function requestModifyTopic($user, $permissions, $topicID, $field, $value): bool
     $result = false;
 
     switch ($field) {
-        case ModifyTopicField::ModifyTitle:
+        case ForumTopicAction::ModifyTitle:
             if (($permissions >= Permissions::Admin) || ($user == $topicData['Author'])) {
                 global $db;
                 $query = "  UPDATE ForumTopic AS ft
@@ -546,7 +546,7 @@ function requestModifyTopic($user, $permissions, $topicID, $field, $value): bool
                 $result = false;
             }
             break;
-        case ModifyTopicField::DeleteTopic:
+        case ForumTopicAction::DeleteTopic:
             if ($permissions >= Permissions::Admin) {
                 $query = "  DELETE FROM ForumTopic
                             WHERE ID=$topicID";
@@ -563,7 +563,7 @@ function requestModifyTopic($user, $permissions, $topicID, $field, $value): bool
                 $result = false;
             }
             break;
-        case ModifyTopicField::RequiredPermissions:
+        case ForumTopicAction::ChangeRequiredPermissions:
             if ($permissions >= Permissions::Admin) {
                 $query = "  UPDATE ForumTopic AS ft
                             SET RequiredPermissions='$value'

--- a/lib/database/message.php
+++ b/lib/database/message.php
@@ -1,6 +1,6 @@
 <?php
 
-use RA\UserPref;
+use RA\UserPreference;
 
 function CreateNewMessage($author, $destUser, $messageTitle, $messagePayloadIn): bool
 {
@@ -21,7 +21,7 @@ function CreateNewMessage($author, $destUser, $messageTitle, $messagePayloadIn):
             $websitePrefs = $userDetails['websitePrefs'];
             $destEmail = $userDetails['EmailAddress'];
 
-            if (BitSet($websitePrefs, UserPref::EmailOn_PrivateMessage)) {
+            if (BitSet($websitePrefs, UserPreference::EmailOn_PrivateMessage)) {
                 sendPrivateMessageEmail($destUser, $destEmail, $messageTitle, $messagePayload, $author);
             }
         }

--- a/lib/database/player-achievement.php
+++ b/lib/database/player-achievement.php
@@ -68,7 +68,7 @@ function unlockAchievement(string $user, $achIDToAward, $isHardcore): array
         return $retVal;
     }
 
-    if ((int) $achData['Flags'] === AchievementType::UNOFFICIAL) { // do not award Unofficial achievements
+    if ((int) $achData['Flags'] === AchievementType::Unofficial) { // do not award Unofficial achievements
         $retVal['Error'] = "Unofficial achievements cannot be unlocked";
         return $retVal;
     }

--- a/lib/database/player-game.php
+++ b/lib/database/player-game.php
@@ -11,7 +11,7 @@ function testFullyCompletedGame($gameID, $user, $isHardcore, $postMastery): arra
 
     $query = "SELECT COUNT(ach.ID) AS NumAch, COUNT(aw.AchievementID) AS NumAwarded FROM Achievements AS ach
               LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID AND aw.User = '$user' AND aw.HardcoreMode = $isHardcore 
-              WHERE ach.GameID = $gameID AND ach.Flags = " . AchievementType::OFFICIAL_CORE;
+              WHERE ach.GameID = $gameID AND ach.Flags = " . AchievementType::OfficialCore;
 
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {
@@ -49,7 +49,7 @@ function getGameRankAndScore($gameID, $requestedBy): ?array
         LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
         LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
         WHERE ( !ua.Untracked OR ua.User = '$requestedBy') 
-          AND ach.Flags = " . AchievementType::OFFICIAL_CORE . " 
+          AND ach.Flags = " . AchievementType::OfficialCore . " 
           AND gd.ID = $gameID
         GROUP BY aw.User
         ORDER BY TotalScore DESC, LastAward ASC
@@ -244,7 +244,7 @@ function getUsersCompletedGamesAndMax($user): array
 
     sanitize_sql_inputs($user);
 
-    $requiredFlags = AchievementType::OFFICIAL_CORE;
+    $requiredFlags = AchievementType::OfficialCore;
     $minAchievementsForCompletion = 5;
 
     $query = "SELECT gd.ID AS GameID, c.Name AS ConsoleName, c.ID AS ConsoleID, gd.ImageIcon, gd.Title, COUNT(ach.GameID) AS NumAwarded, inner1.MaxPossible, (COUNT(ach.GameID)/inner1.MaxPossible) AS PctWon, aw.HardcoreMode
@@ -358,7 +358,7 @@ function getGameTopAchievers(int $gameID, ?string $requestedBy): array
                 LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
                 LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
                 WHERE ( !ua.Untracked OR ua.User = '$requestedBy' ) 
-                  AND ach.Flags = " . AchievementType::OFFICIAL_CORE . " 
+                  AND ach.Flags = " . AchievementType::OfficialCore . " 
                   AND gd.ID = $gameID
                 GROUP BY aw.User
                 ORDER BY TotalScore DESC, LastAward";

--- a/lib/database/rating.php
+++ b/lib/database/rating.php
@@ -1,6 +1,6 @@
 <?php
 
-use RA\ObjectType;
+use RA\RatingType;
 
 function getGameRating($gameID, $user = null): array
 {
@@ -14,8 +14,8 @@ function getGameRating($gameID, $user = null): array
     ];
 
     $retVal = [];
-    $retVal[ObjectType::Game] = $newRatings();
-    $retVal[ObjectType::Achievement] = $newRatings();
+    $retVal[RatingType::Game] = $newRatings();
+    $retVal[RatingType::Achievement] = $newRatings();
 
     sanitize_sql_inputs($gameID);
     settype($gameID, 'integer');

--- a/lib/database/subscription.php
+++ b/lib/database/subscription.php
@@ -1,11 +1,11 @@
 <?php
 
+use RA\SubscriptionSubjectType;
+
 /**
  * Update a subscription, i.e, either subscribe or unsubscribe a given user to or from a subject.
  *
  * @param bool $state whether the user is to be subscribed (true) or unsubscribed (false)
- * @return bool whether the update was successful
- * @throws Exception
  */
 function updateSubscription(string $subjectType, int $subjectID, int $userID, bool $state): bool
 {
@@ -21,7 +21,6 @@ function updateSubscription(string $subjectType, int $subjectID, int $userID, bo
 
     $dbResult = s_mysql_query($query);
     if (!$dbResult) {
-        log_sql_fail();
         return false;
     }
 
@@ -33,10 +32,8 @@ function updateSubscription(string $subjectType, int $subjectID, int $userID, bo
  *
  * @param string|null $implicitSubscriptionQry optional sql query capable of identifying the existence of an implicit
  *                                         subscription to the subject (must be usable inside an EXISTS clause)
- * @return bool whether the user is subscribed to the subject
- * @throws Exception
  */
-function isUserSubscribedTo(string $subjectType, int $subjectID, int $userID, string $implicitSubscriptionQry = null): bool
+function isUserSubscribedTo(string $subjectType, int $subjectID, int $userID, ?string $implicitSubscriptionQry = null): bool
 {
     if (!$userID) {
         return false;
@@ -56,6 +53,8 @@ function isUserSubscribedTo(string $subjectType, int $subjectID, int $userID, st
     } else {
         // either there's an explicit subscription...
         // ...or there's an implicit subscription without an explicit unsubscription
+        // optional sql query capable of identifying the existence of an implicit
+        // subscription to the subject (must be usable inside an EXISTS clause)
         $query = "
             SELECT 1
             FROM Subscription
@@ -88,7 +87,6 @@ function isUserSubscribedTo(string $subjectType, int $subjectID, int $userID, st
 
     $dbResult = s_mysql_query($query);
     if (!$dbResult) {
-        log_sql_fail();
         return false;
     }
 
@@ -103,8 +101,6 @@ function isUserSubscribedTo(string $subjectType, int $subjectID, int $userID, st
  * @param ?int $reqWebsitePrefs optional required website preferences for a user to be considered a subscriber
  * @param ?string $implicitSubscriptionQry sql query that returns the set of users that are implicitly subscribed to
  *                                        the subject (must return whole UserAccounts rows)
- * @return array of subscribers, each as an assoc array with "User" and "Email Address" keys
- * @throws Exception
  */
 function getSubscribersOf(string $subjectType, int $subjectID, int $reqWebsitePrefs = null, string $implicitSubscriptionQry = null): array
 {
@@ -155,7 +151,6 @@ function getSubscribersOf(string $subjectType, int $subjectID, int $reqWebsitePr
     $dbResult = s_mysql_query($query);
 
     if (!$dbResult) {
-        log_sql_fail();
         return [];
     }
 
@@ -184,4 +179,119 @@ function mergeSubscribers(array $subscribersA, array $subscribersB): array
     }
 
     return $subscribersA;
+}
+
+function getSubscribersOfGameWall($gameID): array
+{
+    return getSubscribersOfArticle(1, $gameID, (1 << 1));
+}
+
+function getSubscribersOfAchievement($achievementID, $gameID, $achievementAuthor): array
+{
+    // users directly subscribed to the achievement
+    $achievementSubs = getSubscribersOfArticle(2, $achievementID, (1 << 1), $achievementAuthor);
+
+    // devs subscribed to the achievement through the game
+    $gameAchievementsSubs = getSubscribersOf(SubscriptionSubjectType::GameAchievements, $gameID, (1 << 0) /* (1 << 1) */);
+
+    return mergeSubscribers($achievementSubs, $gameAchievementsSubs);
+}
+
+function getSubscribersOfUserWall($userID, $userName): array
+{
+    return getSubscribersOfArticle(3, $userID, (1 << 2), $userName);
+}
+
+function getSubscribersOfFeedActivity($activityID, $author): array
+{
+    return getSubscribersOfArticle(5, $activityID, (1 << 0), $author, true);
+}
+
+function getSubscribersOfTicket($ticketID, $ticketAuthor, $gameID): array
+{
+    // users directly subscribed to the ticket
+    $ticketSubs = getSubscribersOfArticle(7, $ticketID, (1 << 1), $ticketAuthor, true);
+
+    // devs subscribed to the ticket through the game
+    $gameTicketsSubs = getSubscribersOf(SubscriptionSubjectType::GameTickets, $gameID, (1 << 0) /* (1 << 1) */);
+
+    return mergeSubscribers($ticketSubs, $gameTicketsSubs);
+}
+
+function getSubscribersOfArticle(
+    $articleType,
+    $articleID,
+    $reqWebsitePrefs,
+    $subjectAuthor = null,
+    $noExplicitSubscriptions = false
+): array {
+    $websitePrefsFilter = ($noExplicitSubscriptions !== true
+        ? "" : "AND (_ua.websitePrefs & $reqWebsitePrefs) != 0");
+
+    $authorQry = ($subjectAuthor === null ? "" : "
+        UNION
+        SELECT _ua.*
+        FROM UserAccounts as _ua
+        WHERE _ua.User = '$subjectAuthor'
+              $websitePrefsFilter
+    ");
+
+    $qry = "
+        SELECT DISTINCT _ua.*
+        FROM Comment AS _c
+        INNER JOIN UserAccounts as _ua ON _ua.ID = _c.UserID
+        WHERE _c.ArticleType = $articleType
+              AND _c.ArticleID = $articleID
+              $websitePrefsFilter
+        $authorQry
+    ";
+
+    if ($noExplicitSubscriptions) {
+        $dbResult = s_mysql_query($qry);
+        if (!$dbResult) {
+            log_sql_fail();
+            return [];
+        }
+
+        return mysqli_fetch_all($dbResult, MYSQLI_ASSOC);
+    }
+
+    $subjectType = SubscriptionSubjectType::fromArticleType($articleType);
+    if ($subjectType === null) {
+        return [];
+    }
+
+    return getSubscribersOf(
+        $subjectType,
+        $articleID,
+        (1 << 0),  // code suggests the value of $reqWebsitePrefs should be used, but the feature is disabled for now
+        $qry
+    );
+}
+
+function isUserSubscribedToArticleComments($articleType, $articleID, $userID): bool
+{
+    sanitize_sql_inputs($articleType, $articleID, $userID);
+
+    $subjectType = SubscriptionSubjectType::fromArticleType($articleType);
+
+    if ($subjectType === null) {
+        return false;
+    }
+
+    return isUserSubscribedTo(
+        $subjectType,
+        $articleID,
+        $userID,
+        "
+            SELECT DISTINCT ua.*
+            FROM
+                Comment AS c
+                LEFT JOIN UserAccounts AS ua ON ua.ID = c.UserID
+            WHERE
+                c.ArticleType = $articleType
+                AND c.ArticleID = $articleID
+                AND c.UserID = $userID
+        "
+    );
 }

--- a/lib/database/ticket.php
+++ b/lib/database/ticket.php
@@ -3,8 +3,8 @@
 use RA\AchievementType;
 use RA\ActivityType;
 use RA\ArticleType;
-use RA\Models\TicketModel;
 use RA\SubscriptionSubjectType;
+use RA\Ticket;
 use RA\TicketFilters;
 use RA\TicketState;
 
@@ -369,7 +369,7 @@ function updateTicket($user, $ticketID, $ticketVal, $reason = null): bool
     switch ($ticketVal) {
         case TicketState::Closed:
             if ($reason == TicketState::REASON_DEMOTED) {
-                updateAchievementFlags($achID, AchievementType::UNOFFICIAL);
+                updateAchievementFlags($achID, AchievementType::Unofficial);
             }
             $comment = "Ticket closed by $user. Reason: \"$reason\".";
             postActivity($user, ActivityType::ClosedTicket, $achID);
@@ -984,7 +984,7 @@ function getNumberOfTicketsClosedForOthers(string $user): array
     return $retVal;
 }
 
-function GetTicketModel(int $ticketId): ?TicketModel
+function GetTicketModel(int $ticketId): ?Ticket
 {
     $ticketDbResult = getTicket($ticketId);
 
@@ -992,5 +992,5 @@ function GetTicketModel(int $ticketId): ?TicketModel
         return null;
     }
 
-    return new TicketModel($ticketDbResult);
+    return new Ticket($ticketDbResult);
 }

--- a/lib/database/user-auth.php
+++ b/lib/database/user-auth.php
@@ -102,7 +102,7 @@ function authenticateFromPassword(&$user, $pass): bool
 
     sanitize_sql_inputs($user);
 
-    $query = "SELECT User, Password, SaltedPass, fbUser, cookie, Permissions FROM UserAccounts WHERE User='$user'";
+    $query = "SELECT User, Password, SaltedPass, cookie, Permissions FROM UserAccounts WHERE User='$user'";
     $result = s_mysql_query($query);
     if (!$result) {
         return false;

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -31,7 +31,7 @@ function getAccountDetails(&$user, &$dataOut): bool
 
     $query = "SELECT ID, User, EmailAddress, Permissions, RAPoints, TrueRAPoints,
                      cookie, websitePrefs, UnreadMessageCount, Motto, UserWallActive,
-                     fbUser, fbPrefs, APIKey, ContribCount, ContribYield,
+                     APIKey, ContribCount, ContribYield,
                      RichPresenceMsg, LastGameID, LastLogin, LastActivityID,
                      Created, DeleteRequested, Untracked
                 FROM UserAccounts

--- a/lib/render/site-award.php
+++ b/lib/render/site-award.php
@@ -5,9 +5,9 @@ use RA\AwardType;
 
 function SeparateAwards($userAwards): array
 {
-    $gameAwards = array_values(array_filter($userAwards, fn ($award) => $award['AwardType'] == AwardType::MASTERY && $award['ConsoleName'] != 'Events'));
+    $gameAwards = array_values(array_filter($userAwards, fn ($award) => $award['AwardType'] == AwardType::Mastery && $award['ConsoleName'] != 'Events'));
 
-    $eventAwards = array_filter($userAwards, fn ($award) => $award['AwardType'] == AwardType::MASTERY && $award['ConsoleName'] == 'Events');
+    $eventAwards = array_filter($userAwards, fn ($award) => $award['AwardType'] == AwardType::Mastery && $award['ConsoleName'] == 'Events');
 
     $devEventsPrefix = "[Dev Events - ";
     $devEventsHub = "[Central - Developer Events]";
@@ -24,7 +24,7 @@ function SeparateAwards($userAwards): array
 
     $eventAwards = array_values(array_filter($eventAwards, fn ($award) => !in_array($award, $devEventAwards)));
 
-    $siteAwards = array_values(array_filter($userAwards, fn ($award) => ($award['AwardType'] != AwardType::MASTERY && AwardType::isActive((int) $award['AwardType'])) ||
+    $siteAwards = array_values(array_filter($userAwards, fn ($award) => ($award['AwardType'] != AwardType::Mastery && AwardType::isActive((int) $award['AwardType'])) ||
         in_array($award, $devEventAwards)
     ));
 
@@ -113,7 +113,7 @@ function RenderAward($award, $imageSize, $clickable = true): void
     $awardButGameIsIncomplete = (isset($award['Incomplete']) && $award['Incomplete'] == 1);
     $imgclass = 'badgeimg siteawards';
 
-    if ($awardType == AwardType::MASTERY) {
+    if ($awardType == AwardType::Mastery) {
         if ($awardDataExtra == '1') {
             $tooltip = "MASTERED $awardGameTitle ($awardGameConsole)";
             $imgclass = 'goldimage';
@@ -125,12 +125,12 @@ function RenderAward($award, $imageSize, $clickable = true): void
         }
         $imagepath = $awardGameImage;
         $linkdest = "/game/$awardData";
-    } elseif ($awardType == AwardType::ACHIEVEMENT_UNLOCKS_YIELD) {
+    } elseif ($awardType == AwardType::AchievementUnlocksYield) {
         // Developed a number of earned achievements
         $tooltip = "Awarded for being a hard-working developer and producing achievements that have been earned over " . AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . " times!";
         $imagepath = "/Images/_Trophy" . AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$awardData] . ".png";
         $linkdest = ''; // TBD: referrals page?
-    } elseif ($awardType == AwardType::ACHIEVEMENT_POINTS_YIELD) {
+    } elseif ($awardType == AwardType::AchievementPointsYield) {
         // Yielded an amount of points earned by players
         $tooltip = "Awarded for producing many valuable achievements, providing over " . AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$awardData] . " points to the community!";
         if ($awardData == 0) {
@@ -147,11 +147,11 @@ function RenderAward($award, $imageSize, $clickable = true): void
             $imagepath = "/Images/trophy-gold.png";
         }
         $linkdest = ''; // TBD: referrals page?
-    } elseif ($awardType == AwardType::REFERRALS) {
+    } elseif ($awardType == AwardType::Referrals) {
         $tooltip = "Referred $awardData members";
         $imagepath = "/Badge/00083.png";
         $linkdest = ''; // TBD: referrals page?
-    } elseif ($awardType == AwardType::PATREON_SUPPORTER) {
+    } elseif ($awardType == AwardType::PatreonSupporter) {
         $tooltip = 'Awarded for being a Patreon supporter! Thank-you so much for your support!';
         $imagepath = '/Images/PatreonBadge.png';
         $linkdest = 'https://www.patreon.com/retroachievements';

--- a/lib/render/ticket.php
+++ b/lib/render/ticket.php
@@ -1,10 +1,10 @@
 <?php
 
-use RA\Models\TicketModel;
+use RA\Ticket;
 use RA\TicketState;
 use RA\TicketType;
 
-function GetTicketAndTooltipDiv(TicketModel $ticket): string
+function GetTicketAndTooltipDiv(Ticket $ticket): string
 {
     $tooltipIconSize = 64;
     $ticketStateClass = match ($ticket->ticketState) {

--- a/public/API/API_GetGameRating.php
+++ b/public/API/API_GetGameRating.php
@@ -12,7 +12,7 @@
  *   int         AchievementsNumVotes  number of votes contributing to the game's achievements rating (deprecated)
  */
 
-use RA\ObjectType;
+use RA\RatingType;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../lib/bootstrap.php';
@@ -23,20 +23,20 @@ $gameID = requestInputQuery('i');
 
 $gameRating = getGameRating($gameID);
 
-if (!isset($gameRating[ObjectType::Game])) {
-    $gameRating[ObjectType::Game]['AverageRating'] = 0.0;
-    $gameRating[ObjectType::Game]['RatingCount'] = 0;
+if (!isset($gameRating[RatingType::Game])) {
+    $gameRating[RatingType::Game]['AverageRating'] = 0.0;
+    $gameRating[RatingType::Game]['RatingCount'] = 0;
 }
-if (!isset($gameRating[ObjectType::Achievement])) {
-    $gameRating[ObjectType::Achievement]['AverageRating'] = 0.0;
-    $gameRating[ObjectType::Achievement]['RatingCount'] = 0;
+if (!isset($gameRating[RatingType::Achievement])) {
+    $gameRating[RatingType::Achievement]['AverageRating'] = 0.0;
+    $gameRating[RatingType::Achievement]['RatingCount'] = 0;
 }
 
 $gameData = [];
 $gameData['GameID'] = $gameID;
-$gameData['Ratings']['Game'] = $gameRating[ObjectType::Game]['AverageRating'];
-$gameData['Ratings']['Achievements'] = $gameRating[ObjectType::Achievement]['AverageRating'];
-$gameData['Ratings']['GameNumVotes'] = $gameRating[ObjectType::Game]['RatingCount'];
-$gameData['Ratings']['AchievementsNumVotes'] = $gameRating[ObjectType::Achievement]['RatingCount'];
+$gameData['Ratings']['Game'] = $gameRating[RatingType::Game]['AverageRating'];
+$gameData['Ratings']['Achievements'] = $gameRating[RatingType::Achievement]['AverageRating'];
+$gameData['Ratings']['GameNumVotes'] = $gameRating[RatingType::Game]['RatingCount'];
+$gameData['Ratings']['AchievementsNumVotes'] = $gameRating[RatingType::Achievement]['RatingCount'];
 
 echo json_encode($gameData, JSON_THROW_ON_ERROR);

--- a/public/API/API_GetTicketData.php
+++ b/public/API/API_GetTicketData.php
@@ -227,7 +227,7 @@ if ($gameIDGiven > 0) {
         $ticketData['GameTitle'] = $gameTitle;
         $ticketData['ConsoleName'] = $consoleName;
         $ticketData['OpenTickets'] = countOpenTickets(
-            $gamesTableFlag == AchievementType::UNOFFICIAL,
+            $gamesTableFlag == AchievementType::Unofficial,
             $defaultTicketFilter,
             null,
             null,

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -3,7 +3,7 @@
 use RA\AchievementType;
 use RA\ArticleType;
 use RA\Permissions;
-use RA\Shortcode\Shortcode;
+use RA\Shortcode;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
@@ -109,7 +109,7 @@ RenderHtmlStart(true);
       }
 
       function updateAchievementTypeFlag(typeFlag) {
-        if (!confirm(`Are you sure you want to ${(typeFlag === <?= AchievementType::OFFICIAL_CORE ?> ? 'promote' : 'demote')} these achievements?`)) {
+        if (!confirm(`Are you sure you want to ${(typeFlag === <?= AchievementType::OfficialCore ?> ? 'promote' : 'demote')} these achievements?`)) {
           return;
         }
 
@@ -192,7 +192,7 @@ RenderHtmlStart(true);
 
         echo "<p class='smalldata'>";
         echo "<small>";
-        if ($achFlags === AchievementType::UNOFFICIAL) {
+        if ($achFlags === AchievementType::Unofficial) {
             echo "<b>Unofficial Achievement</b><br>";
         }
         echo "Created by " . GetUserAndTooltipDiv($author, false) . " on: $niceDateCreated<br>Last modified: $niceDateModified<br>";
@@ -268,11 +268,11 @@ RenderHtmlStart(true);
                 <?php
                 echo "<div style='clear:both;'></div>";
 
-                if ($achFlags === AchievementType::OFFICIAL_CORE) {
-                    echo "<li>State: Official&nbsp;<button type='button' onclick='updateAchievementTypeFlag(" . AchievementType::UNOFFICIAL . ")'>Demote To Unofficial</button></li>";
+                if ($achFlags === AchievementType::OfficialCore) {
+                    echo "<li>State: Official&nbsp;<button type='button' onclick='updateAchievementTypeFlag(" . AchievementType::Unofficial . ")'>Demote To Unofficial</button></li>";
                 }
-                if ($achFlags === AchievementType::UNOFFICIAL) {
-                    echo "<li>State: Unofficial&nbsp;<button type='button' onclick='updateAchievementTypeFlag(" . AchievementType::OFFICIAL_CORE . ")'>Promote To Official</button></li>";
+                if ($achFlags === AchievementType::Unofficial) {
+                    echo "<li>State: Unofficial&nbsp;<button type='button' onclick='updateAchievementTypeFlag(" . AchievementType::OfficialCore . ")'>Promote To Official</button></li>";
                 }
             }
 

--- a/public/achievementList.php
+++ b/public/achievementList.php
@@ -65,15 +65,15 @@ RenderHtmlHead("Achievement List" . $requestedConsole);
         echo "<div class='d-flex flex-wrap justify-content-between'>";
         echo "<div>";
 
-        echo $params !== AchievementType::OFFICIAL_CORE ? "<a href='/achievementList.php?s=$sortBy&p=" . AchievementType::OFFICIAL_CORE . "$dev_param'>" : "<b>";
+        echo $params !== AchievementType::OfficialCore ? "<a href='/achievementList.php?s=$sortBy&p=" . AchievementType::OfficialCore . "$dev_param'>" : "<b>";
         echo "Achievements in Core Sets";
-        echo $params !== AchievementType::OFFICIAL_CORE ? "</a>" : "</b>";
+        echo $params !== AchievementType::OfficialCore ? "</a>" : "</b>";
         echo "<br>";
 
         if ($user !== null) {
-            echo $params !== AchievementType::UNOFFICIAL ? "<a href='/achievementList.php?s=$sortBy&p=" . AchievementType::UNOFFICIAL . "$dev_param'>" : "<b>";
+            echo $params !== AchievementType::Unofficial ? "<a href='/achievementList.php?s=$sortBy&p=" . AchievementType::Unofficial . "$dev_param'>" : "<b>";
             echo "Achievements in Unofficial Sets";
-            echo $params !== AchievementType::UNOFFICIAL ? "</a>" : "</b>";
+            echo $params !== AchievementType::Unofficial ? "</a>" : "</b>";
             echo "<br>";
 
             echo $params !== 1 ? "<a href='/achievementList.php?s=$sortBy&p=1$dev_param'>" : "<b>";

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -65,7 +65,7 @@ RenderHtmlHead("Manage Achievements");
       }
     }
 
-    if (!confirm(`Are you sure you want to ${(typeFlag === <?= AchievementType::OFFICIAL_CORE ?> ? 'promote' : 'demote')} these achievements?`)) {
+    if (!confirm(`Are you sure you want to ${(typeFlag === <?= AchievementType::OfficialCore ?> ? 'promote' : 'demote')} these achievements?`)) {
       return;
     }
 
@@ -104,10 +104,10 @@ RenderHtmlHead("Manage Achievements");
         echo "<div id='fullcontainer'>";
     }
 
-    if ($flag === AchievementType::UNOFFICIAL) {
+    if ($flag === AchievementType::Unofficial) {
         echo "<h2 class='longheader'>Unofficial Achievement Inspector</h2>";
     }
-    if ($flag === AchievementType::OFFICIAL_CORE) {
+    if ($flag === AchievementType::OfficialCore) {
         echo "<h2 class='longheader'>Core Achievement Inspector</h2>";
     }
 
@@ -123,21 +123,21 @@ RenderHtmlHead("Manage Achievements");
         }
 
         if ($fullModifyOK) {
-            echo "</br></br>You can " . ($flag === AchievementType::UNOFFICIAL ? "promote" : "demote") . " multiple achievements at the same time from this page by checking " .
-                "the desired checkboxes in the far left column and clicking the '" . ($flag === AchievementType::UNOFFICIAL ? "Promote" : "Demote") . " Selected' " .
+            echo "</br></br>You can " . ($flag === AchievementType::Unofficial ? "promote" : "demote") . " multiple achievements at the same time from this page by checking " .
+                "the desired checkboxes in the far left column and clicking the '" . ($flag === AchievementType::Unofficial ? "Promote" : "Demote") . " Selected' " .
                 "link. You can check or uncheck all checkboxes by clicking the 'All' or 'None' links in the first row of the table.</p><br>";
         }
 
         echo "<div style='text-align:center'><p><a href='/achievementinspector.php?g=$gameID&f=$flag'>Refresh Page</a> | ";
-        if ($flag === AchievementType::UNOFFICIAL) {
+        if ($flag === AchievementType::Unofficial) {
             if ($fullModifyOK) {
-                echo "<a class='pointer' onclick='updateAchievementsTypeFlag(" . AchievementType::OFFICIAL_CORE . ")'>Promote Selected</a> | ";
+                echo "<a class='pointer' onclick='updateAchievementsTypeFlag(" . AchievementType::OfficialCore . ")'>Promote Selected</a> | ";
             }
             echo "<a href='/achievementinspector.php?g=$gameID'>Core Achievement Inspector</a> | ";
         }
-        if ($flag === AchievementType::OFFICIAL_CORE) {
+        if ($flag === AchievementType::OfficialCore) {
             if ($fullModifyOK) {
-                echo "<a class='pointer'onclick='updateAchievementsTypeFlag(" . AchievementType::UNOFFICIAL . ")'>Demote Selected</a> | ";
+                echo "<a class='pointer'onclick='updateAchievementsTypeFlag(" . AchievementType::Unofficial . ")'>Demote Selected</a> | ";
             }
             echo "<a href='/achievementinspector.php?g=$gameID&f=5'>Unofficial Achievement Inspector</a> | ";
         }

--- a/public/createmessage.php
+++ b/public/createmessage.php
@@ -1,7 +1,7 @@
 <?php
 
 use RA\Permissions;
-use RA\Shortcode\Shortcode;
+use RA\Shortcode;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -310,7 +310,7 @@ switch ($requestType) {
             progressFmt: ' ',
             points: requestInput('z', 0, 'integer'),
             mem: requestInput('m'),
-            type: requestInput('f', AchievementType::UNOFFICIAL, 'integer'),
+            type: requestInput('f', AchievementType::Unofficial, 'integer'),
             idInOut: $achievementID,
             badge: requestInput('b'),
             errorOut: $errorOut

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -2,11 +2,11 @@
 
 use RA\ArticleType;
 use RA\ImageType;
-use RA\ObjectType;
 use RA\Permissions;
+use RA\RatingType;
 use RA\SubscriptionSubjectType;
 use RA\TicketFilters;
-use RA\UserPref;
+use RA\UserPreference;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
@@ -78,7 +78,7 @@ $v = requestInputSanitized('v', 0, 'integer');
 if ($v != 1 && $isFullyFeaturedGame) {
     foreach ($gameHubs as $hub) {
         if ($hub['Title'] == '[Theme - Mature]') {
-            if (BitSet($userDetails['websitePrefs'], UserPref::SiteMsgOff_MatureContent)) {
+            if (BitSet($userDetails['websitePrefs'], UserPreference::SiteMsgOff_MatureContent)) {
                 break;
             }
 
@@ -285,10 +285,10 @@ RenderHtmlStart(true);
       }
     </script>
     <script>
-      var lastKnownAchRating = <?= $gameRating[ObjectType::Achievement]['AverageRating'] ?>;
-      var lastKnownGameRating = <?= $gameRating[ObjectType::Game]['AverageRating'] ?>;
-      var lastKnownAchRatingCount = <?= $gameRating[ObjectType::Achievement]['RatingCount'] ?>;
-      var lastKnownGameRatingCount = <?= $gameRating[ObjectType::Game]['RatingCount'] ?>;
+      var lastKnownAchRating = <?= $gameRating[RatingType::Achievement]['AverageRating'] ?>;
+      var lastKnownGameRating = <?= $gameRating[RatingType::Game]['AverageRating'] ?>;
+      var lastKnownAchRatingCount = <?= $gameRating[RatingType::Achievement]['RatingCount'] ?>;
+      var lastKnownGameRatingCount = <?= $gameRating[RatingType::Game]['RatingCount'] ?>;
 
       function SetLitStars(container, numStars) {
         $(container + ' a').removeClass('starlit');
@@ -351,7 +351,7 @@ RenderHtmlStart(true);
           url: '/request/game/update-rating.php?i=' + gameID + '&t=' + ratingObjectType + '&v=' + value,
           dataType: 'json',
           success: function (results) {
-            if (ratingObjectType == <?= ObjectType::Game ?>) {
+            if (ratingObjectType == <?= RatingType::Game ?>) {
               $('.ratinggamelabel').html('Rating: ...');
             } else {
               $('.ratingachlabel').html('Rating: ...');
@@ -368,7 +368,7 @@ RenderHtmlStart(true);
 
                 UpdateRatings();
 
-                if (ratingObjectType == <?= ObjectType::Game ?>) {
+                if (ratingObjectType == <?= RatingType::Game ?>) {
                   index = ratinggametooltip.indexOf("Your rating: ") + 13;
                   index2 = ratinggametooltip.indexOf("</td>", index);
                   ratinggametooltip = ratinggametooltip.substring(0, index) + value + "<br><i>Distribution may have changed</i>" + ratinggametooltip.substring(index2);
@@ -933,7 +933,7 @@ RenderHtmlStart(true);
                         echo "</div></div>";
                     }
 
-                    $renderRatingControl('Game Rating', 'ratinggame', 'ratinggamelabel', $gameRating[ObjectType::Game]);
+                    $renderRatingControl('Game Rating', 'ratinggame', 'ratinggamelabel', $gameRating[RatingType::Game]);
                 }
 
                 // Only show set request option for logged in users, games without achievements, and core achievement page
@@ -951,7 +951,7 @@ RenderHtmlStart(true);
 
                 /*
                 if( $user !== NULL && $numAchievements > 0 ) {
-                    $renderRatingControl('Achievements Rating', 'ratingach', 'ratingachlabel', $gameRating[ObjectType::Achievement]);
+                    $renderRatingControl('Achievements Rating', 'ratingach', 'ratingachlabel', $gameRating[RatingType::Achievement]);
                 }
                 */
 

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -1,6 +1,6 @@
 <?php
 
-use RA\Shortcode\Shortcode;
+use RA\Shortcode;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';

--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -62,13 +62,13 @@ RenderHtmlHead("Reorder Site Awards");
                     $awardGameConsole
                 );
 
-                if ($awardType == AwardType::ACHIEVEMENT_UNLOCKS_YIELD) {
+                if ($awardType == AwardType::AchievementUnlocksYield) {
                     $awardTitle = "Achievements Earned by Others";
-                } elseif ($awardType == AwardType::ACHIEVEMENT_POINTS_YIELD) {
+                } elseif ($awardType == AwardType::AchievementPointsYield) {
                     $awardTitle = "Achievement Points Earned by Others";
-                } elseif ($awardType == AwardType::REFERRALS) {
+                } elseif ($awardType == AwardType::Referrals) {
                     $awardTitle = "Referral Award";
-                } elseif ($awardType == AwardType::PATREON_SUPPORTER) {
+                } elseif ($awardType == AwardType::PatreonSupporter) {
                     $awardTitle = "Patreon Supporter";
                 }
 

--- a/public/request/achievement/update.php
+++ b/public/request/achievement/update.php
@@ -76,16 +76,16 @@ switch ($field) {
         }
 
         $achievement = GetAchievementMetadataJSON((int) (is_array($achievementId) ? $achievementId[0] : $achievementId));
-        if ((int) $value === AchievementType::OFFICIAL_CORE && !isValidConsoleId($achievement['ConsoleID'])) {
+        if ((int) $value === AchievementType::OfficialCore && !isValidConsoleId($achievement['ConsoleID'])) {
             echo json_encode(['success' => false, 'error' => 'Invalid Console']);
             exit;
         }
 
         if (updateAchievementFlags($achievementId, (int) $value)) {
-            if ($value == AchievementType::OFFICIAL_CORE) {
+            if ($value == AchievementType::OfficialCore) {
                 $commentText = 'promoted this achievement to the Core set';
             }
-            if ($value == AchievementType::UNOFFICIAL) {
+            if ($value == AchievementType::Unofficial) {
                 $commentText = 'demoted this achievement to Unofficial';
             }
             addArticleComment("Server", ArticleType::Achievement, $achievementId, "\"$user\" $commentText.", $user);

--- a/public/request/auth/login.php
+++ b/public/request/auth/login.php
@@ -8,7 +8,6 @@ require_once __DIR__ . '/../../../lib/bootstrap.php';
 $user = $_POST["u"];
 $pass = $_POST["p"];
 $redir = $_POST["r"];
-$fbUser = "";
 $cookie = "";
 
 if (authenticateFromPassword($user, $pass)) {

--- a/public/request/forum-topic/modify.php
+++ b/public/request/forum-topic/modify.php
@@ -1,6 +1,6 @@
 <?php
 
-use RA\ModifyTopicField;
+use RA\ForumTopicAction;
 use RA\Permissions;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
@@ -17,7 +17,7 @@ $value = requestInputPost('v');
 
 if (authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     if (requestModifyTopic($user, $permissions, $topicID, $field, $value)) {
-        if ($field == ModifyTopicField::DeleteTopic) {
+        if ($field == ForumTopicAction::DeleteTopic) {
             header("location: " . getenv('APP_URL') . "/forum.php?e=delete_ok");
         } else {
             header("location: " . getenv('APP_URL') . "/viewtopic.php?t=$topicID&e=modify_ok");

--- a/public/request/game/rating.php
+++ b/public/request/game/rating.php
@@ -1,6 +1,6 @@
 <?php
 
-use RA\ObjectType;
+use RA\RatingType;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 require_once __DIR__ . '/../../../lib/bootstrap.php';
@@ -11,9 +11,9 @@ $gameRating = getGameRating($gameID);
 
 $gameData = [];
 $gameData['GameID'] = $gameID;
-$gameData['Ratings']['Game'] = $gameRating[ObjectType::Game]['AverageRating'];
-$gameData['Ratings']['Achievements'] = $gameRating[ObjectType::Achievement]['AverageRating'];
-$gameData['Ratings']['GameNumVotes'] = $gameRating[ObjectType::Game]['RatingCount'];
-$gameData['Ratings']['AchievementsNumVotes'] = $gameRating[ObjectType::Achievement]['RatingCount'];
+$gameData['Ratings']['Game'] = $gameRating[RatingType::Game]['AverageRating'];
+$gameData['Ratings']['Achievements'] = $gameRating[RatingType::Achievement]['AverageRating'];
+$gameData['Ratings']['GameNumVotes'] = $gameRating[RatingType::Game]['RatingCount'];
+$gameData['Ratings']['AchievementsNumVotes'] = $gameRating[RatingType::Achievement]['RatingCount'];
 
 echo json_encode($gameData, JSON_THROW_ON_ERROR);

--- a/public/request/user/update-site-award.php
+++ b/public/request/user/update-site-award.php
@@ -31,7 +31,7 @@ if (!authenticateFromCookie($user, $permissions, $userDetails)) {
 /**
  * change display order for all entries if it's a "stacking" award type
  */
-if (in_array($awardType, [AwardType::ACHIEVEMENT_UNLOCKS_YIELD, AwardType::ACHIEVEMENT_POINTS_YIELD])) {
+if (in_array($awardType, [AwardType::AchievementUnlocksYield, AwardType::AchievementPointsYield])) {
     $query = "UPDATE SiteAwards SET DisplayOrder = $value WHERE User = '$user' " .
         "AND AwardType = $awardType " .
         "AND AwardDataExtra = $awardDataExtra";

--- a/public/test/shortcode.php
+++ b/public/test/shortcode.php
@@ -1,6 +1,6 @@
 <?php
 
-use RA\Shortcode\Shortcode;
+use RA\Shortcode;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../lib/bootstrap.php';

--- a/public/test/tooltip.php
+++ b/public/test/tooltip.php
@@ -1,6 +1,6 @@
 <?php
 
-use RA\Models\TicketModel;
+use RA\Ticket;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../lib/bootstrap.php';
@@ -57,7 +57,7 @@ function tooltip_row(string $text): void
         'ResolvedAt' => null,
         'ResolvedBy' => null,
     ];
-    $ticket = new TicketModel($ticketData);
+    $ticket = new Ticket($ticketData);
     echo "</td>\n        <td>";
     echo GetTicketAndTooltipDiv($ticket);
 

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -179,7 +179,7 @@ if ($ticketID == 0) {
             $gameIDGiven,
             $achievementIDGiven,
             $ticketFilters,
-            $gamesTableFlag === AchievementType::UNOFFICIAL
+            $gamesTableFlag === AchievementType::Unofficial
         );
     }
 }
@@ -249,9 +249,9 @@ RenderHtmlHead($pageTitle);
             if (!isValidUsername($resolvedByUser)) {
                 $resolvedByUser = null;
             }
-            $openTicketsCount = countOpenTickets($gamesTableFlag === AchievementType::UNOFFICIAL);
+            $openTicketsCount = countOpenTickets($gamesTableFlag === AchievementType::Unofficial);
             $filteredTicketsCount = countOpenTickets(
-                $gamesTableFlag === AchievementType::UNOFFICIAL,
+                $gamesTableFlag === AchievementType::Unofficial,
                 $ticketFilters,
                 $assignedToUser,
                 $reportedByUser,
@@ -259,7 +259,7 @@ RenderHtmlHead($pageTitle);
                 $gameIDGiven,
                 $achievementIDGiven
             );
-            echo "<h3 class='longheader'>$pageTitle - " . $openTicketsCount . " Open " . ($gamesTableFlag == AchievementType::UNOFFICIAL ? 'Unofficial ' : '') . " Ticket" . ($openTicketsCount == 1 ? "" : "s") . "</h3>";
+            echo "<h3 class='longheader'>$pageTitle - " . $openTicketsCount . " Open " . ($gamesTableFlag == AchievementType::Unofficial ? 'Unofficial ' : '') . " Ticket" . ($openTicketsCount == 1 ? "" : "s") . "</h3>";
         }
 
         echo "<div class='detaillist'>";
@@ -416,7 +416,7 @@ RenderHtmlHead($pageTitle);
                 }
 
                 // Clear Filter
-                if ($ticketFilters != $defaultFilter || $gamesTableFlag === AchievementType::UNOFFICIAL) {
+                if ($ticketFilters != $defaultFilter || $gamesTableFlag === AchievementType::Unofficial) {
                     echo "<div>";
                     echo "<a href='" . $createLink('t', $defaultFilter, 'f', 3) . "'>Clear Filter</a>";
                     echo "</div>";

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -1,8 +1,8 @@
 <?php
 
-use RA\ModifyTopicField;
+use RA\ForumTopicAction;
 use RA\Permissions;
-use RA\Shortcode\Shortcode;
+use RA\Shortcode;
 use RA\SubscriptionSubjectType;
 
 require_once __DIR__ . '/../vendor/autoload.php';
@@ -103,7 +103,7 @@ RenderHtmlStart();
             echo "<form action='/request/forum-topic/modify.php' method='post' >";
             echo "<input type='text' name='v' value='$thisTopicTitle' size='51' >";
             echo "<input type='hidden' name='t' value='$thisTopicID'>";
-            echo "<input type='hidden' name='f' value='" . ModifyTopicField::ModifyTitle . "'>";
+            echo "<input type='hidden' name='f' value='" . ForumTopicAction::ModifyTitle . "'>";
             echo "<input type='submit' name='submit' value='Submit' size='37'>";
             echo "</form>";
 
@@ -112,7 +112,7 @@ RenderHtmlStart();
                 echo "<form action='/request/forum-topic/modify.php' method='post' onsubmit='return confirm(\"Are you sure you want to permanently delete this topic?\")'>";
                 echo "<input type='hidden' name='v' value='$thisTopicID' size='51' >";
                 echo "<input type='hidden' name='t' value='$thisTopicID' />";
-                echo "<input type='hidden' name='f' value='" . ModifyTopicField::DeleteTopic . "'>";
+                echo "<input type='hidden' name='f' value='" . ForumTopicAction::DeleteTopic . "'>";
                 echo "<input type='submit' name='submit' value='Delete Permanently' size='37'>";
                 echo "</form>";
 
@@ -132,7 +132,7 @@ RenderHtmlStart();
                 echo "<option value='4' $selected4>" . PermissionsToString(Permissions::Admin) . "</option>";
                 echo "</select>";
                 echo "<input type='hidden' name='t' value='$thisTopicID'>";
-                echo "<input type='hidden' name='f' value='" . ModifyTopicField::RequiredPermissions . "'>";
+                echo "<input type='hidden' name='f' value='" . ForumTopicAction::ChangeRequiredPermissions . "'>";
                 echo "<input type='submit' name='submit' value='Change Minimum Permissions' size='37'>";
                 echo "</form>";
             }

--- a/src/AchievementType.php
+++ b/src/AchievementType.php
@@ -4,12 +4,13 @@ namespace RA;
 
 abstract class AchievementType
 {
-    public const OFFICIAL_CORE = 3;
-    public const UNOFFICIAL = 5;
+    public const OfficialCore = 3;
+
+    public const Unofficial = 5;
 
     private const VALID = [
-        self::OFFICIAL_CORE,
-        self::UNOFFICIAL,
+        self::OfficialCore,
+        self::Unofficial,
     ];
 
     public static function isValid(int $type): bool

--- a/src/AwardType.php
+++ b/src/AwardType.php
@@ -4,23 +4,23 @@ namespace RA;
 
 abstract class AwardType
 {
-    public const MASTERY = 1;
+    public const Mastery = 1;
 
-    public const ACHIEVEMENT_UNLOCKS_YIELD = 2;
+    public const AchievementUnlocksYield = 2;
 
-    public const ACHIEVEMENT_POINTS_YIELD = 3;
+    public const AchievementPointsYield = 3;
 
-    public const REFERRALS = 4;
+    public const Referrals = 4;
 
-    public const FACEBOOK_CONNECT = 5;
+    public const FacebookConnect = 5;
 
-    public const PATREON_SUPPORTER = 6;
+    public const PatreonSupporter = 6;
 
     private const ACTIVE = [
-        self::MASTERY,
-        self::ACHIEVEMENT_UNLOCKS_YIELD,
-        self::ACHIEVEMENT_POINTS_YIELD,
-        self::PATREON_SUPPORTER,
+        self::Mastery,
+        self::AchievementUnlocksYield,
+        self::AchievementPointsYield,
+        self::PatreonSupporter,
     ];
 
     public static function isActive(int $value): bool

--- a/src/ForumTopicAction.php
+++ b/src/ForumTopicAction.php
@@ -2,11 +2,11 @@
 
 namespace RA;
 
-abstract class ModifyTopicField
+abstract class ForumTopicAction
 {
     public const ModifyTitle = 0;
 
     public const DeleteTopic = 1;
 
-    public const RequiredPermissions = 2;
+    public const ChangeRequiredPermissions = 2;
 }

--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -17,6 +17,4 @@ abstract class Permissions
     public const Developer = 3;
 
     public const Admin = 4;
-
-    public const Root = 5;
 }

--- a/src/RatingType.php
+++ b/src/RatingType.php
@@ -2,9 +2,7 @@
 
 namespace RA;
 
-// Dynamic typing, misc usage
-// user SubjectType instead - it matches article types
-abstract class ObjectType
+abstract class RatingType
 {
     public const Game = 1;
 

--- a/src/Shortcode.php
+++ b/src/Shortcode.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RA\Shortcode;
+namespace RA;
 
 use Thunder\Shortcode\Event\FilterShortcodesEvent;
 use Thunder\Shortcode\EventContainer\EventContainer;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RA\Models;
+namespace RA;
 
-class TicketModel
+class Ticket
 {
     public int $ticketId;
     public int $achievementId;

--- a/src/TicketType.php
+++ b/src/TicketType.php
@@ -5,6 +5,7 @@ namespace RA;
 abstract class TicketType
 {
     public const TriggeredAtWrongTime = 1;
+
     public const DidNotTrigger = 2;
 
     public static function toString(int $type): string

--- a/src/UserPreference.php
+++ b/src/UserPreference.php
@@ -2,7 +2,7 @@
 
 namespace RA;
 
-abstract class UserPref
+abstract class UserPreference
 {
     public const EmailOn_ActivityComment = 0;
 


### PR DESCRIPTION
- Remove remaining `fbUser` and `fbPrefs` references (migration to drop columns not included yet)
- Rename `ObjectType` to `RatingType` as that's what it seems to be
- Flatten `src` directory, no need to group things yet
- PascalCase for enum-like constants