### PR TITLE
Fix RSS feeds date, strip HTML tags, add guid

### DIFF
--- a/public/rss-forum.xml.php
+++ b/public/rss-forum.xml.php
@@ -47,7 +47,10 @@ for ($i = 0; $i < $numPostsFound; $i++) {
     $article->appendChild($dom->createElement('link', $link));
     $article->appendChild($dom->createElement('description', htmlentities($payload)));
     $article->appendChild($dom->createElement('pubDate', $date));
-    // $article->appendChild( $dom->createElement( 'guid',  $nextData['CommentID'] ) );
+
+    $guid = $dom->createElement('guid', 'retroachievements:forum-post:'.$nextData['CommentID']);
+    $guid->setAttribute('isPermaLink', 'false');
+    $article->appendChild($guid);
 }
 
 return response(html_entity_decode($dom->saveXML()), headers: ['Content-type' => 'text/xml']);

--- a/public/rss-forum.xml.php
+++ b/public/rss-forum.xml.php
@@ -48,7 +48,7 @@ for ($i = 0; $i < $numPostsFound; $i++) {
     $article->appendChild($dom->createElement('description', htmlentities($payload)));
     $article->appendChild($dom->createElement('pubDate', $date));
 
-    $guid = $dom->createElement('guid', 'retroachievements:forum-post:'.$nextData['CommentID']);
+    $guid = $dom->createElement('guid', 'retroachievements:forum-post:' . $nextData['CommentID']);
     $guid->setAttribute('isPermaLink', 'false');
     $article->appendChild($guid);
 }

--- a/public/rss-newachievements.xml.php
+++ b/public/rss-newachievements.xml.php
@@ -67,6 +67,10 @@ for ($i = 0; $i < $numArticles; $i++) {
     $article->appendChild($dom->createElement('link', $link));
     $article->appendChild($dom->createElement('description', htmlentities($payload)));
     $article->appendChild($dom->createElement('pubDate', $date));
+
+    $guid = $dom->createElement('guid', 'retroachievements:new-achievements:'.$achID);
+    $guid->setAttribute('isPermaLink', 'false');
+    $article->appendChild($guid);
 }
 
 return response(html_entity_decode($dom->saveXML()), headers: ['Content-type' => 'text/xml']);

--- a/public/rss-newachievements.xml.php
+++ b/public/rss-newachievements.xml.php
@@ -68,7 +68,7 @@ for ($i = 0; $i < $numArticles; $i++) {
     $article->appendChild($dom->createElement('description', htmlentities($payload)));
     $article->appendChild($dom->createElement('pubDate', $date));
 
-    $guid = $dom->createElement('guid', 'retroachievements:new-achievements:'.$achID);
+    $guid = $dom->createElement('guid', 'retroachievements:new-achievements:' . $achID);
     $guid->setAttribute('isPermaLink', 'false');
     $article->appendChild($guid);
 }

--- a/public/rss-news.xml.php
+++ b/public/rss-news.xml.php
@@ -58,7 +58,7 @@ foreach ($newsData as $news) {
     $article->appendChild($dom->createElement('description', htmlentities($newsPayload)));
     $article->appendChild($dom->createElement('pubDate', $newsDate));
 
-    $guid = $dom->createElement('guid', 'retroachievements:news:'.$newsID);
+    $guid = $dom->createElement('guid', 'retroachievements:news:' . $newsID);
     $guid->setAttribute('isPermaLink', 'false');
     $article->appendChild($guid);
 }

--- a/public/rss-news.xml.php
+++ b/public/rss-news.xml.php
@@ -31,18 +31,18 @@ foreach ($newsData as $news) {
     $article = $xmlRoot->appendChild($article);
 
     $newsID = $news['ID'];
-    $newsDate = date("D, d M Y H:i:s O", $news['TimePosted']);
+    $newsDate = date("D, d M Y H:i:s O", strtotime($news['Timestamp']));
     $newsImage = $news['Image'];
     $newsAuthor = $news['Author'];
     $newsLink = config('app.url');
-    $newsTitle = "<![CDATA[" . htmlspecialchars($news['Title']) . "]]>";
+    $newsTitle = "<![CDATA[" . htmlspecialchars(strip_tags($news['Title'])) . "]]>";
 
     // Image first?
     $payload = "<a href='$newsLink'><img style='padding: 5px;' src='$newsImage' /></a>";
     $payload .= "<br>\r\n";
     $payload .= $news['Payload'];
 
-    $newsPayload = "<![CDATA[" . htmlspecialchars($payload) . "]]>";
+    $newsPayload = "<![CDATA[" . htmlspecialchars(strip_tags($payload)) . "]]>";
 
     // $newsPayload contains relative URLs, which need converting to absolute URLs
     $newsPayload = str_replace("href='/", "href='" . config('app.url') . "/", $newsPayload);
@@ -57,7 +57,10 @@ foreach ($newsData as $news) {
     $article->appendChild($dom->createElement('link', $newsLink));
     $article->appendChild($dom->createElement('description', htmlentities($newsPayload)));
     $article->appendChild($dom->createElement('pubDate', $newsDate));
-    // $article->appendChild( $dom->createElement( 'id', $newsID ) );
+
+    $guid = $dom->createElement('guid', 'retroachievements:news:'.$newsID);
+    $guid->setAttribute('isPermaLink', 'false');
+    $article->appendChild($guid);
 }
 
 return response(html_entity_decode($dom->saveXML()), headers: ['Content-type' => 'text/xml']);


### PR DESCRIPTION
This Pull Request introduces three changes to RSS feeds:
* fix date in News RSS Channel – it had wrong variable, so every item in the feed was showing the same date (actual one)
* strip HTML tags from title and description for News RSS Channel – with encoded content it was difficult to read it
* add "guid" for all available RSS feeds – there was no "guid", so items were distinguished by other means in RSS readers. Now with unique "guid" for each item, it will be easier for readers be sure, which items were read.

In case of the last point, this form of "guid" is my proposition. News doesn't have their permalinks, so it has to be some kind of other string here. I was thinking about going with URI tags (according to [RFC 4151](https://www.rfc-editor.org/rfc/rfc4151.html)), which are sometimes used instead of permalinks, but I'm not sure, if that would be good. In the end, the string in "guid" can be anything, as it only needs to be unique for each item.
I used the similar form to others feeds as well, for consistency.

Let me know, if it's okay and we go with this form of "guid". If you have other idea for it, then it's the best time to report it (these shouldn't be really changed much, as it will confuse RSS readers).