### PR TITLE
cache ability to create tickets

### DIFF
--- a/lib/database/ticket.php
+++ b/lib/database/ticket.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Legacy\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
 use RA\AchievementType;
 use RA\ActivityType;
 use RA\ArticleType;
@@ -12,11 +14,35 @@ use RA\UnlockMode;
 
 function isAllowedToSubmitTickets($user): bool
 {
-    return isValidUsername($user)
-        && getUserActivityRange($user, $firstLogin, $lastLogin)
+    if (!isValidUsername($user)) {
+        return false;
+    }
+
+    $key = $user . ':canTicket';
+
+    $value = Cache::get($key);
+    if ($value !== null) {
+        return $value;
+    }
+
+    $value = getUserActivityRange($user, $firstLogin, $lastLogin)
         && time() - strtotime($firstLogin) > 86400 // 86400 seconds = 1 day
         && getRecentlyPlayedGames($user, 0, 1, $userInfo)
         && $userInfo[0]['GameID'];
+
+    if ($value) {
+        // if the user can create tickets, they should be able to create tickets forever
+        // more. expire once every 30 days so we can purge inactive users
+        $expiresAt = Carbon::now()->addDays(30);
+        Cache::put($key, $value, $expiresAt);
+    } else {
+        // user can't create tickets, which means the account is less than a day old
+        // or has no games played. only cache the value for an hour
+        $ttlSeconds = 60 * 60; // 1 hour
+        Cache::put($key, $value, $ttlSeconds);
+    }
+
+    return $value;
 }
 
 function submitNewTicketsJSON($userSubmitter, $idsCSV, $reportType, $noteIn, $RAHash): array

--- a/lib/database/ticket.php
+++ b/lib/database/ticket.php
@@ -18,9 +18,9 @@ function isAllowedToSubmitTickets($user): bool
         return false;
     }
 
-    $key = $user . ':canTicket';
+    $cacheKey = "user:$user:canTicket";
 
-    $value = Cache::get($key);
+    $value = Cache::get($cacheKey);
     if ($value !== null) {
         return $value;
     }
@@ -33,13 +33,11 @@ function isAllowedToSubmitTickets($user): bool
     if ($value) {
         // if the user can create tickets, they should be able to create tickets forever
         // more. expire once every 30 days so we can purge inactive users
-        $expiresAt = Carbon::now()->addDays(30);
-        Cache::put($key, $value, $expiresAt);
+        Cache::put($cacheKey, $value, Carbon::now()->addDays(30));
     } else {
         // user can't create tickets, which means the account is less than a day old
         // or has no games played. only cache the value for an hour
-        $ttlSeconds = 60 * 60; // 1 hour
-        Cache::put($key, $value, $ttlSeconds);
+        Cache::put($cacheKey, $value, Carbon::now()->addHour());
     }
 
     return $value;


### PR DESCRIPTION
eliminates two expensive queries when viewing achievement info pages:
* `getUserActivityRange` scans the Activity table for the user's first and last login timestamps
* `getRecentlyPlayedGames` scans the Activity table for the user's last new session timestamp