### PR TITLE
add subpage for additional comments

### DIFF
--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -394,6 +394,26 @@ function GetLeaderboardEntriesDataJSON($lbID, $user, $numToFetch, $offset, $frie
     return $retVal;
 }
 
+function getLeaderboardTitle($id, &$gameIDOut): string
+{
+    sanitize_sql_inputs($id);
+    settype($id, "integer");
+
+    $query = "SELECT lb.Title, lb.GameID FROM LeaderboardDef AS lb WHERE lb.ID = $id";
+    $dbResult = s_mysql_query($query);
+    if ($dbResult) {
+        $data = mysqli_fetch_assoc($dbResult);
+        if ($data) {
+            $gameIDOut = $data['GameID'];
+
+            return $data['Title'];
+        }
+    }
+
+    log_sql_fail();
+    return "";
+}
+
 function GetLeaderboardData($lbID, $user, $numToFetch, $offset, $friendsOnly, $nearby = false): array
 {
     sanitize_sql_inputs($lbID, $user, $numToFetch, $offset);

--- a/lib/database/leaderboard.php
+++ b/lib/database/leaderboard.php
@@ -411,6 +411,7 @@ function getLeaderboardTitle($id, &$gameIDOut): string
     }
 
     log_sql_fail();
+
     return "";
 }
 

--- a/lib/render/code-note.php
+++ b/lib/render/code-note.php
@@ -1,16 +1,7 @@
 <?php
 
