### PR TITLE
fix identification of other tickets for same achievement

### DIFF
--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -38,7 +38,7 @@ if ($ticketID != 0) {
     $numArticleComments = getRecentArticleComments(ArticleType::AchievementTicket, $ticketID, $commentData);
 
     // sets all filters enabled so we get closed/resolved tickets as well
-    $altTicketData = getAllTickets(0, 99, null, null, null, null, $ticketID, TicketFilters::All);
+    $altTicketData = ($ticketData !== null) ? getAllTickets(0, 99, null, null, null, null, $ticketData['AchievementID'], TicketFilters::All) : [];
     $numOpenTickets = 0;
     foreach ($altTicketData as $pastTicket) {
         settype($pastTicket["ID"], 'integer');


### PR DESCRIPTION
fixes #1266 

caused by #1247. The fix to prevent dereferencing a null array was causing related items to be looked up for the ticket ID, not the achievement ID.