### PR TITLE
add softcore leaderboard rankings

### DIFF
--- a/database/20220810_000000_Add_UserAccount_SoftcorePoints_Key.sql
+++ b/database/20220810_000000_Add_UserAccount_SoftcorePoints_Key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE UserAccounts ADD KEY `RASoftcorePointsUntracked` (`RASoftcorePoints`,`Untracked`) USING BTREE;

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -515,7 +515,6 @@ function getUserCardData($user, &$userCardInfo): void
     $userCardInfo['TotalTruePoints'] = $userInfo['TrueRAPoints'];
     $userCardInfo['Permissions'] = $userInfo['Permissions'];
     $userCardInfo['Motto'] = $userInfo['Motto'];
-    $userCardInfo['Rank'] = getUserRank($user);
     $userCardInfo['Untracked'] = $userInfo['Untracked'];
     $userCardInfo['LastActivity'] = $userInfo['LastLogin'];
     $userCardInfo['MemberSince'] = $userInfo['Created'];

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -566,8 +566,10 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
     } else {
         if ($unlockMode == UnlockMode::Hardcore) {
             $achPoints = "CASE WHEN HardcoreMode = " . UnlockMode::Hardcore . " THEN ach.Points ELSE 0 END";
+            $achCount = "CASE WHEN HardcoreMode = " . UnlockMode::Hardcore . " THEN 1 ELSE 0 END";
         } else {
             $achPoints = "CASE WHEN HardcoreMode = " . UnlockMode::Softcore . " THEN ach.Points ELSE -ach.Points END";
+            $achCount = "CASE WHEN HardcoreMode = " . UnlockMode::Softcore . " THEN 1 ELSE -1 END";
         }
 
         $query = "SELECT User,
@@ -580,7 +582,7 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
                   (
                       (
                           SELECT aw.User AS User,
-                          COUNT(ach.ID) AS AchievementCount,
+                          SUM($achCount) AS AchievementCount,
                           SUM($achPoints) as Points,
                           SUM(ach.TrueRatio) AS RetroPoints,
                           NULL AS TotalAwards

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\AwardType;
 use RA\Rank;
 use RA\UnlockMode;
 
@@ -150,7 +151,7 @@ function RenderScoreLeaderboardComponent(string $user, bool $friendsOnly, int $n
             }
 
             if ($friendsOnly) {
-                $data = getGlobalRankingData($j, 5, $currentDate, null, $user, 0, 0, $friendCount, 1);
+                $data = getGlobalRankingData($j, 5, $currentDate, null, $user, 0, 0, $friendCount + 1, 1);
             } else {
                 $data = getGlobalRankingData($j, 5, $currentDate, null, null, 0, 0, $numToFetch, 1);
             }
@@ -192,9 +193,9 @@ function RenderScoreLeaderboardComponent(string $user, bool $friendsOnly, int $n
                     echo "</td>";
                     if ($j == 0) {
                         echo "<td><a href='/historyexamine.php?d=$dateUnix&u=" . $dataPoint['User'] . "'>" .
-                            $dataPoint['HardcorePoints'] . "</a>";
+                            $dataPoint['Points'] . "</a>";
                     } else {
-                        echo "<td>" . $dataPoint['HardcorePoints'];
+                        echo "<td>" . $dataPoint['Points'];
                     }
                     echo " <span class='TrueRatio'>(" . $dataPoint['RetroPoints'] . ")</span></td>";
                 } else {
@@ -226,9 +227,9 @@ function RenderScoreLeaderboardComponent(string $user, bool $friendsOnly, int $n
                     echo GetUserAndTooltipDiv($userData[0]['User']);
                     echo "</td>";
                     if ($j == 0) {
-                        echo "<td><a href='/historyexamine.php?d=$dateUnix&u=" . $userData[0]['User'] . "'>" . $userData[0]['HardcorePoints'] . "</a>";
+                        echo "<td><a href='/historyexamine.php?d=$dateUnix&u=" . $userData[0]['User'] . "'>" . $userData[0]['Points'] . "</a>";
                     } else {
-                        echo "<td>" . $userData[0]['HardcorePoints'];
+                        echo "<td>" . $userData[0]['Points'];
                     }
                     echo " <span class='TrueRatio'>(" . $userData[0]['RetroPoints'] . ")</span></td>";
                 }
@@ -359,18 +360,16 @@ function RenderTopAchieversComponent($user, array $gameTopAchievers, array $game
  * @param int $lbType Leaderboard timeframe type
  *            0 - Daily
  *            1 - Weekly
- *            2 - Monthly
- *            3 - Yearly
- *            4 - All Time
+ *            2 - All Time
  * @param int $sort Stats to sort by
  *            1 - User
- *            2 - Total Achievements (no longer supported)
- *            3 - Softcore Achievements (no longer supported)
+ *            2 - Softcore Points (used to be Total Achievements)
+ *            3 - Softcore Achievements
  *            4 - Hardcore Achievements
  *            5 - Hardcore Points
  *            6 - Retro Points
  *            7 - Retro Ratio
- *            8 - Completed Awards (no longer supported)
+ *            8 - Completed Awards
  *            9 - Mastered Awards
  * @param string $date Date to grab information from
  * @param string|null $user User to get data for
@@ -391,6 +390,7 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
     $pointRequirement = "";
 
     settype($lbType, 'integer');
+    $unlockMode = UnlockMode::Hardcore;
 
     $typeCond = match ($lbType) {
         // Daily
@@ -438,29 +438,33 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
 
     // Determine the ORDER BY condition
     switch ($sort) {
-        case 4: // Hardcore Achievements
-            $orderCond = "ORDER BY HardcoreCount " . $sortOrder . ", HardcorePoints DESC, User ASC";
+        case 2: // Softcore Points
+            $orderCond = "ORDER BY Points " . $sortOrder . ", User ASC";
+            $unlockMode = UnlockMode::Softcore;
             break;
+        case 3: // Softcore Achievements
+            $orderCond = "ORDER BY AchievementCount " . $sortOrder . ", Points DESC, User ASC";
+            $unlockMode = UnlockMode::Softcore;
+            break;
+        case 4: // Hardcore Achievements
+            $orderCond = "ORDER BY AchievementCount " . $sortOrder . ", Points DESC, User ASC";
+            break;
+        default: // Hardcore Points by default
         case 5: // Hardcore Points
-            $orderCond = "ORDER BY HardcorePoints " . $sortOrder . ", User ASC";
-
-            // Must have MIN_POINTS hardcore points to show up on All Time Points Sorting
-            $pointRequirement = "AND ua.RAPoints >= " . Rank::MIN_POINTS;
+            $orderCond = "ORDER BY Points " . $sortOrder . ", User ASC";
             break;
         case 6: // Retro Points
             $orderCond = "ORDER BY RetroPoints " . $sortOrder . ", User ASC";
-
-            // Must have at least MIN_TRUE_POINTS hardcore retro ratio points to show up on All Time Retro Ratio Sorting
-            $pointRequirement = "AND ua.TrueRAPoints >= " . Rank::MIN_TRUE_POINTS;
             break;
         case 7: // Retro Ratio
             $orderCond = "ORDER BY RetroRatio " . $sortOrder . ", User ASC";
             break;
-        case 9: // Mastered Awards
-            $orderCond = "ORDER BY MasteredAwards " . $sortOrder . ", User ASC";
+        case 8: // Completed Awards
+            $orderCond = "ORDER BY TotalAwards " . $sortOrder . ", User ASC";
+            $unlockMode = UnlockMode::Softcore;
             break;
-        default: // Hardcore Points by default
-            $orderCond = "ORDER BY HardcorePoints " . $sortOrder . ", User ASC";
+        case 9: // Mastered Awards
+            $orderCond = "ORDER BY TotalAwards " . $sortOrder . ", User ASC";
             break;
     }
 
@@ -471,19 +475,50 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
         default => "",
     };
 
-    // Run the All-Time ranking query
+    if ($unlockMode == UnlockMode::Hardcore) {
+        $totalAwards = "SUM(IF(AwardDataExtra > 0, 1, 0))";
+    } else {
+        $totalAwards = "COUNT(*)";
+        $pointRequirement = "AND ua.RASoftcorePoints >= 0"; // if someone resets a softcore achievement without resetting the hardcore, the query can return negative points
+    }
+
     $retVal = [];
-    if ($lbType == 2) {
+    if ($lbType == 2) { // Run the All-Time ranking query
+        if ($friendsOf === null) {
+            // if not comparing against friends, only look at the ranked users
+            if ($unlockMode == UnlockMode::Softcore) {
+                $pointRequirement = "AND ua.RASoftcorePoints >= " . Rank::MIN_POINTS;
+            } elseif ($sort == 6) {
+                $pointRequirement = "AND ua.TrueRAPoints >= " . Rank::MIN_TRUE_POINTS;
+            } else {
+                $pointRequirement = "AND ua.RAPoints >= " . Rank::MIN_POINTS;
+            }
+        }
+
         if ($info == 0) {
-            $selectQuery = "SELECT ua.User,
-                    (SELECT COALESCE(SUM(CASE WHEN HardcoreMode = " . UnlockMode::Hardcore . " THEN 1 ELSE 0 END), 0) FROM Awarded AS aw WHERE aw.User = ua.User) AS HardcoreCount,
-                    COALESCE(ua.RAPoints, 0) AS HardcorePoints,
-                    COALESCE(ua.TrueRAPoints, 0) AS RetroPoints,
-                    COALESCE(ROUND(ua.TrueRAPoints/ua.RAPoints, 2), 0) AS RetroRatio ";
+            if ($unlockMode == UnlockMode::Hardcore) {
+                $selectQuery = "SELECT ua.User,
+                        (SELECT COALESCE(SUM(CASE WHEN HardcoreMode = " . UnlockMode::Hardcore . " THEN 1 ELSE 0 END), 0) FROM Awarded AS aw WHERE aw.User = ua.User) AS AchievementCount,
+                        COALESCE(ua.RAPoints, 0) AS Points,
+                        COALESCE(ua.TrueRAPoints, 0) AS RetroPoints,
+                        COALESCE(ROUND(ua.TrueRAPoints/ua.RAPoints, 2), 0) AS RetroRatio ";
+            } else {
+                $selectQuery = "SELECT ua.User,
+                        (SELECT COALESCE(SUM(CASE WHEN HardcoreMode = " . UnlockMode::Softcore . " THEN 1 ELSE -1 END), 0) FROM Awarded AS aw WHERE aw.User = ua.User) AS AchievementCount,
+                        COALESCE(ua.RASoftcorePoints, 0) AS Points,
+                        0 AS RetroPoints,
+                        0 AS RetroRatio ";
+            }
         } else {
-            $selectQuery = "SELECT ua.User,
-                    COALESCE(ua.RAPoints, 0) AS HardcorePoints,
-                    COALESCE(ua.TrueRAPoints, 0) AS RetroPoints ";
+            if ($unlockMode == UnlockMode::Hardcore) {
+                $selectQuery = "SELECT ua.User,
+                        COALESCE(ua.RAPoints, 0) AS Points,
+                        COALESCE(ua.TrueRAPoints, 0) AS RetroPoints ";
+            } else {
+                $selectQuery = "SELECT ua.User,
+                        COALESCE(ua.RASoftcorePoints, 0) AS Points,
+                        0 AS RetroPoints ";
+            }
         }
         $query = "$selectQuery
                     FROM UserAccounts AS ua
@@ -500,15 +535,13 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
             }
 
             // Get site award info for each user.
-            // This is not ideal but it was the only way I could figure out to accurately get site award information.
             for ($i = 0; $i < count($users); $i++) {
-                $query2 = "Select COUNT(*) AS TotalAwards, COALESCE(SUM(CASE WHEN aw.test > 1 THEN 1 ELSE 0 END), 0) AS MasteredAwards
-                            FROM (SELECT *, COUNT(AwardData) + AwardDataExtra AS test FROM SiteAwards WHERE User = '" . $users[$i] . "' AND AwardType = 1 GROUP By AwardData order by AwardDataExtra DESC) as aw";
+                $query2 = "SELECT $totalAwards AS TotalAwards FROM SiteAwards WHERE User = '" . $users[$i] . "' AND AwardType = " . AwardType::Mastery;
+
                 $dbResult2 = s_mysql_query($query2);
                 if ($dbResult2 !== false) {
                     $db_entry2 = mysqli_fetch_assoc($dbResult2);
                     $retVal[$i]['TotalAwards'] = $db_entry2['TotalAwards'];
-                    $retVal[$i]['MasteredAwards'] = $db_entry2['MasteredAwards'];
                 }
             }
         }
@@ -517,7 +550,7 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
 
     if ($info == 1) {
         $query = "SELECT aw.User AS User,
-              SUM(ach.Points) AS HardcorePoints,
+              SUM(ach.Points) AS Points,
               SUM(ach.TrueRatio) AS RetroPoints
               FROM Awarded AS aw
               LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
@@ -526,30 +559,35 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
               $friendCondAchievement
               $singleUserAchievementCond
               $untrackedCond
-              AND HardcoreMode = " . UnlockMode::Hardcore . "
+              AND HardcoreMode = " . $unlockMode . "
               GROUP BY aw.User
               $orderCond
               LIMIT $offset, $count";
     } else {
+        if ($unlockMode == UnlockMode::Hardcore) {
+            $achPoints = "CASE WHEN HardcoreMode = " . UnlockMode::Hardcore . " THEN ach.Points ELSE 0 END";
+        } else {
+            $achPoints = "CASE WHEN HardcoreMode = " . UnlockMode::Softcore . " THEN ach.Points ELSE -ach.Points END";
+        }
+
         $query = "SELECT User,
-              COALESCE(MAX(HardcoreCount), 0) AS HardcoreCount,
-              COALESCE(MAX(HardcorePoints), 0) AS HardcorePoints,
+              COALESCE(MAX(AchievementCount), 0) AS AchievementCount,
+              COALESCE(MAX(Points), 0) AS Points,
               COALESCE(MAX(RetroPoints), 0) AS RetroPoints,
-              ROUND(RetroPoints/HardcorePoints, 2) AS RetroRatio,
-              COALESCE(MAX(MasteredAwards), 0) AS MasteredAwards
+              ROUND(RetroPoints/Points, 2) AS RetroRatio,
+              COALESCE(MAX(TotalAwards), 0) AS TotalAwards
               FROM
                   (
                       (
                           SELECT aw.User AS User,
-                          COUNT(ach.ID) AS HardcoreCount,
-                          SUM(ach.Points) AS HardcorePoints,
+                          COUNT(ach.ID) AS AchievementCount,
+                          SUM($achPoints) as Points,
                           SUM(ach.TrueRatio) AS RetroPoints,
-                          NULL AS MasteredAwards
+                          NULL AS TotalAwards
                           FROM Awarded AS aw
                           LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
                           LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
                           WHERE TRUE $whereDateAchievement $typeCond
-                          AND HardcoreMode = " . UnlockMode::Hardcore . "
                           $friendCondAchievement
                           $singleUserAchievementCond
                           $untrackedCond
@@ -558,10 +596,10 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
                       UNION
                       (
                           SELECT sa.User AS User,
-                          NULL AS HardcoreCount,
-                          NULL AS HardcorePoints,
+                          NULL AS AchievementCount,
+                          NULL AS Points,
                           NULL AS RetroPoints,
-                          COALESCE(SUM(CASE WHEN AwardDataExtra = 1 AND AwardType = 1 THEN 1 ELSE 0 END), 0) AS MasteredAwards
+                          $totalAwards AS TotalAwards
                           FROM SiteAwards AS sa
                           LEFT JOIN UserAccounts AS ua ON ua.User = sa.User
                           WHERE TRUE $whereDateAward $typeCond
@@ -572,6 +610,7 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
                       )
                   ) AS Query
               GROUP BY User
+              HAVING Points > 0
               $orderCond
               LIMIT $offset, $count";
     }

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -612,7 +612,7 @@ function getGlobalRankingData($lbType, $sort, $date, $user, $friendsOf = null, $
                       )
                   ) AS Query
               GROUP BY User
-              HAVING Points > 0
+              HAVING Points > 0 AND AchievementCount > 0
               $orderCond
               LIMIT $offset, $count";
     }

--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -2,6 +2,7 @@
 
 use RA\Permissions;
 use RA\Rank;
+use RA\RankType;
 
 /**
  * Create the user and tooltip div that is shown when you hover over a username or user avatar.
@@ -74,11 +75,11 @@ function _GetUserAndTooltipDiv(
     $tooltip .= "<tr>";
     if ($userHardcorePoints > $userSoftcorePoints) {
         $tooltip .= "<td  colspan='2' class='usercardbasictext'><b>Points:</b> $userHardcorePoints ($userTruePoints)</td>";
-        $userRank = $userHardcorePoints < Rank::MIN_POINTS ? 0 : getUserRank($user);
+        $userRank = $userHardcorePoints < Rank::MIN_POINTS ? 0 : getUserRank($user, RankType::Hardcore);
         $userRankLabel = 'Site Rank';
     } elseif ($userSoftcorePoints > 0) {
         $tooltip .= "<td  colspan='2' class='usercardbasictext'><b>Softcore Points:</b> $userSoftcorePoints</td>";
-        $userRank = $userSoftcorePoints < Rank::MIN_POINTS ? 0 : getUserRankSoftcore($user);
+        $userRank = $userSoftcorePoints < Rank::MIN_POINTS ? 0 : getUserRank($user, RankType::Softcore);
         $userRankLabel = 'Softcore Rank';
     } else {
         $tooltip .= "<td  colspan='2' class='usercardbasictext'><b>Points:</b> 0</td>";

--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -44,7 +44,6 @@ function _GetUserAndTooltipDiv(
     $userSoftcorePoints = $userCardInfo['SoftcorePoints'];
     $userTruePoints = $userCardInfo['TotalTruePoints'];
     $userAccountType = Permissions::toString($userCardInfo['Permissions']);
-    $userRank = $userCardInfo['Rank'];
     $userUntracked = $userCardInfo['Untracked'];
     $lastLogin = $userCardInfo['LastActivity'] ? getNiceDate(strtotime($userCardInfo['LastActivity'])) : null;
     $memberSince = $userCardInfo['MemberSince'] ? getNiceDate(strtotime($userCardInfo['MemberSince']), true) : null;
@@ -73,36 +72,40 @@ function _GetUserAndTooltipDiv(
 
     // Add the user points if there are any
     $tooltip .= "<tr>";
-    if ($userHardcorePoints > 0) {
-        $tooltip .= "<td class='usercardbasictext'><b>Hardcore Points:</b> $userHardcorePoints ($userTruePoints)</td>";
-        if ($userSoftcorePoints > 0) {
-            $tooltip .= "</tr><tr><td class='usercardbasictext'><b>Softcore Points:</b> $userSoftcorePoints</td>";
-        }
+    if ($userHardcorePoints > $userSoftcorePoints) {
+        $tooltip .= "<td  colspan='2' class='usercardbasictext'><b>Points:</b> $userHardcorePoints ($userTruePoints)</td>";
+        $userRank = $userHardcorePoints < Rank::MIN_POINTS ? 0 : getUserRank($user);
+        $userRankLabel = 'Site Rank';
     } elseif ($userSoftcorePoints > 0) {
-        $tooltip .= "</tr><tr><td class='usercardbasictext'><b>Softcore Points:</b> $userSoftcorePoints</td>";
+        $tooltip .= "<td  colspan='2' class='usercardbasictext'><b>Softcore Points:</b> $userSoftcorePoints</td>";
+        $userRank = $userSoftcorePoints < Rank::MIN_POINTS ? 0 : getUserRankSoftcore($user);
+        $userRankLabel = 'Softcore Rank';
     } else {
-        $tooltip .= "<td class='usercardbasictext'><b>Points:</b> 0</td>";
+        $tooltip .= "<td  colspan='2' class='usercardbasictext'><b>Points:</b> 0</td>";
+        $userRank = 0;
+        $userRankLabel = 'Site Rank';
     }
     $tooltip .= "</tr>";
 
     // Add the other user information
     $tooltip .= "<tr>";
     if ($userUntracked) {
-        $tooltip .= "<td class='usercardbasictext'><b>Site Rank:</b> Untracked</td>";
-    } elseif ($userHardcorePoints < Rank::MIN_POINTS) {
-        $tooltip .= "<td class='usercardbasictext'><b>Site Rank:</b> Needs at least " . Rank::MIN_POINTS . " points </td>";
+        $tooltip .= "<td colspan='2' class='usercardbasictext'><b>$userRankLabel:</b> Untracked</td>";
+    } elseif ($userRank == 0) {
+        $tooltip .= "<td colspan='2' class='usercardbasictext'><b>$userRankLabel:</b> Needs at least " . Rank::MIN_POINTS . " points </td>";
     } else {
-        $tooltip .= "<td class='usercardbasictext'><b>Site Rank:</b> $userRank</td>";
+        $tooltip .= "<td colspan='2' class='usercardbasictext'><b>$userRankLabel:</b> $userRank</td>";
     }
     $tooltip .= "</tr>";
+
     if ($lastLogin) {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class='usercardbasictext'><b>Last Activity:</b> $lastLogin</td>";
+        $tooltip .= "<td colspan='2' class='usercardbasictext'><b>Last Activity:</b> $lastLogin</td>";
         $tooltip .= "</tr>";
     }
     if ($memberSince) {
         $tooltip .= "<tr>";
-        $tooltip .= "<td class='usercardbasictext'><b>Member Since:</b> $memberSince</td>";
+        $tooltip .= "<td colspan='2' class='usercardbasictext'><b>Member Since:</b> $memberSince</td>";
         $tooltip .= "</tr>";
     }
     $tooltip .= "</tbody></table>";

--- a/public/globalRanking.php
+++ b/public/globalRanking.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
+use RA\RankType;
 use RA\UnlockMode;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -299,11 +300,11 @@ RenderHeader($userDetails);
                     } else {
                         if ($sort < 10 && ($sort % 10) != 1) {
                             if ($sort == 5) {
-                                echo "<td>" . getUserRank($user, 0) . "</td>";
+                                echo "<td>" . getUserRank($user, RankType::Hardcore) . "</td>";
                             } elseif ($sort == 6) {
-                                echo "<td>" . getUserRank($user, 1) . "</td>";
+                                echo "<td>" . getUserRank($user, RankType::TruePoints) . "</td>";
                             } elseif ($sort == 2) {
-                                echo "<td>" . getUserRankSoftcore($user) . "</td>";
+                                echo "<td>" . getUserRank($user, RankType::Softcore) . "</td>";
                             } else {
                                 echo "<td></td>";
                             }

--- a/public/globalRanking.php
+++ b/public/globalRanking.php
@@ -3,6 +3,8 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
+use RA\UnlockMode;
+
 authenticateFromCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
@@ -28,7 +30,7 @@ switch ($type) {
         $lbType = "All Time";
 
         // Set default sorting if the user switches to All Time with an invalid All Time sorting selected.
-        if (($sort % 10) != 5 && ($sort % 10) != 6 && ($sort % 10) != 7) {
+        if (($sort % 10) == 8 || ($sort % 10) == 9) {
             $sort = 5;
         }
         break;
@@ -46,10 +48,17 @@ $lbUsers = match ($friends) {
 if ($friends == 1) {
     // We do a maxCount + 1 so that if we get maxCount + 1 rows returned we know
     // there are more row to get and we can add a "Next X" link for page traversal
-    $data = getGlobalRankingData($type, $sort, $date, null, $user, $untracked, $offset, getFriendCount($user), 0);
+    $data = getGlobalRankingData($type, $sort, $date, null, $user, $untracked, $offset, getFriendCount($user) + 1, 0);
 } else {
     $data = getGlobalRankingData($type, $sort, $date, null, null, $untracked, $offset, $maxCount + 1, 0);
 }
+
+$unlockMode = match ($sort % 10) {
+    2 => UnlockMode::Softcore, // Points
+    3 => UnlockMode::Softcore, // Achievements
+    8 => UnlockMode::Softcore, // Awards
+    default => UnlockMode::Hardcore,
+};
 
 RenderHtmlStart();
 RenderHtmlHead($lbUsers . " Ranking - " . $lbType);
@@ -122,16 +131,6 @@ RenderHeader($userDetails);
         }
         echo "</div>";
 
-        // Toggle ascending or descending sorting
-        $sort2 = ($sort == 2) ? 12 : 2; // Total Achievement (no longer supported)
-        $sort3 = ($sort == 3) ? 13 : 3; // Softcore Achievements (no longer supported)
-        $sort4 = ($sort == 4) ? 14 : 4; // Hardcore Achievements
-        $sort5 = ($sort == 5) ? 15 : 5; // Hardcore Points
-        $sort6 = ($sort == 6) ? 16 : 6; // Retro Points
-        $sort7 = ($sort == 7) ? 17 : 7; // Retro Ratio
-        $sort8 = ($sort == 8) ? 18 : 8; // Completed Awards (no longer supported)
-        $sort9 = ($sort == 9) ? 19 : 9; // Mastered Awards
-
         echo "<table><tbody>";
 
         // Only show the rank when we actually know the rank
@@ -139,64 +138,62 @@ RenderHeader($userDetails);
             echo "<th>Rank</th>";
         }
 
+        $sortFilter = function ($label, $sortValue, $descending = true) use ($sort, $type, $date, $friends) {
+            if (($sort % 10) == $sortValue) {
+                if ($sort == $sortValue) {
+                    $sortValue += 10;
+                    $arrow = $descending ? ' &#9660;' : ' &#9650;';
+                } else {
+                    $arrow = $descending ? ' &#9650;' : ' &#9660;';
+                }
+                echo "<b><a href='/globalRanking.php?s=$sortValue&t=$type&d=$date&f=$friends'>$label$arrow</a></b>";
+            } else {
+                echo "<a href='/globalRanking.php?s=$sortValue&t=$type&d=$date&f=$friends'>$label</a>";
+            }
+        };
+
         // User header
         echo "<th>User</th>";
 
-        if (($sort % 10) == 4) {
-            if ($sort4 == 4) {
-                echo "<th><b><a href='/globalRanking.php?s=$sort4&t=$type&d=$date&f=$friends'>Hardcore Achievements &#9650;</a></b></th>";
-            } else {
-                echo "<th><b><a href='/globalRanking.php?s=$sort4&t=$type&d=$date&f=$friends'>Hardcore Achievements &#9660;</a></b></th>";
-            }
+        // Sortable Achievements header
+        echo "<th>";
+        if ($unlockMode == UnlockMode::Hardcore) {
+            $sortFilter('Hardcore Achievements', 4);
         } else {
-            echo "<th><a href='/globalRanking.php?s=$sort4&t=$type&d=$date&f=$friends'>Hardcore Achievements</a></th>";
+            $sortFilter('Softcore Achievements', 3);
         }
+        echo "</th>";
 
         // Sortable Points header
-        if (($sort % 10) == 5) {
-            if ($sort5 == 5) {
-                echo "<th><b><a href='/globalRanking.php?s=$sort5&t=$type&d=$date&f=$friends'>Hardcore Points &#9650;</a></b> ";
-            } else {
-                echo "<th><b><a href='/globalRanking.php?s=$sort5&t=$type&d=$date&f=$friends'>Hardcore Points &#9660;</a></b> ";
-            }
+        echo "<th>";
+        if ($unlockMode == UnlockMode::Hardcore) {
+            $sortFilter('Hardcore Points', 5);
+            $sortFilter(' (Retro Points)', 6);
         } else {
-            echo "<th><a href='/globalRanking.php?s=$sort5&t=$type&d=$date&f=$friends'>Hardcore Points</a> ";
+            $sortFilter('Softcore Points', 2);
         }
-
-        // Sortable Retro Points header
-        if (($sort % 10) == 6) {
-            if ($sort6 == 6) {
-                echo "<b><a href='/globalRanking.php?s=$sort6&t=$type&d=$date&f=$friends'>(Retro Points) &#9650;</a></b></th>";
-            } else {
-                echo "<b><a href='/globalRanking.php?s=$sort6&t=$type&d=$date&f=$friends'>(Retro Points) &#9660;</a></b></th>";
-            }
-        } else {
-            echo "<a href='/globalRanking.php?s=$sort6&t=$type&d=$date&f=$friends'>(Retro Points)</a></th>";
-        }
+        echo "</th>";
 
         // Sortable Retro Ratio header
-        if (($sort % 10) == 7) {
-            if ($sort7 == 7) {
-                echo "<th><b><a href='/globalRanking.php?s=$sort7&t=$type&d=$date&f=$friends'>Retro Ratio &#9650;</a></b></th>";
-            } else {
-                echo "<th><b><a href='/globalRanking.php?s=$sort7&t=$type&d=$date&f=$friends'>Retro Ratio &#9660;</a></b></th>";
-            }
-        } else {
-            echo "<th><a href='/globalRanking.php?s=$sort7&t=$type&d=$date&f=$friends'>Retro Ratio</a></th>";
+        if ($unlockMode == UnlockMode::Hardcore) {
+            echo "<th>";
+            $sortFilter('Retro Ratio', 7);
+            echo "</th>";
         }
 
         // Sortable Mastered Awards header
-        if ($type == 2) { // Disable sorting if All Time
-            echo "<th>Mastered</th>";
-        } else {
-            if (($sort % 10) == 9) {
-                if ($sort9 == 9) {
-                    echo "<th><b><a href='/globalRanking.php?s=$sort9&t=$type&d=$date&f=$friends'>Mastered &#9650;</a></b></th>";
-                } else {
-                    echo "<th><b><a href='/globalRanking.php?s=$sort9&t=$type&d=$date&f=$friends'>Mastered &#9660;</a></b></th>";
-                }
+        echo "<th>";
+        if ($unlockMode == UnlockMode::Hardcore) {
+            if ($type == 2) { // Disable sorting if All Time
+                echo "Mastered";
             } else {
-                echo "<th><a href='/globalRanking.php?s=$sort9&t=$type&d=$date&f=$friends'>Mastered</a></th>";
+                $sortFilter('Mastered', 9);
+            }
+        } else {
+            if ($type == 2) { // Disable sorting if All Time
+                echo "Completed";
+            } else {
+                $sortFilter('Completed', 8);
             }
         }
 
@@ -233,18 +230,25 @@ RenderHeader($userDetails);
 
                 // If viewing the daily leaderboard then link the total achievements obtained to the users history page for the day
                 if ($type == 0) {
-                    echo "<td><a href='historyexamine.php?d=$dateUnix&u=" . $dataPoint['User'] . "'>" . $dataPoint['HardcoreCount'] . "</a></td>";
+                    echo "<td><a href='historyexamine.php?d=$dateUnix&u=" . $dataPoint['User'] . "'>" . $dataPoint['AchievementCount'] . "</a></td>";
                 } else {
-                    echo "<td>" . $dataPoint['HardcoreCount'] . "</td>";
+                    echo "<td>" . $dataPoint['AchievementCount'] . "</td>";
                 }
-                echo "<td>" . $dataPoint['HardcorePoints'];
-                echo " <span class='TrueRatio'>(" . $dataPoint['RetroPoints'] . ")</span></td>";
-                if ($dataPoint['HardcorePoints'] == 0) {
-                    echo "<td>0.00</td>";
+
+                if ($unlockMode == UnlockMode::Hardcore) {
+                    echo "<td>" . $dataPoint['Points'];
+                    echo " <span class='TrueRatio'>(" . $dataPoint['RetroPoints'] . ")</span></td>";
+                    if ($dataPoint['Points'] == 0) {
+                        echo "<td>0.00</td>";
+                    } else {
+                        echo "<td>" . $dataPoint['RetroRatio'] . "</td>";
+                    }
                 } else {
-                    echo "<td>" . $dataPoint['RetroRatio'] . "</td>";
+                    echo "<td>" . $dataPoint['Points'] . "</td>";
                 }
-                echo "<td>" . $dataPoint['MasteredAwards'] . "</td></tr>";
+
+                echo "<td>" . $dataPoint['TotalAwards'] . "</td></tr>";
+
                 $rank++;
                 $userCount++;
             } else {
@@ -264,7 +268,7 @@ RenderHeader($userDetails);
                 $userData = getGlobalRankingData($type, $sort, $date, $user, null, $untracked, 0, 1);
                 if (count($userData) > 0) {
                     // Add dummy row to seperate the user from the rest of the table
-                    echo "<tr><td colspan='7'></td></tr>";
+                    echo "<tr><td colspan='7'>&nbsp;</td></tr>";
                     echo "<tr style='outline: thin solid'>";
 
                     // Get the user rank when sorting by points or retro points
@@ -279,6 +283,8 @@ RenderHeader($userDetails);
                                 echo "<td>" . getUserRank($user, 0) . "</td>";
                             } elseif ($sort == 6) {
                                 echo "<td>" . getUserRank($user, 1) . "</td>";
+                            } elseif ($sort == 2) {
+                                echo "<td>" . getUserRankSoftcore($user) . "</td>";
                             } else {
                                 echo "<td></td>";
                             }
@@ -291,18 +297,24 @@ RenderHeader($userDetails);
 
                     // If viewing the daily leaderboard then link the total achievements obtained to the users history page for the day
                     if ($type == 0) {
-                        echo "<td><a href='historyexamine.php?d=$dateUnix&u=" . $userData[0]['User'] . "'>" . $userData[0]['HardcoreCount'] . "</a></td>";
+                        echo "<td><a href='historyexamine.php?d=$dateUnix&u=" . $userData[0]['User'] . "'>" . $userData[0]['AchievementCount'] . "</a></td>";
                     } else {
-                        echo "<td>" . $userData[0]['HardcoreCount'] . "</a></td>";
+                        echo "<td>" . $userData[0]['AchievementCount'] . "</a></td>";
                     }
-                    echo "<td>" . $userData[0]['HardcorePoints'];
-                    echo " <span class='TrueRatio'>(" . $userData[0]['RetroPoints'] . ")</span></td>";
-                    if ($userData[0]['HardcorePoints'] == 0) {
-                        echo "<td>0.00</td>";
+
+                    if ($unlockMode == UnlockMode::Hardcore) {
+                        echo "<td>" . $userData[0]['Points'];
+                        echo " <span class='TrueRatio'>(" . $userData[0]['RetroPoints'] . ")</span></td>";
+                        if ($userData[0]['Points'] == 0) {
+                            echo "<td>0.00</td>";
+                        } else {
+                            echo "<td>" . $userData[0]['RetroRatio'] . "</td>";
+                        }
                     } else {
-                        echo "<td>" . $userData[0]['RetroRatio'] . "</td>";
+                        echo "<td>" . $userData[0]['Points'] . "</td>";
                     }
-                    echo "<td>" . $userData[0]['MasteredAwards'] . "</td></tr>";
+
+                    echo "<td>" . $userData[0]['TotalAwards'] . "</td></tr>";
                 }
             }
         }

--- a/public/globalRanking.php
+++ b/public/globalRanking.php
@@ -113,6 +113,21 @@ RenderHeader($userDetails);
             echo "</div>";
         }
 
+        // Create the hardcore filter
+        echo "<div>";
+        echo "<b>Mode:</b> ";
+        if ($unlockMode == UnlockMode::Hardcore) {
+            echo "<b><a href='/globalRanking.php?s=5&t=$type&d=$date&f=$friends'>*Hardcore</a></b> | ";
+        } else {
+            echo "<a href='/globalRanking.php?s=5&t=$type&d=$date&f=$friends'>Hardcore</a> | ";
+        }
+        if ($unlockMode == UnlockMode::Softcore) {
+            echo "<b><a href='/globalRanking.php?s=2&t=$type&d=$date&f=$friends'>*Softcore</a></b>";
+        } else {
+            echo "<a href='/globalRanking.php?s=2&t=$type&d=$date&f=$friends'>Softcore</a>";
+        }
+        echo "</div>";
+
         // Create the custom date folter
         echo "<form action='/globalRanking.php' method='get'>";
         echo "<label for='d'><b>Custom Date: </b></label>";
@@ -124,9 +139,13 @@ RenderHeader($userDetails);
         echo "</form>";
 
         // Clear filter
-        if ($sort != 5 || $type != 0 || $date != date("Y-m-d") || $friends != 0) {
+        if (($sort != 5 && $sort != 2) || $type != 0 || $date != date("Y-m-d") || $friends != 0) {
             echo "<div>";
-            echo "<a href='/globalRanking.php'>Clear Filter</a>";
+            if ($sort == 2) {
+                echo "<a href='/globalRanking.php?s=2'>Clear Filter</a>";
+            } else {
+                echo "<a href='/globalRanking.php'>Clear Filter</a>";
+            }
             echo "</div>";
         }
         echo "</div>";

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -39,8 +39,6 @@ if (!$userMassData) {
 
 $userMotto = $userMassData['Motto'];
 $userPageID = $userMassData['ID'];
-$userTruePoints = $userMassData['TotalTruePoints'];
-$userRank = $userMassData['Rank'];
 $setRequestList = getUserRequestList($userPage);
 $userSetRequestInformation = getUserRequestsInformation($userPage, $setRequestList);
 $userWallActive = $userMassData['UserWallActive'];
@@ -282,33 +280,51 @@ RenderHtmlStart(true);
         echo "<br>";
 
         $totalHardcorePoints = $userMassData['TotalPoints'];
-        $totalSoftcorePoints = $userMassData['TotalSoftcorePoints'];
-        $totalTruePoints = $userMassData['TotalTruePoints'];
-        $retRatio = 0.0;
         if ($totalHardcorePoints > 0) {
-            $retRatio = sprintf("%01.2f", $userTruePoints / $totalHardcorePoints);
+            $totalTruePoints = $userMassData['TotalTruePoints'];
+
+            $retRatio = sprintf("%01.2f", $totalTruePoints / $totalHardcorePoints);
+            echo "Hardcore Points: $totalHardcorePoints points<span class='TrueRatio'> ($totalTruePoints)</span></span><br>";
+
+            echo "Site Rank: ";
+            if ($userIsUntracked) {
+                echo "<b>Untracked</b>";
+            } elseif ($totalHardcorePoints < Rank::MIN_POINTS) {
+                echo "<i>Needs at least " . Rank::MIN_POINTS . " points.</i>";
+            } else {
+                $countRankedUsers = countRankedUsers();
+                $userRank = $userMassData['Rank'];
+                $rankPct = sprintf("%1.2f", (($userRank / $countRankedUsers) * 100.0));
+                $rankOffset = (int) (($userRank - 1) / 25) * 25;
+                echo "<a href='/globalRanking.php?s=5&t=2&o=$rankOffset'>$userRank</a> / $countRankedUsers ranked users (Top $rankPct%)";
+            }
+            echo "<br>";
+
+            echo "Retro Ratio: <span class='TrueRatio'><b>$retRatio</b></span><br>";
+            echo "<br>";
         }
-        if ($totalHardcorePoints > 0 || $totalSoftcorePoints == 0) {
-            echo "Hardcore Points: $totalHardcorePoints points<span class='TrueRatio'> ($userTruePoints)</span></span><br>";
-        }
+
+        $totalSoftcorePoints = $userMassData['TotalSoftcorePoints'];
         if ($totalSoftcorePoints > 0) {
             echo "Softcore Points: $totalSoftcorePoints points<br>";
-        }
-        echo "Retro Ratio: <span class='TrueRatio'><b>$retRatio</b></span><br>";
-        echo "Average Completion: <b>$avgPctWon%</b><br>";
 
-        echo "Site Rank: ";
-        if ($userIsUntracked) {
-            echo "<b>Untracked</b>";
-        } elseif ($totalHardcorePoints < Rank::MIN_POINTS) {
-            echo "<i>Needs at least " . Rank::MIN_POINTS . " points.</i>";
-        } else {
-            $countRankedUsers = countRankedUsers();
-            $rankPct = sprintf("%1.2f", (($userRank / $countRankedUsers) * 100.0));
-            $rankOffset = (int) (($userRank - 1) / 25) * 25;
-            echo "<a href='/globalRanking.php?s=5&t=2&o=$rankOffset'>$userRank</a> / $countRankedUsers ranked users (Top $rankPct%)";
+            echo "Softcore Rank: ";
+            if ($userIsUntracked) {
+                echo "<b>Untracked</b>";
+            } elseif ($totalSoftcorePoints < Rank::MIN_POINTS) {
+                echo "<i>Needs at least " . Rank::MIN_POINTS . " points.</i>";
+            } else {
+                $countRankedUsers = countRankedUsersSoftcore();
+                $userRankSoftcore = getUserRankSoftcore($userPage);
+                $rankPct = sprintf("%1.2f", (($userRankSoftcore / $countRankedUsers) * 100.0));
+                $rankOffset = (int) (($userRankSoftcore - 1) / 25) * 25;
+                echo "<a href='/globalRanking.php?s=2&t=2&o=$rankOffset'>$userRankSoftcore</a> / $countRankedUsers ranked users (Top $rankPct%)";
+            }
+            echo "<br>";
+            echo "<br>";
         }
-        echo "<br>";
+
+        echo "Average Completion: <b>$avgPctWon%</b><br><br>";
 
         echo "<a href='/forumposthistory.php?u=$userPage'>Forum Post History</a>";
         echo "<br>";

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -7,6 +7,7 @@ use RA\ClaimSpecial;
 use RA\ClaimType;
 use RA\Permissions;
 use RA\Rank;
+use RA\RankType;
 use RA\UserAction;
 use RA\UserRelationship;
 
@@ -314,8 +315,8 @@ RenderHtmlStart(true);
             } elseif ($totalSoftcorePoints < Rank::MIN_POINTS) {
                 echo "<i>Needs at least " . Rank::MIN_POINTS . " points.</i>";
             } else {
-                $countRankedUsers = countRankedUsersSoftcore();
-                $userRankSoftcore = getUserRankSoftcore($userPage);
+                $countRankedUsers = countRankedUsers(RankType::Softcore);
+                $userRankSoftcore = getUserRank($userPage, RankType::Softcore);
                 $rankPct = sprintf("%1.2f", (($userRankSoftcore / $countRankedUsers) * 100.0));
                 $rankOffset = (int) (($userRankSoftcore - 1) / 25) * 25;
                 echo "<a href='/globalRanking.php?s=2&t=2&o=$rankOffset'>$userRankSoftcore</a> / $countRankedUsers ranked users (Top $rankPct%)";

--- a/src/RankType.php
+++ b/src/RankType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RA;
+
+abstract class RankType
+{
+    public const Hardcore = 1;
+
+    public const Softcore = 2;
+
+    public const TruePoints = 3;
+}


### PR DESCRIPTION
Allows players who primarily (or exclusively) use softcore mode to better track their own progress compared to other users.

_NOTE: Softcore removes all restrictions on the emulators. In addition to save states and rewind, you can use things like game genie codes, edit memory, disable layers to see through fog, view tile buffers to see stuff offscreen, or even have a TAS script play the whole game for you. Having a softcore leaderboard requires user to acknowledge that other players on that leaderboard could be using those features without any repercussions. The admin team has already stated that they will not investigate cheat reports submitted against softcore unlocks. So while it might be nice to see yourself go up a rank every few weeks, the rank itself loses its meaning. SomeOtherPlayer isn't better than you, he just uses more tools._

If you have at least one hardcore point, the hardcore information will appear on your profile page. If you have at least one softcore point, the softcore information will appear on your profile page. Softcore and hardcore leaderboards are not exclusive to each other. A player may appear in both. The number of ranked users for each leaderboard is simply the number of users in the database with at least the minimum amount of points for the leaderboard (currently 250 for both).

![image](https://user-images.githubusercontent.com/32680403/184070011-532151b0-e5ca-4ff4-83d6-80c61ac1c616.png)

Clicking the softcore rank link takes the user to the softcore global leaderboard. The Community menu still links to the hardcore global leaderboard, but a filter has been added allowing the user to switch between them. Switching the mode resets the offset to 0, showing the top 25 users for the selected mode.

![image](https://user-images.githubusercontent.com/32680403/184191889-df6c6b2f-1fec-4a33-8c3b-e86d39fdd4c7.png)

The user tooltips have also been updated to better distinguish between the two playstyles. For users who have more hardcore than softcore points, only the hardcore points and rank will be shown in the tooltip:

![image](https://user-images.githubusercontent.com/32680403/184070483-215fe4a5-76bf-4e30-9a04-b6fc8de51898.png)

A user with more softcore points than hardcore points will show the softcore points and rank in the tooltip:

![image](https://user-images.githubusercontent.com/32680403/184070661-63516135-50fd-4bff-8fba-4416fbd9372b.png)
