### PR TITLE
add RenderUserLink function

### DIFF
--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -2,6 +2,7 @@
 
 namespace App\Support\Shortcode;
 
+use RA\LinkStyle;
 use Thunder\Shortcode\Event\FilterShortcodesEvent;
 use Thunder\Shortcode\EventContainer\EventContainer;
 use Thunder\Shortcode\Events;
@@ -186,7 +187,7 @@ final class Shortcode
             return '';
         }
 
-        return GetUserAndTooltipDiv($username, false);
+        return GetUserLink($username, LinkStyle::Text);
     }
 
     private function autolinkRetroachievementsUrls(string $text): string

--- a/lib/database/player-achievement.php
+++ b/lib/database/player-achievement.php
@@ -246,40 +246,6 @@ function getUsersRecentAwardedForGames(string $user, $gameIDsCSV, $numAchievemen
     }
 }
 
-function getRecentlyEarnedAchievements(int $count, ?string $user, &$dataOut): int
-{
-    sanitize_sql_inputs($count, $user);
-
-    $query = "SELECT aw.User, aw.Date AS DateAwarded, aw.AchievementID, ach.Title, ach.Description, ach.BadgeName, ach.Points, ach.GameID, gd.Title AS GameTitle, gd.ImageIcon AS GameIcon, c.Name AS ConsoleTitle
-               FROM Awarded AS aw
-               LEFT JOIN Achievements ach ON aw.AchievementID = ach.ID
-               LEFT JOIN GameData gd ON ach.GameID = gd.ID
-               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID ";
-
-    if (!empty($user)) {
-        $query .= "WHERE User='$user' AND HardcoreMode=0 ";
-    } else {
-        $query .= "WHERE HardcoreMode=0 ";
-    }
-
-    $query .= "ORDER BY Date DESC
-                LIMIT 0, $count";
-
-    $dbResult = s_mysql_query($query);
-
-    if (!$dbResult) {
-        log_sql_fail();
-        return 0;
-    }
-
-    $i = 0;
-    while ($db_entry = mysqli_fetch_assoc($dbResult)) {
-        $dataOut[$i] = $db_entry;
-        $i++;
-    }
-    return $i;
-}
-
 function getCommonlyUnlocked($consoleID, $offset, $count, &$dataOut): bool
 {
     sanitize_sql_inputs($consoleID, $offset, $count);

--- a/lib/render/code-note.php
+++ b/lib/render/code-note.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\LinkStyle;
+
 function RenderCodeNotes($codeNotes, $showDisclaimer = false): void
 {
     echo "<h3>Code Notes</h3>";
@@ -15,6 +17,7 @@ function RenderCodeNotes($codeNotes, $showDisclaimer = false): void
 
     echo "<tr><th style='font-size:100%;'>Mem</th><th style='font-size:100%;'>Note</th><th style='font-size:100%;'>Author</th></tr>";
 
+    $userCache = [];
     foreach ($codeNotes as $nextCodeNote) {
         if (empty(trim($nextCodeNote['Note'])) || $nextCodeNote['Note'] == "''") {
             continue;
@@ -41,7 +44,7 @@ function RenderCodeNotes($codeNotes, $showDisclaimer = false): void
         echo "</td>";
 
         echo "<td>";
-        echo GetUserAndTooltipDiv($nextCodeNote['User'], true);
+        RenderUserLink($nextCodeNote['User'], LinkStyle::MediumImage, $userCache);
         echo "</td>";
 
         echo "</tr>";

--- a/lib/render/code-note.php
+++ b/lib/render/code-note.php
@@ -17,7 +17,7 @@ function RenderCodeNotes($codeNotes, $showDisclaimer = false): void
 
     echo "<tr><th style='font-size:100%;'>Mem</th><th style='font-size:100%;'>Note</th><th style='font-size:100%;'>Author</th></tr>";
 
-    $userCache = [];
+    $userToolTipCache = [];
     foreach ($codeNotes as $nextCodeNote) {
         if (empty(trim($nextCodeNote['Note'])) || $nextCodeNote['Note'] == "''") {
             continue;
@@ -44,7 +44,7 @@ function RenderCodeNotes($codeNotes, $showDisclaimer = false): void
         echo "</td>";
 
         echo "<td>";
-        RenderUserLink($nextCodeNote['User'], LinkStyle::MediumImage, $userCache);
+        RenderUserLink($nextCodeNote['User'], LinkStyle::MediumImage, $userToolTipCache);
         echo "</td>";
 
         echo "</tr>";

--- a/lib/render/comment.php
+++ b/lib/render/comment.php
@@ -40,7 +40,7 @@ function RenderCommentsComponent(
 
     $lastID = 0;
     $lastKnownDate = 'Init';
-    $userCache = [];
+    $userToolTipCache = [];
 
     for ($i = 0; $i < $numComments; $i++) {
         $nextTime = $commentData[$i]['Submitted'];
@@ -67,7 +67,7 @@ function RenderCommentsComponent(
             $articleTypeID,
             $commentData[$i]['ID'],
             $canDeleteComments,
-            $userCache
+            $userToolTipCache
         );
     }
 
@@ -91,7 +91,7 @@ function RenderArticleComment(
     $articleTypeID,
     $commentID,
     $allowDelete,
-    $userCache = null
+    $userToolTipCache = null
 ): void {
     $class = '';
     $deleteIcon = '';
@@ -119,14 +119,14 @@ function RenderArticleComment(
 
     echo "<td class='iconscommentsingle'>";
     if ($user !== 'Server') {
-        RenderUserLink($user, LinkStyle::MediumImage, $userCache);
+        RenderUserLink($user, LinkStyle::MediumImage, $userToolTipCache);
     }
     echo "</td>";
     echo "<td class='commenttext w-full' colspan='3'>";
     echo $deleteIcon;
     echo "<div>";
     if ($user !== 'Server') {
-        RenderUserLink($user, LinkStyle::Text, $userCache);
+        RenderUserLink($user, LinkStyle::Text, $userToolTipCache);
     }
     echo " <span class='smalldate'>$niceDate</span>";
     echo "</div>";

--- a/lib/render/comment.php
+++ b/lib/render/comment.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\ArticleType;
+use RA\LinkStyle;
 use RA\Permissions;
 use RA\SubscriptionSubjectType;
 
@@ -39,6 +40,7 @@ function RenderCommentsComponent(
 
     $lastID = 0;
     $lastKnownDate = 'Init';
+    $userCache = [];
 
     for ($i = 0; $i < $numComments; $i++) {
         $nextTime = $commentData[$i]['Submitted'];
@@ -64,7 +66,8 @@ function RenderCommentsComponent(
             $user,
             $articleTypeID,
             $commentData[$i]['ID'],
-            $canDeleteComments
+            $canDeleteComments,
+            $userCache
         );
     }
 
@@ -87,7 +90,8 @@ function RenderArticleComment(
     $localUser,
     $articleTypeID,
     $commentID,
-    $allowDelete
+    $allowDelete,
+    $userCache = null
 ): void {
     $class = '';
     $deleteIcon = '';
@@ -115,14 +119,14 @@ function RenderArticleComment(
 
     echo "<td class='iconscommentsingle'>";
     if ($user !== 'Server') {
-        echo GetUserAndTooltipDiv($user, true);
+        RenderUserLink($user, LinkStyle::MediumImage, $userCache);
     }
     echo "</td>";
     echo "<td class='commenttext w-full' colspan='3'>";
     echo $deleteIcon;
     echo "<div>";
     if ($user !== 'Server') {
-        echo GetUserAndTooltipDiv($user);
+        RenderUserLink($user, LinkStyle::Text, $userCache);
     }
     echo " <span class='smalldate'>$niceDate</span>";
     echo "</div>";

--- a/lib/render/forum.php
+++ b/lib/render/forum.php
@@ -8,7 +8,7 @@ function RenderRecentForumPostsComponent($permissions, $numToFetch = 4): void
     echo "<h3>Forum Activity</h3>";
 
     if (getRecentForumPosts(0, $numToFetch, 100, $permissions, $recentPostData) != 0) {
-        $userCache = [];
+        $userToolTipCache = [];
         foreach ($recentPostData as $nextData) {
             $timestamp = strtotime($nextData['PostedAt']);
             $datePosted = date("d M", $timestamp);
@@ -38,7 +38,7 @@ function RenderRecentForumPostsComponent($permissions, $numToFetch = 4): void
 
             echo "<div class='embedded mb-1 flex justify-between items-center'>";
             echo "<div>";
-            RenderUserLink($author, LinkStyle::SmallImageWithText, $userCache);
+            RenderUserLink($author, LinkStyle::SmallImageWithText, $userToolTipCache);
             echo " <span class='smalldate'>$datePosted $postedAt</span><br>";
             echo "in <a href='/viewtopic.php?t=$forumTopicID&amp;c=$commentID#$commentID'>$forumTopicTitle</a><br>";
             echo "<div class='comment'>$shortMsg</div>";

--- a/lib/render/forum.php
+++ b/lib/render/forum.php
@@ -1,11 +1,14 @@
 <?php
 
+use RA\LinkStyle;
+
 function RenderRecentForumPostsComponent($permissions, $numToFetch = 4): void
 {
     echo "<div class='component'>";
     echo "<h3>Forum Activity</h3>";
 
     if (getRecentForumPosts(0, $numToFetch, 100, $permissions, $recentPostData) != 0) {
+        $userCache = [];
         foreach ($recentPostData as $nextData) {
             $timestamp = strtotime($nextData['PostedAt']);
             $datePosted = date("d M", $timestamp);
@@ -35,9 +38,7 @@ function RenderRecentForumPostsComponent($permissions, $numToFetch = 4): void
 
             echo "<div class='embedded mb-1 flex justify-between items-center'>";
             echo "<div>";
-            echo GetUserAndTooltipDiv($author, true, iconSizeDisplayable: 16);
-            echo " ";
-            echo GetUserAndTooltipDiv($author);
+            RenderUserLink($author, LinkStyle::SmallImageWithText, $userCache);
             echo " <span class='smalldate'>$datePosted $postedAt</span><br>";
             echo "in <a href='/viewtopic.php?t=$forumTopicID&amp;c=$commentID#$commentID'>$forumTopicTitle</a><br>";
             echo "<div class='comment'>$shortMsg</div>";

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 
 function GetGameAndTooltipDiv(
@@ -230,7 +231,7 @@ function RenderRecentGamePlayers($recentPlayerData): void
 {
     echo "<div class='component'>Recent Players:";
     echo "<table><tbody>";
-    echo "<tr><th></th><th>User</th><th>When</th><th class='w-full'>Activity</th>";
+    echo "<tr><th>User</th><th>When</th><th class='w-full'>Activity</th>";
     foreach ($recentPlayerData as $recentPlayer) {
         echo "<tr>";
         $userName = $recentPlayer['User'];
@@ -241,10 +242,7 @@ function RenderRecentGamePlayers($recentPlayerData): void
             $activity
         );
         echo "<td>";
-        echo GetUserAndTooltipDiv($userName, true);
-        echo "</td>";
-        echo "<td>";
-        echo GetUserAndTooltipDiv($userName);
+        RenderUserLink($userName, LinkStyle::MediumImageWithText);
         echo "</td>";
         echo "<td class='whitespace-nowrap'>$date</td>";
         echo "<td>$activity</td>";

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\AwardType;
+use RA\LinkStyle;
 use RA\Rank;
 use RA\UnlockMode;
 
@@ -45,6 +46,7 @@ function RenderGameLeaderboardsComponent($lbData): void
         echo "<table><tbody>";
 
         $count = 0;
+        $userCache = [];
         foreach ($lbData as $lbItem) {
             if ($lbItem['DisplayOrder'] < 0) {
                 continue;
@@ -70,8 +72,7 @@ function RenderGameLeaderboardsComponent($lbData): void
             // Score/Best entry
             echo "<tr class='altdark'>";
             echo "<td>";
-            echo GetUserAndTooltipDiv($bestScoreUser, true, iconSizeDisplayable: 16);
-            echo GetUserAndTooltipDiv($bestScoreUser);
+            RenderUserLink($bestScoreUser, LinkStyle::TinyImageWithText, $userCache);
             echo "</td>";
             echo "<td>";
             echo "<a href='/leaderboardinfo.php?i=$lbID'>";
@@ -187,8 +188,7 @@ function RenderScoreLeaderboardComponent(string $user, bool $friendsOnly, int $n
                     }
                     echo "<td class='rank'>" . $rank . "</td>";
                     echo "<td>";
-                    echo GetUserAndTooltipDiv($dataPoint['User'], true);
-                    echo GetUserAndTooltipDiv($dataPoint['User']);
+                    RenderUserLink($dataPoint['User'], LinkStyle::MediumImageWithText);
                     echo "</td>";
                     if ($j == 0) {
                         echo "<td><a href='/historyexamine.php?d=$dateUnix&u=" . $dataPoint['User'] . "'>" .
@@ -222,8 +222,7 @@ function RenderScoreLeaderboardComponent(string $user, bool $friendsOnly, int $n
                         echo "<td></td>";
                     }
                     echo "<td>";
-                    echo GetUserAndTooltipDiv($userData[0]['User'], true);
-                    echo GetUserAndTooltipDiv($userData[0]['User']);
+                    RenderUserLink($userData[0]['User'], LinkStyle::MediumImageWithText);
                     echo "</td>";
                     if ($j == 0) {
                         echo "<td><a href='/historyexamine.php?d=$dateUnix&u=" . $userData[0]['User'] . "'>" . $userData[0]['Points'] . "</a>";
@@ -291,8 +290,7 @@ function RenderTopAchieversComponent($user, array $gameTopAchievers, array $game
         echo "</td>";
 
         echo "<td>";
-        echo GetUserAndTooltipDiv($nextUser, true, iconSizeDisplayable: 16);
-        echo GetUserAndTooltipDiv($nextUser);
+        RenderUserLink($nextUser, LinkStyle::TinyImageWithText);
         echo "</td>";
 
         echo "<td>";
@@ -330,8 +328,7 @@ function RenderTopAchieversComponent($user, array $gameTopAchievers, array $game
         echo "</td>";
 
         echo "<td>";
-        echo GetUserAndTooltipDiv($nextUser, true, iconSizeDisplayable: 16);
-        echo GetUserAndTooltipDiv($nextUser);
+        RenderUserLink($nextUser, LinkStyle::TinyImageWithText);
         echo "</td>";
 
         echo "<td>";

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -46,7 +46,7 @@ function RenderGameLeaderboardsComponent($lbData): void
         echo "<table><tbody>";
 
         $count = 0;
-        $userCache = [];
+        $userToolTipCache = [];
         foreach ($lbData as $lbItem) {
             if ($lbItem['DisplayOrder'] < 0) {
                 continue;
@@ -72,7 +72,7 @@ function RenderGameLeaderboardsComponent($lbData): void
             // Score/Best entry
             echo "<tr class='altdark'>";
             echo "<td>";
-            RenderUserLink($bestScoreUser, LinkStyle::TinyImageWithText, $userCache);
+            RenderUserLink($bestScoreUser, LinkStyle::TinyImageWithText, $userToolTipCache);
             echo "</td>";
             echo "<td>";
             echo "<a href='/leaderboardinfo.php?i=$lbID'>";

--- a/lib/render/news.php
+++ b/lib/render/news.php
@@ -15,10 +15,10 @@ function RenderNewsComponent(): void
     echo "<div id='carouselcontainer' >";
 
     echo "<div id='carousel'>";
-    $userCache = [];
+    $userToolTipCache = [];
     foreach ($newsData as $news) {
         /** @var News $news */
-        RenderNewsHeader($news, $userCache);
+        RenderNewsHeader($news, $userToolTipCache);
     }
     echo "</div>";
 
@@ -32,7 +32,7 @@ function RenderNewsComponent(): void
     echo "</div>";
 }
 
-function RenderNewsHeader(News $newsData, array &$userCache): void
+function RenderNewsHeader(News $newsData, array &$userToolTipCache): void
 {
     $title = $newsData->Title;
     $payload = $newsData->Payload;
@@ -60,7 +60,7 @@ function RenderNewsHeader(News $newsData, array &$userCache): void
 
     // Author
     echo "<div class='newsauthor shadowoutline absolute' style='width: 470px; top: 196px; left:0; text-align: right'>~~";
-    RenderUserLink($author, LinkStyle::Text, $userCache);
+    RenderUserLink($author, LinkStyle::Text, $userToolTipCache);
     echo ", $niceDate</div>";
 
     echo "</div>";

--- a/lib/render/news.php
+++ b/lib/render/news.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Legacy\Models\News;
+use RA\LinkStyle;
 
 function RenderNewsComponent(): void
 {
@@ -14,9 +15,10 @@ function RenderNewsComponent(): void
     echo "<div id='carouselcontainer' >";
 
     echo "<div id='carousel'>";
+    $userCache = [];
     foreach ($newsData as $news) {
         /** @var News $news */
-        RenderNewsHeader($news);
+        RenderNewsHeader($news, $userCache);
     }
     echo "</div>";
 
@@ -30,7 +32,7 @@ function RenderNewsComponent(): void
     echo "</div>";
 }
 
-function RenderNewsHeader(News $newsData): void
+function RenderNewsHeader(News $newsData, array &$userCache): void
 {
     $title = $newsData->Title;
     $payload = $newsData->Payload;
@@ -39,7 +41,6 @@ function RenderNewsHeader(News $newsData): void
     $link = htmlspecialchars($newsData['Link']);
 
     $author = $newsData['Author'];
-    $authorLink = GetUserAndTooltipDiv($author);
     $niceDate = $newsData->Timestamp->format('F j, Y, H:i');
 
     echo "<div class='newsbluroverlay'>";
@@ -58,7 +59,9 @@ function RenderNewsHeader(News $newsData): void
     echo "<div class='newstext shadowoutline absolute' style='width: 90%; top: 40px; left:10px;'>$payload</div>";
 
     // Author
-    echo "<div class='newsauthor shadowoutline absolute' style='width: 470px; top: 196px; left:0; text-align: right'>~~$authorLink, $niceDate</div>";
+    echo "<div class='newsauthor shadowoutline absolute' style='width: 470px; top: 196px; left:0; text-align: right'>~~";
+    RenderUserLink($author, LinkStyle::Text, $userCache);
+    echo ", $niceDate</div>";
 
     echo "</div>";
 

--- a/lib/render/player-game-compare.php
+++ b/lib/render/player-game-compare.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\LinkStyle;
+
 function RenderGameCompare($user, $gameID, $friendScores, $maxTotalPossibleForGame): void
 {
     echo "<div id='gamecompare' class='component' >";
@@ -14,8 +16,7 @@ function RenderGameCompare($user, $gameID, $friendScores, $maxTotalPossibleForGa
 
                 echo "<tr>";
                 echo "<td>";
-                echo GetUserAndTooltipDiv($friendScoreName, true, $link, iconSizeDisplayable: 16);
-                echo GetUserAndTooltipDiv($friendScoreName, false, $link);
+                RenderUserLink($friendScoreName, LinkStyle::TinyImageWithText);
                 echo "</td>";
 
                 echo "<td>";

--- a/lib/render/set-claim.php
+++ b/lib/render/set-claim.php
@@ -3,6 +3,7 @@
 use RA\ClaimFilters;
 use RA\ClaimSetType;
 use RA\ClaimSorting;
+use RA\LinkStyle;
 
 /**
  * Creates the New Set Claims component.
@@ -17,7 +18,6 @@ function renderNewClaimsComponent(int $count): void
     echo "<table class='mb-1'>";
     echo "<thead>";
     echo "<tr>";
-    echo "<th></th>";
     echo "<th>User</th>";
     echo "<th>Game</th>";
     echo "<th class='whitespace-nowrap'>Started</th>";
@@ -28,10 +28,7 @@ function renderNewClaimsComponent(int $count): void
         $claimUser = $claim['User'];
         echo "<tr>";
         echo "<td>";
-        echo GetUserAndTooltipDiv($claimUser, true);
-        echo "</td>";
-        echo "<td>";
-        echo GetUserAndTooltipDiv($claimUser);
+        RenderUserLink($claimUser, LinkStyle::MediumImageWithText);
         echo "</td>";
         echo "<td class='w-full'>";
         echo GetGameAndTooltipDiv($claim['GameID'], $claim['GameTitle'], $claim['GameIcon'], $claim['ConsoleName']);
@@ -58,7 +55,6 @@ function renderFinishedClaimsComponent(int $count): void
     echo "<table class='mb-1'>";
     echo "<thead>";
     echo "<tr>";
-    echo "<th></th>";
     echo "<th>User</th>";
     echo "<th>Game</th>";
     echo "<th>Type</th>";
@@ -69,10 +65,7 @@ function renderFinishedClaimsComponent(int $count): void
         $claimUser = $claim['User'];
         echo "<tr>";
         echo "<td>";
-        echo GetUserAndTooltipDiv($claimUser, true);
-        echo "</td>";
-        echo "<td>";
-        echo GetUserAndTooltipDiv($claimUser);
+        RenderUserLink($claimUser, LinkStyle::MediumImageWithText);
         echo "</td>";
         echo "<td class='w-full'>";
         echo GetGameAndTooltipDiv($claim['GameID'], $claim['GameTitle'], $claim['GameIcon'], $claim['ConsoleName']);

--- a/lib/render/static.php
+++ b/lib/render/static.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\LinkStyle;
+
 function RenderStaticDataComponent($staticData): void
 {
     echo "<div class='component statistics'>";
@@ -60,8 +62,7 @@ function RenderStaticDataComponent($staticData): void
     echo "<br>";
 
     echo "The last registered user was ";
-    echo GetUserAndTooltipDiv($lastRegisteredUser);
-    // echo "<a href='/user/$lastRegisteredUser'>$lastRegisteredUser</a>";
+    RenderUserLink($lastRegisteredUser, LinkStyle::Text);
     echo " on $niceRegisteredAt.<br>";
 
     // echo "<br>";
@@ -69,7 +70,7 @@ function RenderStaticDataComponent($staticData): void
     // echo GetGameAndTooltipDiv( $nextGameToScanID, $nextGameToScan, $nextGameToScanIcon, $nextGameConsoleToScan, FALSE, 32, TRUE );
     // echo "<br>";
     // echo "Next user to scan: ";
-    // echo GetUserAndTooltipDiv( $nextUserToScan, FALSE );
+    // RenderUserLink($nextUserToScan, LinkStyle::Text);
     // echo "The last achievement earned was ";
     // echo "<a href='/achievement/$lastAchievementEarnedID'>$lastAchievementEarnedTitle</a>";
     // echo " by ";

--- a/lib/render/user-activity-feed.php
+++ b/lib/render/user-activity-feed.php
@@ -117,7 +117,7 @@ function getFeedItemTitle($feedData, $withHyperlinks = true, $site = null): stri
     return $retHTML;
 }
 
-function getFeedItemHTML($feedData, $user, $userCache): string
+function getFeedItemHTML($feedData, $user, $userToolTipCache): string
 {
     $retHTML = '';
 
@@ -175,12 +175,12 @@ function getFeedItemHTML($feedData, $user, $userCache): string
                 true,
                 true
             );
-            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userToolTipCache);
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_won'>";
-            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userToolTipCache);
             $retHTML .= " earned ";
             $retHTML .= GetAchievementAndTooltipDiv(
                 $nextData,
@@ -224,13 +224,13 @@ function getFeedItemHTML($feedData, $user, $userCache): string
             // Images:
             $retHTML .= "<td class='icons'>";
             $retHTML .= "<img alt='$nextUser logged in' title='Logged in' src='/assets/images/activity/login.webp' width='32' height='32' class='badgeimg' />";
-            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userToolTipCache);
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_login'>";
 
-            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userToolTipCache);
             $retHTML .= " logged in";
 
             $retHTML .= "</td>";
@@ -250,14 +250,14 @@ function getFeedItemHTML($feedData, $user, $userCache): string
                 $retHTML .= "<td class='icons'>";
 
                 $retHTML .= GetGameAndTooltipDiv($nextGameID, $nextGameTitle, $nextGameIcon, $nextConsoleName, true);
-                $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
+                $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userToolTipCache);
 
                 $retHTML .= "</td>";
 
                 // Content:
                 $retHTML .= "<td class='feed_startplay'>";
 
-                $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
+                $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userToolTipCache);
                 $retHTML .= " started playing ";
                 $retHTML .= GetGameAndTooltipDiv(
                     $nextGameID,
@@ -295,14 +295,14 @@ function getFeedItemHTML($feedData, $user, $userCache): string
                 true,
                 true
             );
-            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userToolTipCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_dev1'>";
 
-            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userToolTipCache);
             $retHTML .= " uploaded a new achievement: ";
             $retHTML .= GetAchievementAndTooltipDiv(
                 $nextData,
@@ -340,14 +340,14 @@ function getFeedItemHTML($feedData, $user, $userCache): string
                 true,
                 true
             );
-            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userToolTipCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_dev2'>";
 
-            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userToolTipCache);
             $retHTML .= " edited ";
             $retHTML .= GetAchievementAndTooltipDiv(
                 $nextData,
@@ -375,14 +375,14 @@ function getFeedItemHTML($feedData, $user, $userCache): string
             $retHTML .= "<td class='icons'>";
 
             $retHTML .= GetGameAndTooltipDiv($nextGameID, $nextGameTitle, $nextGameIcon, $nextConsoleName, true);
-            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userToolTipCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_completegame'>";
 
-            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userToolTipCache);
             if ($nextData2 == 1) {
                 $retHTML .= " MASTERED ";
             } else {
@@ -420,14 +420,14 @@ function getFeedItemHTML($feedData, $user, $userCache): string
             $retHTML .= "<td class='icons'>";
 
             $retHTML .= GetGameAndTooltipDiv($nextGameID, $nextGameTitle, $nextGameIcon, $nextConsoleName, true);
-            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userToolTipCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_submitrecord'>";
 
-            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userToolTipCache);
             $retHTML .= " submitted ";
             $retHTML .= GetLeaderboardAndTooltipDiv(
                 $nextData,
@@ -472,7 +472,7 @@ function getFeedItemHTML($feedData, $user, $userCache): string
             $retHTML .= "<td class='icons'>";
 
             $retHTML .= GetGameAndTooltipDiv($nextGameID, $nextGameTitle, $nextGameIcon, $nextConsoleName, true);
-            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userToolTipCache);
 
             $retHTML .= "</td>";
 
@@ -484,7 +484,7 @@ function getFeedItemHTML($feedData, $user, $userCache): string
                 'TIMESECS'
             ) == 0) ? "time" : "score";
 
-            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userToolTipCache);
             $retHTML .= " improved their $entryType: ";
             $retHTML .= GetLeaderboardAndTooltipDiv(
                 $nextData,
@@ -539,14 +539,14 @@ function getFeedItemHTML($feedData, $user, $userCache): string
                 true,
                 true
             );
-            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userToolTipCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_dev2'>";
 
-            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userToolTipCache);
             $retHTML .= ($nextActivityType == 9 ? " opened " : " closed ") . " a ticket for ";
             $retHTML .= GetAchievementAndTooltipDiv(
                 $nextData,
@@ -570,9 +570,9 @@ function getFeedItemHTML($feedData, $user, $userCache): string
     return $retHTML;
 }
 
-function RenderFeedItem($feedData, $user, $userCache): void
+function RenderFeedItem($feedData, $user, $userToolTipCache): void
 {
-    echo getFeedItemHTML($feedData, $user, $userCache);
+    echo getFeedItemHTML($feedData, $user, $userToolTipCache);
 }
 
 function RenderFeedComment($user, $comment, $submittedDate): void

--- a/lib/render/user-activity-feed.php
+++ b/lib/render/user-activity-feed.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\LinkStyle;
+
 function RenderFeedComponent($user): void
 {
     echo "<div class='left'>";
@@ -115,7 +117,7 @@ function getFeedItemTitle($feedData, $withHyperlinks = true, $site = null): stri
     return $retHTML;
 }
 
-function getFeedItemHTML($feedData, $user): string
+function getFeedItemHTML($feedData, $user, $userCache): string
 {
     $retHTML = '';
 
@@ -173,12 +175,12 @@ function getFeedItemHTML($feedData, $user): string
                 true,
                 true
             );
-            $retHTML .= GetUserAndTooltipDiv($nextUser, true);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_won'>";
-            $retHTML .= GetUserAndTooltipDiv($nextUser, false);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
             $retHTML .= " earned ";
             $retHTML .= GetAchievementAndTooltipDiv(
                 $nextData,
@@ -222,13 +224,13 @@ function getFeedItemHTML($feedData, $user): string
             // Images:
             $retHTML .= "<td class='icons'>";
             $retHTML .= "<img alt='$nextUser logged in' title='Logged in' src='/assets/images/activity/login.webp' width='32' height='32' class='badgeimg' />";
-            $retHTML .= GetUserAndTooltipDiv($nextUser, true);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_login'>";
 
-            $retHTML .= GetUserAndTooltipDiv($nextUser, false);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
             $retHTML .= " logged in";
 
             $retHTML .= "</td>";
@@ -248,14 +250,14 @@ function getFeedItemHTML($feedData, $user): string
                 $retHTML .= "<td class='icons'>";
 
                 $retHTML .= GetGameAndTooltipDiv($nextGameID, $nextGameTitle, $nextGameIcon, $nextConsoleName, true);
-                $retHTML .= GetUserAndTooltipDiv($nextUser, true);
+                $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
 
                 $retHTML .= "</td>";
 
                 // Content:
                 $retHTML .= "<td class='feed_startplay'>";
 
-                $retHTML .= GetUserAndTooltipDiv($nextUser, false);
+                $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
                 $retHTML .= " started playing ";
                 $retHTML .= GetGameAndTooltipDiv(
                     $nextGameID,
@@ -293,14 +295,14 @@ function getFeedItemHTML($feedData, $user): string
                 true,
                 true
             );
-            $retHTML .= GetUserAndTooltipDiv($nextUser, true);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_dev1'>";
 
-            $retHTML .= GetUserAndTooltipDiv($nextUser, false);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
             $retHTML .= " uploaded a new achievement: ";
             $retHTML .= GetAchievementAndTooltipDiv(
                 $nextData,
@@ -338,14 +340,14 @@ function getFeedItemHTML($feedData, $user): string
                 true,
                 true
             );
-            $retHTML .= GetUserAndTooltipDiv($nextUser, true);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_dev2'>";
 
-            $retHTML .= GetUserAndTooltipDiv($nextUser, false);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
             $retHTML .= " edited ";
             $retHTML .= GetAchievementAndTooltipDiv(
                 $nextData,
@@ -373,14 +375,14 @@ function getFeedItemHTML($feedData, $user): string
             $retHTML .= "<td class='icons'>";
 
             $retHTML .= GetGameAndTooltipDiv($nextGameID, $nextGameTitle, $nextGameIcon, $nextConsoleName, true);
-            $retHTML .= GetUserAndTooltipDiv($nextUser, true);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_completegame'>";
 
-            $retHTML .= GetUserAndTooltipDiv($nextUser, false);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
             if ($nextData2 == 1) {
                 $retHTML .= " MASTERED ";
             } else {
@@ -418,14 +420,14 @@ function getFeedItemHTML($feedData, $user): string
             $retHTML .= "<td class='icons'>";
 
             $retHTML .= GetGameAndTooltipDiv($nextGameID, $nextGameTitle, $nextGameIcon, $nextConsoleName, true);
-            $retHTML .= GetUserAndTooltipDiv($nextUser, true);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_submitrecord'>";
 
-            $retHTML .= GetUserAndTooltipDiv($nextUser, false);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
             $retHTML .= " submitted ";
             $retHTML .= GetLeaderboardAndTooltipDiv(
                 $nextData,
@@ -470,7 +472,7 @@ function getFeedItemHTML($feedData, $user): string
             $retHTML .= "<td class='icons'>";
 
             $retHTML .= GetGameAndTooltipDiv($nextGameID, $nextGameTitle, $nextGameIcon, $nextConsoleName, true);
-            $retHTML .= GetUserAndTooltipDiv($nextUser, true);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
 
             $retHTML .= "</td>";
 
@@ -482,7 +484,7 @@ function getFeedItemHTML($feedData, $user): string
                 'TIMESECS'
             ) == 0) ? "time" : "score";
 
-            $retHTML .= GetUserAndTooltipDiv($nextUser, false);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
             $retHTML .= " improved their $entryType: ";
             $retHTML .= GetLeaderboardAndTooltipDiv(
                 $nextData,
@@ -537,14 +539,14 @@ function getFeedItemHTML($feedData, $user): string
                 true,
                 true
             );
-            $retHTML .= GetUserAndTooltipDiv($nextUser, true);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::MediumImage, $userCache);
 
             $retHTML .= "</td>";
 
             // Content:
             $retHTML .= "<td class='feed_dev2'>";
 
-            $retHTML .= GetUserAndTooltipDiv($nextUser, false);
+            $retHTML .= GetUserLink($nextUser, LinkStyle::Text, $userCache);
             $retHTML .= ($nextActivityType == 9 ? " opened " : " closed ") . " a ticket for ";
             $retHTML .= GetAchievementAndTooltipDiv(
                 $nextData,
@@ -568,9 +570,9 @@ function getFeedItemHTML($feedData, $user): string
     return $retHTML;
 }
 
-function RenderFeedItem($feedData, $user): void
+function RenderFeedItem($feedData, $user, $userCache): void
 {
-    echo getFeedItemHTML($feedData, $user);
+    echo getFeedItemHTML($feedData, $user, $userCache);
 }
 
 function RenderFeedComment($user, $comment, $submittedDate): void

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -4,6 +4,7 @@ use App\Support\Shortcode\Shortcode;
 use RA\AchievementPoints;
 use RA\AchievementType;
 use RA\ArticleType;
+use RA\LinkStyle;
 use RA\Permissions;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -225,7 +226,9 @@ RenderContentStart($achievementTitleRaw);
         if ($achFlags === AchievementType::Unofficial) {
             echo "<b>Unofficial Achievement</b><br>";
         }
-        echo "Created by " . GetUserAndTooltipDiv($author, false) . " on: $niceDateCreated<br>Last modified: $niceDateModified<br>";
+        echo "Created by ";
+        RenderUserLink($author, LinkStyle::Text);
+        echo " on: $niceDateCreated<br>Last modified: $niceDateModified<br>";
         echo "</small>";
         echo "</p>";
 
@@ -378,10 +381,7 @@ RenderContentStart($achievementTitleRaw);
                 $niceDateWon = date("d M, Y H:i", strtotime($userObject['DateAwarded']));
                 echo "<tr>";
                 echo "<td class='w-[32px]'>";
-                echo GetUserAndTooltipDiv($userWinner, true);
-                echo "</td>";
-                echo "<td>";
-                echo GetUserAndTooltipDiv($userWinner, false);
+                RenderUserLink($userWinner, LinkStyle::MediumImageWithText);
                 echo "</td>";
                 echo "<td>";
                 if ($userObject['HardcoreMode']) {

--- a/public/achievementList.php
+++ b/public/achievementList.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\AchievementType;
+use RA\LinkStyle;
 
 $consoleList = getConsoleList();
 $consoleIDInput = requestInputSanitized('z', 0, 'integer');
@@ -140,6 +141,7 @@ RenderContentStart("Achievement List" . $requestedConsole);
             echo "<th><a href='/achievementList.php?s=$sort8&p=$params$dev_param'>Modified</a>$mark8</th>";
         }
 
+        $userCache = [];
         foreach ($achData as $achEntry) {
             // $query = "SELECT ach.ID, ach.Title AS AchievementTitle, ach.Description, ach.Points, ach.Author, ach.DateCreated, ach.DateModified, ach.BadgeName, ach.GameID, gd.Title AS GameTitle, gd.ConsoleID, c.Name AS ConsoleName ";
 
@@ -183,7 +185,7 @@ RenderContentStart("Achievement List" . $requestedConsole);
                 echo "</td>";
 
                 echo "<td>";
-                echo GetUserAndTooltipDiv($achAuthor, true);
+                RenderUserLink($achAuthor, LinkStyle::MediumImage, $userCache);
                 echo "</td>";
             }
 

--- a/public/achievementList.php
+++ b/public/achievementList.php
@@ -141,7 +141,7 @@ RenderContentStart("Achievement List" . $requestedConsole);
             echo "<th><a href='/achievementList.php?s=$sort8&p=$params$dev_param'>Modified</a>$mark8</th>";
         }
 
-        $userCache = [];
+        $userToolTipCache = [];
         foreach ($achData as $achEntry) {
             // $query = "SELECT ach.ID, ach.Title AS AchievementTitle, ach.Description, ach.Points, ach.Author, ach.DateCreated, ach.DateModified, ach.BadgeName, ach.GameID, gd.Title AS GameTitle, gd.ConsoleID, c.Name AS ConsoleName ";
 
@@ -185,7 +185,7 @@ RenderContentStart("Achievement List" . $requestedConsole);
                 echo "</td>";
 
                 echo "<td>";
-                RenderUserLink($achAuthor, LinkStyle::MediumImage, $userCache);
+                RenderUserLink($achAuthor, LinkStyle::MediumImage, $userToolTipCache);
                 echo "</td>";
             }
 

--- a/public/awardedList.php
+++ b/public/awardedList.php
@@ -158,7 +158,7 @@ RenderContentStart("Achievement List" . $requestedConsole);
             echo "</td>";
 
             // echo "<td>";
-            // echo GetUserAndTooltipDiv( $achAuthor, FALSE );
+            // RenderUserLink($achAuthor, LinkStyle::Text);
             // echo "</td>";
 
             echo "<td>";

--- a/public/claimlist.php
+++ b/public/claimlist.php
@@ -173,12 +173,12 @@ RenderContentStart("Claim List");
         echo $linkSorting(ClaimSorting::toString(ClaimSorting::FinishedDateDescending, $claimFilters), ClaimSorting::FinishedDateDescending, ClaimSorting::FinishedDateAscending);
 
         // Loop through the claims and display them in the table
-        $userCache = [];
+        $userToolTipCache = [];
         foreach ($claimData as $claim) {
             $claimUser = $claim['User'];
             echo "<tr>";
             echo "<td>";
-            RenderUserLink($claimUser, LinkStyle::MediumImageWithText, $userCache);
+            RenderUserLink($claimUser, LinkStyle::MediumImageWithText, $userToolTipCache);
             echo "</td>";
             echo "<td>";
             echo GetGameAndTooltipDiv($claim['GameID'], $claim['GameTitle'], $claim['GameIcon'], $claim['ConsoleName']);

--- a/public/claimlist.php
+++ b/public/claimlist.php
@@ -6,6 +6,7 @@ use RA\ClaimSorting;
 use RA\ClaimSpecial;
 use RA\ClaimStatus;
 use RA\ClaimType;
+use RA\LinkStyle;
 use RA\Permissions;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -161,7 +162,6 @@ RenderContentStart("Claim List");
         echo "<br style='clear:both'>";
 
         echo "<div class='table-wrapper'><table><tbody>";
-        echo "<th></th>";
         // Sortable table headers
         echo $linkSorting(ClaimSorting::toString(ClaimSorting::UserDescending), ClaimSorting::UserDescending, ClaimSorting::UserAscending);
         echo $linkSorting(ClaimSorting::toString(ClaimSorting::GameDescending), ClaimSorting::GameDescending, ClaimSorting::GameAscending);
@@ -173,15 +173,13 @@ RenderContentStart("Claim List");
         echo $linkSorting(ClaimSorting::toString(ClaimSorting::FinishedDateDescending, $claimFilters), ClaimSorting::FinishedDateDescending, ClaimSorting::FinishedDateAscending);
 
         // Loop through the claims and display them in the table
+        $userCache = [];
         foreach ($claimData as $claim) {
             $claimUser = $claim['User'];
             echo "<tr>";
             echo "<td>";
-            echo GetUserAndTooltipDiv($claimUser, true);
+            RenderUserLink($claimUser, LinkStyle::MediumImageWithText, $userCache);
             echo "</td>";
-            echo "<td class='whitespace-nowrap'><div>";
-            echo GetUserAndTooltipDiv($claimUser);
-            echo "</div></td>";
             echo "<td>";
             echo GetGameAndTooltipDiv($claim['GameID'], $claim['GameTitle'], $claim['GameIcon'], $claim['ConsoleName']);
             echo "</td>";

--- a/public/createmessage.php
+++ b/public/createmessage.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Support\Shortcode\Shortcode;
+use RA\LinkStyle;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
@@ -60,7 +61,7 @@ $(document).ready(onUserChange);
 
         if ($messageContextData !== null) {
             echo "In reply to ";
-            echo GetUserAndTooltipDiv($messageContextData['UserFrom']);
+            RenderUserLink($messageContextData['UserFrom'], LinkStyle::Text);
             echo " who wrote:<br><br>";
             echo "<div class='comment'>$messageContextPayload</div>";
         }

--- a/public/developerstats.php
+++ b/public/developerstats.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -74,10 +75,11 @@ RenderContentStart("Developer Stats");
 
             $dev = $devStats['Author'];
             echo "<td class='whitespace-nowrap'>";
-            echo GetUserAndTooltipDiv($dev, true);
+            $userCache = [];
+            RenderUserLink($dev, LinkStyle::MediumImage, $userCache);
             echo "</td>";
             echo "<td class='whitespace-nowrap'><div>";
-            echo GetUserAndTooltipDiv($dev, false);
+            RenderUserLink($dev, LinkStyle::Text, $userCache);
             echo "<br><small>";
             if ($devStats['Permissions'] == Permissions::JuniorDeveloper) {
                 echo Permissions::toString(Permissions::JuniorDeveloper);

--- a/public/developerstats.php
+++ b/public/developerstats.php
@@ -75,11 +75,11 @@ RenderContentStart("Developer Stats");
 
             $dev = $devStats['Author'];
             echo "<td class='whitespace-nowrap'>";
-            $userCache = [];
-            RenderUserLink($dev, LinkStyle::MediumImage, $userCache);
+            $userToolTipCache = [];
+            RenderUserLink($dev, LinkStyle::MediumImage, $userToolTipCache);
             echo "</td>";
             echo "<td class='whitespace-nowrap'><div>";
-            RenderUserLink($dev, LinkStyle::Text, $userCache);
+            RenderUserLink($dev, LinkStyle::Text, $userToolTipCache);
             echo "<br><small>";
             if ($devStats['Permissions'] == Permissions::JuniorDeveloper) {
                 echo Permissions::toString(Permissions::JuniorDeveloper);

--- a/public/expiringclaims.php
+++ b/public/expiringclaims.php
@@ -5,6 +5,7 @@ use RA\ClaimSetType;
 use RA\ClaimSorting;
 use RA\ClaimSpecial;
 use RA\ClaimType;
+use RA\LinkStyle;
 
 authenticateFromCookie($user, $permissions, $userDetails);
 
@@ -58,7 +59,7 @@ RenderContentStart("Expiring Claims");
         }
 
         echo "<div class='table-wrapper'><table><tbody>";
-        echo "<th colspan='2'>" . ClaimSorting::toString(ClaimSorting::UserDescending) . "</th>";
+        echo "<th>" . ClaimSorting::toString(ClaimSorting::UserDescending) . "</th>";
         echo "<th>" . ClaimSorting::toString(ClaimSorting::GameDescending) . "</th>";
         echo "<th>" . ClaimSorting::toString(ClaimSorting::ClaimTypeDescending) . "</th>";
         echo "<th>" . ClaimSorting::toString(ClaimSorting::SetTypeDescending) . "</th>";
@@ -71,10 +72,7 @@ RenderContentStart("Expiring Claims");
         foreach ($claimData as $claim) {
             $claimUser = $claim['User'];
             echo "<tr><td class='whitespace-nowrap'>";
-            echo GetUserAndTooltipDiv($claimUser, true);
-            echo "</td>";
-            echo "<td class='whitespace-nowrap'><div>";
-            echo GetUserAndTooltipDiv($claimUser, false);
+            RenderUserLink($claimUser, LinkStyle::MediumImageWithText);
             echo "</div></td>";
 
             echo "<td>";

--- a/public/feed.php
+++ b/public/feed.php
@@ -15,7 +15,7 @@ $numFeedItems = 0;
 
 $feedData = [];
 $numFeedItems = 0;
-if ($activityID !== null) {
+if ($activityID) {
     $numFeedItems = getFeed($user, $maxMessages, $offset, $feedData, $activityID, 'activity');
 } elseif (isset($global)) {
     $numFeedItems = getFeed($user, $maxMessages, $offset, $feedData, 0, 'global');
@@ -58,13 +58,14 @@ RenderContentStart($pageTitle);
             $lastID = 0;
             $lastKnownDate = 'Init';
 
+            $userCache = [];
             for ($i = 0; $i < $numFeedItems; $i++) {
                 $nextTime = $feedData[$i]['timestamp'];
 
                 $dow = date("d/m", $nextTime);
                 if ($lastKnownDate == 'Init') {
                     $lastKnownDate = $dow;
-                    echo "<tr><td class='date'>$dow:</td></tr>";
+                    echo "<tr><td class='date' style='white-space: nowrap'>$dow:</td></tr>";
                 } elseif ($lastKnownDate !== $dow) {
                     $lastKnownDate = $dow;
                     echo "<tr><td class='date'><br>$dow:</td></tr>";
@@ -72,7 +73,7 @@ RenderContentStart($pageTitle);
 
                 if ($lastID != $feedData[$i]['ID']) {
                     $lastID = $feedData[$i]['ID'];
-                    RenderFeedItem($feedData[$i], $user);
+                    RenderFeedItem($feedData[$i], $user, $userCache);
                 }
 
                 if ($feedData[$i]['Comment'] !== null) {

--- a/public/feed.php
+++ b/public/feed.php
@@ -58,7 +58,7 @@ RenderContentStart($pageTitle);
             $lastID = 0;
             $lastKnownDate = 'Init';
 
-            $userCache = [];
+            $userToolTipCache = [];
             for ($i = 0; $i < $numFeedItems; $i++) {
                 $nextTime = $feedData[$i]['timestamp'];
 
@@ -73,7 +73,7 @@ RenderContentStart($pageTitle);
 
                 if ($lastID != $feedData[$i]['ID']) {
                     $lastID = $feedData[$i]['ID'];
-                    RenderFeedItem($feedData[$i], $user, $userCache);
+                    RenderFeedItem($feedData[$i], $user, $userToolTipCache);
                 }
 
                 if ($feedData[$i]['Comment'] !== null) {

--- a/public/forum.php
+++ b/public/forum.php
@@ -49,7 +49,7 @@ RenderContentStart($pageTitle);
         $lastCategory = "_init";
 
         $forumIter = 0;
-        $userCache = [];
+        $userToolTipCache = [];
 
         echo "<div class='table-wrapper'>";
         foreach ((array) $forumList as $forumData) {
@@ -120,7 +120,7 @@ RenderContentStart($pageTitle);
             echo "<td>";
             echo "<div>";
             if (isset($nextForumLastPostAuthor) && mb_strlen($nextForumLastPostAuthor) > 1) {
-                RenderUserLink($nextForumLastPostAuthor, LinkStyle::Text, $userCache);
+                RenderUserLink($nextForumLastPostAuthor, LinkStyle::Text, $userToolTipCache);
             }
             echo "<br><span class='smalldate'>$nextForumCreatedNiceDate</span>";
             echo "<br><a class='btn btn-link' href='/viewtopic.php?t=$nextForumLastPostTopicID&c=$nextForumLastPostID#$nextForumLastPostID'>View</a>";

--- a/public/forum.php
+++ b/public/forum.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 
 $requestedCategoryID = requestInputSanitized('c', null, 'integer');
@@ -48,6 +49,7 @@ RenderContentStart($pageTitle);
         $lastCategory = "_init";
 
         $forumIter = 0;
+        $userCache = [];
 
         echo "<div class='table-wrapper'>";
         foreach ((array) $forumList as $forumData) {
@@ -118,7 +120,7 @@ RenderContentStart($pageTitle);
             echo "<td>";
             echo "<div>";
             if (isset($nextForumLastPostAuthor) && mb_strlen($nextForumLastPostAuthor) > 1) {
-                echo GetUserAndTooltipDiv($nextForumLastPostAuthor);
+                RenderUserLink($nextForumLastPostAuthor, LinkStyle::Text, $userCache);
             }
             echo "<br><span class='smalldate'>$nextForumCreatedNiceDate</span>";
             echo "<br><a class='btn btn-link' href='/viewtopic.php?t=$nextForumLastPostTopicID&c=$nextForumLastPostID#$nextForumLastPostID'>View</a>";

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -45,7 +45,7 @@ RenderContentStart("Forum Recent Posts");
         echo "<th class='whitespace-nowrap'>Posted At</th>";
         echo "</tr>";
 
-        $userCache = [];
+        $userToolTipCache = [];
         foreach ($recentPostsData as $topicPostData) {
             $postMessage = $topicPostData['ShortMsg'];
             $postAuthor = $topicPostData['Author'];
@@ -60,7 +60,7 @@ RenderContentStart("Forum Recent Posts");
             echo "<tr>";
 
             echo "<td>";
-            RenderUserLink($postAuthor, LinkStyle::MediumImageWithText, $userCache);
+            RenderUserLink($postAuthor, LinkStyle::MediumImageWithText, $userToolTipCache);
             echo "</td>";
 
             echo "<td><a href='/viewtopic.php?t=$forumTopicID&c=$forumCommentID'>$forumTopicTitle</a><br>$postMessage...</td>";

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\LinkStyle;
+
 $maxCount = 25;
 
 $offset = requestInputSanitized('o', 0, 'integer');
@@ -38,12 +40,12 @@ RenderContentStart("Forum Recent Posts");
         echo "<tbody>";
 
         echo "<tr>";
-        echo "<th></th>";
         echo "<th>Author</th>";
         echo "<th class='w-full'>Message</th>";
         echo "<th class='whitespace-nowrap'>Posted At</th>";
         echo "</tr>";
 
+        $userCache = [];
         foreach ($recentPostsData as $topicPostData) {
             $postMessage = $topicPostData['ShortMsg'];
             $postAuthor = $topicPostData['Author'];
@@ -58,10 +60,7 @@ RenderContentStart("Forum Recent Posts");
             echo "<tr>";
 
             echo "<td>";
-            echo GetUserAndTooltipDiv($postAuthor, true);
-            echo "</td>";
-            echo "<td>";
-            echo GetUserAndTooltipDiv($postAuthor, false);
+            RenderUserLink($postAuthor, LinkStyle::MediumImageWithText, $userCache);
             echo "</td>";
 
             echo "<td><a href='/viewtopic.php?t=$forumTopicID&c=$forumCommentID'>$forumTopicTitle</a><br>$postMessage...</td>";

--- a/public/friends.php
+++ b/public/friends.php
@@ -25,7 +25,7 @@ asort($blockedUsersList);
 
 $followersList = GetFollowers($user);
 
-function RenderUserList(string $header, array $users, int $friendshipType, array $followingList, array &$userCache)
+function RenderUserList(string $header, array $users, int $friendshipType, array $followingList, array &$userToolTipCache)
 {
     if (count($users) == 0) {
         return;
@@ -37,7 +37,7 @@ function RenderUserList(string $header, array $users, int $friendshipType, array
         echo "<tr>";
 
         echo "<td class='w-full'>";
-        RenderUserLink($user, LinkStyle::MediumImageWithText, $userCache);
+        RenderUserLink($user, LinkStyle::MediumImageWithText, $userToolTipCache);
         echo "</td>";
 
         echo "<td style='vertical-align:middle;'>";
@@ -86,14 +86,14 @@ RenderContentStart("Following");
             echo "You don't appear to be following anyone yet. Why not <a href='/userList.php'>browse the user pages</a> to find someone to add to follow?<br>";
         } else {
             echo "<table><tbody>";
-            $userCache = [];
+            $userToolTipCache = [];
             foreach ($followingList as $entry) {
                 echo "<tr>";
 
                 $followingUser = $entry['User'];
 
                 echo "<td>";
-                RenderUserLink($followingUser, LinkStyle::LargeImageWithText, $userCache);
+                RenderUserLink($followingUser, LinkStyle::LargeImageWithText, $userToolTipCache);
                 echo "</td>";
 
                 echo "<td class='w-full'>";
@@ -143,8 +143,8 @@ RenderContentStart("Following");
             echo "</tbody></table>";
         }
 
-        RenderUserList('Followers', $followersList, UserRelationship::Following, $followingList, $userCache);
-        RenderUserList('Blocked', $blockedUsersList, UserRelationship::Blocked, $followingList, $userCache);
+        RenderUserList('Followers', $followersList, UserRelationship::Following, $followingList, $userToolTipCache);
+        RenderUserList('Blocked', $blockedUsersList, UserRelationship::Blocked, $followingList, $userToolTipCache);
         ?>
     </div>
 </div>

--- a/public/friends.php
+++ b/public/friends.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 use RA\UserRelationship;
 
@@ -24,7 +25,7 @@ asort($blockedUsersList);
 
 $followersList = GetFollowers($user);
 
-function RenderUserList(string $header, array $users, int $friendshipType, array $followingList)
+function RenderUserList(string $header, array $users, int $friendshipType, array $followingList, array &$userCache)
 {
     if (count($users) == 0) {
         return;
@@ -35,12 +36,8 @@ function RenderUserList(string $header, array $users, int $friendshipType, array
     foreach ($users as $user) {
         echo "<tr>";
 
-        echo "<td>";
-        echo GetUserAndTooltipDiv($user, true);
-        echo "</td>";
-
         echo "<td class='w-full'>";
-        echo GetUserAndTooltipDiv($user);
+        RenderUserLink($user, LinkStyle::MediumImageWithText, $userCache);
         echo "</td>";
 
         echo "<td style='vertical-align:middle;'>";
@@ -89,17 +86,14 @@ RenderContentStart("Following");
             echo "You don't appear to be following anyone yet. Why not <a href='/userList.php'>browse the user pages</a> to find someone to add to follow?<br>";
         } else {
             echo "<table><tbody>";
+            $userCache = [];
             foreach ($followingList as $entry) {
                 echo "<tr>";
 
                 $followingUser = $entry['User'];
 
                 echo "<td>";
-                echo GetUserAndTooltipDiv($followingUser, true, null, 42);
-                echo "</td>";
-
-                echo "<td>";
-                echo GetUserAndTooltipDiv($followingUser);
+                RenderUserLink($followingUser, LinkStyle::LargeImageWithText, $userCache);
                 echo "</td>";
 
                 echo "<td class='w-full'>";
@@ -149,8 +143,8 @@ RenderContentStart("Following");
             echo "</tbody></table>";
         }
 
-        RenderUserList('Followers', $followersList, UserRelationship::Following, $followingList);
-        RenderUserList('Blocked', $blockedUsersList, UserRelationship::Blocked, $followingList);
+        RenderUserList('Followers', $followersList, UserRelationship::Following, $followingList, $userCache);
+        RenderUserList('Blocked', $blockedUsersList, UserRelationship::Blocked, $followingList, $userCache);
         ?>
     </div>
 </div>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -6,6 +6,7 @@ use RA\ClaimFilters;
 use RA\ClaimSetType;
 use RA\ClaimType;
 use RA\ImageType;
+use RA\LinkStyle;
 use RA\Permissions;
 use RA\RatingType;
 use RA\SubscriptionSubjectType;
@@ -950,7 +951,7 @@ sanitize_outputs(
                     $numItems = count($authorInfo);
                     $i = 0;
                     foreach ($authorInfo as $author => $achievementCount) {
-                        echo GetUserAndTooltipDiv($author, false);
+                        RenderUserLink($author, LinkStyle::Text);
                         echo " (" . $achievementCount . ")";
                         if (++$i !== $numItems) {
                             echo ', ';
@@ -1063,7 +1064,8 @@ sanitize_outputs(
                         foreach ($claimData as $claim) {
                             $revisionText = $claim['SetType'] == ClaimSetType::Revision && $primaryClaim ? " (" . ClaimSetType::toString(ClaimSetType::Revision) . ")" : "";
                             $claimExpiration = getNiceDate(strtotime($claim['Expiration']));
-                            echo GetUserAndTooltipDiv($claim['User'], false) . $revisionText;
+                            RenderUserLink($claim['User'], LinkStyle::Text);
+                            echo $revisionText;
                             if ($claimListLength > 1) {
                                 echo ", ";
                             }

--- a/public/gamecompare.php
+++ b/public/gamecompare.php
@@ -98,7 +98,7 @@ RenderContentStart("Game Compare");
             echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> points.<br>";
 
             $iconSize = 48;
-            $userCache = [];
+            $userToolTipCache = [];
 
             echo "<table><tbody>";
             echo "<tr>";
@@ -106,7 +106,7 @@ RenderContentStart("Game Compare");
             echo "<th>";
             echo "<a style='float: right' href='/user/$user'>$user</a><br>";
             echo "<div style='float: right'>";
-            RenderUserLink($user, LinkStyle::LargeImage, $userCache);
+            RenderUserLink($user, LinkStyle::LargeImage, $userToolTipCache);
             echo "</div>";
             echo "</th>";
 
@@ -114,7 +114,7 @@ RenderContentStart("Game Compare");
 
             echo "<th>";
             echo "<a style='float: left' href='/user/$user2'>$user2</a><br>";
-            RenderUserLink($user2, LinkStyle::LargeImage, $userCache);
+            RenderUserLink($user2, LinkStyle::LargeImage, $userToolTipCache);
             echo "</th>";
 
             echo "</tr>";
@@ -216,7 +216,7 @@ RenderContentStart("Game Compare");
 
             echo "<td>";
             echo "<div style='float:right'>";
-            RenderUserLink($user, LinkStyle::LargeImage, $userCache);
+            RenderUserLink($user, LinkStyle::LargeImage, $userToolTipCache);
             echo "</div>";
             echo "</td>";
 
@@ -224,7 +224,7 @@ RenderContentStart("Game Compare");
 
             echo "<td>";
             echo "<div>";
-            RenderUserLink($user2, LinkStyle::LargeImage, $userCache);
+            RenderUserLink($user2, LinkStyle::LargeImage, $userToolTipCache);
             echo "</div>";
             echo "</td>";
 

--- a/public/gamecompare.php
+++ b/public/gamecompare.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
@@ -97,20 +98,23 @@ RenderContentStart("Game Compare");
             echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> points.<br>";
 
             $iconSize = 48;
+            $userCache = [];
 
             echo "<table><tbody>";
             echo "<tr>";
 
             echo "<th>";
             echo "<a style='float: right' href='/user/$user'>$user</a><br>";
-            echo GetUserAndTooltipDiv($user, true, null, $iconSize, "badgeimg float-right");
+            echo "<div style='float: right'>";
+            RenderUserLink($user, LinkStyle::LargeImage, $userCache);
+            echo "</div>";
             echo "</th>";
 
             echo "<th><center>Achievement</center></th>";
 
             echo "<th>";
             echo "<a style='float: left' href='/user/$user2'>$user2</a><br>";
-            echo GetUserAndTooltipDiv($user2, true, null, $iconSize);
+            RenderUserLink($user2, LinkStyle::LargeImage, $userCache);
             echo "</th>";
 
             echo "</tr>";
@@ -195,7 +199,7 @@ RenderContentStart("Game Compare");
                         $rightSoftcoreAwardedPoints += $achPoints;
                         echo "<small class='smalldate'>$awardedRight</small>";
                     }
-                    echo GetAchievementAndTooltipDiv($achID, $achTitle, $achDesc, $achPoints, $gameTitle, $badgeName, true, true, "", $iconSize, "awardremote");
+                    echo GetAchievementAndTooltipDiv($achID, $achTitle, $achDesc, $achPoints, $gameTitle, $badgeName, true, true, "", $iconSize, (isset($awardedHCRight) ? 'goldimage' : ''));
                     echo "</div>";
                 } else {
                     echo "<div style='float:right;' >";
@@ -212,7 +216,7 @@ RenderContentStart("Game Compare");
 
             echo "<td>";
             echo "<div style='float:right'>";
-            echo GetUserAndTooltipDiv($user, true, null, $iconSize, "badgeimg float-right");
+            RenderUserLink($user, LinkStyle::LargeImage, $userCache);
             echo "</div>";
             echo "</td>";
 
@@ -220,7 +224,7 @@ RenderContentStart("Game Compare");
 
             echo "<td>";
             echo "<div>";
-            echo GetUserAndTooltipDiv($user2, true, null, $iconSize);
+            RenderUserLink($user2, LinkStyle::LargeImage, $userCache);
             echo "</div>";
             echo "</td>";
 

--- a/public/globalRanking.php
+++ b/public/globalRanking.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\RankType;
 use RA\UnlockMode;
 
@@ -234,8 +235,7 @@ RenderContentStart($lbUsers . " Ranking - " . $lbType);
                     echo "<td>" . $rank . "</td>";
                 }
                 echo "<td>";
-                echo GetUserAndTooltipDiv($dataPoint['User'], true);
-                echo GetUserAndTooltipDiv($dataPoint['User'], false);
+                RenderUserLink($dataPoint['User'], LinkStyle::MediumImageWithText);
                 echo "</td>";
 
                 // If viewing the daily leaderboard then link the total achievements obtained to the users history page for the day
@@ -301,8 +301,7 @@ RenderContentStart($lbUsers . " Ranking - " . $lbType);
                         }
                     }
                     echo "<td>";
-                    echo GetUserAndTooltipDiv($userData[0]['User'], true);
-                    echo GetUserAndTooltipDiv($userData[0]['User'], false);
+                    RenderUserLink($userData[0]['User'], LinkStyle::MediumImageWithText);
                     echo "</td>";
 
                     // If viewing the daily leaderboard then link the total achievements obtained to the users history page for the day

--- a/public/historyexamine.php
+++ b/public/historyexamine.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\UnlockMode;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -108,6 +109,7 @@ RenderContentStart("$userPage's Legacy - $dateStr");
 
         usort($achEarnedLib, fn ($a, $b) => $a['Date'] <=> $b['Date']);
 
+        $userCache = [];
         foreach ($achEarnedLib as $achEarned) {
             $achAwardedAt = $achEarned['Date'];
             $achID = $achEarned['AchievementID'];
@@ -149,7 +151,7 @@ RenderContentStart("$userPage's Legacy - $dateStr");
             echo "</td>";
 
             echo "<td>";
-            echo GetUserAndTooltipDiv($achAuthor, true);
+            RenderUserLink($achAuthor, LinkStyle::MediumImage, $userCache);
             echo "</td>";
 
             echo "<td>";

--- a/public/historyexamine.php
+++ b/public/historyexamine.php
@@ -109,7 +109,7 @@ RenderContentStart("$userPage's Legacy - $dateStr");
 
         usort($achEarnedLib, fn ($a, $b) => $a['Date'] <=> $b['Date']);
 
-        $userCache = [];
+        $userToolTipCache = [];
         foreach ($achEarnedLib as $achEarned) {
             $achAwardedAt = $achEarned['Date'];
             $achID = $achEarned['AchievementID'];
@@ -151,7 +151,7 @@ RenderContentStart("$userPage's Legacy - $dateStr");
             echo "</td>";
 
             echo "<td>";
-            RenderUserLink($achAuthor, LinkStyle::MediumImage, $userCache);
+            RenderUserLink($achAuthor, LinkStyle::MediumImage, $userToolTipCache);
             echo "</td>";
 
             echo "<td>";

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Support\Shortcode\Shortcode;
+use RA\LinkStyle;
 
 $maxCount = 10;
 
@@ -91,15 +92,16 @@ function MarkAsUnread(msgID) {
             echo "<tr>";
             echo "<th>Date</th>";
             if ($outbox) {
-                echo "<th colspan='2' style='min-width:150px'>To</th>";
+                echo "<th style='min-width:150px'>To</th>";
             } else {
-                echo "<th colspan='2' style='min-width:150px'>From</th>";
+                echo "<th style='min-width:150px'>From</th>";
             }
             echo "<th style='width:100%'>Title</th>";
             echo "</tr>";
 
             $totalMsgs = count($allMessages);
 
+            $userCache = [];
             for ($i = 0; $i < $totalMsgs; $i++) {
                 $msgID = $allMessages[$i]['ID'];
                 $msgTime = $allMessages[$i]['TimeSent'];
@@ -134,10 +136,7 @@ function MarkAsUnread(msgID) {
                 echo "</td>";
 
                 echo "<td style='width:34px'>";
-                echo GetUserAndTooltipDiv($msgUser, true);
-                echo "</td>";
-                echo "<td>";
-                echo GetUserAndTooltipDiv($msgUser, false);
+                RenderUserLink($msgUser, LinkStyle::MediumImageWithText, $userCache);
                 echo "</td>";
 
                 // echo "<td>" . $msgTo . "</td>";

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -101,7 +101,7 @@ function MarkAsUnread(msgID) {
 
             $totalMsgs = count($allMessages);
 
-            $userCache = [];
+            $userToolTipCache = [];
             for ($i = 0; $i < $totalMsgs; $i++) {
                 $msgID = $allMessages[$i]['ID'];
                 $msgTime = $allMessages[$i]['TimeSent'];
@@ -136,7 +136,7 @@ function MarkAsUnread(msgID) {
                 echo "</td>";
 
                 echo "<td style='width:34px'>";
-                RenderUserLink($msgUser, LinkStyle::MediumImageWithText, $userCache);
+                RenderUserLink($msgUser, LinkStyle::MediumImageWithText, $userToolTipCache);
                 echo "</td>";
 
                 // echo "<td>" . $msgTo . "</td>";

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\TicketState;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -768,8 +769,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User with Most Completed Awards:</td><td>";
             if (!empty($anyDevUserMostCompleted)) {
                 echo $anyDevUserMostCompleted['Completed'] . " - ";
-                echo GetUserAndTooltipDiv($anyDevUserMostCompleted['User'], true);
-                echo GetUserAndTooltipDiv($anyDevUserMostCompleted['User'], false);
+                RenderUserLink($anyDevUserMostCompleted['User'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }
@@ -779,8 +779,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User with Most Mastered Awards:</td><td>";
             if (!empty($anyDevUserMostMastered)) {
                 echo $anyDevUserMostMastered['Mastered'] . " - ";
-                echo GetUserAndTooltipDiv($anyDevUserMostMastered['User'], true);
-                echo GetUserAndTooltipDiv($anyDevUserMostMastered['User'], false);
+                RenderUserLink($anyDevUserMostMastered['User'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }
@@ -880,8 +879,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User with Most Completed Awards:</td><td>";
             if (!empty($majorityDevUserMostCompleted)) {
                 echo $majorityDevUserMostCompleted['Completed'] . " - ";
-                echo GetUserAndTooltipDiv($majorityDevUserMostCompleted['User'], true);
-                echo GetUserAndTooltipDiv($majorityDevUserMostCompleted['User'], false);
+                RenderUserLink($majorityDevUserMostCompleted['User'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }
@@ -891,8 +889,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User with Most Mastered Awards:</td><td>";
             if (!empty($majorityDevUserMostMastered)) {
                 echo $majorityDevUserMostMastered['Mastered'] . " - ";
-                echo GetUserAndTooltipDiv($majorityDevUserMostMastered['User'], true);
-                echo GetUserAndTooltipDiv($majorityDevUserMostMastered['User'], false);
+                RenderUserLink($majorityDevUserMostMastered['User'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }
@@ -992,8 +989,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User with Most Completed Awards:</td><td>";
             if (!empty($onlyDevUserMostCompleted)) {
                 echo $onlyDevUserMostCompleted['Completed'] . " - ";
-                echo GetUserAndTooltipDiv($onlyDevUserMostCompleted['User'], true);
-                echo GetUserAndTooltipDiv($onlyDevUserMostCompleted['User'], false);
+                RenderUserLink($majorityDevUserMostCompleted['User'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }
@@ -1003,8 +999,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User with Most Mastered Awards:</td><td>";
             if (!empty($onlyDevUserMostMastered)) {
                 echo $onlyDevUserMostMastered['Mastered'] . " - ";
-                echo GetUserAndTooltipDiv($onlyDevUserMostMastered['User'], true);
-                echo GetUserAndTooltipDiv($onlyDevUserMostMastered['User'], false);
+                RenderUserLink($onlyDevUserMostMastered['User'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }
@@ -1104,8 +1099,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User Who Obtained the Most Achievements:</td><td>";
             if (!empty($mostAchievementObtainer)) {
                 echo $mostAchievementObtainer['SoftcoreCount'] . " <b>(" . $mostAchievementObtainer['HardcoreCount'] . ")</b> - ";
-                echo GetUserAndTooltipDiv($mostAchievementObtainer['User'], true);
-                echo GetUserAndTooltipDiv($mostAchievementObtainer['User'], false);
+                RenderUserLink($mostAchievementObtainer['User'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }
@@ -1139,6 +1133,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "</tbody></table>";
             echo "<div id='devstatsscrollpane'>";
             echo "<table><tbody>";
+            $userCache = [];
             $rowCount = 0;
             for ($i = 0; $i < count($recentlyObtainedAchievements) && $rowCount < ($maxRecentAchievements / 2); $i++) {
                 $skipNextEntry = false;
@@ -1158,8 +1153,7 @@ RenderContentStart("$dev's Developer Stats");
                 echo "</td><td width='35%'>";
                 echo GetGameAndTooltipDiv($recentlyObtainedAchievements[$i]['GameID'], $recentlyObtainedAchievements[$i]['GameTitle'], $recentlyObtainedAchievements[$i]['GameIcon'], $recentlyObtainedAchievements[$i]['ConsoleName'], false, 32);
                 echo "</td><td width='20%'>";
-                echo GetUserAndTooltipDiv($recentlyObtainedAchievements[$i]['User'], true);
-                echo GetUserAndTooltipDiv($recentlyObtainedAchievements[$i]['User'], false);
+                RenderUserLink($recentlyObtainedAchievements[$i]['User'], LinkStyle::MediumImageWithText, $userCache);
                 echo "</td><td width='10%'>";
                 echo $recentlyObtainedAchievements[$i]['Date'];
                 echo "</td></tr>";
@@ -1250,8 +1244,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User Who Created the Most Tickets for $dev:</td><td>";
             if ($mostTicketCreator !== null) {
                 echo $mostTicketCreator['TicketCount'] . " - ";
-                echo GetUserAndTooltipDiv($mostTicketCreator['TicketCreator'], true);
-                echo GetUserAndTooltipDiv($mostTicketCreator['TicketCreator'], false);
+                RenderUserLink($mostTicketCreator['TicketCreator'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }
@@ -1264,8 +1257,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User $dev Has Closed the Most Tickets For:</td><td>";
             if ($closedResolvedTicketInfo['ClosedCount'] > 0) {
                 echo $closedResolvedTicketInfo['ClosedAuthorCount'] . " - ";
-                echo GetUserAndTooltipDiv($closedResolvedTicketInfo['ClosedAuthor'], true);
-                echo GetUserAndTooltipDiv($closedResolvedTicketInfo['ClosedAuthor'], false);
+                RenderUserLink($closedResolvedTicketInfo['ClosedAuthor'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }
@@ -1275,8 +1267,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr><td>User $dev Has Resolved the Most Tickets For:</td><td>";
             if ($closedResolvedTicketInfo['ResolvedCount'] > 0) {
                 echo $closedResolvedTicketInfo['ResolvedAuthorCount'] . " - ";
-                echo GetUserAndTooltipDiv($closedResolvedTicketInfo['ResolvedAuthor'], true);
-                echo GetUserAndTooltipDiv($closedResolvedTicketInfo['ResolvedAuthor'], false);
+                RenderUserLink($closedResolvedTicketInfo['ResolvedAuthor'], LinkStyle::MediumImageWithText);
             } else {
                 echo "N/A";
             }

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -1133,7 +1133,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "</tbody></table>";
             echo "<div id='devstatsscrollpane'>";
             echo "<table><tbody>";
-            $userCache = [];
+            $userToolTipCache = [];
             $rowCount = 0;
             for ($i = 0; $i < count($recentlyObtainedAchievements) && $rowCount < ($maxRecentAchievements / 2); $i++) {
                 $skipNextEntry = false;
@@ -1153,7 +1153,7 @@ RenderContentStart("$dev's Developer Stats");
                 echo "</td><td width='35%'>";
                 echo GetGameAndTooltipDiv($recentlyObtainedAchievements[$i]['GameID'], $recentlyObtainedAchievements[$i]['GameTitle'], $recentlyObtainedAchievements[$i]['GameIcon'], $recentlyObtainedAchievements[$i]['ConsoleName'], false, 32);
                 echo "</td><td width='20%'>";
-                RenderUserLink($recentlyObtainedAchievements[$i]['User'], LinkStyle::MediumImageWithText, $userCache);
+                RenderUserLink($recentlyObtainedAchievements[$i]['User'], LinkStyle::MediumImageWithText, $userToolTipCache);
                 echo "</td><td width='10%'>";
                 echo $recentlyObtainedAchievements[$i]['Date'];
                 echo "</td></tr>";

--- a/public/latesthasheslinked.php
+++ b/public/latesthasheslinked.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
@@ -51,6 +52,7 @@ RenderContentStart("Hash List");
 
             $hashCount = 0;
 
+            $userCache = [];
             foreach ($hashList as $hash) {
                 if ($hashCount++ % 2 == 0) {
                     echo "<tr>";
@@ -64,7 +66,7 @@ RenderContentStart("Hash List");
                 echo "</td>";
                 echo "<td>";
                 if (!empty($hash['User'])) {
-                    echo GetUserAndTooltipDiv($hash['User'], false);
+                    RenderUserLink($hash['User'], LinkStyle::Text, $userCache);
                 }
                 echo "</td>";
                 echo "<td>" . $hash['DateAdded'] . "</td>";

--- a/public/latesthasheslinked.php
+++ b/public/latesthasheslinked.php
@@ -52,7 +52,7 @@ RenderContentStart("Hash List");
 
             $hashCount = 0;
 
-            $userCache = [];
+            $userToolTipCache = [];
             foreach ($hashList as $hash) {
                 if ($hashCount++ % 2 == 0) {
                     echo "<tr>";
@@ -66,7 +66,7 @@ RenderContentStart("Hash List");
                 echo "</td>";
                 echo "<td>";
                 if (!empty($hash['User'])) {
-                    RenderUserLink($hash['User'], LinkStyle::Text, $userCache);
+                    RenderUserLink($hash['User'], LinkStyle::Text, $userToolTipCache);
                 }
                 echo "</td>";
                 echo "<td>" . $hash['DateAdded'] . "</td>";

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\ArticleType;
+use RA\LinkStyle;
 use RA\Permissions;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -84,7 +85,9 @@ RenderContentStart('Leaderboard');
             if (is_null($lbAuthor)) {
                 echo "Created by Unknown on: $niceDateCreated<br>Last modified: $niceDateModified<br>";
             } else {
-                echo "Created by " . GetUserAndTooltipDiv($lbAuthor, false) . " on: $niceDateCreated<br>Last modified: $niceDateModified<br>";
+                echo "Created by ";
+                RenderUserLink($lbAuthor, LinkStyle::Text);
+                echo " on: $niceDateCreated<br>Last modified: $niceDateModified<br>";
             }
             echo "</small>";
             echo "</p>";
@@ -183,8 +186,7 @@ RenderContentStart('Leaderboard');
                 echo "<td class='lb_rank'>$injectFmt1$nextRank$injectFmt2</td>";
 
                 echo "<td class='lb_user'>";
-                echo GetUserAndTooltipDiv($nextUser, true);
-                echo GetUserAndTooltipDiv($nextUser, false);
+                RenderUserLink($nextUser, LinkStyle::MediumImageWithText);
                 echo "</td>";
 
                 echo "<td class='lb_result'>$injectFmt1$nextScoreFormatted$injectFmt2</td>";

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
@@ -67,7 +68,8 @@ RenderContentStart("Linked Hashes");
 
             echo '<br/><code> ' . $hash['Hash'] . '</code>';
             if (!empty($hash['User'])) {
-                echo ' linked by ' . GetUserAndTooltipDiv($hash['User']);
+                echo ' linked by ';
+                RenderUserLink($hash['User'], LinkStyle::Text);
             }
             echo '</p></li>';
         }
@@ -81,7 +83,8 @@ RenderContentStart("Linked Hashes");
 
                 echo '<code> ' . $hash['Hash'] . '</code>';
                 if (!empty($hash['User'])) {
-                    echo " linked by " . GetUserAndTooltipDiv($hash['User']);
+                    echo " linked by ";
+                    RenderUserLink($hash['User'], LinkStyle::Text);
                 }
                 echo '<br/>';
             }

--- a/public/manageclaims.php
+++ b/public/manageclaims.php
@@ -6,6 +6,7 @@ use RA\ClaimSorting;
 use RA\ClaimSpecial;
 use RA\ClaimStatus;
 use RA\ClaimType;
+use RA\LinkStyle;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Admin)) {
@@ -150,7 +151,7 @@ RenderContentStart("Manage Claims");
         echo "</div></br>";
 
         echo "<div class='table-wrapper'><table><tbody>";
-        echo "<th colspan='2'>" . ClaimSorting::toString(ClaimSorting::UserDescending) . "</th>";
+        echo "<th>" . ClaimSorting::toString(ClaimSorting::UserDescending) . "</th>";
         echo "<th>" . ClaimSorting::toString(ClaimSorting::ClaimTypeDescending) . "</th>";
         echo "<th>" . ClaimSorting::toString(ClaimSorting::SetTypeDescending) . "</th>";
         echo "<th>" . ClaimSorting::toString(ClaimSorting::ClaimStatusDescending) . "</th>";
@@ -163,11 +164,8 @@ RenderContentStart("Manage Claims");
         foreach ($claimData as $claim) {
             $claimID = $claim['ID'];
             $claimUser = $claim['User'];
-            echo "<tr><td class='whitespace-nowrap'>";
-            echo GetUserAndTooltipDiv($claimUser, true);
-            echo "</td>";
-            echo "<td class='whitespace-nowrap'><div id='claimUser_$claimUser'>";
-            echo GetUserAndTooltipDiv($claimUser, false);
+            echo "<tr><td class='whitespace-nowrap'><div id='claimUser_$claimUser'>";
+            RenderUserLink($claimUser, LinkStyle::MediumImageWithText);
             echo "</div></td>";
 
             echo "<td>";

--- a/public/managehashes.php
+++ b/public/managehashes.php
@@ -92,7 +92,7 @@ function UnlinkHash(user, gameID, hash, elem) {
         echo "<div class='table-wrapper'><table id='hashTable'><tbody>";
         echo "<th>RetroAchievements Hash</th><th>Linked By</th><th>Description</th><th>Labels</th><th>Actions</th><th></th>\n";
 
-        $userCache = [];
+        $userToolTipCache = [];
         foreach ($hashes as $hashData) {
             $hash = $hashData['Hash'];
 
@@ -101,7 +101,7 @@ function UnlinkHash(user, gameID, hash, elem) {
 
             if (!empty($hashData['User'])) {
                 echo "<td style='width: 10%; white-space: nowrap'>";
-                RenderUserLink($hashData['User'], LinkStyle::Text, $userCache);
+                RenderUserLink($hashData['User'], LinkStyle::Text, $userToolTipCache);
                 echo "</td>";
             } else {
                 echo "<td style='width: 10%'></td>";

--- a/public/managehashes.php
+++ b/public/managehashes.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\ArticleType;
+use RA\LinkStyle;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
@@ -91,6 +92,7 @@ function UnlinkHash(user, gameID, hash, elem) {
         echo "<div class='table-wrapper'><table id='hashTable'><tbody>";
         echo "<th>RetroAchievements Hash</th><th>Linked By</th><th>Description</th><th>Labels</th><th>Actions</th><th></th>\n";
 
+        $userCache = [];
         foreach ($hashes as $hashData) {
             $hash = $hashData['Hash'];
 
@@ -99,7 +101,7 @@ function UnlinkHash(user, gameID, hash, elem) {
 
             if (!empty($hashData['User'])) {
                 echo "<td style='width: 10%; white-space: nowrap'>";
-                echo GetUserAndTooltipDiv($hashData['User']);
+                RenderUserLink($hashData['User'], LinkStyle::Text, $userCache);
                 echo "</td>";
             } else {
                 echo "<td style='width: 10%'></td>";

--- a/public/recentMastery.php
+++ b/public/recentMastery.php
@@ -75,7 +75,7 @@ RenderContentStart("Recent " . $lbUsers . " Masteries");
         echo "<th>Date</th>";
         echo "</tr>";
 
-        $userCache = [];
+        $userToolTipCache = [];
         $userCount = 0;
         $skip = false;
         // Create the table rows
@@ -90,7 +90,7 @@ RenderContentStart("Recent " . $lbUsers . " Masteries");
                 echo "<tr>";
 
                 echo "<td>";
-                RenderUserLink($dataPoint['User'], LinkStyle::MediumImageWithText, $userCache);
+                RenderUserLink($dataPoint['User'], LinkStyle::MediumImageWithText, $userToolTipCache);
                 echo "</td>";
 
                 echo "<td>";

--- a/public/recentMastery.php
+++ b/public/recentMastery.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\LinkStyle;
+
 authenticateFromCookie($user, $permissions, $userDetails);
 
 $maxCount = 25;
@@ -73,6 +75,7 @@ RenderContentStart("Recent " . $lbUsers . " Masteries");
         echo "<th>Date</th>";
         echo "</tr>";
 
+        $userCache = [];
         $userCount = 0;
         $skip = false;
         // Create the table rows
@@ -87,8 +90,7 @@ RenderContentStart("Recent " . $lbUsers . " Masteries");
                 echo "<tr>";
 
                 echo "<td>";
-                echo GetUserAndTooltipDiv($dataPoint['User'], true);
-                echo GetUserAndTooltipDiv($dataPoint['User'], false);
+                RenderUserLink($dataPoint['User'], LinkStyle::MediumImageWithText, $userCache);
                 echo "</td>";
 
                 echo "<td>";

--- a/public/searchresults.php
+++ b/public/searchresults.php
@@ -47,7 +47,7 @@ RenderContentStart("Search");
                 echo "</tr>";
                 $lastType = '';
                 $iter = 0;
-                $userCache = [];
+                $userToolTipCache = [];
                 foreach ($searchResults as $nextResult) {
                     $nextType = $nextResult['Type'];
                     $nextID = $nextResult['ID'];
@@ -69,10 +69,10 @@ RenderContentStart("Search");
                     // echo "<td>$nextID</td>";
                     if ($nextType == 'User') {
                         echo "<td>";
-                        RenderUserLink($nextID, LinkStyle::MediumImage, $userCache);
+                        RenderUserLink($nextID, LinkStyle::MediumImage, $userToolTipCache);
                         echo "</td>";
                         echo "<td>";
-                        RenderUserLink($nextID, LinkStyle::Text, $userCache);
+                        RenderUserLink($nextID, LinkStyle::Text, $userToolTipCache);
                         echo "</td>";
                     } else {
                         if ($nextType == 'Achievement') {
@@ -85,7 +85,7 @@ RenderContentStart("Search");
                         } else {
                             if ($nextType == 'Forum Comment' || $nextType == 'Comment') {
                                 echo "<td>";
-                                RenderUserLink($nextID, LinkStyle::MediumImage, $userCache);
+                                RenderUserLink($nextID, LinkStyle::MediumImage, $userToolTipCache);
                                 echo "</td>";
                                 echo "<td><a href='$nextTarget'>$nextTitle</a></td>";
                             } else {

--- a/public/searchresults.php
+++ b/public/searchresults.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\LinkStyle;
+
 authenticateFromCookie($user, $permissions, $userDetails);
 
 $searchQuery = requestInputSanitized('s', null);
@@ -45,6 +47,7 @@ RenderContentStart("Search");
                 echo "</tr>";
                 $lastType = '';
                 $iter = 0;
+                $userCache = [];
                 foreach ($searchResults as $nextResult) {
                     $nextType = $nextResult['Type'];
                     $nextID = $nextResult['ID'];
@@ -66,10 +69,10 @@ RenderContentStart("Search");
                     // echo "<td>$nextID</td>";
                     if ($nextType == 'User') {
                         echo "<td>";
-                        echo GetUserAndTooltipDiv($nextID, true);
+                        RenderUserLink($nextID, LinkStyle::MediumImage, $userCache);
                         echo "</td>";
                         echo "<td>";
-                        echo GetUserAndTooltipDiv($nextID, false);
+                        RenderUserLink($nextID, LinkStyle::Text, $userCache);
                         echo "</td>";
                     } else {
                         if ($nextType == 'Achievement') {
@@ -82,7 +85,7 @@ RenderContentStart("Search");
                         } else {
                             if ($nextType == 'Forum Comment' || $nextType == 'Comment') {
                                 echo "<td>";
-                                echo GetUserAndTooltipDiv($nextID, true);
+                                RenderUserLink($nextID, LinkStyle::MediumImage, $userCache);
                                 echo "</td>";
                                 echo "<td><a href='$nextTarget'>$nextTitle</a></td>";
                             } else {

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -1,5 +1,7 @@
 <?php
 
+use RA\LinkStyle;
+
 if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     abort(401);
 }
@@ -103,8 +105,7 @@ RenderContentStart("Set Requests");
                 echo "</td><td>";
                 $claims = explode(',', $request['Claims']);
                 foreach ($claims as $devClaim) {
-                    echo GetUserAndTooltipDiv($devClaim, true);
-                    echo GetUserAndTooltipDiv($devClaim, false);
+                    RenderUserLink($devClaim, LinkStyle::MediumImageWithText);
                     echo "</br>";
                 }
                 echo "</td>";
@@ -166,8 +167,7 @@ RenderContentStart("Set Requests");
                         echo "<td>";
                         $claims = explode(',', $request['Claims']);
                         foreach ($claims as $devClaim) {
-                            echo GetUserAndTooltipDiv($devClaim, true);
-                            echo GetUserAndTooltipDiv($devClaim, false);
+                            RenderUserLink($devClaim, LinkStyle::MediumImageWithText);
                             echo "</br>";
                         }
                         echo "</td>";
@@ -190,8 +190,7 @@ RenderContentStart("Set Requests");
                     echo "<td>";
                     $claims = explode(',', $request['Claims']);
                     foreach ($claims as $devClaim) {
-                        echo GetUserAndTooltipDiv($devClaim, true);
-                        echo GetUserAndTooltipDiv($devClaim, false);
+                        RenderUserLink($devClaim, LinkStyle::MediumImageWithText);
                         echo "</br>";
                     }
                     echo "</td>";

--- a/public/setRequestors.php
+++ b/public/setRequestors.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
@@ -30,7 +31,9 @@ RenderContentStart("Set Requests");
         echo "<ul>";
         if (!empty($requestors)) {
             foreach ($requestors as $requestor) {
-                echo "<code><li>" . GetUserAndTooltipDiv($requestor['Requestor'], false) . "</code></li>";
+                echo "<code><li>";
+                RenderUserLink($requestor['Requestor'], LinkStyle::Text);
+                echo "</code></li>";
             }
         }
         echo "</ul>";

--- a/public/test/tooltip.php
+++ b/public/test/tooltip.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Ticket;
 
 RenderContentStart();
@@ -33,7 +34,9 @@ function tooltip_row(string $text): void
         'LastActivity' => '1/2/2022',
         'MemberSince' => '7/8/2018',
     ];
-    echo _GetUserAndTooltipDiv($text, $userCardInfo);
+
+    $tooltip = _BuildUserTooltipDiv($text, $userCardInfo);
+    echo _BuildLink($text, '', "/user/$text", LinkStyle::Text, $tooltip);
 
     $ticketData = [
         'ID' => 1,

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -396,7 +396,7 @@ RenderContentStart($pageTitle);
                 echo "<th class='whitespace-nowrap'>Reported At</th>";
 
                 $rowCount = 0;
-                $userCache = [];
+                $userToolTipCache = [];
 
                 foreach ($ticketData as $nextTicket) {
                     $ticketID = $nextTicket['ID'];
@@ -456,14 +456,14 @@ RenderContentStart($pageTitle);
                     echo "</td>";
 
                     echo "<td>";
-                    RenderUserLink($achAuthor, LinkStyle::MediumImageWithText, $userCache);
+                    RenderUserLink($achAuthor, LinkStyle::MediumImageWithText, $userToolTipCache);
                     echo "</td>";
                     echo "<td>";
-                    RenderUserLink($reportedBy, LinkStyle::MediumImageWithText, $userCache);
+                    RenderUserLink($reportedBy, LinkStyle::MediumImageWithText, $userToolTipCache);
                     echo "</td>";
                     if ($closedTickets || $resolvedTickets) {
                         echo "<td>";
-                        RenderUserLink($resolvedBy, LinkStyle::MediumImageWithText, $userCache);
+                        RenderUserLink($resolvedBy, LinkStyle::MediumImageWithText, $userToolTipCache);
                         echo "</td>";
                     }
 

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -2,6 +2,7 @@
 
 use RA\AchievementType;
 use RA\ArticleType;
+use RA\LinkStyle;
 use RA\Permissions;
 use RA\TicketAction;
 use RA\TicketFilters;
@@ -395,6 +396,7 @@ RenderContentStart($pageTitle);
                 echo "<th class='whitespace-nowrap'>Reported At</th>";
 
                 $rowCount = 0;
+                $userCache = [];
 
                 foreach ($ticketData as $nextTicket) {
                     $ticketID = $nextTicket['ID'];
@@ -454,17 +456,14 @@ RenderContentStart($pageTitle);
                     echo "</td>";
 
                     echo "<td>";
-                    echo GetUserAndTooltipDiv($achAuthor, true);
-                    echo GetUserAndTooltipDiv($achAuthor, false);
+                    RenderUserLink($achAuthor, LinkStyle::MediumImageWithText, $userCache);
                     echo "</td>";
                     echo "<td>";
-                    echo GetUserAndTooltipDiv($reportedBy, true);
-                    echo GetUserAndTooltipDiv($reportedBy, false);
+                    RenderUserLink($reportedBy, LinkStyle::MediumImageWithText, $userCache);
                     echo "</td>";
                     if ($closedTickets || $resolvedTickets) {
                         echo "<td>";
-                        echo GetUserAndTooltipDiv($resolvedBy, true);
-                        echo GetUserAndTooltipDiv($resolvedBy, false);
+                        RenderUserLink($resolvedBy, LinkStyle::MediumImageWithText, $userCache);
                         echo "</td>";
                     }
 
@@ -554,18 +553,15 @@ RenderContentStart($pageTitle);
                 echo "</td>";
 
                 echo "<td>";
-                echo GetUserAndTooltipDiv($achAuthor, true);
-                echo GetUserAndTooltipDiv($achAuthor, false);
+                RenderUserLink($achAuthor, LinkStyle::MediumImageWithText);
                 echo "</td>";
 
                 echo "<td>";
-                echo GetUserAndTooltipDiv($reportedBy, true);
-                echo GetUserAndTooltipDiv($reportedBy, false);
+                RenderUserLink($reportedBy, LinkStyle::MediumImageWithText);
                 echo "</td>";
 
                 echo "<td>";
-                echo GetUserAndTooltipDiv($resolvedBy, true);
-                echo GetUserAndTooltipDiv($resolvedBy, false);
+                RenderUserLink($resolvedBy, LinkStyle::MediumImageWithText);
                 echo "</td>";
 
                 echo "<td class='smalldate'>";

--- a/public/userList.php
+++ b/public/userList.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 
 $sortBy = (int) request()->query('s');
@@ -92,7 +93,7 @@ RenderContentStart("Users");
             echo "<th>Rank</th>";
         }
 
-        echo "<th colspan='2'><a href='/userList.php?s=$sort1&p=$perms" . ($showUntracked ? "&u=1" : '') . "'>User</a></th>";
+        echo "<th><a href='/userList.php?s=$sort1&p=$perms" . ($showUntracked ? "&u=1" : '') . "'>User</a></th>";
         echo "<th><a href='/userList.php?s=$sort2&p=$perms" . ($showUntracked ? "&u=1" : '') . "'>Points</a></th>";
         echo "<th><a href='/userList.php?s=$sort3&p=$perms" . ($showUntracked ? "&u=1" : '') . "'>Num Achievements Earned</a></th>";
         echo "<th><a href='/userList.php?s=$sort4&p=$perms" . ($showUntracked ? "&u=1" : '') . "'>Last Login</a></th>";
@@ -118,10 +119,7 @@ RenderContentStart("Users");
             }
 
             echo "<td>";
-            echo GetUserAndTooltipDiv($nextUser, true);
-            echo "</td>";
-            echo "<td class='user'>";
-            echo GetUserAndTooltipDiv($nextUser, false);
+            RenderUserLink($nextUser, LinkStyle::MediumImageWithText);
             echo "</td>";
 
             echo "<td>$totalPoints</td>";

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -100,7 +100,7 @@ RenderContentStart("Forum: $thisForumTitle");
         $topicCount = is_countable($topicList) ? count($topicList) : 0;
 
         // Output all topics, and offer 'prev/next page'
-        $userCache = [];
+        $userToolTipCache = [];
         foreach ($topicList as $topicData) {
             // Output one forum, then loop
             $nextTopicID = $topicData['ForumTopicID'];
@@ -143,13 +143,13 @@ RenderContentStart("Forum: $thisForumTitle");
             echo "</td>";
             echo "<td>";
             echo "<div>";
-            RenderUserLink($nextTopicAuthor, LinkStyle::Text, $userCache);
+            RenderUserLink($nextTopicAuthor, LinkStyle::Text, $userToolTipCache);
             echo "<br><span class='smalldate'>$nextTopicPostedNiceDate</span></div>";
             echo "</td>";
             echo "<td>$nextTopicNumReplies</td>";
             echo "<td>";
             echo "<div>";
-            RenderUserLink($nextTopicLastCommentAuthor, LinkStyle::Text, $userCache);
+            RenderUserLink($nextTopicLastCommentAuthor, LinkStyle::Text, $userToolTipCache);
             echo "<br><span class='smalldate'>$nextTopicLastCommentPostedNiceDate</span>";
             echo "<br><a class='btn btn-link' href='viewtopic.php?t=$nextTopicID&amp;c=$nextTopicLastCommentID#$nextTopicLastCommentID' title='View latest post'>View</a>";
             echo "</div>";

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\LinkStyle;
 use RA\Permissions;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -99,6 +100,7 @@ RenderContentStart("Forum: $thisForumTitle");
         $topicCount = is_countable($topicList) ? count($topicList) : 0;
 
         // Output all topics, and offer 'prev/next page'
+        $userCache = [];
         foreach ($topicList as $topicData) {
             // Output one forum, then loop
             $nextTopicID = $topicData['ForumTopicID'];
@@ -140,11 +142,15 @@ RenderContentStart("Forum: $thisForumTitle");
             echo "<div class='mb-1' style='word-break:break-word'>$nextTopicPreview...</div>";
             echo "</td>";
             echo "<td>";
-            echo "<div>" . GetUserAndTooltipDiv($nextTopicAuthor) . "<br><span class='smalldate'>$nextTopicPostedNiceDate</span></div>";
+            echo "<div>";
+            RenderUserLink($nextTopicAuthor, LinkStyle::Text, $userCache);
+            echo "<br><span class='smalldate'>$nextTopicPostedNiceDate</span></div>";
             echo "</td>";
             echo "<td>$nextTopicNumReplies</td>";
             echo "<td>";
-            echo "<div>" . GetUserAndTooltipDiv($nextTopicLastCommentAuthor) . "<br><span class='smalldate'>$nextTopicLastCommentPostedNiceDate</span>";
+            echo "<div>";
+            RenderUserLink($nextTopicLastCommentAuthor, LinkStyle::Text, $userCache);
+            echo "<br><span class='smalldate'>$nextTopicLastCommentPostedNiceDate</span>";
             echo "<br><a class='btn btn-link' href='viewtopic.php?t=$nextTopicID&amp;c=$nextTopicLastCommentID#$nextTopicLastCommentID' title='View latest post'>View</a>";
             echo "</div>";
             echo "</td>";

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -154,7 +154,7 @@ RenderContentStart($pageTitle);
         echo "<div class='table-wrapper'>";
         echo "<table><tbody>";
         // Output all topics, and offer 'prev/next page'
-        $userCache = [];
+        $userToolTipCache = [];
         foreach ($commentList as $commentData) {
             // Output one forum, then loop
             $nextCommentID = $commentData['ID'];
@@ -206,14 +206,14 @@ RenderContentStart($pageTitle);
             }
 
             echo "<td class='align-top'>";
-            RenderUserLink($nextCommentAuthor, LinkStyle::ExtraLargeImage, $userCache);
+            RenderUserLink($nextCommentAuthor, LinkStyle::ExtraLargeImage, $userToolTipCache);
             echo "</td>";
 
             echo "<td class='w-full' id='$nextCommentID'>";
 
             echo "<div class='flex justify-between mb-2'>";
             echo "<div>";
-            RenderUserLink($nextCommentAuthor, LinkStyle::Text, $userCache);
+            RenderUserLink($nextCommentAuthor, LinkStyle::Text, $userToolTipCache);
             if ($showDisclaimer) {
                 echo " <b class='cursor-help' title='Unverified: not yet visible to the public. Please wait for a moderator to authorise this comment.'>(Unverified)</b>";
             }
@@ -272,9 +272,9 @@ RenderContentStart($pageTitle);
             echo "<tr>";
 
             echo "<td class='align-top'>";
-            RenderUserLink($user, LinkStyle::Text, $userCache);
+            RenderUserLink($user, LinkStyle::Text, $userToolTipCache);
             echo "<br>";
-            RenderUserLink($user, LinkStyle::ExtraLargeImage, $userCache);
+            RenderUserLink($user, LinkStyle::ExtraLargeImage, $userToolTipCache);
             echo "</td>";
 
             echo "<td class='w-full'>";

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Support\Shortcode\Shortcode;
+use RA\LinkStyle;
 use RA\Permissions;
 use RA\SubscriptionSubjectType;
 use RA\UserAction;
@@ -153,6 +154,7 @@ RenderContentStart($pageTitle);
         echo "<div class='table-wrapper'>";
         echo "<table><tbody>";
         // Output all topics, and offer 'prev/next page'
+        $userCache = [];
         foreach ($commentList as $commentData) {
             // Output one forum, then loop
             $nextCommentID = $commentData['ID'];
@@ -204,14 +206,14 @@ RenderContentStart($pageTitle);
             }
 
             echo "<td class='align-top'>";
-            echo GetUserAndTooltipDiv($nextCommentAuthor, true, iconSizeDisplayable: 64);
+            RenderUserLink($nextCommentAuthor, LinkStyle::ExtraLargeImage, $userCache);
             echo "</td>";
 
             echo "<td class='w-full' id='$nextCommentID'>";
 
             echo "<div class='flex justify-between mb-2'>";
             echo "<div>";
-            echo GetUserAndTooltipDiv($nextCommentAuthor);
+            RenderUserLink($nextCommentAuthor, LinkStyle::Text, $userCache);
             if ($showDisclaimer) {
                 echo " <b class='cursor-help' title='Unverified: not yet visible to the public. Please wait for a moderator to authorise this comment.'>(Unverified)</b>";
             }
@@ -270,9 +272,9 @@ RenderContentStart($pageTitle);
             echo "<tr>";
 
             echo "<td class='align-top'>";
-            echo GetUserAndTooltipDiv($user, false, null, 64);
+            RenderUserLink($user, LinkStyle::Text, $userCache);
             echo "<br>";
-            echo GetUserAndTooltipDiv($user, true, null, 64);
+            RenderUserLink($user, LinkStyle::ExtraLargeImage, $userCache);
             echo "</td>";
 
             echo "<td class='w-full'>";

--- a/src/LinkStyle.php
+++ b/src/LinkStyle.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace RA;
+
+abstract class LinkStyle
+{
+    public const Text = 0;
+    public const TinyImage = 1; // 16x16
+    public const SmallImage = 2; // 24x24
+    public const MediumImage = 3; // 32x32
+    public const LargeImage = 4; // 48x48
+    public const ExtraLargeImage = 5; // 64x64
+    public const TinyImageWithText = 6; // 16x16
+    public const SmallImageWithText = 7; // 24x24
+    public const MediumImageWithText = 8; // 32x32
+    public const LargeImageWithText = 9; // 48x48
+    public const ExtraLargeImageWithText = 10; // 64x64
+
+    public static function hasText(int $style): bool
+    {
+        return match ($style) {
+            LinkStyle::Text => true,
+            LinkStyle::TinyImageWithText => true,
+            LinkStyle::SmallImageWithText => true,
+            LinkStyle::MediumImageWithText => true,
+            LinkStyle::LargeImageWithText => true,
+            LinkStyle::ExtraLargeImageWithText => true,
+            default => false,
+        };
+    }
+
+    public static function getImageSize(int $style): int
+    {
+        return match ($style) {
+            LinkStyle::TinyImage => 16,
+            LinkStyle::TinyImageWithText => 16,
+            LinkStyle::SmallImage => 24,
+            LinkStyle::SmallImageWithText => 24,
+            LinkStyle::MediumImage => 32,
+            LinkStyle::MediumImageWithText => 32,
+            LinkStyle::LargeImage => 48,
+            LinkStyle::LargeImageWithText => 48,
+            LinkStyle::ExtraLargeImage => 64,
+            LinkStyle::ExtraLargeImageWithText => 64,
+            default => 0,
+        };
+    }
+}


### PR DESCRIPTION
Replaces two calls to `GetUserAndTooltipDiv` for every place where a user and their icon was shown. Each call to `GetUserAndTooltipDiv` makes two queries: A simple one to fetch some data from the UserAccounts table, and a more complex one to calculate the user's rank. The first is relatively quick, but the second has measurable impact.

Additionally, for widgets that show the user/icon links, the tooltip can be cached between rows to avoid even more queries. For forum pages and the comments widget, this reduced page load times by 10-20%. For code notes, it reduced the load time by as much as 90%.