### PR TITLE
Add type filter to search page

### DIFF
--- a/lib/database/search.php
+++ b/lib/database/search.php
@@ -88,5 +88,13 @@ function performSearch(int $searchType, string $searchQuery, int $offset, int $c
         $resultCount++;
     }
 
+    if ($offset != 0 || $resultCount == $count) {
+        $query = "SELECT FOUND_ROWS() AS NumResults";
+        $dbResult = s_mysql_query($query);
+        if ($dbResult !== false) {
+            $resultCount = mysqli_fetch_assoc($dbResult)['NumResults'];
+        }
+    }
+
     return $resultCount;
 }

--- a/lib/database/search.php
+++ b/lib/database/search.php
@@ -92,7 +92,7 @@ function performSearch(int $searchType, string $searchQuery, int $offset, int $c
         $resultCount++;
     }
 
-    if ($offset != 0 || $resultCount == $count) {
+    if ($offset != 0 || $resultCount >= $count) {
         $query = "SELECT FOUND_ROWS() AS NumResults";
         $dbResult = s_mysql_query($query);
         if ($dbResult !== false) {

--- a/lib/database/search.php
+++ b/lib/database/search.php
@@ -70,6 +70,7 @@ function performSearch(int $searchType, string $searchQuery, int $offset, int $c
         LEFT JOIN UserAccounts AS ua ON ( ua.ID = c.ArticleID )
         LEFT JOIN UserAccounts AS cua ON cua.ID = c.UserID
         WHERE c.Payload LIKE '%$searchQuery%'
+        AND cua.User != 'Server'
         AND c.articletype IN (1,2,3,5,7)
         ORDER BY c.Submitted DESC)";
     }

--- a/public/searchresults.php
+++ b/public/searchresults.php
@@ -7,7 +7,7 @@ authenticateFromCookie($user, $permissions, $userDetails);
 $searchQuery = requestInputSanitized('s', null);
 $searchType = requestInputSanitized('t', SearchType::All, 'integer');
 $offset = requestInputSanitized('o', 0, 'integer');
-$maxCount = requestInputSanitized('c', 50, 'integer');
+$maxCount = 50;
 
 if (!SearchType::isValid($searchType)) {
     $searchType = SearchType::All;
@@ -110,18 +110,7 @@ RenderContentStart("Search");
                 echo "</tbody></table>";
 
                 echo "<div class='float-right row'>";
-                if ($offset > 0) {
-                    $prevOffset = $offset - $maxCount;
-                    echo "<a href='/searchresults.php?s=$searchQueryEscaped&t=$searchType&o=$prevOffset'>&lt; Previous $maxCount</a>";
-                }
-                if ($resultsCount == $maxCount) {
-                    if ($offset > 0) {
-                        echo " - ";
-                    }
-                    // Max number fetched, i.e. there are more. Can goto next 25.
-                    $nextOffset = $offset + $maxCount;
-                    echo "<a href='/searchresults.php?s=$searchQueryEscaped&t=$searchType&o=$nextOffset'>Next $maxCount &gt;</a>";
-                }
+                RenderPaginator($resultsCount, $maxCount, $offset, "/searchresults.php?s=$searchQueryEscaped&t=$searchType&o=");
                 echo "</div>";
             }
         }

--- a/public/searchresults.php
+++ b/public/searchresults.php
@@ -4,7 +4,7 @@ use RA\SearchType;
 
 authenticateFromCookie($user, $permissions, $userDetails);
 
-$searchQuery = requestInputSanitized('s', null);
+$searchQuery = requestInputSanitized('s', '');
 $searchType = requestInputSanitized('t', SearchType::All, 'integer');
 $offset = requestInputSanitized('o', 0, 'integer');
 $maxCount = 50;
@@ -15,7 +15,7 @@ if (!SearchType::isValid($searchType)) {
 
 $searchResults = [];
 $resultsCount = 0;
-if ($searchQuery !== null) {
+if (strlen($searchQuery) >= 2) {
     $resultsCount = performSearch($searchType, $searchQuery, $offset, $maxCount, $permissions, $searchResults);
 }
 

--- a/src/SearchType.php
+++ b/src/SearchType.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace RA;
+
+abstract class SearchType
+{
+    public const All = 0;
+
+    public const Game = 1;
+
+    public const Achievement = 2;
+
+    public const User = 3;
+
+    public const Forum = 4;
+
+    public const Comment = 5;
+
+    public static function cases(): array
+    {
+        return [
+            self::All,
+            self::Game,
+            self::Achievement,
+            self::User,
+            self::Forum,
+            self::Comment,
+        ];
+    }
+
+    public static function isValid(int $type): bool
+    {
+        return in_array($type, self::cases());
+    }
+
+    public static function toString(int $type): string
+    {
+        return match ($type) {
+            SearchType::All => "Everything",
+            SearchType::Game => "Games",
+            SearchType::Achievement => "Achievements",
+            SearchType::User => "Users",
+            SearchType::Forum => "Forums",
+            SearchType::Comment => "Comments",
+            default => "Invalid search type",
+        };
+    }
+}


### PR DESCRIPTION
Implements #1064

Adds a type selector to the search results page:
![image](https://user-images.githubusercontent.com/32680403/195127570-44260f17-fb24-407f-9ad0-1bd7605af55c.png)

When searching by specific types, items are sorted:
* Achievements, Games, and Users alphabetically
* Forum posts and comments by most recent

NOTE: The subquery sorts appear to be ignored when the subqueries are unioned together for the Everything search. This is consistent with the existing behavior.

I've also made the following changes:
* Replace "Previous 50"/"Next 50" with Paginator widget
* If forum post or comment is less than 64 characters long, don't wrap it in ellipsis
* Don't perform query if search term is a single character
* Don't match "audit" comments (comments associated to Server user)
* Don't match deleted users or comments on their walls
* Use same search queries for autocomplete and search results page (eliminate duplicated code)