### PR TITLE
prevent exception trying to create a ticket when not logged in

### DIFF
--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -2,9 +2,11 @@
 
 use App\Legacy\Models\User;
 
-authenticateFromCookie($user, $permissions, $userDetails);
-
 $achievementID = requestInputSanitized('i', 0, 'integer');
+
+if (!authenticateFromCookie($user, $permissions, $userDetails)) {
+    return redirect(route('achievement.show', $achievementID));
+}
 
 $dataOut = null;
 if ($achievementID == 0 || !getAchievementMetadata($achievementID, $dataOut)) {


### PR DESCRIPTION
Fixes `getExistingTicketID(): Argument #1 ($user) must be of type App\Legacy\Models\User, null given` error