-function RenderCodeNotes($codeNotes, $showDisclaimer = false): void
+function RenderCodeNotes($codeNotes): void
 {
-    echo "<h3>Code Notes</h3>";
-
-    if ($showDisclaimer) {
-        echo "The RetroAchievements addressing scheme for most systems is to access the system memory " .
-             "at address $00000000, immediately followed by the cartridge memory. As such, the addresses " .
-             "displayed below may not directly correspond to the addresses on the real hardware.";
-        echo "<br/><br/>";
-    }
-
     echo "<table><tbody>";
 
     echo "<tr><th style='font-size:100%;'>Mem</th><th style='font-size:100%;'>Note</th><th style='font-size:100%;'>Author</th></tr>";

--- a/lib/render/comment.php
+++ b/lib/render/comment.php
@@ -27,12 +27,10 @@ function RenderCommentsComponent(
         if ($numComments > $count) {
             RenderPaginator($numComments, $count, $offset, "/comments.php?t=$articleTypeID&i=$articleID&o=");
         }
+    } else if ($numComments > count($commentData)) {
+        echo "Recent comments: <span class='smalltext'>(<a href='/comments.php?t=$articleTypeID&i=$articleID'>All $numComments</a>)</span>";
     } else {
-        echo "Recent comments:";
-
-        if ($numComments > count($commentData)) {
-            echo " <span class='smalltext'>(<a href='/comments.php?t=$articleTypeID&i=$articleID'>All $numComments</a>)</span>";
-        }
+        echo "Comments:";
     }
     echo "</div>";
     if (isset($user)) {

--- a/lib/render/comment.php
+++ b/lib/render/comment.php
@@ -23,11 +23,11 @@ function RenderCommentsComponent(
     echo "<div>";
     if ($numComments == 0) {
         echo "<i>No comments</i>";
-    } else if (!$embedded) {
+    } elseif (!$embedded) {
         if ($numComments > $count) {
             RenderPaginator($numComments, $count, $offset, "/comments.php?t=$articleTypeID&i=$articleID&o=");
         }
-    } else if ($numComments > count($commentData)) {
+    } elseif ($numComments > count($commentData)) {
         echo "Recent comments: <span class='smalltext'>(<a href='/comments.php?t=$articleTypeID&i=$articleID'>All $numComments</a>)</span>";
     } else {
         echo "Comments:";

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -75,7 +75,7 @@ if ($dateWonLocal === "") {
 
 $achievedLocal = ($dateWonLocal !== "");
 
-$numArticleComments = getArticleComments(ArticleType::Achievement, $achievementID, 0, 20, $commentData);
+$numArticleComments = getRecentArticleComments(ArticleType::Achievement, $achievementID, $commentData);
 
 getCodeNotes($gameID, $codeNotes);
 

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -229,6 +229,7 @@ function updateAchievementsTypeFlag(typeFlag) {
 
     if (!empty($codeNotes)) {
         echo "<div id='rightcontainer'>";
+        echo "<h3>Code Notes</h3>";
         RenderCodeNotes($codeNotes);
         echo "</div>";
     }

--- a/public/codenotes.php
+++ b/public/codenotes.php
@@ -18,7 +18,20 @@ RenderContentStart('Code Notes');
 ?>
 <div id='mainpage'>
     <div id="fullcontainer">
-        <?php echo "Game: " . gameAvatar($gameData); ?>
+        <div class='navpath'>
+            <a href='/gameList.php'>All Games</a>
+            &raquo; <a href='/gameList.php?c=<?= $gameData['ConsoleID'] ?>'><?= $gameData['ConsoleName'] ?></a>
+            &raquo; <a href='/game/<?= $gameID ?>'><?= $gameData['Title'] ?></a>
+            &raquo; <b>Code Notes</b>
+        </div>
+        <h3>Code Notes</h3>
+        <?= gameAvatar($gameData, iconSize: 64); ?>
+        <br/>
+        <br/>
+        <p>The RetroAchievements addressing scheme for most systems is to access the system memory
+        at address $00000000, immediately followed by the cartridge memory. As such, the addresses
+        displayed below may not directly correspond to the addresses on the real hardware.</p>
+        <br/>
         <?php
         if (isset($gameData) && isset($user) && $permissions >= Permissions::Registered) {
             RenderCodeNotes($codeNotes, true);

--- a/public/codenotes.php
+++ b/public/codenotes.php
@@ -34,7 +34,7 @@ RenderContentStart('Code Notes');
         <br/>
         <?php
         if (isset($gameData) && isset($user) && $permissions >= Permissions::Registered) {
-            RenderCodeNotes($codeNotes, true);
+            RenderCodeNotes($codeNotes);
         }
         ?>
     </div>

--- a/public/comments.php
+++ b/public/comments.php
@@ -85,6 +85,19 @@ switch ($articleTypeID)
         ];
         break;
 
+    case ArticleType::AchievementTicket:
+        $ticket = getTicket($articleID);
+        if ($ticket == null) {
+            abort(404);
+        }
+        $pageTitle = "Ticket $articleID: " . $ticket['AchievementTitle'];
+        $navPath =
+        [
+            'Ticket Manager' => '/ticketmanager.php',
+            $articleID => '/ticketmanager.php?i=' . $articleID
+        ];
+        break;
+
     default:
         abort(404);
         break;

--- a/public/comments.php
+++ b/public/comments.php
@@ -1,10 +1,7 @@
 <?php
 
-use App\Support\Shortcode\Shortcode;
 use RA\ArticleType;
 use RA\Permissions;
-use RA\SubscriptionSubjectType;
-use RA\UserAction;
 
 authenticateFromCookie($user, $permissions, $userDetails);
 
@@ -34,7 +31,7 @@ switch ($articleTypeID)
         [
             'All Games' => '/gameList.php',
             $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
-            $gameData['Title'] => '/game/' . $gameData['ID']
+            $gameData['Title'] => '/game/' . $gameData['ID'],
         ];
         break;
 
@@ -53,7 +50,7 @@ switch ($articleTypeID)
             'All Games' => '/gameList.php',
             $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
             $gameData['Title'] => '/game/' . $gameData['ID'],
-            'Manage Hashes' => '/managehashes.php?g=' . $gameData['ID']
+            'Manage Hashes' => '/managehashes.php?g=' . $gameData['ID'],
         ];
         break;
 
@@ -71,7 +68,7 @@ switch ($articleTypeID)
         [
             'All Games' => '/gameList.php',
             $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
-            $gameData['Title'] => '/game/' . $gameData['ID']
+            $gameData['Title'] => '/game/' . $gameData['ID'],
         ];
         break;
 
@@ -90,7 +87,7 @@ switch ($articleTypeID)
             'All Games' => '/gameList.php',
             $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
             $gameData['Title'] => '/game/' . $gameData['ID'],
-            'Manage Claims' => '/manageclaims.php?g=' . $gameData['ID']
+            'Manage Claims' => '/manageclaims.php?g=' . $gameData['ID'],
         ];
         break;
 
@@ -108,7 +105,7 @@ switch ($articleTypeID)
             'All Games' => '/gameList.php',
             $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
             $gameData['Title'] => '/game/' . $gameData['ID'],
-            $pageTitle => '/achievement/' . $articleID
+            $pageTitle => '/achievement/' . $articleID,
         ];
         break;
 
@@ -126,7 +123,7 @@ switch ($articleTypeID)
             'All Games' => '/gameList.php',
             $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
             $gameData['Title'] => '/game/' . $gameData['ID'],
-            $pageTitle => '/leaderboard/' . $articleID
+            $pageTitle => '/leaderboard/' . $articleID,
         ];
         break;
 
@@ -138,7 +135,7 @@ switch ($articleTypeID)
         $navPath =
         [
             'All Users' => '/userList.php',
-            $pageTitle => '/user/' . $pageTitle
+            $pageTitle => '/user/' . $pageTitle,
         ];
         break;
 
@@ -154,7 +151,7 @@ switch ($articleTypeID)
         $navPath =
         [
             'All Users' => '/userList.php',
-            $pageTitle => '/user/' . $pageTitle
+            $pageTitle => '/user/' . $pageTitle,
         ];
         break;
 
@@ -167,13 +164,12 @@ switch ($articleTypeID)
         $navPath =
         [
             'Ticket Manager' => '/ticketmanager.php',
-            $articleID => '/ticketmanager.php?i=' . $articleID
+            $articleID => '/ticketmanager.php?i=' . $articleID,
         ];
         break;
 
     default:
         abort(404);
-        break;
 }
 
 RenderContentStart("$commentsLabel: $pageTitle");

--- a/public/comments.php
+++ b/public/comments.php
@@ -38,6 +38,25 @@ switch ($articleTypeID)
         ];
         break;
 
