### PR TITLE
don't return null records for invalid game IDs

### DIFF
--- a/lib/database/user-activity.php
+++ b/lib/database/user-activity.php
@@ -476,7 +476,7 @@ FROM (
  GROUP BY act.data
  ORDER BY MAX( act.lastupdate ) DESC
  ) AS Inner1
-LEFT JOIN GameData AS gd ON gd.ID = Inner1.data
+INNER JOIN GameData AS gd ON gd.ID = Inner1.data
 LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
 LEFT JOIN Rating AS r ON r.RatingObjectType = " . RatingType::Game . " AND r.RatingID=Inner1.data AND r.User='$user'
 LIMIT $offset, $count";


### PR DESCRIPTION
fixes "foreach() argument must be of type array|object, null given" in API_GetUserRecentlyPlayedGames when the queried user's only play history is for invalid game IDs. 

For example, `JB`s only played game (`Activity.data WHERE activitytype=3`) was game 0.