### PR TITLE
Fix progress reset response

### DIFF
--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -156,7 +156,6 @@ function RenderUserPref($websitePrefs, $userPref, $setIfTrue, $state = null): vo
 
   function onResetComplete(data) {
     if (data.substr(0, 2) !== 'OK') {
-      alert(data);
       //showStatusFailure('Error: ' + data);
       $('#loadingiconreset').attr('src', '<?= asset('Images/tick.png') ?>').delay(750).fadeTo('slow', 0.0);
       return;

--- a/public/request/user/reset-achievements.php
+++ b/public/request/user/reset-achievements.php
@@ -7,18 +7,15 @@ $gameID = requestInputPost('g', null, 'integer');
 $achID = requestInputPost('a', null, 'integer');
 
 if (!authenticateFromCookie($user, $permissions, $userDetails)) {
-    redirect(back() . '?e=error');
     exit;
 }
 
 if (!empty($achID) && resetSingleAchievement($user, $achID)) {
-    redirect(back() . '?reset=ok');
+    echo "OK";
     exit;
 }
 
 if (!empty($gameID) && resetAchievements($user, $gameID) > 0) {
-    redirect(back() . '?reset=ok');
+    echo "OK";
     exit;
 }
-
-redirect(back() . '?e=error');


### PR DESCRIPTION
Revert request responses to be strings, not header redirects.

This area still has some logic issues - I don't want to take care of those in this PR though as i rewrote a lot of that in the v2 branch already.