+    case ArticleType::GameHash:
+        if ($permissions < Permissions::Developer) {
+            abort(403);
+        }
+        $gameData = getGameData($articleID);
+        if ($gameData === null) {
+            abort(404);
+        }
+        $pageTitle = $gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')';
+        $commentsLabel = "Hash Comments";
+        $navPath =
+        [
+            'All Games' => '/gameList.php',
+            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
+            $gameData['Title'] => '/game/' . $gameData['ID'],
+            'Manage Hashes' => '/managehashes.php?g=' . $gameData['ID']
+        ];
+        break;
+
     case ArticleType::Achievement:
         $pageTitle = getAchievementTitle($articleID, $gameTitle, $gameID);
         if (empty($pageTitle)) {
@@ -87,7 +106,6 @@ switch ($articleTypeID)
         break;
 
     case ArticleType::UserModeration:
-        $commentsLabel = "Moderation Comments";
         if ($permissions < Permissions::Admin) {
             abort(403);
         }
@@ -95,6 +113,7 @@ switch ($articleTypeID)
         if (empty($pageTitle) || !getAccountDetails($pageTitle, $userData)) {
             abort(404);
         }
+        $commentsLabel = "Moderation Comments";
         $navPath =
         [
             'All Users' => '/userList.php',

--- a/public/comments.php
+++ b/public/comments.php
@@ -21,6 +21,7 @@ $count = 25;
 $commentData = [];
 $numArticleComments = getArticleComments($articleTypeID, $articleID, $offset, $count, $commentData);
 
+$commentsLabel = "Comments";
 switch ($articleTypeID)
 {
     case ArticleType::Game:
@@ -85,6 +86,22 @@ switch ($articleTypeID)
         ];
         break;
 
+    case ArticleType::UserModeration:
+        $commentsLabel = "Moderation Comments";
+        if ($permissions < Permissions::Admin) {
+            abort(403);
+        }
+        $pageTitle = getUserFromID($articleID);
+        if (empty($pageTitle) || !getAccountDetails($pageTitle, $userData)) {
+            abort(404);
+        }
+        $navPath =
+        [
+            'All Users' => '/userList.php',
+            $pageTitle => '/user/' . $pageTitle
+        ];
+        break;
+
     case ArticleType::AchievementTicket:
         $ticket = getTicket($articleID);
         if ($ticket == null) {
@@ -103,11 +120,7 @@ switch ($articleTypeID)
         break;
 }
 
-//if ($permissions < $topicData['RequiredPermissions']) {
-//    abort(403);
-//}
-
-RenderContentStart("Comments: $pageTitle");
+RenderContentStart("$commentsLabel: $pageTitle");
 ?>
 <div id="mainpage">
     <div id="fullcontainer">
@@ -116,7 +129,7 @@ RenderContentStart("Comments: $pageTitle");
             foreach ($navPath as $text => $link) {
                 echo "<a href='$link'>$text</a> &raquo; ";
             }
-            echo "<b>Comments</b></div>";
+            echo "<b>$commentsLabel</b></div>";
 
             echo "<h2>$pageTitle</h2>";
 

--- a/public/comments.php
+++ b/public/comments.php
@@ -57,6 +57,25 @@ switch ($articleTypeID)
         ];
         break;
 
+    case ArticleType::SetClaim:
+        if ($permissions < Permissions::Admin) {
+            abort(403);
+        }
+        $gameData = getGameData($articleID);
+        if ($gameData === null) {
+            abort(404);
+        }
+        $pageTitle = $gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')';
+        $commentsLabel = "Claim Comments";
+        $navPath =
+        [
+            'All Games' => '/gameList.php',
+            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
+            $gameData['Title'] => '/game/' . $gameData['ID'],
+            'Manage Claims' => '/manageclaims.php?g=' . $gameData['ID']
+        ];
+        break;
+
     case ArticleType::Achievement:
         $pageTitle = getAchievementTitle($articleID, $gameTitle, $gameID);
         if (empty($pageTitle)) {

--- a/public/comments.php
+++ b/public/comments.php
@@ -55,6 +55,24 @@ switch ($articleTypeID)
         ];
         break;
 
+    case ArticleType::Leaderboard:
+        $pageTitle = getleaderboardTitle($articleID, $gameID);
+        if (empty($pageTitle)) {
+            abort(404);
+        }
+        $gameData = getGameData($gameID);
+        if ($gameData === null) {
+            abort(404);
+        }
+        $navPath =
+        [
+            'All Games' => '/gameList.php',
+            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
+            $gameData['Title'] => '/game/' . $gameData['ID'],
+            $pageTitle => '/leaderboard/' . $articleID
+        ];
+        break;
+
     case ArticleType::User:
         $pageTitle = getUserFromID($articleID);
         if (empty($pageTitle) || !getAccountDetails($pageTitle, $userData)) {

--- a/public/comments.php
+++ b/public/comments.php
@@ -55,6 +55,18 @@ switch ($articleTypeID)
         ];
         break;
 
+    case ArticleType::User:
+        $pageTitle = getUserFromID($articleID);
+        if (empty($pageTitle) || !getAccountDetails($pageTitle, $userData)) {
+            abort(404);
+        }
+        $navPath =
+        [
+            'All Users' => '/userList.php',
+            $pageTitle => '/user/' . $pageTitle
+        ];
+        break;
+
     default:
         abort(404);
         break;

--- a/public/comments.php
+++ b/public/comments.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Support\Shortcode\Shortcode;
+use RA\ArticleType;
+use RA\Permissions;
+use RA\SubscriptionSubjectType;
+use RA\UserAction;
+
+authenticateFromCookie($user, $permissions, $userDetails);
+
+$articleTypeID = requestInputSanitized('t', 0, 'integer');
+$articleID = requestInputSanitized('i', 0, 'integer');
+
+if ($articleID == 0 || !ArticleType::isValid($articleTypeID)) {
+    abort(404);
+}
+
+$offset = requestInputSanitized('o', 0, 'integer');
+$count = 25;
+
+$commentData = [];
+$numArticleComments = getArticleComments($articleTypeID, $articleID, $offset, $count, $commentData);
+
+switch ($articleTypeID)
+{
+    case ArticleType::Game:
+        $gameData = getGameData($articleID);
+        if ($gameData === null) {
+            abort(404);
+        }
+        $pageTitle = $gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')';
+        $navPath =
+        [
+            'All Games' => '/gameList.php',
+            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
+            $gameData['Title'] => '/game/' . $gameData['ID']
+        ];
+        break;
+
+    default:
+        abort(404);
+        break;
+}
+
+//if ($permissions < $topicData['RequiredPermissions']) {
+//    abort(403);
+//}
+
+RenderContentStart("Comments: $pageTitle");
+?>
+<div id="mainpage">
+    <div id="fullcontainer">
+        <?php
+            echo "<div class='navpath'>";
+            foreach ($navPath as $text => $link) {
+                echo "<a href='$link'>$text</a> &raquo; ";
+            }
+            echo "<b>Comments</b></div>";
+
+            echo "<h2>$pageTitle</h2>";
+
+            RenderCommentsComponent($user, $numArticleComments, $commentData, $articleID, $articleTypeID, $permissions, $count, $offset, embedded: false);
+        ?>
+        <br>
+        <div class='flex justify-between mb-3'><div>
+        <?php
+            if ($numArticleComments > count($commentData)) {
+                RenderPaginator($numArticleComments, $count, $offset, "/comments.php?t=$articleTypeID&i=$articleID&o=");
+            }
+        ?>
+        </div></div>
+    </div>
+</div>
+<?php RenderContentEnd(); ?>

--- a/public/comments.php
+++ b/public/comments.php
@@ -57,6 +57,24 @@ switch ($articleTypeID)
         ];
         break;
 
