### PR TITLE
fix completion badge not being awarded if last unlock was hardcore

### DIFF
--- a/lib/database/player-game.php
+++ b/lib/database/player-game.php
@@ -11,8 +11,11 @@ function testFullyCompletedGame($gameID, $user, $isHardcore, $postMastery): arra
     sanitize_sql_inputs($gameID, $user, $isHardcore);
     settype($isHardcore, 'integer');
 
-    $query = "SELECT COUNT(ach.ID) AS NumAch, COUNT(aw.AchievementID) AS NumAwarded FROM Achievements AS ach
-              LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID AND aw.User = '$user' AND aw.HardcoreMode = $isHardcore 
+    $query = "SELECT COUNT(DISTINCT ach.ID) AS NumAch,
+                     COUNT(IF(aw.HardcoreMode=1,1,NULL)) AS NumAwardedHC,
+                     COUNT(IF(aw.HardcoreMode=0,1,NULL)) AS NumAwardedSC
+              FROM Achievements AS ach
+              LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID AND aw.User = '$user'
               WHERE ach.GameID = $gameID AND ach.Flags = " . AchievementType::OfficialCore;
 
     $dbResult = s_mysql_query($query);
@@ -20,15 +23,25 @@ function testFullyCompletedGame($gameID, $user, $isHardcore, $postMastery): arra
         $minToCompleteGame = 5;
 
         $data = mysqli_fetch_assoc($dbResult);
-        if ($postMastery && ($data['NumAwarded'] == $data['NumAch']) && ($data['NumAwarded'] > $minToCompleteGame)) {
-            // Every achievement earned!
-            // Test that this wasn't very recently posted!
-            if (!RecentlyPostedCompletionActivity($user, $gameID, $isHardcore)) {
-                postActivity($user, ActivityType::CompleteGame, $gameID, $isHardcore);
+
+        if ($postMastery) {
+            if ($isHardcore && $data['NumAwardedHC'] == $data['NumAch']) {
+                // all hardcore achievements unlocked, award mastery
+                if (!RecentlyPostedCompletionActivity($user, $gameID, 1)) {
+                    postActivity($user, ActivityType::CompleteGame, $gameID, 1);
+                }
+            } elseif ($data['NumAwardedSC'] == $data['NumAch']) {
+                // all non-hardcore achievements unlocked, award completion
+                if (!RecentlyPostedCompletionActivity($user, $gameID, 0)) {
+                    postActivity($user, ActivityType::CompleteGame, $gameID, 0);
+                }
             }
         }
 
-        return $data;
+        return [
+            'NumAch' => $data['NumAch'],
+            'NumAwarded' => $isHardcore ? $data['NumAwardedHC'] : $data['NumAwardedSC'],
+        ];
     }
 
     return [];

--- a/lib/database/player-game.php
+++ b/lib/database/player-game.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Cache;
 use RA\AchievementType;
 use RA\ActivityType;
+use RA\AwardType;
 use RA\Permissions;
 use RA\UnlockMode;
 
@@ -31,9 +32,13 @@ function testFullyCompletedGame($gameID, $user, $isHardcore, $postMastery): arra
                     postActivity($user, ActivityType::CompleteGame, $gameID, 1);
                 }
             } elseif ($data['NumAwardedSC'] == $data['NumAch']) {
-                // all non-hardcore achievements unlocked, award completion
-                if (!RecentlyPostedCompletionActivity($user, $gameID, 0)) {
-                    postActivity($user, ActivityType::CompleteGame, $gameID, 0);
+                // if unlocking a hardcore achievement, don't update the completion date
+                // if the user already has a completion badge
+                if (!$isHardcore || !HasSiteAward($user, AwardType::Mastery, $gameID, 0)) {
+                    // all non-hardcore achievements unlocked, award completion
+                    if (!RecentlyPostedCompletionActivity($user, $gameID, 0)) {
+                        postActivity($user, ActivityType::CompleteGame, $gameID, 0);
+                    }
                 }
             }
         }

--- a/lib/database/site-award.php
+++ b/lib/database/site-award.php
@@ -27,6 +27,24 @@ function AddSiteAward($user, $awardType, $data, $dataExtra = 0): void
     mysqli_query($db, $query);
 }
 
