### PR TITLE
Lazily load tooltip cards

### DIFF
--- a/app/Legacy/Models/Achievement.php
+++ b/app/Legacy/Models/Achievement.php
@@ -6,6 +6,11 @@ namespace App\Legacy\Models;
 
 use App\Legacy\Database\Eloquent\BaseModel;
 
+/**
+ * @property string $BadgeName
+ * @property string $Description
+ * @property string $Title
+ */
 class Achievement extends BaseModel
 {
     protected $table = 'Achievements';

--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -135,6 +135,7 @@ final class Shortcode
     {
         $achData = [];
         getAchievementMetadata($id, $achData);
+
         if (empty($achData)) {
             return '';
         }
@@ -147,7 +148,6 @@ final class Shortcode
             $achData['GameTitle'],
             $achData['BadgeName'],
             $achData['ConsoleName'],
-            false
         );
     }
 
@@ -186,7 +186,7 @@ final class Shortcode
             return '';
         }
 
-        return GetUserAndTooltipDiv($username, false);
+        return GetUserAndTooltipDiv($username);
     }
 
     private function autolinkRetroachievementsUrls(string $text): string

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -510,6 +510,7 @@ function getUserCardData($user, &$userCardInfo): void
 
     // getUserActivityRange($user, $firstLogin, $lastLogin);
     $userCardInfo = [];
+    $userCardInfo['User'] = $userInfo['User'];
     $userCardInfo['HardcorePoints'] = $userInfo['RAPoints'];
     $userCardInfo['SoftcorePoints'] = $userInfo['RASoftcorePoints'];
     $userCardInfo['TotalTruePoints'] = $userInfo['TrueRAPoints'];

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Cache;
 use RA\AwardThreshold;
 use RA\ClaimStatus;
 use RA\Permissions;
@@ -28,24 +29,27 @@ function getAccountDetails(&$user, &$dataOut): bool
         return false;
     }
 
-    sanitize_sql_inputs($user);
+    $dataOut = Cache::store('array')->rememberForever($user . ':account-details', function () use ($user) {
+        sanitize_sql_inputs($user);
 
-    $query = "SELECT ID, User, EmailAddress, Permissions, RAPoints, RASoftcorePoints, TrueRAPoints,
-                     cookie, websitePrefs, UnreadMessageCount, Motto, UserWallActive,
-                     APIKey, ContribCount, ContribYield,
-                     RichPresenceMsg, LastGameID, LastLogin, LastActivityID,
-                     Created, DeleteRequested, Untracked
-                FROM UserAccounts
-                WHERE User='$user'
-                AND Deleted IS NULL";
+        $query = "SELECT ID, User, EmailAddress, Permissions, RAPoints, RASoftcorePoints, TrueRAPoints,
+                         cookie, websitePrefs, UnreadMessageCount, Motto, UserWallActive,
+                         APIKey, ContribCount, ContribYield,
+                         RichPresenceMsg, LastGameID, LastLogin, LastActivityID,
+                         Created, DeleteRequested, Untracked
+                    FROM UserAccounts
+                    WHERE User='$user'
+                    AND Deleted IS NULL";
 
-    $dbResult = s_mysql_query($query);
-    if (!$dbResult || mysqli_num_rows($dbResult) !== 1) {
-        return false;
-    }
+        $dbResult = s_mysql_query($query);
+        if (!$dbResult || mysqli_num_rows($dbResult) !== 1) {
+            return false;
+        }
 
-    $dataOut = mysqli_fetch_array($dbResult);
-    $user = $dataOut['User'];    // Fix case!
+        return mysqli_fetch_array($dbResult);
+    });
+
+    $user = $dataOut['User'];
 
     return true;
 }

