### PR TITLE
Fix emails for site badge updates and Recent Progress graph for softcore

### DIFF
--- a/public/request/achievement/update-image.php
+++ b/public/request/achievement/update-image.php
@@ -44,6 +44,6 @@ if (!$dbResult) {
     exit;
 }
 
-addArticleComment('Server', ArticleType::Achievement, $achievementID, "$user edited this achievement's badge.");
+addArticleComment('Server', ArticleType::Achievement, $achievementID, "$user edited this achievement's badge.", $user);
 
 redirect("achievement/$achievementID?e=uploadok");

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -169,7 +169,8 @@ RenderHtmlStart(true);
 
     // Declare columns
     dataRecentProgress.addColumn('date', 'Date');    // NOT date! this is non-continuous data
-    dataRecentProgress.addColumn('number', 'Score');
+    dataRecentProgress.addColumn('number', 'Hardcore Score');
+    dataRecentProgress.addColumn('number', 'Softcore Score');
 
     dataRecentProgress.addRows([
         <?php
@@ -187,9 +188,10 @@ RenderHtmlStart(true);
             $nextDate = $dayInfo['Date'];
 
             $dateStr = getNiceDate(strtotime($nextDate), true);
-            $value = $dayInfo['CumulHardcoreScore'];
+            $hardcoreValue = $dayInfo['CumulHardcoreScore'];
+            $softcoreValue = $dayInfo['CumulSoftcoreScore'];
 
-            echo "[ {v:new Date($nextYear,$nextMonth,$nextDay), f:'$dateStr'}, $value ]";
+            echo "[ {v:new Date($nextYear,$nextMonth,$nextDay), f:'$dateStr'}, $hardcoreValue, $softcoreValue ]";
         }
         ?>
     ]);
@@ -204,7 +206,7 @@ RenderHtmlStart(true);
       chartArea: { left: 42, width: 458, 'height': '100%' },
       showRowNumber: false,
       view: { columns: [0, 1] },
-      colors: ['#cc9900'],
+      colors: ['#186DEE','#8c8c8c'],
     };
 
     function resize() {


### PR DESCRIPTION
Uploading badges through the site was sending emails for changes even if you were the author (thanks for reporting TeddyWestside)

Fixes Recent Progress to show softcore and hardcore progress similar to the history view graph update (thanks for reporting p8lg6xtb and Jamiras)
![image](https://user-images.githubusercontent.com/4047771/184032044-a85109e1-97a6-4d55-ad54-0bf0c4f2662c.png)
