### PR TITLE
Finished claims widget

### DIFF
--- a/lib/render/set-claim.php
+++ b/lib/render/set-claim.php
@@ -5,28 +5,19 @@ use RA\ClaimSetType;
 use RA\ClaimSorting;
 
 /**
- * Creates the Set Claims component.
+ * Creates the New Set Claims component.
  */
-function renderClaimsComponent(int $count, int $claimFilter = ClaimFilters::Default, int $claimSort = ClaimSorting::ClaimDateDescending): void
+function renderNewClaimsComponent(int $count): void
 {
     echo "<div class='component'>";
-    if ($claimFilter == ClaimFilters::CompletedFilter) {
-        echo "<h3>Finished Set Claims</h3>";
-    } else {
-        echo "<h3>New Set Claims</h3>";
-    }
+    echo "<h3>New Set Claims</h3>";
 
-    $claimData = getFilteredClaimData(0, $claimFilter, $claimSort, false, null, false, 0, $count);
+    $claimData = getFilteredClaimData(0, ClaimFilters::Default, ClaimSorting::ClaimDateDescending, false, null, false, 0, $count);
 
     echo "<tbody><table>";
     echo "<th>User</th>";
     echo "<th>Game</th>";
-    if ($claimFilter == ClaimFilters::CompletedFilter) {
-        echo "<th nowrap>Type</th>";
-        echo "<th nowrap>Finished On</th>";
-    } else {
-        echo "<th nowrap>Claimed On</th>";
-    }
+    echo "<th nowrap>Claimed On</th>";
     foreach ($claimData as $claim) {
         $claimUser = $claim['User'];
         echo "<tr><td class='text-nowrap'>";
@@ -38,17 +29,48 @@ function renderClaimsComponent(int $count, int $claimFilter = ClaimFilters::Defa
         echo GetGameAndTooltipDiv($claim['GameID'], $claim['GameTitle'], $claim['GameIcon'], $claim['ConsoleName']);
         echo "</td>";
 
-        if ($claimFilter == ClaimFilters::CompletedFilter) {
-            echo "<td>" . ($claim['SetType'] == ClaimSetType::NewSet ? ClaimSetType::toString(ClaimSetType::NewSet) : ClaimSetType::toString(ClaimSetType::Revision)) . "</td>";
-            echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['DoneTime'])) . "</td>";
-        } else {
-            echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['Created'])) . "</td>";
-        }
+        echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['Created'])) . "</td>";
     }
     echo "</tbody></table>";
 
     echo "<br>";
-    echo "<div class='morebutton'><a href='/claimlist.php" . ($claimFilter == ClaimFilters::CompletedFilter ? "?f=" . ClaimFilters::CompletedFilter : "") . "''>more...</a></div>";
+    echo "<div class='morebutton'><a href='/claimlist.php'>more...</a></div>";
+    echo "</div>";
+}
 
+/**
+ * Creates the Completed Set Claims component.
+ */
+function renderFinishedClaimsComponent(int $count): void
+{
+    echo "<div class='component'>";
+    echo "<h3>Finished Set Claims</h3>";
+
+    $claimData = getFilteredClaimData(0, ClaimFilters::AllCompletedPrimaryClaims, ClaimSorting::FinishedDateDescending, false, null, false, 0, $count);
+
+    echo "<tbody><table>";
+    echo "<th>User</th>";
+    echo "<th>Game</th>";
+    echo "<th nowrap>Type</th>";
+    echo "<th nowrap>Finished On</th>";
+    foreach ($claimData as $claim) {
+        $claimUser = $claim['User'];
+        echo "<tr><td class='text-nowrap'>";
+        echo GetUserAndTooltipDiv($claimUser, true);
+        echo GetUserAndTooltipDiv($claimUser, false);
+        echo "</td>";
+
+        echo "<td>";
+        echo GetGameAndTooltipDiv($claim['GameID'], $claim['GameTitle'], $claim['GameIcon'], $claim['ConsoleName']);
+        echo "</td>";
+
+        echo "<td>" . ($claim['SetType'] == ClaimSetType::NewSet ? ClaimSetType::toString(ClaimSetType::NewSet) : ClaimSetType::toString(ClaimSetType::Revision)) . "</td>";
+
+        echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['DoneTime'])) . "</td>";
+    }
+    echo "</tbody></table>";
+
+    echo "<br>";
+    echo "<div class='morebutton'><a href='/claimlist.php?f=" . ClaimFilters::AllCompletedPrimaryClaims . "'>more...</a></div>";
     echo "</div>";
 }

