### PR TITLE
prevent exception accessing history with an invalid date

### DIFF
--- a/public/historyexamine.php
+++ b/public/historyexamine.php
@@ -14,7 +14,7 @@ if (!$userMassData) {
     abort(404);
 }
 
-$dateInput = requestInputSanitized('d', 0);
+$dateInput = requestInputSanitized('d', 0, 'integer');
 
 $userPageHardcorePoints = 0;
 $userPageSoftcorePoints = 0;


### PR DESCRIPTION
fixes `date(): Argument #2 ($timestamp) must be of type ?int, string given` error when accessing the historyexamine page with a non-numeric timestamp