### PR TITLE
also export hardcore values in receently played games API

### DIFF
--- a/public/API/API_GetUserProgress.php
+++ b/public/API/API_GetUserProgress.php
@@ -9,8 +9,8 @@
  *   string     [key]                       unique identifier of the game
  *    string     NumPossibleAchievements    number of core achievements for the game
  *    string     PossibleScore              maximum number of points that can be earned from the game
- *    string     NumAchieved                number of achievements earned by the user
- *    string     ScoreAchieved              number of points earned by the user
+ *    string     NumAchieved                number of achievements earned by the user in softcore
+ *    string     ScoreAchieved              number of points earned by the user in softcore
  *    string     NumAchievedHardcore        number of achievements earned by the user in hardcore
  *    string     ScoreAchievedHardcore      number of points earned by the user in hardcore
  */

--- a/public/API/API_GetUserRecentlyPlayedGames.php
+++ b/public/API/API_GetUserRecentlyPlayedGames.php
@@ -17,8 +17,10 @@
  *    string     ImageIcon                site-relative path to the game's icon image
  *    datetime   LastPlayed               when the user last played the game
  *    string     MyVote                   user's rating of the game (1-5)
- *    int        NumAchieved              number of achievements earned by the user
- *    int        ScoreAchieved            number of points earned by the user
+ *    int        NumAchieved              number of achievements earned by the user in softcore
+ *    int        ScoreAchieved            number of points earned by the user in softcore
+ *    int        NumAchievedHardcore      number of achievements earned by the user in hardcore
+ *    int        ScoreAchievedHardcore    number of points earned by the user in hardcore
  */
 
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -41,13 +43,11 @@ if (!empty($recentlyPlayedData)) {
 
     getUserProgress($user, $gameIDsCSV, $awardedData);
 
-    $iter = 0;
     foreach ($awardedData as $nextAwardID => $nextAwardData) {
-        $recentlyPlayedData[$iter]['NumPossibleAchievements'] = $nextAwardData['NumPossibleAchievements'];
-        $recentlyPlayedData[$iter]['PossibleScore'] = $nextAwardData['PossibleScore'];
-        $recentlyPlayedData[$iter]['NumAchieved'] = $nextAwardData['NumAchieved'];
-        $recentlyPlayedData[$iter]['ScoreAchieved'] = $nextAwardData['ScoreAchieved'];
-        $iter++; // Assumes a LOT about the order of this array!
+        $entry = array_search($nextAwardID, array_column($recentlyPlayedData, 'GameID'));
+        if ($entry !== false) {
+            $recentlyPlayedData[$entry] = array_merge($recentlyPlayedData[$entry], $nextAwardData);
+        }
     }
 
     $libraryOut['Awarded'] = $awardedData;


### PR DESCRIPTION
implements #1037 

`API_GetUserRecentlyPlayedGames` is calling the same function as `API_GetUserProgress` (which does return the hardcore progress), it's just copying the results to merge them into the rest of the data being returned, at it wasn't copying all of the fields. I've updated it to copy all of the fields.