--- a/lib/render/set-claim.php
+++ b/lib/render/set-claim.php
@@ -4,19 +4,28 @@ use RA\ClaimFilters;
 use RA\ClaimSorting;
 
 /**
- * Creates the New Set Claims component.
+ * Creates the Set Claims component.
  */
-function renderNewClaimsComponent(int $count): void
+function renderClaimsComponent(int $count, int $claimFilter = ClaimFilters::Default): void
 {
     echo "<div class='component'>";
-    echo "<h3>New Set Claims</h3>";
+    if ($claimFilter == ClaimFilters::CompletedFilter) {
+        echo "<h3>Finished Set Claims</h3>";
+    } else {
+        echo "<h3>New Set Claims</h3>";
+    }
 
-    $claimData = getFilteredClaimData(0, ClaimFilters::Default, ClaimSorting::ClaimDateDescending, false, null, false, 0, $count);
+    $claimData = getFilteredClaimData(0, $claimFilter, ClaimSorting::ClaimDateDescending, false, null, false, 0, $count);
 
     echo "<tbody><table>";
     echo "<th>User</th>";
     echo "<th>Game</th>";
-    echo "<th nowrap>Claimed On</th>";
+    if ($claimFilter == ClaimFilters::CompletedFilter) {
+        echo "<th nowrap>Type</th>";
+        echo "<th nowrap>Finished On</th>";
+    } else {
+        echo "<th nowrap>Claimed On</th>";
+    }
     foreach ($claimData as $claim) {
         $claimUser = $claim['User'];
         echo "<tr><td class='text-nowrap'>";
@@ -28,11 +37,12 @@ function renderNewClaimsComponent(int $count): void
         echo GetGameAndTooltipDiv($claim['GameID'], $claim['GameTitle'], $claim['GameIcon'], $claim['ConsoleName']);
         echo "</td>";
 
-        echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['Created'])) . "</td>";
+        echo "<td class='smalldate'>" . ($claimFilter == ClaimFilters::CompletedFilter ? getNiceDate(strtotime($claim['DoneTime'])) : getNiceDate(strtotime($claim['Created']))) . " </td>";
     }
     echo "</tbody></table>";
 
     echo "<br>";
-    echo "<div class='morebutton'><a href='/claimlist.php'>more...</a></div>";
+    echo "<div class='morebutton'><a href='/claimlist.php" . ($claimFilter == ClaimFilters::CompletedFilter ? "?f=" . ClaimFilters::CompletedFilter : "") . "''>more...</a></div>";
+
     echo "</div>";
 }

--- a/lib/render/set-claim.php
+++ b/lib/render/set-claim.php
@@ -7,7 +7,7 @@ use RA\ClaimSorting;
 /**
  * Creates the Set Claims component.
  */
