### PR TITLE
append search results instead of overwriting

### DIFF
--- a/lib/database/search.php
+++ b/lib/database/search.php
@@ -89,7 +89,7 @@ function performSearch(int $searchType, string $searchQuery, int $offset, int $c
 
     $resultCount = 0;
     while ($nextData = mysqli_fetch_assoc($dbResult)) {
-        $searchResultsOut[$resultCount] = $nextData;
+        $searchResultsOut[] = $nextData;
         $resultCount++;
     }
 


### PR DESCRIPTION
fixes quick search results not containing all elements from full page search