### PR TITLE
fix mature content user preference not saving

### DIFF
--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -185,7 +185,7 @@ function RenderUserPref($websitePrefs, $userPref, $setIfTrue, $state = null): vo
     }
 
     // 7 is set if unchecked
-    var checkbox = document.getElementById('UserPref7');
+    var checkbox = document.getElementById('UserPreference7');
     if (checkbox != null && !checkbox.checked)
       newUserPrefs += (1 << 7);
 


### PR DESCRIPTION
fixes #1034 

#1008 [renamed the input fields](https://github.com/RetroAchievements/RAWeb/pull/1008/files#diff-c217b8190030ab7ae176fb7a26083812018fb555b076716a211eb5b041eaec70L183) for the user preference checkboxes, but missed one.