### PR TITLE
don't show authorisation message for non-admins

### DIFF
--- a/lib/database/forum.php
+++ b/lib/database/forum.php
@@ -55,7 +55,7 @@ function getForumDetails($forumID, &$forumDataOut): bool
     $dbResult = s_mysql_query($query);
     if ($dbResult !== false) {
         $forumDataOut = mysqli_fetch_assoc($dbResult);
-        return true;
+        return $forumDataOut != null;
     } else {
         log_sql_fail();
         $forumDataOut = null;

--- a/lib/render/error.php
+++ b/lib/render/error.php
@@ -24,6 +24,7 @@ function RenderErrorCodeWarning(?string $errorCode): void
         'nopermission' => "You don't have permission to view this page! If this is incorrect, please leave a message in the forums.",
         'resetfailed' => "Problems encountered while performing reset. Do you have any achievements to reset?",
         'subscription_update_fail' => "Failed to update topic subscription.",
+        'unknownforum' => "Unknown forum",
         default => null,
     },
     successMessage: match ($errorCode) {

--- a/public/forum.php
+++ b/public/forum.php
@@ -12,7 +12,7 @@ authenticateFromCookie($user, $permissions, $userDetails);
 $forumList = getForumList($requestedCategoryID);
 
 $numUnofficialLinks = 0;
-if ($permissions >= Permissions::Developer) {
+if ($permissions >= Permissions::Admin) {
     $unofficialLinks = getUnauthorisedForumLinks();
     $numUnofficialLinks = is_countable($unofficialLinks) ? count($unofficialLinks) : 0;
 }
@@ -51,7 +51,7 @@ RenderHtmlHead($pageTitle);
             // Output all forums fetched, by category
 
             if ($numUnofficialLinks > 0) {
-                echo "<br><a href='/viewforum.php?f=0'><b>Developer Notice:</b> $numUnofficialLinks unofficial posts need authorising: please verify them!</a><br>";
+                echo "<br><a href='/viewforum.php?f=0'><b>Administrator Notice:</b> $numUnofficialLinks unofficial posts need authorising: please verify them!</a><br>";
             }
 
             $lastCategory = "_init";

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -38,7 +38,7 @@ if ($requestedForumID == 0 && $permissions >= Permissions::Admin) {
     $requestedForum = "Unauthorised Links";
 } else {
     if (!getForumDetails($requestedForumID, $forumDataOut)) {
-        header("location: " . getenv('APP_URL') . "/forum.php?e=unknownforum2");
+        header("location: " . getenv('APP_URL') . "/forum.php?e=unknownforum");
         exit;
     }
 


### PR DESCRIPTION
The page it directs to requires admin permission. Clicking the link as a non-admin redirects back to the forum list, where it was supposed to display an "Unknown forum" error. I've also corrected that.

https://discord.com/channels/310192285306454017/493200466222776342/991419417579761704