### PR TITLE
include calling function location in silenced sql failure

### DIFF
--- a/lib/util/database.php
+++ b/lib/util/database.php
@@ -73,6 +73,10 @@ function log_sql_fail(): void
         if (config('app.debug')) {
             throw new Exception($error);
         }
+
+        $calling_function = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
+        $error .= ' at ' . $calling_function['file'] . ':' . $calling_function['line'];
+
         Log::error($error);
     }
 }


### PR DESCRIPTION
To help track down errors like `You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-8, 15' at line 6`

Alternately, we could just throw the exception in production (see line 74) and let the framework log it normally. 