-function renderClaimsComponent(int $count, int $claimFilter = ClaimFilters::Default): void
+function renderClaimsComponent(int $count, int $claimFilter = ClaimFilters::Default, int $claimSort = ClaimSorting::ClaimDateDescending): void
 {
     echo "<div class='component'>";
     if ($claimFilter == ClaimFilters::CompletedFilter) {
@@ -16,7 +16,7 @@ function renderClaimsComponent(int $count, int $claimFilter = ClaimFilters::Defa
         echo "<h3>New Set Claims</h3>";
     }
 
-    $claimData = getFilteredClaimData(0, $claimFilter, ClaimSorting::ClaimDateDescending, false, null, false, 0, $count);
+    $claimData = getFilteredClaimData(0, $claimFilter, $claimSort, false, null, false, 0, $count);
 
     echo "<tbody><table>";
     echo "<th>User</th>";

--- a/lib/render/set-claim.php
+++ b/lib/render/set-claim.php
@@ -52,7 +52,7 @@ function renderFinishedClaimsComponent(int $count): void
     echo "<th>User</th>";
     echo "<th>Game</th>";
     echo "<th nowrap>Type</th>";
-    echo "<th nowrap>Finished On</th>";
+    echo "<th nowrap>Finished</th>";
     foreach ($claimData as $claim) {
         $claimUser = $claim['User'];
         echo "<tr><td class='text-nowrap'>";

--- a/lib/render/set-claim.php
+++ b/lib/render/set-claim.php
@@ -10,14 +10,14 @@ use RA\ClaimSorting;
 function renderNewClaimsComponent(int $count): void
 {
     echo "<div class='component'>";
-    echo "<h3>New Set Claims</h3>";
+    echo "<h3>Sets in Progress</h3>";
 
     $claimData = getFilteredClaimData(0, ClaimFilters::Default, ClaimSorting::ClaimDateDescending, false, null, false, 0, $count);
 
     echo "<tbody><table>";
     echo "<th>User</th>";
     echo "<th>Game</th>";
-    echo "<th nowrap>Claimed On</th>";
+    echo "<th nowrap>Started</th>";
     foreach ($claimData as $claim) {
         $claimUser = $claim['User'];
         echo "<tr><td class='text-nowrap'>";
@@ -44,7 +44,7 @@ function renderNewClaimsComponent(int $count): void
 function renderFinishedClaimsComponent(int $count): void
 {
     echo "<div class='component'>";
-    echo "<h3>Finished Set Claims</h3>";
+    echo "<h3>New Sets/Revisions</h3>";
 
     $claimData = getFilteredClaimData(0, ClaimFilters::AllCompletedPrimaryClaims, ClaimSorting::FinishedDateDescending, false, null, false, 0, $count);
 

--- a/lib/render/set-claim.php
+++ b/lib/render/set-claim.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\ClaimFilters;
+use RA\ClaimSetType;
 use RA\ClaimSorting;
 
 /**
@@ -37,7 +38,12 @@ function renderClaimsComponent(int $count, int $claimFilter = ClaimFilters::Defa
         echo GetGameAndTooltipDiv($claim['GameID'], $claim['GameTitle'], $claim['GameIcon'], $claim['ConsoleName']);
         echo "</td>";
 
-        echo "<td class='smalldate'>" . ($claimFilter == ClaimFilters::CompletedFilter ? getNiceDate(strtotime($claim['DoneTime'])) : getNiceDate(strtotime($claim['Created']))) . " </td>";
+        if ($claimFilter == ClaimFilters::CompletedFilter) {
+            echo "<td>" . ($claim['SetType'] == ClaimSetType::NewSet ? ClaimSetType::toString(ClaimSetType::NewSet) : ClaimSetType::toString(ClaimSetType::Revision)) . "</td>";
+            echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['DoneTime'])) . "</td>";
+        } else {
+            echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['Created'])) . "</td>";
+        }
     }
     echo "</tbody></table>";
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,8 +1,5 @@
 <?php
 
-use RA\ClaimFilters;
-use RA\ClaimSorting;
-
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
@@ -192,11 +189,11 @@ RenderHeader($userDetails);
             RenderWelcomeComponent();
         }
         RenderNewsComponent();
-        renderClaimsComponent(5, ClaimFilters::CompletedFilter, ClaimSorting::FinishedDateDescending);
+        renderFinishedClaimsComponent(5);
         RenderActivePlayersComponent();
         RenderCurrentlyOnlineComponent();
         echo "<div style='min-height: 160px;' id='chart_usersonline'></div>";
-        renderClaimsComponent(5, ClaimFilters::Default, ClaimSorting::ClaimDateDescending);
+        renderNewClaimsComponent(5);
         RenderRecentForumPostsComponent($permissions, 4);
         ?>
     </div>

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\ClaimFilters;
+use RA\ClaimSorting;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
@@ -191,11 +192,11 @@ RenderHeader($userDetails);
             RenderWelcomeComponent();
         }
         RenderNewsComponent();
-        renderClaimsComponent(5, ClaimFilters::CompletedFilter);
+        renderClaimsComponent(5, ClaimFilters::CompletedFilter, ClaimSorting::FinishedDateDescending);
         RenderActivePlayersComponent();
         RenderCurrentlyOnlineComponent();
         echo "<div style='min-height: 160px;' id='chart_usersonline'></div>";
-        renderClaimsComponent(5, ClaimFilters::Default);
+        renderClaimsComponent(5, ClaimFilters::Default, ClaimSorting::ClaimDateDescending);
         RenderRecentForumPostsComponent($permissions, 4);
         ?>
     </div>

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\ClaimFilters;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../lib/bootstrap.php';
 
@@ -189,11 +191,11 @@ RenderHeader($userDetails);
             RenderWelcomeComponent();
         }
         RenderNewsComponent();
-        RenderRecentlyUploadedComponent(5);
+        renderClaimsComponent(5, ClaimFilters::CompletedFilter);
         RenderActivePlayersComponent();
         RenderCurrentlyOnlineComponent();
         echo "<div style='min-height: 160px;' id='chart_usersonline'></div>";
-        renderNewClaimsComponent(5);
+        renderClaimsComponent(5, ClaimFilters::Default);
         RenderRecentForumPostsComponent($permissions, 4);
         ?>
     </div>

--- a/src/ClaimFilters.php
+++ b/src/ClaimFilters.php
@@ -34,7 +34,7 @@ abstract class ClaimFilters
     public const AllFilters = (1 << 13) - 1;
 
     // Filter to show all Complete Primary claims
-    public const CompletedFilter = self::AllFilters & ~self::ActiveClaim
+    public const AllCompletedPrimaryClaims = self::AllFilters & ~self::ActiveClaim
                                             & ~self::DroppedClaim
                                             & ~self::CollaborationClaim;
 

--- a/src/ClaimFilters.php
+++ b/src/ClaimFilters.php
@@ -33,6 +33,11 @@ abstract class ClaimFilters
     // This should be updated every time a new filter is added so it has all possible filter bits set
     public const AllFilters = (1 << 13) - 1;
 
+    // Filter to show all Complete Primary claims
+    public const CompletedFilter = self::AllFilters & ~self::ActiveClaim
+                                            & ~self::DroppedClaim
+                                            & ~self::CollaborationClaim;
+
     // Default filter is everything except Complete and Dropped claims
     public const Default = self::AllFilters & ~self::CompleteClaim
                                             & ~self::DroppedClaim;


### PR DESCRIPTION
Changes out the New Achievements component with Finished Set Claims component

Old
![image](https://user-images.githubusercontent.com/4047771/184251557-78a96630-4b09-4e1f-a138-5cca92665a63.png)


New
![image](https://user-images.githubusercontent.com/4047771/184251576-476203ae-a819-4fad-b3c1-cd4b3fb1a1d9.png)


Reasoning being that a majority of the time New Achievements essentially shows that a single game got a set created. Changing to show newly finished sets/revisions show more useful details and if you want to see specific new achievements you will likely be checking the Achievement List page anyways which shows them all.

Finished Claims "more..." link will take you to the Claim List page filtered on Complete statuses.