### PR TITLE
adjust contributions for hardcore/softcore split

### DIFF
--- a/cronjobs/cron_1m.php
+++ b/cronjobs/cron_1m.php
@@ -47,6 +47,7 @@ for ($i = 0; $i < 3; $i++) {
     $user = getUserFromID($userID);
     if (!empty($user)) {
         recalculatePlayerPoints($user);
+        recalculateDeveloperContribution($user);
     }
     $userID = GetNextHighestUserID($userID);
 }

--- a/lib/database/achievement-creator.php
+++ b/lib/database/achievement-creator.php
@@ -1,6 +1,7 @@
 <?php
 
 use RA\AchievementType;
+use RA\AwardThreshold;
 use RA\UnlockMode;
 
 /**
@@ -176,4 +177,76 @@ function checkIfSoleDeveloper(string $user, int $gameID): bool
     }
 
     return $userFound;
+}
+
+function attributeDevelopmentAuthor(string $author, int $points): void
+{
+    sanitize_sql_inputs($author, $points);
+
+    $query = "SELECT ContribCount, ContribYield FROM UserAccounts WHERE User = '$author'";
+    $dbResult = s_mysql_query($query);
+    $oldResults = mysqli_fetch_assoc($dbResult);
+    if (!$oldResults) {
+        // could not find a record for the author, nothing to update
+        return;
+    }
+
+    $oldContribCount = (int) $oldResults['ContribCount'];
+    $oldContribYield = (int) $oldResults['ContribYield'];
+
+    // Update the fact that this author made an achievement that just got earned.
+    $query = "UPDATE UserAccounts AS ua
+              SET ua.ContribCount = ua.ContribCount+1, ua.ContribYield = ua.ContribYield + $points
+              WHERE ua.User = '$author'";
+
+    $dbResult = s_mysql_query($query);
+
+    if (!$dbResult) {
+        log_sql_fail();
+
+        return;
+    }
+
+    for ($i = 0; $i < count(AwardThreshold::DEVELOPER_COUNT_BOUNDARIES); $i++) {
+        if ($oldContribCount < AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$i] && $oldContribCount + 1 >= AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$i]) {
+            // This developer has arrived at this point boundary!
+            AddSiteAward($author, 2, $i);
+        }
+    }
+    for ($i = 0; $i < count(AwardThreshold::DEVELOPER_POINT_BOUNDARIES); $i++) {
+        if ($oldContribYield < AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$i] && $oldContribYield + $points >= AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$i]) {
+            // This developer is newly above this point boundary!
+            AddSiteAward($author, 3, $i);
+        }
+    }
+}
+
+function recalculateDeveloperContribution(string $author): void
+{
+    sanitize_sql_inputs($author);
+
+    $query = "SELECT COUNT(*) AS ContribCount, SUM(Points) AS ContribYield
+              FROM (SELECT aw.User, ach.ID, MAX(aw.HardcoreMode) as HardcoreMode, ach.Points
+                    FROM Achievements ach LEFT JOIN Awarded aw ON aw.AchievementID=ach.ID
+                    WHERE ach.Author='$author' AND aw.User != '$author' GROUP BY 1,2) AS UniqueUnlocks";
+
+    $dbResult = s_mysql_query($query);
+    if ($dbResult !== false) {
+        $contribCount = 0;
+        $contribYield = 0;
+
+        if ($data = mysqli_fetch_assoc($dbResult)) {
+            $contribCount = $data['ContribCount'] ?? 0;
+            $contribYield = $data['ContribYield'] ?? 0;
+        }
+
+        $query = "UPDATE UserAccounts
+                  SET ContribCount = $contribCount, ContribYield = $contribYield
+                  WHERE User = '$author'";
+
+        $dbResult = s_mysql_query($query);
+        if (!$dbResult) {
+            log_sql_fail();
+        }
+    }
 }

--- a/lib/database/player-achievement.php
+++ b/lib/database/player-achievement.php
@@ -152,7 +152,11 @@ function unlockAchievement(string $user, $achIDToAward, $isHardcore): array
     static_setlastearnedachievement($achIDToAward, $user, $achData['Points']);
 
     if ($user != $achData['Author']) {
-        attributeDevelopmentAuthor($achData['Author'], $pointsToGive);
+        if ($isHardcore && $hasRegular) {
+            // developer received contribution points when the regular version was unlocked
+        } else {
+            attributeDevelopmentAuthor($achData['Author'], $pointsToGive);
+        }
     }
 
     return $retVal;

--- a/lib/database/user.php
+++ b/lib/database/user.php
@@ -1,6 +1,5 @@
 <?php
 
-use RA\AwardThreshold;
 use RA\ClaimStatus;
 use RA\Permissions;
 use RA\TicketState;
@@ -494,48 +493,6 @@ function GetUserFields($username, $fields): ?array
     }
 
     return mysqli_fetch_assoc($dbResult);
-}
-
-function attributeDevelopmentAuthor($author, $points): void
-{
-    sanitize_sql_inputs($author, $points);
-
-    $query = "SELECT ContribCount, ContribYield FROM UserAccounts WHERE User = '$author'";
-    $dbResult = s_mysql_query($query);
-    $oldResults = mysqli_fetch_assoc($dbResult);
-    if (!$oldResults) {
-        // could not find a record for the author, nothing to update
-        return;
-    }
-
-    $oldContribCount = (int) $oldResults['ContribCount'];
-    $oldContribYield = (int) $oldResults['ContribYield'];
-
-    // Update the fact that this author made an achievement that just got earned.
-    $query = "UPDATE UserAccounts AS ua
-              SET ua.ContribCount = ua.ContribCount+1, ua.ContribYield = ua.ContribYield + $points
-              WHERE ua.User = '$author'";
-
-    $dbResult = s_mysql_query($query);
-
-    if (!$dbResult) {
-        log_sql_fail();
-
-        return;
-    }
-
-    for ($i = 0; $i < count(AwardThreshold::DEVELOPER_COUNT_BOUNDARIES); $i++) {
-        if ($oldContribCount < AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$i] && $oldContribCount + 1 >= AwardThreshold::DEVELOPER_COUNT_BOUNDARIES[$i]) {
-            // This developer has arrived at this point boundary!
-            AddSiteAward($author, 2, $i);
-        }
-    }
-    for ($i = 0; $i < count(AwardThreshold::DEVELOPER_POINT_BOUNDARIES); $i++) {
-        if ($oldContribYield < AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$i] && $oldContribYield + $points >= AwardThreshold::DEVELOPER_POINT_BOUNDARIES[$i]) {
-            // This developer is newly above this point boundary!
-            AddSiteAward($author, 3, $i);
-        }
-    }
 }
 
 /**


### PR DESCRIPTION
"Achievements won by others" and "Points awarded to others" are currently only updated when an achievement is unlocked. As such, they haven't been adjusted for the hardcore/softcore split, and aren't updated if a user resets an achievement.

This adds code to the cron job that already automatically recalculates the user's score to also recalculate their contributions. For some of the more prolific achievement authors, the query may exceed the 1m period of the cron. I'm worried that this may be problematic as the `NextUserIDToScan` isn't updated until the cron finishes, so the next cron will try to process the same user again. **Please advise**.

Here are the adjusted values for the 10 developers with the most contribution points (using data from several months ago):
```
Top 10 Yield   Count    Yield  

Brian         1233834 12930508
              1001743  7339733

dude1286       903009 12709905
               720692  5875845

Salsa         1089084 11441213
               920887  7071644
               
Jaarl          881603  9247955
               666841  4581515

Scott          809485  8708781
               649135  3494926

Pereira006     441276  6885936
               344507  2790022

Falconburns    387508  6865953
               296258  2334036

Dissection     519237  6814952
               416825  3207827

FernandoFFS    461377  6580997
               353991  2750143

matheus2653    501324  6571013
               429962  3331016
```
Only three users would have earned the 5M points badge proposed in the new tiers in #775

And for the 10 developers with the most achievements created:
```
Top 10 Achvs    Count   Yield
	
voiceofautumn  115616  1244248
               112228   645406
	
televandalist  375214  4782574
               359412  2738911

Salsa         1089084 11441213
               920887  7071644
	
SporyTike      460462  5124312
               424373  2590712
	
MGNS8M         315508  3845067
               282504  2073741
	
SnowPin        145167  1459474
               139137   759244
	
wilhitewarrior 196353  2109491
               186570  1212025
	
Alena          108224  1518445
               107708   851849
	
pinguupinguu    39302   383127
                38350   197983
	
Dexterspet     554601  5752856
               440952  2828126
```

The drop in Yield is mostly due to the softcore/hardcore split. Prior to that, a hardcore unlock would award double points. The drop in Count is related to resets and softcore unlocks being upgraded to hardcore (which would award a second unlock and an additional double points).