### PR TITLE
Fix game award counters overflow

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1612,47 +1612,6 @@ svg > g > g:last-child { pointer-events: none }
   border: 1px solid rgb(44, 151, 250);
 }
 
-.tabcontentscores th {
-  text-align: center;
-  font-weight: bold;
-}
-
-.tabcontentscores td {
-  text-align: center;  
-  padding: 2px 5px;
-}
-
-.tabcontentscores td.rank {
-  width: 15%;
-}
-
-.tabcontentscores td.user {
-  width: 55%;
-  text-align: left;
-}
-
-.tabcontentscores td.lastaward, .tabcontentscores td.points {
-  width: 30%;
-}
-
-.tabcontentscores td.user span:first-of-type {
-  margin-right: 6px;
-}
-
-.tabcontentscores td.user span:nth-of-type(2) {
-  display: inline-block;
-  width: 0;
-}
-
-.tabcontentscores .rank {
-  font-weight: bold;
-}
-
-.tabcontentscores .lastaward {
-  font-size: 0.85em;
-  font-style: italic;
-}
-
 /* More info buttons */
 .info-button{
   display:block;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -163,6 +163,10 @@ a:hover {
   background: -moz-linear-gradient(top, #1a1a1a, #2a2a2a); /* for firefox 3.6+ */
 }
 
+#rightcontainer h3 {
+  font-size: 1.8em;
+}
+
 .d-flex {
   display: flex;
 }
@@ -1606,6 +1610,47 @@ svg > g > g:last-child { pointer-events: none }
   display: none;
   padding: 2px 2px 2px;
   border: 1px solid rgb(44, 151, 250);
+}
+
+.tabcontentscores th {
+  text-align: center;
+  font-weight: bold;
+}
+
+.tabcontentscores td {
+  text-align: center;  
+  padding: 2px 5px;
+}
+
+.tabcontentscores td.rank {
+  width: 15%;
+}
+
+.tabcontentscores td.user {
+  width: 55%;
+  text-align: left;
+}
+
+.tabcontentscores td.lastaward, .tabcontentscores td.points {
+  width: 30%;
+}
+
+.tabcontentscores td.user span:first-of-type {
+  margin-right: 6px;
+}
+
+.tabcontentscores td.user span:nth-of-type(2) {
+  display: inline-block;
+  width: 0;
+}
+
+.tabcontentscores .rank {
+  font-weight: bold;
+}
+
+.tabcontentscores .lastaward {
+  font-size: 0.85em;
+  font-style: italic;
 }
 
 /* More info buttons */


### PR DESCRIPTION
This is a simple amend for #1070. One of the two counters used to overflow below (at least in Windows) in case there were too many digits to display:

![counter-overflow](https://user-images.githubusercontent.com/22218549/184240658-00327b27-10e0-4f7e-b1fc-57c081085e67.png)

Fixed by decreasing `<h3>`'s size on the right container (which has a rather positive side-effect since those were too big anyway).  Now it should hold up to 6 digits total.