### PR TITLE
update active players tooltips to match new style

### DIFF
--- a/lib/database/user-activity.php
+++ b/lib/database/user-activity.php
@@ -542,7 +542,7 @@ function getCurrentlyOnlinePlayers(): array
     $playersFound = [];
 
     // Select all users active in the last 10 minutes:
-    $query = "SELECT ua.User, ua.RAPoints, act.timestamp AS LastActivityAt, ua.RichPresenceMsg AS LastActivity, act.data as GameID
+    $query = "SELECT ua.User, ua.RAPoints, ua.RASoftcorePoints, act.timestamp AS LastActivityAt, ua.RichPresenceMsg AS LastActivity, act.data as GameID
               FROM UserAccounts AS ua
               LEFT JOIN Activity AS act ON act.ID = ua.LastActivityID
               WHERE ua.LastLogin > TIMESTAMPADD( MINUTE, -$recentMinutes, NOW() )
@@ -569,7 +569,8 @@ function getLatestRichPresenceUpdates(): array
     $recentMinutes = 10;
     $permissionsCutoff = Permissions::Registered;
 
-    $query = "SELECT ua.User, ua.RAPoints, ua.RichPresenceMsg, gd.ID AS GameID, gd.Title AS GameTitle, gd.ImageIcon AS GameIcon, c.Name AS ConsoleName
+    $query = "SELECT ua.User, ua.RAPoints, ua.RASoftcorePoints, ua.RichPresenceMsg,
+                     gd.ID AS GameID, gd.Title AS GameTitle, gd.ImageIcon AS GameIcon, c.Name AS ConsoleName
               FROM UserAccounts AS ua
               LEFT JOIN GameData AS gd ON gd.ID = ua.LastGameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