+    case ArticleType::GameModification:
+        if ($permissions < Permissions::JuniorDeveloper) {
+            abort(403);
+        }
+        $gameData = getGameData($articleID);
+        if ($gameData === null) {
+            abort(404);
+        }
+        $pageTitle = $gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')';
+        $commentsLabel = "Modifications";
+        $navPath =
+        [
+            'All Games' => '/gameList.php',
+            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
+            $gameData['Title'] => '/game/' . $gameData['ID']
+        ];
+        break;
+
     case ArticleType::SetClaim:
         if ($permissions < Permissions::Admin) {
             abort(403);
@@ -169,7 +187,7 @@ RenderContentStart("$commentsLabel: $pageTitle");
             }
             echo "<b>$commentsLabel</b></div>";
 
-            echo "<h2>$pageTitle</h2>";
+            echo "<h3>$pageTitle</h3>";
 
             RenderCommentsComponent($user, $numArticleComments, $commentData, $articleID, $articleTypeID, $permissions, $count, $offset, embedded: false);
         ?>

--- a/public/comments.php
+++ b/public/comments.php
@@ -37,6 +37,24 @@ switch ($articleTypeID)
         ];
         break;
 
+    case ArticleType::Achievement:
+        $pageTitle = getAchievementTitle($articleID, $gameTitle, $gameID);
+        if (empty($pageTitle)) {
+            abort(404);
+        }
+        $gameData = getGameData($gameID);
+        if ($gameData === null) {
+            abort(404);
+        }
+        $navPath =
+        [
+            'All Games' => '/gameList.php',
+            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
+            $gameData['Title'] => '/game/' . $gameData['ID'],
+            $pageTitle => '/achievement/' . $articleID
+        ];
+        break;
+
     default:
         abort(404);
         break;

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -153,7 +153,7 @@ if ($isFullyFeaturedGame) {
     $achDist = getAchievementDistribution($gameID, 0, $user, $flags, $numAchievements);
     $achDistHardcore = getAchievementDistribution($gameID, 1, $user, $flags, $numAchievements);
 
-    $numArticleComments = getArticleComments(ArticleType::Game, $gameID, 0, 20, $commentData);
+    $numArticleComments = getRecentArticleComments(ArticleType::Game, $gameID, $commentData);
 
     $numLeaderboards = getLeaderboardsForGame($gameID, $lbData, $user);
 

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -940,7 +940,7 @@ sanitize_outputs(
                     }
                 }
 
