### PR TITLE
fix first mutual follower showing follow link

### DIFF
--- a/public/friends.php
+++ b/public/friends.php
@@ -55,7 +55,7 @@ function RenderUserList(string $header, string $user, array $users, int $friends
         echo "<div>";
         switch ($friendshipType) {
             case UserRelationship::Following:
-                if (!array_search($user, array_column($followingList, 'User'))) {
+                if (array_search($user, array_column($followingList, 'User')) === false) {
                     echo "<span style='display:block; line-height:1.6;'><a href='/request/user/update-relationship.php?f=$user&amp;a=" . UserRelationship::Following . "'>Follow&nbsp;user</a></span>";
                 }
                 echo "<span style='display:block; line-height:1.6;'><a href='/request/user/update-relationship.php?f=$user&amp;a=" . UserRelationship::Blocked . "'>Block&nbsp;user</a></span>";


### PR DESCRIPTION
`array_search` returns `0` when it matches the first element in the array, or `false` if no elements were found. The boolean check `!array_search()` returns true for both. I've updated the logic to explicitly look for `false`.