### PR TITLE
prevent exception trying to fetch data for deleted user

### DIFF
--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -49,6 +49,10 @@ function getAccountDetails(&$user, &$dataOut): bool
         return mysqli_fetch_array($dbResult);
     });
 
+    if (!$dataOut) {
+        return false;
+    }
+
     $user = $dataOut['User'];
 
     return true;


### PR DESCRIPTION
A deleted user will return false on line 46, and `false['User']` throws an exception on line 56.