-                $numModificationComments = getArticleComments(ArticleType::GameModification, $gameID, 0, 1000, $modificationCommentData);
+                $numModificationComments = getRecentArticleComments(ArticleType::GameModification, $gameID, $modificationCommentData);
                 RenderCommentsComponent(null, $numModificationComments, $modificationCommentData, $gameID, ArticleType::GameModification, $permissions);
 
                 echo "</div>"; // devboxcontent

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -449,6 +449,7 @@ function ReloadLBPageByGame() {
 <?php
 if (!empty($codeNotes) && $permissions >= Permissions::JuniorDeveloper) {
     echo "<div id='rightcontainer'>";
+    echo "<h3>Code Notes</h3>";
     RenderCodeNotes($codeNotes);
     echo "</div>";
 }

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -43,7 +43,7 @@ $forumTopicID = $lbData['ForumTopicID'];
 $pageTitle = "Leaderboard: $lbTitle ($gameTitle)";
 
 $numLeaderboards = getLeaderboardsForGame($gameID, $allGameLBData, $user);
-$numArticleComments = getArticleComments(ArticleType::Leaderboard, $lbID, 0, 20, $commentData);
+$numArticleComments = getRecentArticleComments(ArticleType::Leaderboard, $lbID, $commentData);
 
 function ExplainLeaderboardTrigger(string $name, string $triggerDef, array $codeNotes): void
 {
@@ -84,20 +84,29 @@ RenderContentStart('Leaderboard');
             echo "<a href='/gameList.php'>All Games</a>";
             echo " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
             echo " &raquo; <a href='/game/$gameID'>$gameTitle</a></b>";
-            echo " &raquo; <b>Leaderboard</b>";
+            echo " &raquo; <b>$lbTitle</b>";
             echo "</div>";
 
-            echo "<div style='float:left; padding: 4px;'>";
-            echo gameAvatar($lbData, label: false, iconSize: 96);
+            echo "<h3>$gameTitle ($consoleName)</h3>";
 
-            echo "</div>";
+            echo "<table class='nicebox'><tbody>";
+
+            echo "<tr>";
+            echo "<td style='width:70px'>";
+            echo gameAvatar($lbData, label: false, iconSize: 64);
+            echo "</td>";
+
+            echo "<td>";
+            echo "<div class='flex justify-between'>";
             echo "<div>";
-            echo "<h3>$pageTitle</h3>";
+            echo "<a href='/leaderboard/$lbID'><strong>$lbTitle</strong></a><br>";
+            echo "$lbDescription";
             echo "</div>";
+            echo "</div>";
+            echo "</td>";
 
-            echo "<br>";
-            echo "<br>";
-            echo "<br>";
+            echo "</tr>";
+            echo "</tbody></table>";
 
             $niceDateCreated = date("d M, Y H:i", strtotime($lbCreated));
             $niceDateModified = date("d M, Y H:i", strtotime($lbUpdated));

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -23,8 +23,14 @@ RenderContentStart("Linked Hashes");
 ?>
 <div id="mainpage">
     <div id='fullcontainer'>
+        <div class='navpath'>
+            <a href='/gameList.php'>All Games</a>
+            &raquo; <a href='/gameList.php?c=<?= $consoleID ?>'><?= $consoleName ?></a>
+            &raquo; <a href='/game/<?= $gameID ?>'><?= $gameTitle ?></a>
+            &raquo; <b>Linked Hashes</b>
+        </div>
 
-        <h2>List of Linked Hashes</h2>
+        <h3>List of Linked Hashes</h3>
 
         <?php
         echo gameAvatar($gameData, iconSize: 64);

--- a/public/manageclaims.php
+++ b/public/manageclaims.php
@@ -122,6 +122,13 @@ RenderContentStart("Manage Claims");
 </script>
 <div id='mainpage'>
     <div id='fullcontainer'>
+        <div class='navpath'>
+            <a href='/gameList.php'>All Games</a>
+            &raquo; <a href='/gameList.php?c=<?= $gameData['ConsoleID'] ?>'><?= $gameData['ConsoleName'] ?></a>
+            &raquo; <a href='/game/<?= $gameID ?>'><?= $gameTitle ?></a>
+            &raquo; <b>Manage Claims</b>
+        </div>
+
         <?php
         echo "<h3>Manage Claims</h3>";
         echo gameAvatar($gameData, iconSize: 64);
@@ -234,7 +241,7 @@ RenderContentStart("Manage Claims");
         }
         echo "</tbody></table></div>";
 
-        $numLogs = getArticleComments(ArticleType::SetClaim, $gameID, 0, 1000, $logs);
+        $numLogs = getRecentArticleComments(ArticleType::SetClaim, $gameID, $logs);
         RenderCommentsComponent($user,
             $numLogs,
             $logs,

--- a/public/managehashes.php
+++ b/public/managehashes.php
@@ -79,14 +79,21 @@ function UnlinkHash(user, gameID, hash, elem) {
 </script>
 <div id="mainpage">
     <div id="fullcontainer">
-        <h2>Manage Hashes</h2>
+        <div class='navpath'>
+            <a href='/gameList.php'>All Games</a>
+            &raquo; <a href='/gameList.php?c=<?= $consoleID ?>'><?= $consoleName ?></a>
+            &raquo; <a href='/game/<?= $gameID ?>'><?= $gameTitle ?></a>
+            &raquo; <b>Manage Hashes</b>
+        </div>
+
+        <h3>Manage Hashes</h3>
 
         <?php
         echo gameAvatar($gameData, iconSize: 64);
 
         echo "<br><div class='text-danger'><b>Warning:</b> PLEASE be careful with this tool. If in doubt, <a href='/createmessage.php?t=RAdmin&s=Attempt to Unlink $gameTitle'>leave a message for admins</a> and they'll help sort it.</div>";
 
-        echo "<div id='hashCount'>Currently this game has <b>$numLinks</b> unique hashes registered for it:</div><br>";
+        echo "<br/><div id='hashCount'>Currently this game has <b>$numLinks</b> unique hashes registered for it:</div>";
 
         echo "<div class='table-wrapper'><table id='hashTable'><tbody>";
         echo "<th>RetroAchievements Hash</th><th>Linked By</th><th>Description</th><th>Labels</th><th>Actions</th><th></th>\n";
@@ -112,7 +119,7 @@ function UnlinkHash(user, gameID, hash, elem) {
         }
 
         echo "</tbody></table><br><br>";
-        $numLogs = getArticleComments(ArticleType::GameHash, $gameID, 0, 1000, $logs);
+        $numLogs = getRecentArticleComments(ArticleType::GameHash, $gameID, $logs);
         RenderCommentsComponent($user,
             $numLogs,
             $logs,

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -35,7 +35,7 @@ if ($ticketID != 0) {
         $ticketID = 0;
     }
 
-    $numArticleComments = getArticleComments(ArticleType::AchievementTicket, $ticketID, 0, 20, $commentData);
+    $numArticleComments = getRecentArticleComments(ArticleType::AchievementTicket, $ticketID, $commentData);
 
     // sets all filters enabled so we get closed/resolved tickets as well
     $altTicketData = getAllTickets(0, 99, null, null, null, null, $ticketData['AchievementID'], TicketFilters::All);

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -477,7 +477,7 @@ RenderContentStart($userPage);
 
             echo "<tr><td colspan=2>";
             echo "<div class='commentscomponent left'>";
-            $numLogs = getArticleComments(ArticleType::UserModeration, $userPageID, 0, 1000, $logs);
+            $numLogs = getRecentArticleComments(ArticleType::UserModeration, $userPageID, $logs);
             RenderCommentsComponent($user,
                 $numLogs,
                 $logs,

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -33,7 +33,7 @@ $userWallActive = $userMassData['UserWallActive'];
 $userIsUntracked = $userMassData['Untracked'];
 
 // Get wall
-$numArticleComments = getArticleComments(ArticleType::User, $userPageID, 0, 100, $commentData);
+$numArticleComments = getRecentArticleComments(ArticleType::User, $userPageID, $commentData);
 
 // Get user's feed
 // $numFeedItems = getFeed( $userPage, 20, 0, $feedData, 0, 'individual' );


### PR DESCRIPTION
Implements #1056 

If a comment block has more than 20 items, the "Comments:" header will change to "Recent Comments (All XXX)" where the XXX is the total number of comments and the "All XXX" is a link to a paginated view of the comments.

![image](https://user-images.githubusercontent.com/32680403/205509673-d8c9f80c-f564-464b-92e8-8617c9c6c001.png)

![image](https://user-images.githubusercontent.com/32680403/205509689-013fbf28-985d-4db3-9580-3b5c65c18d37.png)

Also added nav bars to code notes, linked hashes, and manage claims pages.