### PR TITLE
don't allow completing claim from unofficial

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -780,15 +780,21 @@ sanitize_outputs(
 
                         // if the set has achievements and the current user is the primary claim owner then allow completing the claim
                         if ($user === $primaryClaimUser && $numAchievements > 0) {
-                            $isRecentPrimaryClaim = $primaryClaimMinutesActive <= 1440; // within 24 hours of claim date
-                            echo "<form action='/request/set-claim/complete-claim.php' method='post' onsubmit='return completeClaim(\"$escapedGameTitle\", " . ($isRecentPrimaryClaim ? 'true' : 'false') . ")'>";
-                            echo csrf_field();
-                            echo "<input type='hidden' name='game' value='$gameID'>";
-                            echo "<button>Complete Claim</button>";
-                            if ($isRecentPrimaryClaim) {
-                                echo "<span class='ml-3 text-danger'>Within 24 Hours of Claim!</span>";
+                            // for valid consoles, only allow completing if core achievements exist
+                            // for rollout consoles, achievements can't be pushed to core, so don't restrict completing
+                            if (isValidConsoleId($consoleID) && $flags == $unofficialFlag) {
+                                echo "<div><span class='ml-2'>Cannot Complete Claim until Promoted</span></div>";
+                            } else {
+                                $isRecentPrimaryClaim = $primaryClaimMinutesActive <= 1440; // within 24 hours of claim date
+                                echo "<form action='/request/set-claim/complete-claim.php' method='post' onsubmit='return completeClaim(\"$escapedGameTitle\", " . ($isRecentPrimaryClaim ? 'true' : 'false') . ")'>";
+                                echo csrf_field();
+                                echo "<input type='hidden' name='game' value='$gameID'>";
+                                echo "<button>Complete Claim</button>";
+                                if ($isRecentPrimaryClaim) {
+                                    echo "<span class='ml-3 text-danger'>Within 24 Hours of Claim!</span>";
+                                }
+                                echo "</form>";
                             }
-                            echo "</form>";
                         }
 
                         echo "<div><a class='btn btn-link' href='/claimlist.php?g=$gameID&f=" . ClaimFilters::AllFilters . "'>Claim History</a></div>";


### PR DESCRIPTION
Completing a claim implies the set is ready for players. That's not true if the achievements are still in Unofficial.

Replaces the "Complete Claim" button on the Unofficial achievements page with a message:
![image](https://user-images.githubusercontent.com/32680403/202873269-7ef4d213-21f9-4361-9174-683651c01db3.png)

Would it make more sense to be more generic? i.e. "Cannot Complete Claim from Unofficial" in case there are Core achievements, but the user is just on the Unofficial view?

https://discord.com/channels/310192285306454017/493200466222776342/1043618294495715328