### PR TITLE
cache top achievers per game

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -374,6 +374,7 @@ function UploadNewAchievement(
                             $author
                         );
                     }
+                    expireGameTopAchievers($gameID);
                 } else {
                     $fields = [];
                     if ($changingPoints) {

--- a/lib/database/player-achievement.php
+++ b/lib/database/player-achievement.php
@@ -182,6 +182,8 @@ function resetAchievements(string $user, $gameID): int
         $numRowsDeleted = (int) mysqli_affected_rows($db);
     }
 
+    expireGameTopAchievers($gameID);
+
     recalculatePlayerPoints($user);
     return $numRowsDeleted;
 }
@@ -201,6 +203,9 @@ function resetSingleAchievement(string $user, $achID): bool
     if (!$dbResult) {
         log_sql_fail();
     }
+
+    getAchievementTitle($achID, $gameTitle, $gameID);
+    expireGameTopAchievers($gameID);
 
     recalculatePlayerPoints($user);
     return true;

--- a/lib/database/user-activity.php
+++ b/lib/database/user-activity.php
@@ -185,6 +185,7 @@ function postActivity($userIn, $activity, $customMsg, $isalt = null): bool
             $gameLink = str_replace("'", "''", $gameLink);
 
             AddSiteAward($user, 1, $gameID, $isalt);
+            expireGameTopAchievers((int) $gameID);
 
             $query .= "(NOW(), $activity, '$user', '$gameID', $isalt)";
             break;

--- a/public/API/API_GetGameRankAndScore.php
+++ b/public/API/API_GetGameRankAndScore.php
@@ -20,7 +20,7 @@ if ($gameId <= 0) {
 $username = request()->query('z');
 $type = (int) request()->query('t');
 
-$gameTopAchievers = getGameTopAchievers($gameId, $username);
+$gameTopAchievers = getGameTopAchievers($gameId);
 
 if ($type == 1) {
     return response()->json($gameTopAchievers['Masters']);

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -201,7 +201,7 @@ if ($isFullyFeaturedGame) {
     }
 
     // Get the top ten players at this game:
-    $gameTopAchievers = getGameTopAchievers($gameID, $user);
+    $gameTopAchievers = getGameTopAchievers($gameID);
 
     // Determine if the logged in user is the sole author of the set
     if (isset($user)) {

--- a/public/request/achievement/update-flag.php
+++ b/public/request/achievement/update-flag.php
@@ -32,6 +32,7 @@ if (updateAchievementFlags($achievementIds, $value)) {
         $commentText = 'demoted this achievement to Unofficial';
     }
     addArticleComment("Server", ArticleType::Achievement, $achievementIds, "\"$user\" $commentText.", $user);
+    expireGameTopAchievers($achievement['GameID']);
 
     return response()->json(['message' => __('legacy.success.ok')]);
 }


### PR DESCRIPTION
eliminates an expensive query on the game page. only cached if there are at least 10 masteries (full list), minimizing the expiration logic to: new mastery, achievement promoted/demoted, and reset achievement.

NOTE: the current user is no longer shown in the mastery list if they are untracked. I believe this is consistent with the messaging around being untracked:
> An untracked account **doesn't appear in the global ranking**, its activities do not appear in the feed, it's **no longer listed among all other earners of each achievement** (on the achievement page) and their entries on specific leaderboards will not be publicly visible.