### PR TITLE
adjust page links to multiple of page size

### DIFF
--- a/lib/render/layout.php
+++ b/lib/render/layout.php
@@ -223,6 +223,9 @@ function RenderToolbar(): void
 
 function RenderPaginator($numItems, $perPage, $offset, $urlPrefix): void
 {
+    // floor to current page
+    $offset = floor($offset / $perPage) * $perPage;
+
     if ($offset > 0) {
         echo "<a title='First' href='{$urlPrefix}0'>&#x226A;</a>&nbsp;";
 


### PR DESCRIPTION
Fixes error:
> You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-8, 15' at line 6 at /srv/web/releases/2022-12-22T225652-2.4.1-ae5bf5e/lib/database/forum.php:199

If the user arbitrarily jumps to an offset by manually modifying the URL (i.e. specifying `o=100`), the offset for the next/previous page is adjusted by the page size. If the offset is in the middle of the page, there can be a Prev link on the first page, and clicking that results in a negative offset, generating the reported error. This ensures the first page won't have a Prev link, but does not prevent the user from entering a negative offset manually.