@@ -583,6 +584,7 @@ function getLatestRichPresenceUpdates(): array
         while ($db_entry = mysqli_fetch_assoc($dbResult)) {
             settype($db_entry['GameID'], 'integer');
             settype($db_entry['RAPoints'], 'integer');
+            settype($db_entry['RASoftcorePoints'], 'integer');
             $playersFound[] = $db_entry;
         }
     } else {

--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -49,7 +49,7 @@ function _GetUserAndTooltipDiv(
     $lastLogin = $userCardInfo['LastActivity'] ? getNiceDate(strtotime($userCardInfo['LastActivity'])) : null;
     $memberSince = $userCardInfo['MemberSince'] ? getNiceDate(strtotime($userCardInfo['MemberSince']), true) : null;
 
-    $tooltip = "<div id='objtooltip'>";
+    $tooltip = "<div id='objtooltip' class='flex items-start' style='max-width: 400px;'>";
     $tooltip .= "<table><tbody>";
     $tooltip .= "<tr>";
     $tooltip .= "<td><img width='128' height='128' src='/UserPic/" . $userSanitized . ".png'/>";
@@ -74,15 +74,15 @@ function _GetUserAndTooltipDiv(
     // Add the user points if there are any
     $tooltip .= "<tr>";
     if ($userHardcorePoints > $userSoftcorePoints) {
-        $tooltip .= "<td  colspan='2' class='usercardbasictext'><b>Points:</b> $userHardcorePoints ($userTruePoints)</td>";
+        $tooltip .= "<td colspan='2' class='usercardbasictext'><b>Points:</b> $userHardcorePoints ($userTruePoints)</td>";
         $userRank = $userHardcorePoints < Rank::MIN_POINTS ? 0 : getUserRank($user, RankType::Hardcore);
         $userRankLabel = 'Site Rank';
     } elseif ($userSoftcorePoints > 0) {
-        $tooltip .= "<td  colspan='2' class='usercardbasictext'><b>Softcore Points:</b> $userSoftcorePoints</td>";
+        $tooltip .= "<td colspan='2' class='usercardbasictext'><b>Softcore Points:</b> $userSoftcorePoints</td>";
         $userRank = $userSoftcorePoints < Rank::MIN_POINTS ? 0 : getUserRank($user, RankType::Softcore);
         $userRankLabel = 'Softcore Rank';
     } else {
-        $tooltip .= "<td  colspan='2' class='usercardbasictext'><b>Points:</b> 0</td>";
+        $tooltip .= "<td colspan='2' class='usercardbasictext'><b>Points:</b> 0</td>";
         $userRank = 0;
         $userRankLabel = 'Site Rank';
     }

--- a/public/js/activePlayersBootstrap.js
+++ b/public/js/activePlayersBootstrap.js
@@ -78,7 +78,7 @@ var ActivePlayersViewModel = function () {
       gameTitle: ko.observable(player.GameTitle),
       consoleName: ko.observable(player.ConsoleName),
       richPresence: ko.observable(player.RichPresenceMsg),
-      playerHtml: ko.observable(GetUserAndTooltipDiv(player.User, player.RAPoints, player.Motto, true, '')),
+      playerHtml: ko.observable(GetUserAndTooltipDiv(player.User, player.RAPoints, player.RASoftcorePoints, true, '')),
       gameHtml: ko.observable(GetGameAndTooltipDiv(player.GameID, player.GameTitle, player.GameIcon, player.ConsoleName, true))
     };
   };

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -114,63 +114,21 @@ function replaceAll(find, replace, str) {
   return str.replace(new RegExp(find, 'g'), replace);
 }
 
-function GetAchievementAndTooltipDiv(
-  achID,
-  achName,
-  achDesc,
-  achPoints,
-  gameName,
-  badgeName,
-  inclSmallBadge,
-  smallBadgeOnly
-) {
+function GetTooltipDiv(icon, header, body) {
   var tooltipImageSize = 64;
-  var tooltip = '<div id=\'objtooltip\'>'
-    + '<img src=\'' + mediaAsset(`Badge/${badgeName}.png`) + '\' width=' + tooltipImageSize + ' height='
-    + tooltipImageSize + ' />'
-    + '<b>' + achName + ' (' + achPoints.toString() + ')</b><br>'
-    + '<i>(' + gameName + ')</i><br>'
-    + '<br>'
-    + achDesc + '<br>'
-    + '</div>';
+  var tooltip = '<div id=\'objtooltip\' class=\'flex items-start\' style=\'max-width: 400px;\'>'
+    + '<img style=\'margin-right:5px\' src=\'' + icon + '\' width=\'' + tooltipImageSize + '\' height=\'' + tooltipImageSize + '\' />'
+    + '<div><b>' + header + '</b><br><span style=\'white-space: nowrap\'>' + body + '</span></div></div>';
   tooltip = replaceAll('<', '&lt;', tooltip);
   tooltip = replaceAll('>', '&gt;', tooltip);
   tooltip = replaceAll('\'', '\\\'', tooltip);
   tooltip = replaceAll('"', '&quot;', tooltip);
-  var smallBadge = '';
-  var displayable = achName + ' (' + achPoints.toString() + ')';
-  if (inclSmallBadge) {
-    var smallBadgePath = mediaAsset(`Badge/${badgeName}.png`);
-    smallBadge = '<img width=\'32\' height=\'32\' style=\'floatimg\' src=\''
-      + smallBadgePath + '\' alt="' + achName + '" title="' + achName
-      + '" class=\'badgeimg\' />';
-    if (smallBadgeOnly) {
-      displayable = '';
-    }
-  }
-
-  return '<div class=\'inline\' onmouseover="Tip(\'' + tooltip
-    + '\')" onmouseout="UnTip()" >'
-    + '<a href=\'/achievement/' + achID + '\'>'
-    + smallBadge
-    + displayable
-    + '</a>'
-    + '</div>';
+  return tooltip;
 }
 
 function GetGameAndTooltipDiv(gameID, gameTitle, gameIcon, consoleName, imageInstead) {
-  var tooltipImageSize = 64;
   var consoleStr = '(' + consoleName + ')';
-  var tooltip = '<div id=\'objtooltip\'>'
-    + '<img src=\'' + gameIcon + '\' width=\'' + tooltipImageSize
-    + '\' height=\'' + tooltipImageSize + '\' />'
-    + '<b>' + gameTitle + '</b><br>'
-    + consoleStr
-    + '</div>';
-  tooltip = replaceAll('<', '&lt;', tooltip);
-  tooltip = replaceAll('>', '&gt;', tooltip);
-  tooltip = replaceAll('\'', '\\\'', tooltip);
-  tooltip = replaceAll('"', '&quot;', tooltip);
+  var tooltip = GetTooltipDiv(gameIcon, gameTitle, consoleStr);
   var displayable = gameTitle + ' ' + consoleStr;
   if (imageInstead) {
     displayable = '<img alt="started playing ' + gameTitle
@@ -185,37 +143,16 @@ function GetGameAndTooltipDiv(gameID, gameTitle, gameIcon, consoleName, imageIns
     + '</div>';
 }
 
-function GetUserAndTooltipDiv(user, points, motto, imageInstead, extraText) {
-  var tooltipImageSize = 128;
-  var tooltip = '<div id=\'objtooltip\'>';
-  tooltip += '<table><tbody>';
-  tooltip += '<tr>';
-  // Image
-  tooltip += '<td><img src=\'/UserPic/' + user
-    + '.png\' width=\'' + tooltipImageSize + '\' height=\'' + tooltipImageSize
-    + '\' /></td>';
-  // Username (points)
-  tooltip += '<td>';
-  tooltip += '<b>' + user + '</b>';
-  if (points !== null) {
-    tooltip += '&nbsp;(' + points.toString() + ')';
+function GetUserAndTooltipDiv(user, hardcorePoints, softcorePoints, imageInstead, extraText) {
+  if (hardcorePoints > softcorePoints) {
+    points = 'Points: ' + hardcorePoints;
+  } else if (softcorePoints > 0) {
+    points = 'Softcore Points: ' + softcorePoints;
+  } else {
+    points = 'Points: 0';
   }
-  // Motto
-  if (motto && motto.length > 2) {
-    tooltip += '<br><span class=\'usermotto\'>' + motto + '</span>';
-  }
-  if (extraText.length > 0) {
-    tooltip += extraText;
-  }
-  tooltip += '</td>';
-  tooltip += '</tr>';
-  tooltip += '</tbody></table>';
-  tooltip += '</div>';
-  // tooltip = escapeHtml( tooltip );
-  tooltip = replaceAll('<', '&lt;', tooltip);
-  tooltip = replaceAll('>', '&gt;', tooltip);
-  tooltip = replaceAll('\'', '\\\'', tooltip); // &#039;
-  tooltip = replaceAll('"', '&quot;', tooltip);
+
+  var tooltip = GetTooltipDiv('/UserPic/' + user + '.png', user, points);
   var displayable = user;
   if (imageInstead) {
     displayable = '<img src=\'/UserPic/' + user
@@ -225,35 +162,6 @@ function GetUserAndTooltipDiv(user, points, motto, imageInstead, extraText) {
   return '<div class=\'inline\' onmouseover="Tip(\'' + tooltip
     + '\')" onmouseout="UnTip()" >'
     + '<a href=\'/user/' + user + '\'>'
-    + displayable
-    + '</a>'
-    + '</div>';
-}
-
-function GetLeaderboardAndTooltipDiv(
-  lbID,
-  lbName,
-  lbDesc,
-  gameName,
-  gameIcon,
-  displayable
-) {
-  var tooltipImageSize = 64;
-  var tooltip = '<div id=\'objtooltip\'>'
-    + '<img src=\'' + gameIcon + '\' width=\'' + tooltipImageSize
-    + '\' height=\'' + tooltipImageSize + '\' />'
-    + '<b>' + lbName + '</b><br>'
-    + '<i>(' + gameName + ')</i><br>'
-    + '<br>'
-    + lbDesc + '<br>'
-    + '</div>';
-  tooltip = replaceAll('<', '&lt;', tooltip);
-  tooltip = replaceAll('>', '&gt;', tooltip);
-  tooltip = replaceAll('\'', '\\\'', tooltip);
-  tooltip = replaceAll('"', '&quot;', tooltip);
-  return '<div class=\'inline\' onmouseover="Tip(\'' + tooltip
-    + '\')" onmouseout="UnTip()" >'
-    + '<a href=\'/leaderboardinfo.php?i=' + lbID + '\'>'
     + displayable
     + '</a>'
     + '</div>';
@@ -404,42 +312,6 @@ function showStatusFailure(message) {
 
 function hideStatusMessage() {
   $('#status').hide();
-}
-
-function refreshOnlinePlayers() {
-  $.post('/request/user/list-currently-online.php')
-    .done(function (data) {
-      var playerList = data;
-      var numPlayersOnline = playerList.length;
-
-      var htmlOut = '<div>There are currently <strong>' + numPlayersOnline
-        + '</strong> players online:</div>';
-
-      for (var i = 0; i < numPlayersOnline; i += 1) {
-        var player = playerList[i];
-
-        if (i > 0 && i === numPlayersOnline - 1) {
-          // last but one:
-          htmlOut += ' and ';
-        } else if (i > 0) {
-          htmlOut += ', ';
-        }
-
-        var extraText = '<br>' + player.LastActivityAt + ': ' + player.User + ' '
-          + player.LastActivity;
-        htmlOut += GetUserAndTooltipDiv(player.User, player.RAPoints, player.Motto, false, extraText);
-      }
-
-      var d = new Date();
-
-      $('#playersonlinebox').html(htmlOut);
-      $('#playersonlinebox').fadeTo('fast', 1.0);
-      $('#playersonline-update').html('Last updated at ' + d.toLocaleTimeString());
-      $('#playersonline-update').fadeTo('fast', 0.5);
-    });
-
-  $('#playersonlinebox').fadeTo('fast', 0.0);
-  $('#playersonline-update').fadeTo('fast', 0.0);
 }
 
 function tabClick(evt, tabName, type) {

--- a/public/request/user/list-currently-online.php
+++ b/public/request/user/list-currently-online.php
@@ -1,3 +1,0 @@
-<?php
-
-return response()->json(getCurrentlyOnlinePlayers());

--- a/resources/css/card.css
+++ b/resources/css/card.css
@@ -12,3 +12,7 @@
   text-align: right;
   text-decoration: underline;
 }
+
+.usercardbasictext {
+  white-space: nowrap;
+}


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/32680403/190870311-1c425948-77df-4e30-b538-f466ae7f8622.png)

after:
![image](https://user-images.githubusercontent.com/32680403/190870350-5f182a88-30a0-4c26-bd61-fc577903c59c.png)

NOTE: I've chosen to go with a simpler tooltip for the user (to match the game tooltip) as the API that refreshes the active widget doesn't provide all of the information available in the normal user tooltip:
![image](https://user-images.githubusercontent.com/32680403/190870420-d36e1e75-4ab4-4d9c-8d35-05d080dc20c1.png)