--- a/lib/render/achievement.php
+++ b/lib/render/achievement.php
@@ -13,33 +13,12 @@ function GetAchievementAndTooltipDiv(
     $smallBadgeSize = 32,
     $imgclass = 'badgeimg'
 ): string {
-    $tooltipIconSize = 64; // 96;
-
     sanitize_outputs(
         $achName,
         $consoleName,
         $gameName,
         $achPoints
     );
-
-    $achNameStr = $achName;
-    $achDescStr = $achDesc;
-    $gameNameStr = $gameName;
-
-    $tooltip = "<div id='objtooltip' class='flex items-start' style='max-width: 400px'>";
-    $tooltip .= "<img style='margin-right:5px' src='" . media_asset("Badge/$badgeName.png") . "' width='$tooltipIconSize' height='$tooltipIconSize' />";
-    $tooltip .= "<div>";
-    $tooltip .= "<b>$achNameStr</b><br>";
-    $tooltip .= "$achDescStr<br>";
-    if ($achPoints) {
-        $tooltip .= "<br>$achPoints Points<br>";
-    }
-    $tooltip .= "<i>$gameNameStr</i><br>";
-    $tooltip .= $extraText;
-    $tooltip .= "</div>";
-    $tooltip .= "</div>";
-
-    $tooltip = tipEscape($tooltip);
 
     $smallBadge = '';
     $displayable = "$achName";
@@ -59,12 +38,42 @@ function GetAchievementAndTooltipDiv(
         }
     }
 
-    return "<div class='inline' onmouseover=\"Tip('$tooltip')\" onmouseout=\"UnTip()\" >" .
+    return "<div class='inline' onmouseover=\"Tip(loadCard('achievement', $achID))\" onmouseout=\"UnTip()\" >" .
         "<a href='/achievement/$achID'>" .
         "$smallBadge" .
         "$displayable" .
         "</a>" .
         "</div>";
