### PR TITLE
ensure achievements with no hardcore earned get their true ratio recalculated

### DIFF
--- a/lib/database/achievement-points.php
+++ b/lib/database/achievement-points.php
@@ -6,12 +6,11 @@ function recalculateTrueRatio($gameID): bool
 {
     sanitize_sql_inputs($gameID);
 
-    $query = "SELECT ach.ID, ach.Points, COUNT(*) AS NumAchieved
+    $query = "SELECT ach.ID, ach.Points, COUNT(aw.HardcoreMode) AS NumAchieved
               FROM Achievements AS ach
-              LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID
-              LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
-              WHERE ach.GameID = $gameID AND ach.Flags = 3 AND (aw.HardcoreMode = 1 OR aw.HardcoreMode IS NULL)
-              AND (NOT ua.Untracked OR ua.Untracked IS NULL)
+              LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID AND aw.HardcoreMode = 1
+              LEFT JOIN UserAccounts AS ua ON ua.User = aw.User AND NOT ua.Untracked
+              WHERE ach.GameID = $gameID AND ach.Flags = " . AchievementType::OfficialCore . "
               GROUP BY ach.ID";
 
     $dbResult = s_mysql_query($query);


### PR DESCRIPTION
fixes #1284 

The query was filtering on `HardcoreMode=1 or HardcoreMode=NULL`. If only softcore unlocks exist, HardcoreMode would be 0 and the row would be filtered out. Changing the `COUNT(*)` to `COUNT(aw.HardcoreMode)` and removing the NULL filter allows it to return a count of 0 for both the NULL case (no unlocks) and the 0 case (only softcore unlocks).