### PR TITLE
Improve title/description for Portuguese-speaking forum

### DIFF
--- a/database/seeders/ForumTableSeeder.php
+++ b/database/seeders/ForumTableSeeder.php
@@ -51,8 +51,8 @@ class ForumTableSeeder extends Seeder
                     ],
                     [
                         'id' => 21,
-                        'title' => 'Jogadores Portugueses!',
-                        'description' => 'A seção para todos os nossos amigos portugueses para conversar e se divertir!',
+                        'title' => 'RA em Português!',
+                        'description' => 'Onde todos os nossos amigos lusófonos podem conversar e se divertir!',
                     ],
                     [
                         'id' => 25,


### PR DESCRIPTION
Simple correction. The old text wrongly referred to Portuguese nationality (instead of as a language) and was grammatically incorrect.

Old:
```
'title' => 'Portuguese players!',
'description' => 'The section for all our Portuguese friends for talking and having fun!',
```

New:
```
'title' => 'RA in Portuguese!',
'description' => 'Where all our Lusophone friends can talk and have fun!',
```