### PR TITLE
explicitly return error to prevent logging exception

### DIFF
--- a/public/request/user/update-avatar.php
+++ b/public/request/user/update-avatar.php
@@ -6,6 +6,10 @@ if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Regi
     return back()->withErrors(__('legacy.error.permissions'));
 }
 
-UploadAvatar($user, request()->post('imageData'));
+try {
+    UploadAvatar($user, request()->post('imageData'));
+} catch (Exception $ex) {
+    return response()->json(['message' => $ex->getMessage()], 400);
+}
 
 return response()->json(['message' => __('legacy.success.ok')]);

--- a/public/request/user/update-avatar.php
+++ b/public/request/user/update-avatar.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Log;
 use RA\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
@@ -9,7 +10,17 @@ if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Regi
 try {
     UploadAvatar($user, request()->post('imageData'));
 } catch (Exception $ex) {
-    return response()->json(['message' => $ex->getMessage()], 400);
+    $error = $ex->getMessage();
+    if ($error == 'Invalid file type' || $error == 'File too large') {
+        return response()->json(['message' => $error], 400);
+    }
+
+    if (preg_match('/(not a .* file)/i', $ex->getMessage(), $match)) {
+        return response()->json(['message' => ucfirst($match[0])], 400);
+    }
+
+    Log::error($ex);
+    abort(500);
 }
 
 return response()->json(['message' => __('legacy.success.ok')]);


### PR DESCRIPTION
prevents logging of the following errors (while still reporting them to the client):

> Invalid file type {"userId":354831,"exception":"[object] (Exception(code: 0): Invalid file type at /srv/web/releases/2022-12-22T225652-2.4.1-ae5bf5e/lib/util/media.php:36)

>imagecreatefromjpeg(): gd-jpeg: JPEG library reports unrecoverable error: Not a JPEG file: starts with 0x52 0x49 {"userId":352525,"exception":"[object] (ErrorException(code: 0): imagecreatefromjpeg(): gd-jpeg: JPEG library reports unrecoverable error: Not a JPEG file: starts with 0x52 0x49 at /srv/web/releases/2022-12-22T225652-2.4.1-ae5bf5e/lib/util/media.php:53)

> imagecreatefrompng(): &quot;/tmp/data-url3Fhk3J&quot; is not a valid PNG file {"userId":354508,"exception":"[object] (ErrorException(code: 0): imagecreatefrompng(): &quot;/tmp/data-url3Fhk3J&quot; is not a valid PNG file at /srv/web/releases/2022-12-22T225652-2.4.1-ae5bf5e/lib/util/media.php:52)