### PR TITLE
prevent 500 response when attributed developer was hard deleted

### DIFF
--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -527,6 +527,11 @@ function attributeDevelopmentAuthor($author, $points): void
     $query = "SELECT ContribCount, ContribYield FROM UserAccounts WHERE User = '$author'";
     $dbResult = s_mysql_query($query);
     $oldResults = mysqli_fetch_assoc($dbResult);
+    if (!$oldResults) {
+        // could not find a record for the author, nothing to update
+        return;
+    }
+
     $oldContribCount = (int) $oldResults['ContribCount'];
     $oldContribYield = (int) $oldResults['ContribYield'];
 


### PR DESCRIPTION
Fixes "Trying to access array offset on value of type null" exception (returned as a 500 error) when unlocking an achievement associated to an author that doesn't have an entry in the UserAccounts table.