+function HasSiteAward(string $user, int $awardType, int $data, ?int $dataExtra = null): bool
+{
+    sanitize_sql_inputs($user);
+    $query = "SELECT AwardDate FROM SiteAwards WHERE User='$user' AND AwardType=$awardType AND AwardData=$data";
+    if ($dataExtra !== null) {
+        $query .= " AND AwardDataExtra=$dataExtra";
+    }
+
+    $dbResult = s_mysql_query($query);
+    if (!$dbResult) {
+        log_sql_fail();
+        return false;
+    }
+
+    $dbData = mysqli_fetch_assoc($dbResult);
+    return (isset($dbData['AwardDate']));
+}
+
 function getUsersSiteAwards($user, $showHidden = false): array
 {
     sanitize_sql_inputs($user);

--- a/lib/database/user-activity.php
+++ b/lib/database/user-activity.php
@@ -82,20 +82,6 @@ function postActivity($userIn, $activity, $customMsg, $isalt = null): bool
     switch ($activity) {
         case ActivityType::EarnedAchievement:
             $achID = $customMsg;
-
-            $achData = [];
-            getAchievementMetadata($achID, $achData);
-
-            $gameName = $achData['GameTitle'];
-            $gameID = $achData['GameID'];
-            $achName = $achData['Title'];
-
-            $gameLink = "<a href='/game/$gameID'>$gameName</a>";
-            $achLink = "<a href='/achievement/$achID'>$achName</a>";
-
-            $gameLink = str_replace("'", "''", $gameLink);
-            $achLink = str_replace("'", "''", $achLink);
-
             $query .= "(NOW(), $activity, '$user', '$achID', $isalt )";
             break;
 
@@ -199,11 +185,6 @@ function postActivity($userIn, $activity, $customMsg, $isalt = null): bool
         case ActivityType::CompleteGame:
             // Completed a game!
             $gameID = $customMsg;
-            getGameTitleFromID($gameID, $gameTitle, $consoleIDOut, $consoleName, $forumTopicID, $gameData);
-
-            $gameLink = "<a href='/game/$gameID'>$gameTitle</a>";
-            $gameLink = str_replace("'", "''", $gameLink);
-
             AddSiteAward($user, 1, $gameID, $isalt);
             expireGameTopAchievers((int) $gameID);
 
@@ -213,21 +194,10 @@ function postActivity($userIn, $activity, $customMsg, $isalt = null): bool
         case ActivityType::NewLeaderboardEntry:
         case ActivityType::ImprovedLeaderboardEntry:
             $lbID = $customMsg['LBID'];
-            $lbTitle = $customMsg['LBTitle'];
             $score = $customMsg['Score'];
-            $gameID = $customMsg['GameID'];
-            $scoreFormatted = $customMsg['ScoreFormatted'];
-            getGameTitleFromID($gameID, $gameTitle, $consoleIDOut, $consoleName, $forumTopicID, $gameData);
-
-            $gameLink = "<a href='/game/$gameID'>$gameTitle</a>";
-            $gameLink = str_replace("'", "''", $gameLink);
-            $lbLinkScore = "<a href='/leaderboardinfo.php?i=$lbID'>$scoreFormatted</a>";
-            $lbLinkScore = str_replace("'", "''", $lbLinkScore);
-            $lbLinkTitle = "<a href='/leaderboardinfo.php?i=$lbID'>$lbTitle</a>";
-            $lbLinkTitle = str_replace("'", "''", $lbLinkTitle);
-
             $query .= "(NOW(), $activity, '$user', '$lbID', '$score')";
             break;
+
         case ActivityType::Unknown:
         default:
             $query .= "(NOW(), $activity, '$user', '$customMsg', '$customMsg')";


### PR DESCRIPTION
When unlocking a hardcore achievement, the code would only check to see if the hardcore badge should be awarded. If the user had some non-hardcore unlocks, and the last achievement for the set was unlocked in hardcore mode, it would not award the completion badge.

Also eliminated some queries fetching unused achievement/game data when creating Activity records for unlocking achievements and completing/mastering games.