### PR TITLE
Fix hub matching for values containing ampersands

### DIFF
--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -158,9 +158,10 @@ function RenderGameAlts($gameAlts, $headerText = null): void
 function RenderMetadataTableRow($label, $gameDataValue, $gameHubs = null, $altLabels = []): void
 {
     $gameDataValues = !empty($gameDataValue) ? array_map('trim', explode(',', $gameDataValue)) : [];
+    $unmergedKeys = array_keys($gameDataValues);
 
     if ($gameHubs) {
-        $mergeMetadata = function ($hubCategory) use (&$gameHubs, &$gameDataValues) {
+        $mergeMetadata = function ($hubCategory) use (&$gameHubs, &$gameDataValues, &$unmergedKeys) {
             $hubPrefix = "[$hubCategory - ";
             foreach ($gameHubs as $hub) {
                 $title = $hub['Title'];
@@ -191,6 +192,7 @@ function RenderMetadataTableRow($label, $gameDataValue, $gameHubs = null, $altLa
 
                     if ($key !== false) {
                         $gameDataValues[$key] = $link;
+                        unset($unmergedKeys[$key]);
                     } else {
                         $gameDataValues[] = $link;
                     }
@@ -206,6 +208,10 @@ function RenderMetadataTableRow($label, $gameDataValue, $gameHubs = null, $altLa
     }
 
     if (!empty($gameDataValues)) {
+        foreach ($unmergedKeys as $key) {
+            sanitize_outputs($gameDataValues[$key]);
+        }
+
         echo "<tr>";
         echo "<td style='white-space: nowrap'>$label:</td>";
         echo "<td><b>" . implode(', ', $gameDataValues) . "</b></td>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -622,13 +622,6 @@ RenderHtmlStart(true);
             $imageIngame = $gameData['ImageIngame'];
             $pageTitleAttr = attributeEscape($pageTitle);
 
-            sanitize_outputs(
-                $developer,
-                $publisher,
-                $genre,
-                $released,
-            );
-
             echo "<h3 class='longheader'>$pageTitle</h3>";
             echo "<table><tbody>";
             echo "<tr>";


### PR DESCRIPTION
Relocating the `sanitize_outputs` in https://github.com/RetroAchievements/RAWeb/commit/76e5ef9066e1de281d0e487bca22e6c3cd529951#diff-66930c10e82ee4f8d7cf1fd91cb8a68f42f751f9e653b776fbca42c44603cf56R625-R630 caused the value to become escaped, and then it doesn't match the hub name, resulting in
![image](https://user-images.githubusercontent.com/32680403/184149447-fab391a3-d9fc-4387-9150-f5ad5b2e1eb7.png)

Since the previous location of `sanitize_outputs` was before they were being initialized, it doesn't seem like it's necessary. I've removed it, and things appear to be working. The `attribute_escape` is handling the sanitization when it becomes necessary.