### PR TITLE
Change way of breaking text in forum post content preview

### DIFF
--- a/lib/render/forum.php
+++ b/lib/render/forum.php
@@ -38,7 +38,7 @@ function RenderRecentForumPostsComponent($permissions, $numToFetch = 4): void
             echo userAvatar($author, iconSize: 16);
             echo " <span class='smalldate'>$datePosted $postedAt</span><br>";
             echo "in <a href='/viewtopic.php?t=$forumTopicID&amp;c=$commentID#$commentID'>$forumTopicTitle</a><br>";
-            echo "<div class='comment break-all'>$shortMsg</div>";
+            echo "<div class='comment text-overflow-wrap'>$shortMsg</div>";
             echo "</div>";
             echo "<a class='btn btn-link' href='/viewtopic.php?t=$forumTopicID&amp;c=$commentID#$commentID'>View</a>";
             echo "</div>";

--- a/lib/render/forum.php
+++ b/lib/render/forum.php
@@ -38,7 +38,7 @@ function RenderRecentForumPostsComponent($permissions, $numToFetch = 4): void
             echo userAvatar($author, iconSize: 16);
             echo " <span class='smalldate'>$datePosted $postedAt</span><br>";
             echo "in <a href='/viewtopic.php?t=$forumTopicID&amp;c=$commentID#$commentID'>$forumTopicTitle</a><br>";
-            echo "<div class='comment'>$shortMsg</div>";
+            echo "<div class='comment break-all'>$shortMsg</div>";
             echo "</div>";
             echo "<a class='btn btn-link' href='/viewtopic.php?t=$forumTopicID&amp;c=$commentID#$commentID'>View</a>";
             echo "</div>";

--- a/resources/css/typography.css
+++ b/resources/css/typography.css
@@ -32,7 +32,7 @@ pre, code, .code {
   white-space: pre-wrap;
 }
 
-.text-overflow-wrap{
+.text-overflow-wrap {
   overflow-wrap: anywhere;
   word-break: normal;
 }

--- a/resources/css/typography.css
+++ b/resources/css/typography.css
@@ -31,3 +31,8 @@ pre, code, .code {
   word-break: break-word;
   white-space: pre-wrap;
 }
+
+.text-overflow-wrap{
+  overflow-wrap: anywhere;
+  word-break: normal;
+}


### PR DESCRIPTION
This PR resolves #1224 issue.

At first, I just added one of the Tailwind's utility class, "break-all", to div containing post content for forum activity preview.
The problem with it, though, is that normal words are also broken this way. I was searching for other way of breaking words, and got a solution, which breaks words only when it's necessary (word is longer than whole line, otherwise just wrap to the next line).
```
overflow-wrap: anywhere;
word-break: normal;
```
Wanted to get this effect with Tailwind's classes (https://tailwindcss.com/docs/word-break), but none of them provide this combo: `break-normal` doesn't breakes long words, `break-words` as well, `break-all` breakes also normal words.
I felt, that aforementioned combo works good, because it wraps words not fit into the line, while breaks only when it is necessary – so in our cases of trolling/spam (?) or posting a link.

I created a new class `.text-overflow-wrap` on typography.css – I guess it suits there.