### PR TITLE
fix Mastered being displayed when 99.5+% of achievements earned, but not 100%

### DIFF
--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -269,8 +269,8 @@ function RenderGameProgress(int $numAchievements, int $numEarnedCasual, int $num
             $pctAwardedHardcoreProportion = $numEarnedHardcore / ($numEarnedHardcore + $numEarnedCasual);
         }
 
-        $pctComplete = sprintf("%01.0f", $pctAwardedCasual * 100.0);
-        $pctHardcore = sprintf("%01.0f", $pctAwardedHardcore * 100.0);
+        $pctComplete = sprintf("%01.0f", floor($pctAwardedCasual * 100.0));
+        $pctHardcore = sprintf("%01.0f", floor($pctAwardedHardcore * 100.0));
         $pctHardcoreProportion = sprintf("%01.0f", $pctAwardedHardcoreProportion * 100.0);
 
         if ($numEarnedCasual && $numEarnedHardcore) {


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/962817919698501702/1020473949571788851