### PR TITLE
Update update/unlink hash comments to match current format

### DIFF
--- a/public/managehashes.php
+++ b/public/managehashes.php
@@ -46,9 +46,9 @@ function UpdateHashDetails(user, hash) {
         .done(function () {
             // Get comment date
             var date = new Date();
-            var dateStr = date.getUTCDate() + ' ' + shortMonths[date.getUTCMonth()] + ' ' + date.getUTCFullYear() + '<br>' + date.getUTCHours() + ':' + ('0' + date.getUTCMinutes()).slice(-2);
+            var dateStr = date.getUTCDate() + ' ' + shortMonths[date.getUTCMonth()] + ' ' + date.getUTCFullYear() + ' ' + date.getUTCHours() + ':' + ('0' + date.getUTCMinutes()).slice(-2);
 
-            $('.comment-textarea').parents('tr').before('<tr class="comment system"><td class="smalldate">' + dateStr + '</td><td></td><td>' + hash + ' updated by ' + user + '. Description: "' + name + '". Label: "' + labels + '"</td></tr>');
+            $('.comment-textarea').parents('tr').before('<tr class="comment system"><td></td><td class="w-full" colspan="3"><div><span class="smalldate">' + dateStr + '</span></div><div style="word-break: break-word">' + hash + ' updated by ' + user + '. Description: "' + name + '". Label: "' + labels + '"</div></td></tr>');
         });
 }
 
@@ -71,9 +71,9 @@ function UnlinkHash(user, gameID, hash, elem) {
 
             // Get comment date
             var date = new Date();
-            var dateStr = date.getUTCDate() + ' ' + shortMonths[date.getUTCMonth()] + ' ' + date.getUTCFullYear() + '<br>' + date.getUTCHours() + ':' + ('0' + date.getUTCMinutes()).slice(-2);
+            var dateStr = date.getUTCDate() + ' ' + shortMonths[date.getUTCMonth()] + ' ' + date.getUTCFullYear() + ' ' + date.getUTCHours() + ':' + ('0' + date.getUTCMinutes()).slice(-2);
 
-            $('.comment-textarea').parents('tr').before('<tr class="comment system"><td class="smalldate">' + dateStr + '</td><td></td><td>' + hash + ' unlinked by ' + user + '</td></tr>');
+            $('.comment-textarea').parents('tr').before('<tr class="comment system"><td></td><td class="w-full" colspan="3"><div><span class="smalldate">' + dateStr + '</span></div><div style="word-break: break-word">' + hash + ' unlinked by ' + user + '</div></td></tr>');
         });
 }
 </script>


### PR DESCRIPTION
Updates comment to match new format.

Current code puts the date in the left most column
![image](https://user-images.githubusercontent.com/16140035/193420533-0754182b-8d75-48cc-ae66-ca5e5eef84d0.png)

This update will put the date in the same column as the comment with the same formatting. So reloading the page shows no differences.
![image](https://user-images.githubusercontent.com/16140035/193420565-cd007df8-24cf-415a-ab55-7bf71a9ee72d.png)
