### PR TITLE
return 404 for dev stats of deleted user

### DIFF
--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Legacy\Models\User;
 use RA\TicketState;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -9,6 +10,13 @@ $dev = requestInputSanitized('u');
 if (empty($dev)) {
     return redirect(route('home'));
 }
+
+/** @var ?User $devUser */
+$devUser = User::firstWhere('User', $dev);
+if (!$devUser) {
+    abort(404);
+}
+$dev = $devUser->User; // get case-corrected username
 
 $userArchInfo = getUserAchievementInformation($dev);
 


### PR DESCRIPTION
Prevents "Attempt to read property "ID" on null" exception accessing dev stats for a deleted user.

An alternate solution would be to modify `getCodeNoteCounts` to allow retrieving data for deleted accounts.
```
$user = User::withTrashed()->firstWhere('User', $username);
```
But the only link being generated to the individualdevstats page is from the user page, which returns 404 for deleted users, so I've mimicked that behavior for the dev stats page.