### PR TITLE
don't show joystick for 'null' user

### DIFF
--- a/lib/render/user.php
+++ b/lib/render/user.php
@@ -17,6 +17,10 @@ function userAvatar(
     ?string $link = null,
     bool|string|array $tooltip = true,
 ): string {
+    if (empty($username)) {
+        return '';
+    }
+
     $user = Cache::store('array')->rememberForever('user:' . $username . ':card-data', function () use ($username) {
         getAccountDetails($username, $data);
 


### PR DESCRIPTION
Prevents showing joystick on:
* unclaimed games in the most requested games list 
* leaderboards with no entries on games pages
* resolver for unresolved tickets