+}
+
+function renderAchievementCard(int $achievementId): string
+{
+    $achData = [];
+    getAchievementMetadata($achievementId, $achData);
+
+    $badgeName = $achData['BadgeName'];
+    $achNameStr = $achData['AchievementTitle'];
+    $achDescStr = $achData['Description'];
+    $gameNameStr = $achData['GameTitle'];
+    $achPoints = $achData['Points'];
+
+    $tooltip = "<div class='tooltip-body flex items-start gap-2 p-2' style='max-width: 400px'>";
+    $tooltip .= "<img src='" . media_asset("Badge/$badgeName.png") . "' width='64' height='64' />";
+    $tooltip .= "<div>";
+    $tooltip .= "<div><b>$achNameStr</b></div>";
+    $tooltip .= "<div class='mb-1'>$achDescStr</div>";
+    if ($achPoints) {
+        $tooltip .= "<div>$achPoints Points</div>";
+    }
+    $tooltip .= "<div><i>$gameNameStr</i></div>";
+
+    // TODO: extra text should tell if user has unlocked the achievement; use request()->user() for that
+    // $tooltip .= $extraText;
+
+    $tooltip .= "</div>";
+    $tooltip .= "</div>";
+
+    return $tooltip;
 }
 
 function RenderRecentlyUploadedComponent($numToFetch): void

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -11,8 +11,6 @@ function GetGameAndTooltipDiv(
     $imgSizeOverride = 32,
     $justText = false
 ): string {
-    $tooltipIconSize = 64;
-
     $gameNameEscaped = attributeEscape($gameName);
     sanitize_outputs(
         $gameName,
@@ -26,15 +24,6 @@ function GetGameAndTooltipDiv(
 
     $gameIcon = $gameIcon != null ? $gameIcon : "assets/images/activity/playing.webp";
 
-    $tooltip = "<div id='objtooltip' class='flex items-start' style='max-width: 400px'>";
-    $tooltip .= "<img style='margin-right:5px' src='" . media_asset($gameIcon) . "' width='$tooltipIconSize' height='$tooltipIconSize' />";
-    $tooltip .= "<div>";
-    $tooltip .= "<b>$gameName</b><br>";
-    $tooltip .= $consoleStr;
-    $tooltip .= "</div>";
-    $tooltip .= "</div>";
-    $tooltip = tipEscape($tooltip);
-
     $displayable = "";
 
     if (!$justText) {
@@ -45,11 +34,34 @@ function GetGameAndTooltipDiv(
         $displayable .= " $gameName $consoleStr";
     }
 
-    return "<div class='inline' onmouseover=\"Tip('$tooltip')\" onmouseout=\"UnTip()\" >" .
+    return "<div class='inline' onmouseover=\"Tip(loadCard('game', $gameID))\" onmouseout=\"UnTip()\" >" .
         "<a href='/game/$gameID'>" .
         "$displayable" .
         "</a>" .
         "</div>";
+}
+
+function renderGameCard(int $gameId): string
+{
+    $gameData = [];
+    getGameTitleFromID(
+        $gameId,
+        $gameName,
+        $consoleIDOut,
+        $consoleName,
+        $forumTopicID,
+        $gameData
+    );
+
+    $tooltip = "<div class='tooltip-body flex items-start' style='max-width: 400px'>";
+    $tooltip .= "<img style='margin-right:5px' src='" . media_asset($gameData['GameIcon']) . "' width='64' height='64' />";
+    $tooltip .= "<div>";
+    $tooltip .= "<b>$gameName</b><br>";
+    $tooltip .= $consoleName;
+    $tooltip .= "</div>";
+    $tooltip .= "</div>";
+
+    return $tooltip;
 }
 
 function RenderMostPopularTitles($daysRange = 7, $offset = 0, $count = 10): void

--- a/lib/render/leaderboard.php
+++ b/lib/render/leaderboard.php
@@ -4,35 +4,6 @@ use RA\AwardType;
 use RA\Rank;
 use RA\UnlockMode;
 
-function GetLeaderboardAndTooltipDiv($lbID, $lbName, $lbDesc, $gameName, $gameIcon, $displayable): string
-{
-    $tooltipIconSize = 64; // 96;
-
-    sanitize_outputs(
-        $lbName,
-        $lbDesc,
-        $gameName,
-        $displayable
-    );
-
-    $tooltip = "<div id='objtooltip' class='flex items-start' style='max-width: 400px'>";
-    $tooltip .= "<img style='margin-right:5px' src='$gameIcon' width='$tooltipIconSize' height='$tooltipIconSize' alt='Game Icons'>";
-    $tooltip .= "<div>";
-    $tooltip .= "<b>$lbName</b>";
-    $tooltip .= "<br>$lbDesc";
-    $tooltip .= "<br><br><i>$gameName</i>";
-    $tooltip .= "</div>";
-    $tooltip .= "</div>";
-
-    $tooltip = tipEscape($tooltip);
-
-    return "<div class='inline' onmouseover=\"Tip('$tooltip')\" onmouseout=\"UnTip()\" >" .
-        "<a href='/leaderboardinfo.php?i=$lbID'>" .
-        "$displayable" .
-        "</a>" .
-        "</div>";
-}
-
 function RenderGameLeaderboardsComponent($lbData): void
 {
     $numLBs = is_countable($lbData) ? count($lbData) : 0;

--- a/lib/render/ticket.php
+++ b/lib/render/ticket.php
@@ -6,7 +6,27 @@ use RA\TicketType;
 
 function GetTicketAndTooltipDiv(Ticket $ticket): string
 {
-    $tooltipIconSize = 64;
+    $ticketStateClass = match ($ticket->ticketState) {
+        TicketState::Open => 'open',
+        TicketState::Closed => 'closed',
+        TicketState::Resolved => 'closed',
+        default => '',
+    };
+
+    $achNameAttr = attributeEscape($ticket->achievementTitle);
+    $smallBadgePath = "/Badge/" . $ticket->badgeName . ".png";
+
+    return "<a class='ticket-block inline-block $ticketStateClass' href='/ticketmanager.php?i=" . $ticket->id
+            . "' onmouseover=\"Tip(loadCard('ticket', {$ticket->id}))\" onmouseout=\"UnTip()\">" .
+            "<img loading='lazy' width='32' height='32' src=\"" . media_asset($smallBadgePath) . "\" alt='$achNameAttr' title='$achNameAttr' class='badgeimg' />" .
+            "<div class='ticket-displayable-block'>Ticket #$ticket->id</div>" .
+        "</a>";
+}
+
+function renderTicketCard(int $ticketId): string
+{
+    $ticket = GetTicketModel($ticketId);
+
     $ticketStateClass = match ($ticket->ticketState) {
         TicketState::Open => 'open',
         TicketState::Closed => 'closed',
@@ -15,26 +35,17 @@ function GetTicketAndTooltipDiv(Ticket $ticket): string
     };
 
     $tooltip =
-    "<div id='objtooltip' class='flex items-start' style='max-width: 400px'>" .
-        "<img style='margin-right:5px' src='" . media_asset('/Badge/' . $ticket->badgeName . '.png') . "' width='$tooltipIconSize' height='$tooltipIconSize' />" .
+        "<div class='tooltip-body flex items-start' style='max-width: 400px'>" .
+        "<img style='margin-right:5px' src='" . media_asset('/Badge/' . $ticket->badgeName . '.png') . "' width='64' height='64' />" .
         "<div class='ticket-tooltip-info $ticketStateClass'>" .
-            "<div><b>" . $ticket->achievementTitle . "</b> <i>(" . $ticket->gameTitle . ")</i></div>" .
-            "<div>Reported by $ticket->createdBy</div>" .
-            "<div>Issue: " . TicketType::toString($ticket->ticketType) . "</div>" .
-            "<div class='tooltip-closer'>Closed by $ticket->closedBy, " . getNiceDate(strtotime($ticket->closedOn)) . "</div>" .
-            "<div class='tooltip-opened-date'> Opened " . getNiceDate(strtotime($ticket->createdOn)) . "</div>" .
+        "<div><b>" . $ticket->achievementTitle . "</b> <i>(" . $ticket->gameTitle . ")</i></div>" .
+        "<div>Reported by $ticket->createdBy</div>" .
+        "<div>Issue: " . TicketType::toString($ticket->ticketType) . "</div>" .
+        "<div class='tooltip-closer'>Closed by $ticket->closedBy, " . getNiceDate(strtotime($ticket->closedOn)) . "</div>" .
+        "<div class='tooltip-opened-date'> Opened " . getNiceDate(strtotime($ticket->createdOn)) . "</div>" .
         "</div>" .
         "<div class='ticket-tooltip-state'>" . TicketState::toString($ticket->ticketState) . "</div>" .
-    "</div>";
+        "</div>";
 
-    $tooltip = tipEscape($tooltip);
-
-    $achNameAttr = attributeEscape($ticket->achievementTitle);
-    $smallBadgePath = "/Badge/" . $ticket->badgeName . ".png";
-
-    return "<a class='ticket-block inline-block $ticketStateClass' href='/ticketmanager.php?i=" . $ticket->ticketId
-            . "' onmouseover=\"Tip('$tooltip')\" onmouseout=\"UnTip()\">" .
-            "<img loading='lazy' width='32' height='32' src=\"" . media_asset($smallBadgePath) . "\" alt='$achNameAttr' title='$achNameAttr' class='badgeimg' />" .
-            "<div class='ticket-displayable-block'>Ticket #$ticket->ticketId</div>" .
-        "</a>";
+    return $tooltip;
 }

--- a/lib/util/string.php
+++ b/lib/util/string.php
@@ -23,17 +23,6 @@ function attributeEscape(?string $input): string
     return str_replace('"', "&quot;", $input);
 }
 
-function tipEscape(string $input): string
-{
-    // the Tip() function expects single quotes to be escaped, and other html reserved
-    // characters to be converted to entities.
-    $input = htmlentities($input, ENT_COMPAT | ENT_HTML401);
-    // ENT_COMPAT will not convert single quotes. do so ourself.
-    $input = str_replace("'", "\'", $input);
-
-    return str_replace("\n", "<br/>", $input);
-}
-
 function isValidUsername($userTest): bool
 {
     if (

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -985,7 +985,7 @@ sanitize_outputs(
                         $labelcontent = "More ratings needed ($voters votes)";
 
                         $star1 = $star2 = $star3 = $star4 = $star5 = "";
-                        $tooltip = "<div id='objtooltip' class='flex items-start' style='max-width: 400px'>";
+                        $tooltip = "<div class='tooltip-body flex items-start' style='max-width: 400px'>";
                         $tooltip .= "<table><tr><td class='whitespace-nowrap'>Your rating: $yourRating</td></tr></table>";
                         $tooltip .= "</div>";
                     } else {
@@ -998,7 +998,7 @@ sanitize_outputs(
                         $percent4 = round($ratingData['Rating4'] * 100 / $voters);
                         $percent5 = round($ratingData['Rating5'] * 100 / $voters);
 
-                        $tooltip = "<div id='objtooltip' class='flex items-start' style='max-width: 400px'>";
+                        $tooltip = "<div class='tooltip-body flex items-start' style='max-width: 400px'>";
                         $tooltip .= "<table>";
                         $tooltip .= "<tr><td colspan=3>Your rating: $yourRating</td></tr>";
                         $tooltip .= "<tr><td class='whitespace-nowrap'>5 star</td><td>";

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -114,9 +114,33 @@ function replaceAll(find, replace, str) {
   return str.replace(new RegExp(find, 'g'), replace);
 }
 
+var cardsCache = {};
+function loadCard(type, id) {
+  var cardId = `tooltip_card_${type}_${id}`;
+
+  if (cardsCache[cardId]) {
+    return cardsCache[cardId];
+  }
+
+  $.post('/request/card.php', {
+    type: type,
+    id: id,
+  })
+    .done(function (data) {
+      cardsCache[cardId] = data.html;
+      $(`#${cardId}`).html(data.html);
+    });
+
+  return `<div id="${cardId}">
+    <div class="flex justify-center items-center" style="width: 30px; height: 30px">
+        <img class="m-5" src="${asset('assets/images/icon/loading.gif')}" alt="Loading">
+    </div>
+  </div>`;
+}
+
 function GetTooltipDiv(icon, header, body) {
   var tooltipImageSize = 64;
-  var tooltip = '<div id=\'objtooltip\' class=\'flex items-start\' style=\'max-width: 400px;\'>'
+  var tooltip = '<div class=\'tooltip-body flex items-start\' style=\'max-width: 400px;\'>'
     + '<img style=\'margin-right:5px\' src=\'' + icon + '\' width=\'' + tooltipImageSize + '\' height=\'' + tooltipImageSize + '\' />'
     + '<div><b>' + header + '</b><br><span style=\'white-space: nowrap\'>' + body + '</span></div></div>';
   tooltip = replaceAll('<', '&lt;', tooltip);

--- a/public/request/card.php
+++ b/public/request/card.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+
+$input = Validator::validate(request()->post(), [
+    'type' => ['required', 'string', Rule::in(['user', 'achievement', 'game', 'ticket'])],
+    'id' => 'required',
+]);
+
+return response()->json([
+    'html' => match ($input['type']) {
+        'achievement' => renderAchievementCard($input['id']),
+        'game' => renderGameCard($input['id']),
+        'ticket' => renderTicketCard($input['id']),
+        'user' => renderUserCard($input['id']),
+        default => '?',
+    },
+]);

--- a/public/test/cards.php
+++ b/public/test/cards.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Support\Shortcode\Shortcode;
+
+RenderContentStart();
+?>
+<script src='/vendor/wz_tooltip.js'></script>
+<article class="flex flex-col gap-3">
+    <h1>Cards</h1>
+    <div class="flex justify-between">
+        <div>
+            <?= Shortcode::render("[user=Scott]") ?>
+            <?= Shortcode::render("[user=Jamiras]") ?>
+            <?= Shortcode::render("[user=luchaos]") ?>
+        </div>
+        <div>
+            <?= renderUserCard('Scott') ?>
+        </div>
+    </div>
+    <div class="flex justify-between">
+        <div>
+            <?= Shortcode::render("[ach=1]") ?>
+        </div>
+        <div>
+            <?= renderAchievementCard(1) ?>
+        </div>
+    </div>
+    <div class="flex justify-between">
+        <div>
+            <?= Shortcode::render("[game=1]") ?>
+        </div>
+        <div>
+            <?= renderGameCard(1) ?>
+        </div>
+    </div>
+    <div class="flex justify-between">
+        <div>
+            <?= Shortcode::render("[ticket=1]") ?>
+        </div>
+        <div>
+            <?= renderTicketCard(1) ?>
+        </div>
+    </div>
+</article>
+<?php RenderContentEnd(); ?>

--- a/public/test/tooltip.php
+++ b/public/test/tooltip.php
@@ -19,21 +19,7 @@ function tooltip_row(string $text): void
     echo GetAchievementAndTooltipDiv(1, $text, $text, 5, $text, $badge, true);
 
     echo "</td>\n        <td>";
-    echo GetLeaderboardAndTooltipDiv(1, $text, $text, $text, "/Badge/$badge.png", $text);
-
-    echo "</td>\n        <td>";
-    $userCardInfo = [
-        'HardcorePoints' => 12345,
-        'SoftcorePoints' => 45678,
-        'TotalTruePoints' => 98765,
-        'Permissions' => 1,
-        'Motto' => htmlspecialchars($text), // ASSERT: getUserCardData does this escaping
-        'Rank' => 56,
-        'Untracked' => 0,
-        'LastActivity' => '1/2/2022',
-        'MemberSince' => '7/8/2018',
-    ];
-    echo _GetUserAndTooltipDiv($text, $userCardInfo);
+    echo GetUserAndTooltipDiv('luchaos');
 
     $ticketData = [
         'ID' => 1,
@@ -65,7 +51,7 @@ function tooltip_row(string $text): void
 <script src='/vendor/wz_tooltip.js'></script>
 <div style="width:1024px">
     <h1>Tooltip</h1>
-    <table><th>alt</th><th>game</th><th>achievement</th><th>leaderboard</th><th>user</th><th>ticket</th>
+    <table><th>alt</th><th>game</th><th>achievement</th><th>user</th><th>ticket</th>
 <?php
     tooltip_row("Simple text");
     tooltip_row("Text\nwith\nmultiple\nlines");

--- a/public/vendor/wz_tooltip.js
+++ b/public/vendor/wz_tooltip.js
@@ -76,10 +76,10 @@ config. FadeOut			= 100
 config. FadeInterval	= 30		// Duration of each fade step in ms (recommended: 30) - shorter is smoother but causes more CPU-load
 config. Fix				= null		// Fixated position, two modes. Mode 1: x- an y-coordinates in brackets, e.g. [210, 480]. Mode 2: Show tooltip at a position related to an HTML element: [ID of HTML element, x-offset, y-offset from HTML element], e.g. ['SomeID', 10, 30]. Value null (default) for no fixated positioning.
 config. FollowMouse		= true		// false or true - tooltip follows the mouse
-config. FontColor		= '#000044'
-config. FontFace		= 'Verdana,Geneva,sans-serif'
-config. FontSize		= '8pt'		// E.g. '9pt' or '12px' - unit is mandatory
-config. FontWeight		= 'normal'	// 'normal' or 'bold';
+config. FontColor		= 'inherit'
+config. FontFace		= 'inherit'
+config. FontSize		= 'inherit'		// E.g. '9pt' or '12px' - unit is mandatory
+config. FontWeight		= 'inherit'	// 'normal' or 'bold';
 config. Height			= 0			// Tooltip height; 0 for automatic adaption to tooltip content, < 0 (e.g. -100) for a maximum for automatic adaption
 config. JumpHorz		= false		// false or true - jump horizontally to other side of mouse if tooltip would extend past clientarea boundary
 config. JumpVert		= true		// false or true - jump vertically		"
@@ -1200,7 +1200,7 @@ function tt_GetWndCliSiz(s)
 		return(
 			// Gecko or Opera with scrollbar
 			// ... quirks mode
-			((db = document.body) && typeof(y2 = db[sC]) == sN && y2 &&  y2 <= y) ? y2 
+			((db = document.body) && typeof(y2 = db[sC]) == sN && y2 &&  y2 <= y) ? y2
 			// ... strict mode
 			: ((db = document.documentElement) && typeof(y2 = db[sC]) == sN && y2 && y2 <= y) ? y2
 			// No scrollbar, or clientarea size == 0, or other browser (KHTML etc.)
@@ -1211,7 +1211,7 @@ function tt_GetWndCliSiz(s)
 	return(
 		// document.documentElement.client+s functional, returns > 0
 		((db = document.documentElement) && (y = db[sC])) ? y
-		// ... not functional, in which case document.body.client+s 
+		// ... not functional, in which case document.body.client+s
 		// is the clientarea size, fortunately
 		: document.body[sC]
 	);

--- a/resources/css/card.css
+++ b/resources/css/card.css
@@ -8,11 +8,6 @@
   font-size: theme('fontSize.lg');
 }
 
-.usercardaccounttype {
-  text-align: right;
-  text-decoration: underline;
-}
-
 .usercardbasictext {
   white-space: nowrap;
 }

--- a/resources/css/tooltip.css
+++ b/resources/css/tooltip.css
@@ -1,19 +1,31 @@
+#WzTtDiV {
+  width: auto !important;
+}
+
 #WzBoDy {
-  border-radius: 4px !important;
-  background: var(--bg-color) !important;
-  border-color: var(--embed-highlight-color) !important;
+  background: none !important;
+  border: none !important;
+  padding: 0 !important;
+  width: auto !important;
 }
 
-#WzBoDy tr {
-  background: none;
+#WzBoDyI {
+  font-size: inherit;
 }
 
-#WzBoDy td {
+.tooltip-body tr {
+  background: none !important;
+}
+
+.tooltip-body td {
   padding: 2px;
   color: var(--menu-link-color);
 }
 
-#objtooltip {
+.tooltip-body {
   background: var(--box-bg-color);
   color: var(--menu-link-color);
+  border-radius: 4px !important;
+  border: 1px solid var(--embed-highlight-color);
+  line-height: theme('fontSize.base') !important;
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5,7 +5,7 @@ namespace RA;
 // TODO refactor into legacy model
 class Ticket
 {
-    public int $ticketId;
+    public int $id;
     public int $achievementId;
     public string $achievementTitle;
     public string $achievementDesc;
@@ -25,7 +25,7 @@ class Ticket
 
     public function __construct(array $ticketDbResult)
     {
-        $this->ticketId = $ticketDbResult['ID'];
+        $this->id = $ticketDbResult['ID'];
         $this->achievementId = $ticketDbResult['AchievementID'];
         $this->achievementTitle = $this->sanitize($ticketDbResult['AchievementTitle']);
         $this->achievementDesc = $this->sanitize($ticketDbResult['AchievementDesc']);


### PR DESCRIPTION
Includes multiple layers of caching.

Moves rendering of cards (user, achievement, game, ticket) to a dedicated function that can be invoked asynchronously in a new card render request endpoint.

- Load tooltip cards lazily; best way to improve performance is to not load nor render data that is not needed immediately
- Cache (local/javascript) card responses per page visit
- Cache (server/redis) user rank data

User rank cache is not invalidated but can be. Reflecting the correct rank in the card is not important enough to find all valid invalidation opportunities yet. It would be if cache TTL was way above 15 minutes.