### PR TITLE
update max game progress to 100%

### DIFF
--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -259,3 +259,43 @@ function RenderRecentGamePlayers($recentPlayerData): void
     echo "</tbody></table>";
     echo "</div>";
 }
+
+function RenderGameProgress(int $numAchievements, int $numEarnedCasual, int $numEarnedHardcore)
+{
+    $pctComplete = 0;
+    $pctHardcore = 0;
+    $pctHardcoreProportion = 0;
+    $title = '';
+
+    if ($numAchievements) {
+        $pctAwardedCasual = ($numEarnedCasual + $numEarnedHardcore) / $numAchievements;
+        $pctAwardedHardcore = $numEarnedHardcore / $numAchievements;
+        $pctAwardedHardcoreProportion = 0;
+        if ($numEarnedHardcore > 0) {
+            $pctAwardedHardcoreProportion = $numEarnedHardcore / ($numEarnedHardcore + $numEarnedCasual);
+        }
+
+        $pctComplete = sprintf("%01.0f", $pctAwardedCasual * 100.0);
+        $pctHardcore = sprintf("%01.0f", $pctAwardedHardcore * 100.0);
+        $pctHardcoreProportion = sprintf("%01.0f", $pctAwardedHardcoreProportion * 100.0);
+
+        if ($numEarnedCasual && $numEarnedHardcore) {
+            $title = " title='$pctHardcore% hardcore'";
+        }
+    }
+
+    echo "<div class='progressbar'>";
+    echo "<div class='completion' style='width:$pctComplete%'$title>";
+    echo "<div class='completionhardcore' style='width:$pctHardcoreProportion%'>";
+    echo "&nbsp;";
+    echo "</div>"; // completionhardcore
+    echo "</div>"; // completion
+
+    if ($pctHardcore >= 100.0) {
+        echo "Mastered<br>";
+    } else {
+        echo "$pctComplete% complete<br>";
+    }
+
+    echo "</div>"; // progressbar
+}

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -956,37 +956,7 @@ RenderHtmlStart(true);
                 }
 
                 if (isset($user)) {
-                    $pctAwardedCasual = 0;
-                    $pctAwardedHardcore = 0;
-                    $pctComplete = 0;
-
-                    if ($numAchievements) {
-                        $pctAwardedCasual = ($numEarnedCasual + $numEarnedHardcore) / $numAchievements;
-                        $pctAwardedHardcore = $numEarnedHardcore / $numAchievements;
-                        $pctAwardedHardcoreProportion = 0;
-                        if ($numEarnedHardcore > 0) {
-                            $pctAwardedHardcoreProportion = $numEarnedHardcore / ($numEarnedHardcore + $numEarnedCasual);
-                        }
-
-                        $pctAwardedCasual = sprintf("%01.0f", $pctAwardedCasual * 100.0);
-                        $pctAwardedHardcore = sprintf("%01.0f", $pctAwardedHardcoreProportion * 100.0);
-
-                        $pctComplete = sprintf(
-                            "%01.0f",
-                            (($numEarnedCasual + $numEarnedHardcore * 2) * 100.0 / $numAchievements)
-                        );
-                    }
-
-                    echo "<div class='progressbar'>";
-                    echo "<div class='completion' style='width:$pctAwardedCasual%'>";
-                    echo "<div class='completionhardcore' style='width:$pctAwardedHardcore%'>&nbsp;</div>";
-                    echo "</div>";
-                    if ($pctComplete > 100.0) {
-                        echo "<b>$pctComplete%</b> complete<br>";
-                    } else {
-                        echo "$pctComplete% complete<br>";
-                    }
-                    echo "</div>";
+                    RenderGameProgress($numAchievements, $numEarnedCasual, $numEarnedHardcore);
                 }
 
                 if ($numAchievements > 0) {

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -486,7 +486,22 @@ RenderHtmlStart(true);
 
                 echo "<a href='/game/$gameID'>$gameTitle ($consoleName)</a><br>";
                 echo "Last played $gameLastPlayed<br>";
-                echo "Earned $numAchieved of $numPossibleAchievements achievements, $scoreEarned/$maxPossibleScore points.<br>";
+
+                if ($numPossibleAchievements) {
+                    echo "Earned $numAchieved of $numPossibleAchievements achievements, ";
+                    if ($scoreEarnedHardcore) {
+                        echo "$scoreEarnedHardcore/$maxPossibleScore points";
+                        if ($scoreEarned > $scoreEarnedHardcore) {
+                            $scoreEarnedSoftcore = $scoreEarned - $scoreEarnedHardcore;
+                            echo ", $scoreEarnedSoftcore softcore points";
+                        }
+                    } elseif ($scoreEarned) {
+                        echo "$scoreEarned/$maxPossibleScore softcore points";
+                    } else {
+                        echo "0/$maxPossibleScore points";
+                    }
+                    echo ".<br/>";
+                }
 
                 if (isset($userMassData['RecentAchievements'][$gameID])) {
                     foreach ($userMassData['RecentAchievements'][$gameID] as $achID => $achData) {

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -482,38 +482,7 @@ RenderHtmlStart(true);
 
                 echo "<div class='userpagegames'>";
 
-                $pctAwardedCasual = "0";
-                $pctAwardedHardcore = "0";
-                $pctComplete = "0";
-
-                if ($numPossibleAchievements > 0) {
-                    $pctAwardedCasualVal = $numAchieved / $numPossibleAchievements;
-
-                    $pctAwardedHardcoreProportion = 0;
-                    if ($numAchieved > 0) {
-                        $pctAwardedHardcoreProportion = $numAchievedHardcore / $numAchieved;
-                    }
-
-                    $pctAwardedCasual = sprintf("%01.0f", $pctAwardedCasualVal * 100.0);
-                    $pctAwardedHardcore = sprintf("%01.0f", $pctAwardedHardcoreProportion * 100.0);
-                    $pctComplete = sprintf(
-                        "%01.0f",
-                        (($numAchieved + $numAchievedHardcore) * 100.0 / $numPossibleAchievements)
-                    );
-                }
-
-                echo "<div class='progressbar'>";
-                echo "<div class='completion'             style='width:$pctAwardedCasual%'>";
-                echo "<div class='completionhardcore'     style='width:$pctAwardedHardcore%'>";
-                echo "&nbsp;";
-                echo "</div>";
-                echo "</div>";
-                if ($pctComplete > 100.0) {
-                    echo "<b>$pctComplete%</b> complete<br>";
-                } else {
-                    echo "$pctComplete% complete<br>";
-                }
-                echo "</div>";
+                RenderGameProgress($numPossibleAchievements, $numAchieved - $numAchievedHardcore, $numAchievedHardcore);
 
                 echo "<a href='/game/$gameID'>$gameTitle ($consoleName)</a><br>";
                 echo "Last played $gameLastPlayed<br>";


### PR DESCRIPTION
Game progress no longer reports values over 100% (mastering a game is no longer 200%)

Reported progress is now the maximum of (hardcore progress/softcore progress), and if the game has 100% hardcore completion, it's reported as Mastered:
![image](https://user-images.githubusercontent.com/32680403/183663758-f2793626-a221-400f-a673-dd0921b2fcaf.png)

If the user has both hardcore and softcore unlocks, the bar gains a tooltip indicating the hardcore progress. The reported progress will be for the softcore progress.

The change affects the recently played games on the user's profile page, and the bar shown on individual game pages (showing tooltip):
![image](https://user-images.githubusercontent.com/32680403/183655822-e3090b21-de01-4602-920f-10f633324768.png)
