### PR TITLE
restore Set Exists marker on All User Set Requests page

### DIFF
--- a/lib/database/set-request.php
+++ b/lib/database/set-request.php
@@ -1,5 +1,6 @@
 <?php
 
+use RA\AchievementType;
 use RA\ClaimStatus;
 
 /**
@@ -36,9 +37,35 @@ function getUserRequestList(string $user = null): array
     $dbResult = s_mysql_query($query);
 
     if ($dbResult !== false) {
+        $gameIDs = [];
         while ($nextData = mysqli_fetch_assoc($dbResult)) {
+            $gameIDs[] = $nextData['GameID'];
+            $nextData['AchievementCount'] = 0;
             $retVal[] = $nextData;
         }
+
+        if (!empty($gameIDs)) {
+            $query = "SELECT GameID, COUNT(ID) AS AchievementCount FROM Achievements"
+                   . " WHERE GameID IN (" . implode(',', $gameIDs) . ")"
+                   . " AND Flags = " . AchievementType::OfficialCore
+                   . " GROUP BY GameID";
+
+            $dbResult = s_mysql_query($query);
+
+            if ($dbResult !== false) {
+                while ($nextData = mysqli_fetch_assoc($dbResult)) {
+                    foreach ($retVal as &$game) {
+                        if ($game['GameID'] == $nextData['GameID']) {
+                            $game['AchievementCount'] = $nextData['AchievementCount'];
+                            break;
+                        }
+                    }
+                }
+            } else {
+                log_sql_fail();
+            }
+        }
+
     } else {
         log_sql_fail();
     }
@@ -86,7 +113,7 @@ function getUserRequestsInformation(string $user, array $list, int $gameID = -1)
     // Requests made for games that since received achievements do not count towards a used request
     foreach ($list as $request) {
         // If the game does not have achievements then it counts as a legit request
-        if (empty(getAchievementIDsByGame($request['GameID'])['AchievementIDs'])) {
+        if ($request['AchievementCount'] == 0) {
             $requests['used']++;
         }
 

--- a/public/setRequestList.php
+++ b/public/setRequestList.php
@@ -154,45 +154,28 @@ RenderContentStart("Set Requests");
 
             // Loop through each set request and display them if they do not have any achievements
             foreach ($setRequestList as $request) {
-                if ($flag == 0) {
-                    if (empty(getAchievementIDsByGame($request['GameID'])['AchievementIDs'])) {
-                        echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
+                $setExists = $request['AchievementCount'] > 0;
+                if ($flag == 0 && $setExists) {
+                    continue;
+                }
 
-                        echo "<td>";
-                        echo gameAvatar($request);
-                        echo "</td>";
+                echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
 
-                        echo "<td>";
-                        $claims = explode(',', $request['Claims']);
-                        foreach ($claims as $devClaim) {
-                            echo userAvatar($devClaim);
-                            echo "</br>";
-                        }
-                        echo "</td>";
-                    }
-                } else {
-                    if (empty(getAchievementIDsByGame($request['GameID'])['AchievementIDs'])) {
-                        echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
+                echo "<td>";
+                echo gameAvatar($request);
+                echo "</td>";
 
-                        echo "<td>";
-                        echo gameAvatar($request);
-                        echo "</td>";
-                    } else {
-                        echo $gameCounter++ % 2 == 0 ? "<tr>" : "<tr class=\"alt\">";
-
-                        echo "<td>";
-                        echo gameAvatar($request);
-                        echo "</td>";
-                    }
-
-                    echo "<td>";
+                echo "<td>";
+                if (!$setExists) {
                     $claims = explode(',', $request['Claims']);
                     foreach ($claims as $devClaim) {
                         echo userAvatar($devClaim);
                         echo "</br>";
                     }
-                    echo "</td>";
+                } else {
+                    echo "Set Exists";
                 }
+                echo "</td>";
             }
             echo "</tbody></table></div>";
         }


### PR DESCRIPTION
As mentioned in https://retroachievements.org/viewtopic.php?t=18451.

I've taken the opportunity to move the "Set Exists" moniker into the Claimed By column, whereas it was previously appended to the game.

Before:
![image](https://user-images.githubusercontent.com/32680403/194912184-64603395-8c4f-4cdd-9904-93d2b38e695e.png)

After:
![image](https://user-images.githubusercontent.com/32680403/194912227-f9d17480-c149-4280-80d2-74557812b655.png)

Also modifies the `getUserRequestList` function to return how many achievements each requested set has to avoid doing that query twice for each item: once for determining how many requests the user has consumed, and once for determining if the item should be visible on the page.