### PR TITLE
fix hardcore indicator on player history page

### DIFF
--- a/public/historyexamine.php
+++ b/public/historyexamine.php
@@ -101,18 +101,18 @@ RenderHtmlHead("$userPage's Legacy - $dateStr");
         $achCount = count($achEarnedOnDay);
         $earnedCount = 0;
         $pointsCount = 0;
-        // foreach( $achEarnedOnDay as $achEarned )
 
         $achEarnedLib = [];
+        foreach ($achEarnedOnDay as $achEarned) {
+            $achID = $achEarned['AchievementID'];
+            $achPoints = $achEarned['Points'];
 
-        // Potentially overwrite HARDCORE into $achEarnedLib
-        for ($i = 0; $i < $achCount; $i++) {
-            $achID = $achEarnedOnDay[$i]['AchievementID'];
-            $achEarnedLib[$achID] = $achEarnedOnDay[$i];
-            $achPoints = $achEarnedLib[$achID]['Points'];
-            if ($achEarnedOnDay[$i]['HardcoreMode'] == UnlockMode::Hardcore) {
+            // capture the entry if it's a hardcore unlock, or a hardcore unlock has not yet been seen
+            if ($achEarned['HardcoreMode'] == UnlockMode::Hardcore) {
+                $achEarnedLib[$achID] = $achEarned;
                 $achEarnedLib[$achID]['PointsNote'] = "$achPoints";
-            } else { // else Softcore
+            } elseif (!isset($achEarnedLib[$achID])) {
+                $achEarnedLib[$achID] = $achEarned;
                 $achEarnedLib[$achID]['PointsNote'] = "<span class='softcore'>$achPoints</span>";
             }
         }


### PR DESCRIPTION
Changes made to support the hardcore/softcore split broke the player history page such that it would sometimes show achievements earned in hardcore as softcore. This is due to the way the data is stored in the database as two separate unlocks (one for the hardcode version and one for the softcore version). When both are generated at the same time, they have the same timestamp and the query that retrieves them may not return them in a deterministic order. If the softcore unlock was returned after the hardcore unlock, the unlock would appear as softcore in the list.

The code prior to the change populated the list with softcore unlocks first, then looped through the list a second time overwriting the softcore unlocks with the hardcore unlock data. This PR keeps the simplified single-pass logic, but only overwrites the softcore unlock with the hardcore data and not the other way around.