### PR TITLE
only fetch tooltip if hovering

### DIFF
--- a/lib/render/avatar.php
+++ b/lib/render/avatar.php
@@ -25,7 +25,7 @@ function avatar(
 
     $tooltipTrigger = '';
     if ($tooltip) {
-        $tooltipTrigger = "onmouseover=\"Tip(loadCard('$resource', '$id', '$context'))\" onmouseout=\"UnTip()\"";
+        $tooltipTrigger = "onmouseover=\"Tip(loadCard(this, '$resource', '$id', '$context'))\" onmouseout=\"UnTip()\"";
         if (is_string($tooltip)) {
             $escapedTooltip = tooltipEscape($tooltip);
             $tooltipTrigger = "onmouseover=\"Tip(useCard('$resource', '$id', '$context', '$escapedTooltip'))\" onmouseout=\"UnTip()\"";

--- a/public/js/activePlayersBootstrap.js
+++ b/public/js/activePlayersBootstrap.js
@@ -1,6 +1,6 @@
 function CreateCardIconDiv(type, id, title, icon, url) {
   return '<div class=\'inline\' '
-    + 'onmouseover="Tip(loadCard(\'' + type + '\', \'' + id + '\'))" onmouseout="UnTip()" >'
+    + 'onmouseover="Tip(loadCard(this, \'' + type + '\', \'' + id + '\'))" onmouseout="UnTip()" >'
     + '<a href=\'' + url + '\'>'
     + '<img src=\'' + mediaAsset(icon) + '\' width=\'32\' height=\'32\' '
     + ' alt="' + title + '" title="' + title + '" class=\'badgeimg\' loading=\'lazy\' />'

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -139,7 +139,7 @@ function useCard(type, id, context = null, html = '') {
   return html;
 }
 
-function loadCard(owner, type, id, context = null) {
+function loadCard(target, type, id, context = null) {
   var cardId = `tooltip_card_${type}_${id}`;
 
   if (context) {
@@ -152,7 +152,7 @@ function loadCard(owner, type, id, context = null) {
 
   // delay requesting the tooltip for 200ms in case the mouse is just passing over the avatar
   timeoutObject = setTimeout(function () {
-    $(owner).off('mouseleave');
+    $(target).off('mouseleave');
     $.post('/request/card.php', {
       type: type,
       id: id,
@@ -163,8 +163,8 @@ function loadCard(owner, type, id, context = null) {
         $(`#${cardId}_yield`).html(data.html);
       });
   }, 200);
-  $(owner).mouseleave(function () {
-    $(owner).off('mouseleave');
+  $(target).mouseleave(function () {
+    $(target).off('mouseleave');
     clearTimeout(timeoutObject);
   });
 

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -139,7 +139,7 @@ function useCard(type, id, context = null, html = '') {
   return html;
 }
 
-function loadCard(type, id, context = null) {
+function loadCard(owner, type, id, context = null) {
   var cardId = `tooltip_card_${type}_${id}`;
 
   if (context) {
@@ -150,23 +150,29 @@ function loadCard(type, id, context = null) {
     return cardsCache[cardId];
   }
 
-  cardsCache[cardId] = `<div id="${cardId}_yield">
+  // delay requesting the tooltip for 200ms in case the mouse is just passing over the avatar
+  timeoutObject = setTimeout(function () {
+    $(owner).off('mouseleave');
+    $.post('/request/card.php', {
+      type: type,
+      id: id,
+      context: context,
+    })
+      .done(function (data) {
+        cardsCache[cardId] = data.html;
+        $(`#${cardId}_yield`).html(data.html);
+      });
+  }, 200);
+  $(owner).mouseleave(function () {
+    $(owner).off('mouseleave');
+    clearTimeout(timeoutObject);
+  });
+
+  return `<div id="${cardId}_yield">
     <div class="flex justify-center items-center" style="width: 30px; height: 30px">
         <img class="m-5" src="${asset('assets/images/icon/loading.gif')}" alt="Loading">
     </div>
   </div>`;
-
-  $.post('/request/card.php', {
-    type: type,
-    id: id,
-    context: context,
-  })
-    .done(function (data) {
-      cardsCache[cardId] = data.html;
-      $(`#${cardId}_yield`).html(data.html);
-    });
-
-  return cardsCache[cardId];
 }
 
 function UpdateMailboxCount(messageCount) {


### PR DESCRIPTION
Requires the cursor to be over a image/link for 200ms before fetching the tooltip.

Should minimize the occurrences of the 429 error when scrolling through a page or just moving the cursor around.