### PR TITLE
restore messaging to prevent client error

### DIFF
--- a/lib/database/player-achievement.php
+++ b/lib/database/player-achievement.php
@@ -103,13 +103,15 @@ function unlockAchievement(string $user, $achIDToAward, $isHardcore): array
     }
 
     if ($alreadyAwarded) {
-        // XXX: do not change the messages here. the client detects them and does not report
-        // them as errors.
+        // =============================================================================
+        // ===== DO NOT CHANGE THESE MESSAGES ==========================================
+        // The client detects the "User already has" and does not report them as errors.
         if ($isHardcore) {
-            $retVal['Error'] = "Player already unlocked this achievement in hardcore mode";
+            $retVal['Error'] = "User already has this achievement unlocked in hardcore mode.";
         } else {
-            $retVal['Error'] = "Player already unlocked this achievement";
+            $retVal['Error'] = "User already has this achievement unlocked.";
         }
+        // =============================================================================
 
         return $retVal;
     }


### PR DESCRIPTION
Fixes https://github.com/libretro/RetroArch/issues/14041

When the server receives a request to unlock an achievement the player has already unlocked, it responds with an error. The client is looking for a specific substring to indicate that the error isn't actually something that needs to be reported, and despite having a comment suggesting that the string should not be changed, it was. This modifies the string to reflect the intent of the change without breaking the client substring matching.