### PR TITLE
add TicketFilters::EmulatorOther

### DIFF
--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -285,6 +285,7 @@ RenderContentStart($pageTitle);
                 echo $linkFilter('RA Emulator', TicketFilters::EmulatorRA) . ' | ';
                 echo $linkFilter('RetroArch - Core Specified', TicketFilters::EmulatorRetroArchCoreSpecified) . ' | ';
                 echo $linkFilter('RetroArch - Core Not Specified', TicketFilters::EmulatorRetroArchCoreNotSpecified) . ' | ';
+                echo $linkFilter('Other', TicketFilters::EmulatorOther) . ' | ';
                 echo $linkFilter('Unknown', TicketFilters::EmulatorUnknown);
                 echo "</div>";
 

--- a/src/TicketFilters.php
+++ b/src/TicketFilters.php
@@ -42,8 +42,10 @@ abstract class TicketFilters
 
     public const StateRequest = 1 << 18;
 
+    public const EmulatorOther = 1 << 19;
+
     // This should updated every time a new filter is added so it has all possible filter bits set
-    public const AllFilters = (1 << 19) - 1;
+    public const AllFilters = (1 << 20) - 1;
 
     // All filter is everything except Not Author (Not Author filter excludes items)
     public const All = self::AllFilters & ~self::ResolvedByNonAuthor;


### PR DESCRIPTION
Separates tickets that don't specify an emulator (most likely submitted from the standalones) from those associated to emulators that aren't `RA*` or `RetroArch`.

Previously everything that wasn't `RA*` or `RetroArch` was tossed into the Unknown bucket. Now Unknown only matches those items where an emulator is not specified.