### PR TITLE
also return full URLs for game images and achievement badges

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -447,6 +447,12 @@ function GetAchievementsPatch($gameID, $flags): array
             settype($db_entry['Created'], 'integer');
             settype($db_entry['Flags'], 'integer');
 
+            $badgeName = $db_entry['BadgeName'];
+            if ($badgeName) {
+                $db_entry['BadgeURL'] = media_asset("Badge/$badgeName.png");
+                $db_entry['BadgeLockedURL'] = media_asset("Badge/${badgeName}_lock.png");
+            }
+
             $retVal[] = $db_entry;
         }
     } else {
@@ -468,7 +474,23 @@ function GetPatchData($gameID, $flags, $user): array
         // cannot look up game with gameID $gameID for user $user
         return $retVal;
     }
-    $retVal = array_merge(getGameData($gameID));
+
+    $gameData = getGameData($gameID);
+
+    if ($gameData['ImageIcon']) {
+        $gameData['ImageIconURL'] = media_asset($gameData['ImageIcon']);
+    }
+    if ($gameData['ImageTitle']) {
+        $gameData['ImageTitleURL'] = media_asset($gameData['ImageTitle']);
+    }
+    if ($gameData['ImageIngame']) {
+        $gameData['ImageIngameURL'] = media_asset($gameData['ImageIngame']);
+    }
+    if ($gameData['ImageBoxArt']) {
+        $gameData['ImageBoxArtURL'] = media_asset($gameData['ImageBoxArt']);
+    }
+
+    $retVal = array_merge($gameData);
 
     $retVal['Achievements'] = GetAchievementsPatch($gameID, $flags);
     $retVal['Leaderboards'] = GetLBPatch($gameID);

--- a/resources/helpers/helpers.php
+++ b/resources/helpers/helpers.php
@@ -22,6 +22,10 @@ if (!function_exists('percentage')) {
 if (!function_exists('media_asset')) {
     function media_asset(string $path): string
     {
-        return app('filesystem')->disk('media')->url($path);
+        $url = app('filesystem')->disk('media')->url($path);
+        if (!request()->isSecure()) {
+          $url = str_replace('https://', 'http://', $url);
+        }
+        return $url;
     }
 }


### PR DESCRIPTION
Eliminates the need for the client to construct the URL, and allows us to change the URL without breaking the clients. 

The recent move to the new framework had some issues around migrating resources from `i.retroachievements.org` to `media.retroachievements.org` and others related to accessing them directly through `retroachievements.org`.