### PR TITLE
add explain blocks for leaderboards

### DIFF
--- a/lib/util/trigger.php
+++ b/lib/util/trigger.php
@@ -277,7 +277,7 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
       <th nowrap>Hits</th>
     </tr>';
 
-    $res = "\n<table whitespace-nowrap>";
+    $res = "\n<table>";
 
     // separating CoreGroup and AltGroups
     $groups = preg_split("/(?<!0x)S/", $mem);

--- a/lib/util/trigger.php
+++ b/lib/util/trigger.php
@@ -263,19 +263,19 @@ function getNoteForAddress($memNotes, $address)
 
 function getAchievementPatchReadableHTML($mem, $memNotes)
 {
-    $tableHeader = '
+    $tableHeader = "
     <tr>
-      <th nowrap>ID</th>
-      <th nowrap>Flag</th>
-      <th nowrap>Type</th>
-      <th nowrap>Size</th>
-      <th nowrap>Memory</th>
-      <th nowrap>Cmp</th>
-      <th nowrap>Type</th>
-      <th nowrap>Size</th>
-      <th nowrap>Mem/Val</th>
-      <th nowrap>Hits</th>
-    </tr>';
+      <th class='whitespace-nowrap'>ID</th>
+      <th class='whitespace-nowrap'>Flag</th>
+      <th class='whitespace-nowrap'>Type</th>
+      <th class='whitespace-nowrap'>Size</th>
+      <th class='whitespace-nowrap'>Memory</th>
+      <th class='whitespace-nowrap'>Cmp</th>
+      <th class='whitespace-nowrap'>Type</th>
+      <th class='whitespace-nowrap'>Size</th>
+      <th class='whitespace-nowrap'>Mem/Val</th>
+      <th class='whitespace-nowrap'>Hits</th>
+    </tr>";
 
     $res = "\n<table>";
 
@@ -309,11 +309,11 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
                 $lTooltip = " class=\"cursor-help\" title=\"" . hexdec($lMemory) . "\"";
             }
 
-            $res .= "\n<tr>\n  <td nowrap>" . ($j + 1) . "</td>";
-            $res .= "\n  <td nowrap> " . $flag . " </td>";
-            $res .= "\n  <td nowrap> " . $lType . " </td>";
-            $res .= "\n  <td nowrap> " . $lSize . " </td>";
-            $res .= "\n  <td" . $lTooltip . " nowrap> " . $lMemory . " </td>";
+            $res .= "\n<tr>\n  <td class='whitespace-nowrap'>" . ($j + 1) . "</td>";
+            $res .= "\n  <td class='whitespace-nowrap'> " . $flag . " </td>";
+            $res .= "\n  <td class='whitespace-nowrap'> " . $lType . " </td>";
+            $res .= "\n  <td class='whitespace-nowrap'> " . $lSize . " </td>";
+            $res .= "\n  <td" . $lTooltip . " class='whitespace-nowrap'> " . $lMemory . " </td>";
             if (!$cmp) {
                 $res .= "\n  <td colspan=5 style='text-align: center'> </td>";
             } else {
@@ -328,11 +328,11 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
                     $rTooltip = " class=\"cursor-help\" title=\"" . hexdec($rMemVal) . "\"";
                 }
 
-                $res .= "\n  <td nowrap> " . htmlspecialchars($cmp) . " </td>";
-                $res .= "\n  <td nowrap> " . $rType . " </td>";
-                $res .= "\n  <td nowrap> " . $rSize . " </td>";
-                $res .= "\n  <td" . $rTooltip . " nowrap> " . $rMemVal . " </td>";
-                $res .= "\n  <td nowrap> (" . $hits . ") </td>";
+                $res .= "\n  <td class='whitespace-nowrap'> " . htmlspecialchars($cmp) . " </td>";
+                $res .= "\n  <td class='whitespace-nowrap'> " . $rType . " </td>";
+                $res .= "\n  <td class='whitespace-nowrap'> " . $rSize . " </td>";
+                $res .= "\n  <td" . $rTooltip . " class='whitespace-nowrap'> " . $rMemVal . " </td>";
+                $res .= "\n  <td class='whitespace-nowrap'> (" . $hits . ") </td>";
             }
             $res .= "\n</tr>\n";
         }

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -45,6 +45,29 @@ $pageTitle = "Leaderboard: $lbTitle ($gameTitle)";
 $numLeaderboards = getLeaderboardsForGame($gameID, $allGameLBData, $user);
 $numArticleComments = getArticleComments(ArticleType::Leaderboard, $lbID, 0, 20, $commentData);
 
+function ExplainLeaderboardTrigger(string $name, string $triggerDef, array $codeNotes): void
+{
+    echo "<div class='devbox'>";
+    echo "<span onclick=\"$('#devbox{$name}content').toggle(); return false;\">$name ▼</span>";
+    echo "<div id='devbox{$name}content' style='display: none'>";
+
+    echo "<div>";
+
+    echo "<li>Mem:</li>";
+    echo "<code>" . htmlspecialchars($triggerDef) . "</code>";
+
+    if ($name === 'Value') {
+        $triggerDef = ValueToTrigger($triggerDef);
+    }
+
+    echo "<li>Mem explained:</li>";
+    echo "<code>" . getAchievementPatchReadableHTML($triggerDef, $codeNotes) . "</code>";
+    echo "</div>";
+
+    echo "</div>"; // devboxcontent
+    echo "</div>"; // devbox
+}
+
 RenderOpenGraphMetadata(
     $pageTitle,
     "Leaderboard",
@@ -125,6 +148,32 @@ RenderContentStart('Leaderboard');
                     echo "</td></tr>";
                 }
                 echo "</div>";
+
+                echo "<br/>";
+
+                $memStart = "";
+                $memCancel = "";
+                $memSubmit = "";
+                $memValue = "";
+                $memChunks = explode("::", $lbMemory);
+                foreach ($memChunks as &$memChunk) {
+                    $part = substr($memChunk, 0, 4);
+                    if ($part == 'STA:') {
+                        $memStart = substr($memChunk, 4);
+                    } elseif ($part == 'CAN:') {
+                        $memCancel = substr($memChunk, 4);
+                    } elseif ($part == 'SUB:') {
+                        $memSubmit = substr($memChunk, 4);
+                    } elseif ($part == 'VAL:') {
+                        $memValue = substr($memChunk, 4);
+                    }
+                }
+
+                getCodeNotes($gameID, $codeNotes);
+                ExplainLeaderboardTrigger('Start', $memStart, $codeNotes);
+                ExplainLeaderboardTrigger('Cancel', $memCancel, $codeNotes);
+                ExplainLeaderboardTrigger('Submit', $memSubmit, $codeNotes);
+                ExplainLeaderboardTrigger('Value', $memValue, $codeNotes);
 
                 echo "</div>";
                 echo "</div>";


### PR DESCRIPTION
implements #1215 

Adds collapsible sections for start/cancel/submit/value triggers to the leaderboard page (not the manage leaderboards page). Includes support for translating legacy value definitions to Measured strings.

![image](https://user-images.githubusercontent.com/32680403/200181708-dde2a719-130b-4aac-86d3-e3c56747f261.png)

![image](https://user-images.githubusercontent.com/32680403/200181800-3c2caa61-11cf-407f-9132-127735d8b809.png)

![image](https://user-images.githubusercontent.com/32680403/200181787-b23b0f98-67fb-44ef-b314-fd64090b983b.png)

![image](https://user-images.githubusercontent.com/32680403/200181750-0353506b-ee0e-4bac-a019-e89cb7df3e58.png)



