### PR TITLE
Set up rate limits

### DIFF
--- a/app/Api/RouteServiceProvider.php
+++ b/app/Api/RouteServiceProvider.php
@@ -8,7 +8,10 @@ use App\Api\Controllers\WebApiController;
 use App\Api\Controllers\WebApiV1Controller;
 use App\Api\Middleware\LogApiUsage;
 use App\Support\Http\HandlesPublicFileRequests;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
@@ -22,8 +25,7 @@ class RouteServiceProvider extends ServiceProvider
 
     protected function configureRateLimiting(): void
     {
-        // TODO setup rate limiting
-        // RateLimiter::for('api', fn (Request $request) => Limit::perMinute(120)->by($request->user()?->ID ?: $request->ip()));
+        RateLimiter::for('api', fn (Request $request) => Limit::perMinute(120)->by($request->user()?->ID ?: $request->ip()));
     }
 
     public function map(): void

--- a/app/Connect/RouteServiceProvider.php
+++ b/app/Connect/RouteServiceProvider.php
@@ -6,7 +6,10 @@ namespace App\Connect;
 
 use App\Connect\Controllers\ConnectApiController;
 use App\Support\Http\HandlesPublicFileRequests;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
@@ -20,8 +23,7 @@ class RouteServiceProvider extends ServiceProvider
 
     protected function configureRateLimiting(): void
     {
-        // TODO setup rate limiting
-        // RateLimiter::for('connect', fn (Request $request) => Limit::perMinute(90)->by($request->user()?->ID ?: $request->ip()));
+        RateLimiter::for('connect', fn (Request $request) => Limit::perMinute(90)->by($request->user()?->ID ?: $request->ip()));
     }
 
     public function map(): void

--- a/app/Site/RouteServiceProvider.php
+++ b/app/Site/RouteServiceProvider.php
@@ -9,7 +9,10 @@ use App\Site\Controllers\HomeController;
 use App\Site\Controllers\RedirectController;
 use App\Site\Controllers\UserController;
 use App\Support\Http\HandlesPublicFileRequests;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Laravel\Octane\Facades\Octane;
 
@@ -51,8 +54,7 @@ class RouteServiceProvider extends ServiceProvider
 
     protected function configureRateLimiting(): void
     {
-        // TODO setup rate limiting
-        // RateLimiter::for('web', fn (Request $request) => Limit::perMinute(90)->by($request->user()?->ID ?: $request->ip()));
+        RateLimiter::for('web', fn (Request $request) => Limit::perMinute(90)->by($request->user()?->ID ?: $request->ip()));
     }
 
     public function map(): void


### PR DESCRIPTION
Fix #1227
Fix #1055

Allow to control rate limits in the application' route service providers.

Requires some additional adjustments in the webserver configuration.