### PR TITLE
make hash link redirect to hash page

### DIFF
--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -571,7 +571,7 @@ RenderContentStart($pageTitle);
                 $hashes = getHashListByGameID($gameID);
                 foreach ($hashes as $hash) {
                     if (stripos($reportNotes, $hash['Hash']) !== false) {
-                        $replacement = "<a class='cursor-help' title='" .
+                        $replacement = "<a href='/linkedhashes.php?g=$gameID' title='" .
                             attributeEscape($hash['Name']) . "'>" . $hash['Hash'] . "</a>";
                         $reportNotes = str_ireplace($hash['Hash'], $replacement, $reportNotes);
                     }


### PR DESCRIPTION
Allows quick access to the list of hashes for the game in case the user can't see the tooltip (mobile), or if the user is just curious which other hashes are available.

Tooltip still appears on hover.