### PR TITLE
Handle missing referers in wiki edit redirects

### DIFF
--- a/public/wiki-edit-redirect.php
+++ b/public/wiki-edit-redirect.php
@@ -18,7 +18,7 @@ $repoDomainMap = [
     'docs.retroachievements.org' => 'docs',
     'guides.retroachievements.org' => 'guides',
 ];
-$repo = $repoDomainMap[parse_url($_SERVER['HTTP_REFERER'])['host']] ?? null;
+$repo = $repoDomainMap[parse_url($_SERVER['HTTP_REFERER'] ?? null)['host'] ?? null] ?? null;
 
 if (empty($repo)) {
     return redirect('https://github.com/RetroAchievements');


### PR DESCRIPTION
Fixes `Undefined array key "HTTP_REFERER"`