### PR TITLE
Small fixes for set up project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ DB_PASSWORD=retroachievements
 
 MAIL_MAILER=smtp
 MAIL_HOST=mailhog
-MAIL_PORT=2525
+MAIL_PORT=1025
 MAIL_USERNAME=retroachievements
 MAIL_PASSWORD=password
 MAIL_FROM_ADDRESS=noreply@retroachievements.org

--- a/database/20180212_170235_RA_Template.sql
+++ b/database/20180212_170235_RA_Template.sql
@@ -375,7 +375,7 @@ CREATE TABLE IF NOT EXISTS `UserAccounts` (
   `RAPoints` int(11) NOT NULL COMMENT 'Gamerscore :P',
   `fbUser` bigint(20) NOT NULL COMMENT 'FBUser ID',
   `fbPrefs` smallint(6) DEFAULT NULL COMMENT 'Preferences for FB Cross-posting',
-  `cookie` varchar(20) COLLATE latin1_general_ci DEFAULT NULL COMMENT 'Random string to be matched against the user for validation.',
+  `cookie` varchar(255) COLLATE latin1_general_ci DEFAULT NULL COMMENT 'Random string to be matched against the user for validation.',
   `appToken` varchar(20) COLLATE latin1_general_ci DEFAULT NULL COMMENT 'Token used by the app',
   `appTokenExpiry` datetime DEFAULT NULL COMMENT 'Expiry of token used by the app',
   `websitePrefs` smallint(5) unsigned DEFAULT '0',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
   php:
     build: ./docker/php
     image: raweb/app
+    extra_hosts:
+      - host.docker.internal:host-gateway
     volumes:
       - .:/srv/web
       - ./docker/php/configs/php-ini-overrides.ini:/usr/local/etc/php/conf.d/php-ini-overrides.ini:ro


### PR DESCRIPTION
```
extra_hosts:
      - host.docker.internal:host-gateway
```
lines above added to docker-compose.yml, because **host.docker.internal** not supporting in Docker for Linux out of box (this connection from container to local machine needs for **xDebug**)
https://medium.com/@TimvanBaarsen/how-to-connect-to-the-docker-host-from-inside-a-docker-container-112b4c71bc66