### PR TITLE
Expand Junior Developer Permissions

### DIFF
--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -330,7 +330,7 @@ function UploadNewAchievement(
                 // Only allow jr. devs to modify core achievements if they are the author and not updating logic or state
                 if ($userPermissions < Permissions::Developer && ($changingLogic || $changingAchSet || $data['Author'] != $author)) {
                     // Must be developer to modify core logic!
-                    $errorOut = "You must be a developer to perform this action! Please drop a message in the forums to applyer.";
+                    $errorOut = "You must be a developer to perform this action! Please drop a message in the forums to apply.";
 
                     return false;
                 }

--- a/lib/database/achievement.php
+++ b/lib/database/achievement.php
@@ -326,9 +326,11 @@ function UploadNewAchievement(
 
             if ($type === AchievementType::OfficialCore || $changingAchSet) { // If modifying core or changing achievement state
                 // changing ach set detected; user is $author, permissions is $userPermissions, target set is $type
-                if ($userPermissions < Permissions::Developer) {
-                    // Must be developer to modify core!
-                    $errorOut = "You must be a developer to perform this action! Please drop a message in the forums to apply.";
+
+                // Only allow jr. devs to modify core achievements if they are the author and not updating logic or state
+                if ($userPermissions < Permissions::Developer && ($changingLogic || $changingAchSet || $data['Author'] != $author)) {
+                    // Must be developer to modify core logic!
+                    $errorOut = "You must be a developer to perform this action! Please drop a message in the forums to applyer.";
 
                     return false;
                 }

--- a/lib/database/set-claim.php
+++ b/lib/database/set-claim.php
@@ -50,15 +50,20 @@ function insertClaim(string $user, int $gameID, int $claimType, int $setType, in
 }
 
 /**
- * Checks if the user already has the game claimed. Allows for checking primary and collaboration claims.
+ * Checks if the user already has the game claimed. Allows for checking primary/collaboration claims as well as set type.
  */
-function hasSetClaimed(string $user, int $gameID, bool $isPrimaryClaim = false): bool
+function hasSetClaimed(string $user, int $gameID, bool $isPrimaryClaim = false, ?int $setType = null): bool
 {
     sanitize_sql_inputs($user, $gameID);
 
     $claimTypeCondition = '';
     if ($isPrimaryClaim) {
         $claimTypeCondition = 'AND ClaimType = ' . ClaimType::Primary;
+    }
+
+    $setTypeCondition = '';
+    if (isset($setType)) {
+        $setTypeCondition = 'AND SetType = ' . $setType;
     }
 
     $query = "
@@ -69,6 +74,7 @@ function hasSetClaimed(string $user, int $gameID, bool $isPrimaryClaim = false):
         WHERE
             Status = " . ClaimStatus::Active . "
             $claimTypeCondition
+            $setTypeCondition
             AND User = '$user'
             AND GameID = '$gameID'";
 

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -34,7 +34,7 @@ $author = $dataOut['Author'];
 $dateCreated = $dataOut['DateCreated'];
 $dateModified = $dataOut['DateModified'];
 $achMem = $dataOut['MemAddr'];
-$isSoleAuthor = false;
+$isAuthor = $user == $author;
 
 $achievementTitleRaw = $dataOut['AchievementTitle'];
 $achievementDescriptionRaw = $dataOut['Description'];
@@ -55,11 +55,6 @@ $numPossibleWinners = 0;
 $numRecentWinners = 0;
 
 getAchievementUnlocksData($achievementID, $numWinners, $numPossibleWinners, $numRecentWinners, $winnerInfo, $user, 0, 50);
-
-// Determine if the logged in user is the sole author of the set
-if ($permissions >= Permissions::JuniorDeveloper && isset($user)) {
-    $isSoleAuthor = checkIfSoleDeveloper($user, $gameID);
-}
 
 $dateWonLocal = "";
 foreach ($winnerInfo as $userObject) {
@@ -88,7 +83,7 @@ $pageTitle = "$achievementTitleRaw in $gameTitleRaw ($consoleName)";
 RenderOpenGraphMetadata($pageTitle, "achievement", media_asset("/Badge/$badgeName.png"), "$gameTitleRaw ($consoleName) - $achievementDescriptionRaw");
 RenderContentStart($pageTitle);
 ?>
-<?php if ($permissions >= Permissions::Developer || ($permissions >= Permissions::JuniorDeveloper && $isSoleAuthor && $achFlags === AchievementType::Unofficial)): ?>
+<?php if ($permissions >= Permissions::Developer || ($permissions >= Permissions::JuniorDeveloper && $isAuthor)): ?>
     <script>
     function updateAchievementDetails() {
         showStatusMessage('Updating...');
@@ -260,7 +255,7 @@ RenderContentStart($pageTitle);
             echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Dev ▼</span>";
             echo "<div id='devboxcontent' style='display: none'>";
 
-            if ($permissions >= Permissions::Developer || ($isSoleAuthor && $permissions >= Permissions::JuniorDeveloper && $achFlags === AchievementType::Unofficial)) {
+            if ($permissions >= Permissions::Developer || $isAuthor) {
                 echo "<div>Update achievement details:</div>";
                 echo "<table><tbody>";
                 echo "<tr><td>Title:</td><td style='width:100%'><input id='titleinput' type='text' name='t' value='" . attributeEscape($achievementTitle) . "' style='width:100%' maxlength='64'></td></tr>";

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\AchievementType;
+use RA\ClaimSetType;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
@@ -12,7 +13,7 @@ $fullModifyOK = $permissions >= Permissions::Developer;
 $gameID = requestInputSanitized('g', null, 'integer');
 $flag = requestInputSanitized('f', 3, 'integer');
 
-$partialModifyOK = $permissions == Permissions::JuniorDeveloper && checkIfSoleDeveloper($user, $gameID);
+$partialModifyOK = $permissions == Permissions::JuniorDeveloper && (checkIfSoleDeveloper($user, $gameID) || hasSetClaimed($user, $gameID, true, ClaimSetType::NewSet));
 
 $achievementList = [];
 $gamesList = [];

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -669,7 +669,7 @@ sanitize_outputs(
 
             // Display dev section if logged in as either a developer or a jr. developer viewing a non-hub page
             if (isset($user) && ($permissions >= Permissions::Developer || ($isFullyFeaturedGame && $permissions >= Permissions::JuniorDeveloper))) {
-                $hasMinimumDeveloperPermissions = $permissions >= Permissions::Developer || ($isSoleAuthor && $permissions >= Permissions::JuniorDeveloper);
+                $hasMinimumDeveloperPermissions = $permissions >= Permissions::Developer || (($isSoleAuthor || hasSetClaimed($user, $gameID, true, ClaimSetType::NewSet)) && $permissions >= Permissions::JuniorDeveloper);
                 echo "<div class='devbox mb-3'>";
                 echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Dev ▼</span>";
                 echo "<div id='devboxcontent' style='display: none'>";

--- a/public/request/achievement/update-base.php
+++ b/public/request/achievement/update-base.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\Validator;
-use RA\AchievementType;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
@@ -17,8 +16,8 @@ $input = Validator::validate(request()->post(), [
 
 $achievement = GetAchievementData((int) $input['achievement']);
 
-// Only allow jr. devs to update base data if they are the sole author of the set
-if ($permissions == Permissions::JuniorDeveloper && ((int) $achievement['Flags'] !== AchievementType::Unofficial || !checkIfSoleDeveloper($user, (int) $achievement['GameId']))) {
+// Only allow jr. devs to update base data if they are the author
+if ($permissions == Permissions::JuniorDeveloper && $user != $achievement['Author']) {
     abort(403);
 }
 

--- a/public/request/achievement/update-display-order.php
+++ b/public/request/achievement/update-display-order.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Validator;
+use RA\ClaimSetType;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
@@ -17,8 +18,8 @@ $achievementId = $input['achievement'];
 $gameId = $input['game'];
 $number = $input['number'];
 
-// Only allow jr. devs to update the display order if they are the sole author of the set
-if ($permissions == Permissions::JuniorDeveloper && !checkIfSoleDeveloper($user, $gameId)) {
+// Only allow jr. devs to update the display order if they are the sole author of the set or have the primary claim
+if ($permissions == Permissions::JuniorDeveloper && (!checkIfSoleDeveloper($user, $gameId) && !hasSetClaimed($user, $gameId, true, ClaimSetType::NewSet))) {
     abort(403);
 }
 

--- a/public/request/achievement/update-image.php
+++ b/public/request/achievement/update-image.php
@@ -20,7 +20,10 @@ if (!$achievement) {
     return back()->withErrors(__('legacy.error.image_upload'));
 }
 
-if ($permissions == Permissions::JuniorDeveloper && !checkIfSoleDeveloper($user, $achievement['GameID'])) {
+$gameId = (int) $achievement['GameID'];
+
+// Only allow jr. devs to update achievement image if they are the author
+if ($permissions == Permissions::JuniorDeveloper && $user != $achievement['Author']) {
     return back()->withErrors(__('legacy.error.permissions'));
 }
 

--- a/public/request/achievement/update-image.php
+++ b/public/request/achievement/update-image.php
@@ -20,8 +20,6 @@ if (!$achievement) {
     return back()->withErrors(__('legacy.error.image_upload'));
 }
 
-$gameId = (int) $achievement['GameID'];
-
 // Only allow jr. devs to update achievement image if they are the author
 if ($permissions == Permissions::JuniorDeveloper && $user != $achievement['Author']) {
     return back()->withErrors(__('legacy.error.permissions'));

--- a/public/request/game/update-image.php
+++ b/public/request/game/update-image.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use RA\ArticleType;
+use RA\ClaimSetType;
 use RA\ImageType;
 use RA\Permissions;
 
@@ -19,7 +20,8 @@ $input = Validator::validate(request()->post(), [
 $gameID = (int) $input['game'];
 $imageType = $input['type'];
 
-if ($permissions == Permissions::JuniorDeveloper && !checkIfSoleDeveloper($user, $gameID)) {
+// Only allow jr. devs if they are the sole author of the set or have the primary claim
+if ($permissions == Permissions::JuniorDeveloper && (!checkIfSoleDeveloper($user, $gameID) && !hasSetClaimed($user, $gameID, true, ClaimSetType::NewSet))) {
     return back()->withErrors(__('legacy.error.permissions'));
 }
 

--- a/public/request/game/update-meta.php
+++ b/public/request/game/update-meta.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Validator;
+use RA\ClaimSetType;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
@@ -17,8 +18,8 @@ $input = Validator::validate(request()->post(), [
 
 $gameId = (int) $input['game'];
 
-// Only allow jr. devs if they are the sole author of the set
-if ($permissions === Permissions::JuniorDeveloper && !checkIfSoleDeveloper($user, $gameId)) {
+// Only allow jr. devs if they are the sole author of the set or have the primary claim
+if ($permissions === Permissions::JuniorDeveloper && (!checkIfSoleDeveloper($user, $gameId) && !hasSetClaimed($user, $gameId, true, ClaimSetType::NewSet))) {
     return back()->withErrors(__('legacy.error.permissions'));
 }
 

--- a/public/request/game/update-rich-presence.php
+++ b/public/request/game/update-rich-presence.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Validator;
+use RA\ClaimSetType;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
@@ -14,8 +15,8 @@ $input = Validator::validate(request()->post(), [
 
 $gameId = (int) $input['game'];
 
-// Only allow jr. devs if they are the sole author of the set
-if ($permissions === Permissions::JuniorDeveloper && !checkIfSoleDeveloper($user, $gameId)) {
+// Only allow jr. devs if they are the sole author of the set or have the primary claim
+if ($permissions === Permissions::JuniorDeveloper && (!checkIfSoleDeveloper($user, $gameId) && !hasSetClaimed($user, $gameId, true, ClaimSetType::NewSet))) {
     return back()->withErrors(__('legacy.error.permissions'));
 }
 


### PR DESCRIPTION
This gives Junior Developers a few more permissions if they have an active primary new set claim, allowing them to do the following:

- Update game page information (Developer, Publisher, Genre, & First Released)
- Update game page images (Icon, Title, In-Game, Boxart)
- Update Rich Presence script
- Update achievement ordering

This also allows Junior Developers to update their achievement titles, descriptions, points, & badges via site or emulator without requiring the achievement to be demoted first.