### PR TITLE
split comment search type into subtypes

### DIFF
--- a/lib/database/search.php
+++ b/lib/database/search.php
@@ -1,16 +1,36 @@
 <?php
 
+use RA\ArticleType;
+use RA\Permissions;
 use RA\SearchType;
+
+function canSearch(int $searchType, int $permissions): bool {
+    switch ($searchType) {
+        case SearchType::UserModerationComment:
+        case SearchType::SetClaimComment:
+            return $permissions >= Permissions::Admin;
+
+        case SearchType::GameHashComment:
+            return $permissions >= Permissions::Developer;
+
+        default:
+            return true;
+    }
+}
 
 function performSearch(int $searchType, string $searchQuery, int $offset, int $count,
     int $permissions, array &$searchResultsOut): int
 {
     sanitize_sql_inputs($searchQuery, $offset, $count);
 
+    if (!canSearch($searchType, $permissions)) {
+        return 0;
+    }
+
     $parts = [];
     if ($searchType == SearchType::Game || $searchType == SearchType::All) {
         $parts[] = "(
-        SELECT 'Game' AS Type, gd.ID, CONCAT( '/game/', gd.ID ) AS Target, CONCAT(gd.Title, ' (', c.Name, ')') as Title FROM GameData AS gd
+        SELECT " . SearchType::Game . " AS Type, gd.ID, CONCAT( '/game/', gd.ID ) AS Target, CONCAT(gd.Title, ' (', c.Name, ')') as Title FROM GameData AS gd
         LEFT JOIN Achievements AS ach ON ach.GameID = gd.ID AND ach.Flags = 3
         LEFT JOIN Console AS c ON gd.ConsoleID = c.ID
         WHERE gd.Title LIKE '%$searchQuery%'
@@ -20,13 +40,13 @@ function performSearch(int $searchType, string $searchQuery, int $offset, int $c
 
     if ($searchType == SearchType::Achievement || $searchType == SearchType::All) {
         $parts[] = "(
-        SELECT 'Achievement' AS Type, ach.ID, CONCAT( '/achievement/', ach.ID ) AS Target, ach.Title FROM Achievements AS ach
+        SELECT " . SearchType::Achievement . " AS Type, ach.ID, CONCAT( '/achievement/', ach.ID ) AS Target, ach.Title FROM Achievements AS ach
         WHERE ach.Flags = 3 AND ach.Title LIKE '%$searchQuery%' ORDER BY ach.Title)";
     }
 
     if ($searchType == SearchType::User || $searchType == SearchType::All) {
         $parts[] = "(
-        SELECT 'User' AS Type,
+        SELECT " . SearchType::User . " AS Type,
         ua.User AS ID,
         CONCAT( '/user/', ua.User ) AS Target,
         ua.User AS Title
@@ -37,7 +57,7 @@ function performSearch(int $searchType, string $searchQuery, int $offset, int $c
 
     if ($searchType == SearchType::Forum || $searchType == SearchType::All) {
         $parts[] = "(
-        SELECT 'Forum Comment' AS Type,
+        SELECT " . SearchType::Forum . " AS Type,
         ua.User AS ID,
         CONCAT( '/viewtopic.php?t=', ftc.ForumTopicID, '&c=', ftc.ID, '#', ftc.ID ) AS Target,
         CASE WHEN CHAR_LENGTH(ftc.Payload) <= 64 THEN ftc.Payload ELSE
@@ -51,35 +71,86 @@ function performSearch(int $searchType, string $searchQuery, int $offset, int $c
         ORDER BY DateModified DESC)";
     }
 
-    if ($searchType == SearchType::Comment || $searchType == SearchType::All) {
+    $articleTypes = [];
+
+    if ($searchType == SearchType::GameComment || $searchType == SearchType::All) {
+        $articleTypes[] = ArticleType::Game;
+    }
+
+    if ($searchType == SearchType::AchievementComment || $searchType == SearchType::All) {
+        $articleTypes[] = ArticleType::Achievement;
+    }
+
+    if ($searchType == SearchType::LeaderboardComment || $searchType == SearchType::All) {
+        $articleTypes[] = ArticleType::Leaderboard;
+    }
+
+    if ($searchType == SearchType::TicketComment || $searchType == SearchType::All) {
+        $articleTypes[] = ArticleType::AchievementTicket;
+    }
+
+    if ($searchType == SearchType::UserComment || $searchType == SearchType::All) {
+        $articleTypes[] = ArticleType::User;
+    }
+
+    if ($searchType == SearchType::UserModerationComment || $searchType == SearchType::All) {
+        if (canSearch(SearchType::UserModerationComment, $permissions)) {
+            $articleTypes[] = ArticleType::UserModeration;
+        }
+    }
+
+    if ($searchType == SearchType::GameHashComment || $searchType == SearchType::All) {
+        if (canSearch(SearchType::GameHashComment, $permissions)) {
+            $articleTypes[] = ArticleType::GameHash;
+        }
+    }
+
+    if ($searchType == SearchType::SetClaimComment || $searchType == SearchType::All) {
+        if (canSearch(SearchType::SetClaimComment, $permissions)) {
+            $articleTypes[] = ArticleType::SetClaim;
+        }
+    }
+
+    if (count($articleTypes) > 0) {
         $parts[] = "(
-        SELECT 'Comment' AS Type, cua.User AS ID,
-
-        CASE
-            WHEN c.articletype=1 THEN CONCAT( '/game/', c.ArticleID )
-            WHEN c.articletype=2 THEN CONCAT( '/achievement/', c.ArticleID )
-            WHEN c.articletype=3 THEN CONCAT( '/user/', ua.User )
-            WHEN c.articletype=5 THEN CONCAT( '/feed.php?a=', c.ArticleID )
-            WHEN c.articletype=7 THEN CONCAT( '/ticketmanager.php?i=', c.ArticleID )
-            ELSE CONCAT( c.articletype, '/', c.ArticleID )
-        END
-        AS Target,
-
-        CASE WHEN CHAR_LENGTH(c.Payload) <= 64 THEN c.Payload ELSE
-        CONCAT( '...', MID( c.Payload, GREATEST( LOCATE('$searchQuery', c.Payload)-25, 1), 60 ), '...' ) END AS Title
-
-        FROM Comment AS c
-        LEFT JOIN UserAccounts AS ua ON ( ua.ID = c.ArticleID )
-        LEFT JOIN UserAccounts AS cua ON cua.ID = c.UserID
-        WHERE c.Payload LIKE '%$searchQuery%'
-        AND cua.User != 'Server'
-        AND ua.UserWallActive AND ua.Deleted IS NULL
-        AND c.articletype IN (1,2,3,5,7)
-        ORDER BY c.Submitted DESC)";
+            SELECT CASE
+                WHEN c.articletype=" . ArticleType::Game . " THEN " . SearchType::GameComment . "
+                WHEN c.articletype=" . ArticleType::Achievement . " THEN " . SearchType::AchievementComment . "
+                WHEN c.articletype=" . ArticleType::Leaderboard . " THEN " . SearchType::LeaderboardComment . "
+                WHEN c.articletype=" . ArticleType::AchievementTicket . " THEN " . SearchType::TicketComment . "
+                WHEN c.articletype=" . ArticleType::User . " THEN " . SearchType::UserComment . "
+                WHEN c.articletype=" . ArticleType::UserModeration . " THEN " . SearchType::UserModerationComment . "
+                WHEN c.articletype=" . ArticleType::GameHash . " THEN " . SearchType::GameHashComment . "
+                WHEN c.articletype=" . ArticleType::SetClaim . " THEN " . SearchType::SetClaimComment . "
+                ELSE 9999
+            END AS Type,
+            cua.User AS ID,
+            CASE
+                WHEN c.articletype=" . ArticleType::Game . " THEN CONCAT('/game/', c.ArticleID)
+                WHEN c.articletype=" . ArticleType::Achievement . " THEN CONCAT('/achievement/', c.ArticleID)
+                WHEN c.articletype=" . ArticleType::Leaderboard . " THEN CONCAT('/leaderboardinfo.php?i=', c.ArticleID)
+                WHEN c.articletype=" . ArticleType::AchievementTicket . " THEN CONCAT('/ticketmanager.php?i=', c.ArticleID)
+                WHEN c.articletype=" . ArticleType::User . " THEN CONCAT('/user/', ua.User)
+                WHEN c.articletype=" . ArticleType::UserModeration . " THEN CONCAT('/user/', ua.User)
+                WHEN c.articletype=" . ArticleType::GameHash . " THEN CONCAT('/managehashes.php?g=', c.ArticleID)
+                WHEN c.articletype=" . ArticleType::SetClaim . " THEN CONCAT('/manageclaims.php?g=', c.ArticleID)
+                ELSE CONCAT(c.articletype, '/', c.ArticleID)
+            END AS Target,
+            CASE
+                WHEN CHAR_LENGTH(c.Payload) <= 64 THEN c.Payload
+                ELSE CONCAT( '...', MID( c.Payload, GREATEST( LOCATE('$searchQuery', c.Payload)-25, 1), 60 ), '...' )
+            END AS Title
+            FROM Comment AS c
+            LEFT JOIN UserAccounts AS cua ON cua.ID=c.UserID
+            LEFT JOIN UserAccounts AS ua ON ua.ID=c.ArticleID AND c.articletype=" . ArticleType::User . "
+            WHERE c.Payload LIKE '%$searchQuery%'
+            AND cua.User != 'Server' AND c.articletype IN (" . implode(',', $articleTypes) . ")
+            AND ua.Deleted IS NULL AND (ua.UserWallActive OR ua.UserWallActive IS NULL)
+            ORDER BY c.articletype, c.Submitted DESC)";
     }
 
     $query = "SELECT SQL_CALC_FOUND_ROWS * FROM (" .
-        implode(' UNION ALL ', $parts) . ") AS results LIMIT $offset, $count";
+        implode(' UNION ALL ', $parts) . ") AS results ORDER BY Type LIMIT $offset, $count";
 
     $dbResult = s_mysql_sanitized_query($query);
     if (!$dbResult) {

--- a/public/request/search.php
+++ b/public/request/search.php
@@ -41,9 +41,7 @@ $dataOut = [];
 foreach ($results as $nextRow) {
     $dataOut[] = [
         'label' => $nextRow['Title'] ?? null,
-        'id' => $nextRow['ID'] ?? null,
         'mylink' => $nextRow['Target'] ?? null,
-        'category' => $nextRow['Type'],
     ];
 }
 

--- a/src/SearchType.php
+++ b/src/SearchType.php
@@ -14,17 +14,40 @@ abstract class SearchType
 
     public const Forum = 4;
 
-    public const Comment = 5;
+    public const GameComment = 5;
+
+    public const AchievementComment = 6;
+
+    public const LeaderboardComment = 7;
+
+    public const UserComment = 8;
+
+    public const TicketComment = 9;
+
+    public const GameHashComment = 10;
+
+    public const SetClaimComment = 11;
+
+    public const UserModerationComment = 12;
 
     public static function cases(): array
     {
+        // NOTE: this order determines the order of the items in the 'search in' dropdown
+        //       the actual numerical order determines the order of the results
         return [
             self::All,
             self::Game,
             self::Achievement,
             self::User,
             self::Forum,
-            self::Comment,
+            self::GameComment,
+            self::AchievementComment,
+            self::LeaderboardComment,
+            self::UserComment,
+            self::TicketComment,
+            self::GameHashComment,
+            self::SetClaimComment,
+            self::UserModerationComment,
         ];
     }
 
@@ -41,7 +64,14 @@ abstract class SearchType
             SearchType::Achievement => "Achievements",
             SearchType::User => "Users",
             SearchType::Forum => "Forums",
-            SearchType::Comment => "Comments",
+            SearchType::GameComment => "Game Comments",
+            SearchType::AchievementComment => "Achievement Comments",
+            SearchType::LeaderboardComment => "Leaderboard Comments",
+            SearchType::TicketComment => "Ticket Comments",
+            SearchType::UserComment => "User Wall Comments",
+            SearchType::UserModerationComment => "User Moderation Comments",
+            SearchType::GameHashComment => "Game Hash Comments",
+            SearchType::SetClaimComment => "Set Claim Comments",
             default => "Invalid search type",
         };
     }


### PR DESCRIPTION
implements #1252 

comments as a searchable subtype has been replaced with all of the relevant comment types (filtered by permission level):

![image](https://user-images.githubusercontent.com/32680403/205528120-4b556d81-d699-4eaa-9752-65e813275bb9.png)
![image](https://user-images.githubusercontent.com/32680403/205528123-a9201801-13fc-4b31-aee7-f6e17687c70e.png)

![image](https://user-images.githubusercontent.com/32680403/205528136-6f460742-480c-4b4c-b15b-9e3abf78734a.png)
