### PR TITLE
Fix claim tables on front page & cleanup

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -78,8 +78,15 @@ ${PHP_BIN} artisan config:cache
 
 ### Cleanup ###
 
-# cleanup releases - keep the last five (pass +6 to tail)
+# cleanup releases
+
+# keep the last five (pass +1 to tail)
+#cd "${BASEDIR}/${RELEASES_DIR}"
+#ls -1t | tail -n +6 | xargs -d '\n' rm -rf --
+
+# keep the last
 cd "${BASEDIR}/${RELEASES_DIR}"
-ls -1t | tail -n +6 | xargs -d '\n' rm -rf --
+ls -1t | tail -n +2 | xargs -d '\n' rm -rf --
+
 # negative -n value not allowed on all systems
 #ls -1tr | head -n -5 | xargs -d '\n' rm -rf --

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -326,10 +326,6 @@ function RenderGameProgress(int $numAchievements, int $numEarnedCasual, int $num
 
 /**
  * Render completion icon, given that player achieved 100% set progress
- * @param int $awardedCount How many cheevos player has gotten in set
- * @param int $totalCount How many cheevos set has in total
- * @param float|string $hardcoreRatio Percentage of total cheevos earned on hardcore
- * @param bool $tooltip Whether to show hover tooltip or not
  */
 function renderCompletionIcon(
     int $awardedCount,

--- a/lib/render/game.php
+++ b/lib/render/game.php
@@ -53,8 +53,6 @@ function gameAvatar(
 
 /**
  * Render game title, wrapping categories for styling
- * @param   string  $title  Raw game title
- * @return  string  The resulting HTML code
  */
 function renderGameTitle(?string $title): string
 {
@@ -328,11 +326,10 @@ function RenderGameProgress(int $numAchievements, int $numEarnedCasual, int $num
 
 /**
  * Render completion icon, given that player achieved 100% set progress
- * @param   $awardedCount   How many cheevos player has gotten in set
- * @param   $totalCount     How many cheevos set has in total
- * @param   $hardcoreRatio  Percentage of total cheevos earned on hardcore
- * @param   $tooltip        Whether to show hover tooltip or not
- * @return  string  The resulting HTML code
+ * @param int $awardedCount How many cheevos player has gotten in set
+ * @param int $totalCount How many cheevos set has in total
+ * @param float|string $hardcoreRatio Percentage of total cheevos earned on hardcore
+ * @param bool $tooltip Whether to show hover tooltip or not
  */
 function renderCompletionIcon(
     int $awardedCount,

--- a/lib/render/set-claim.php
+++ b/lib/render/set-claim.php
@@ -19,6 +19,7 @@ function renderNewClaimsComponent(int $count): void
     echo "<tr>";
     echo "<th></th>";
     echo "<th>User</th>";
+    echo "<th></th>";
     echo "<th>Game</th>";
     echo "<th class='whitespace-nowrap'>Started</th>";
     echo "</tr>";
@@ -33,8 +34,11 @@ function renderNewClaimsComponent(int $count): void
         echo "<td>";
         echo userAvatar($claimUser, label: true);
         echo "</td>";
+        echo "<td>";
+        echo gameAvatar($claim, label: false);
+        echo "</td>";
         echo "<td class='w-full'>";
-        echo gameAvatar($claim);
+        echo gameAvatar($claim, icon: false);
         echo "</td>";
         echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['Created'])) . "</td>";
         echo "</tr>";
@@ -60,6 +64,7 @@ function renderFinishedClaimsComponent(int $count): void
     echo "<tr>";
     echo "<th></th>";
     echo "<th>User</th>";
+    echo "<th></th>";
     echo "<th>Game</th>";
     echo "<th>Type</th>";
     echo "<th>Finished</th>";
@@ -74,8 +79,11 @@ function renderFinishedClaimsComponent(int $count): void
         echo "<td>";
         echo userAvatar($claimUser, icon: false);
         echo "</td>";
+        echo "<td>";
+        echo gameAvatar($claim, label: false);
+        echo "</td>";
         echo "<td class='w-full'>";
-        echo gameAvatar($claim);
+        echo gameAvatar($claim, icon: false);
         echo "</td>";
         echo "<td>" . ($claim['SetType'] == ClaimSetType::NewSet ? ClaimSetType::toString(ClaimSetType::NewSet) : ClaimSetType::toString(ClaimSetType::Revision)) . "</td>";
         echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['DoneTime'])) . "</td>";

--- a/lib/render/set-claim.php
+++ b/lib/render/set-claim.php
@@ -17,9 +17,9 @@ function renderNewClaimsComponent(int $count): void
     echo "<table class='mb-1'>";
     echo "<thead>";
     echo "<tr>";
-    echo "<th></th>";
+    echo "<th class='pr-0'></th>";
     echo "<th>User</th>";
-    echo "<th></th>";
+    echo "<th class='pr-0'></th>";
     echo "<th>Game</th>";
     echo "<th class='whitespace-nowrap'>Started</th>";
     echo "</tr>";
@@ -28,13 +28,13 @@ function renderNewClaimsComponent(int $count): void
     foreach ($claimData as $claim) {
         $claimUser = $claim['User'];
         echo "<tr>";
-        echo "<td>";
+        echo "<td class='pr-0'>";
         echo userAvatar($claimUser, label: false);
         echo "</td>";
         echo "<td>";
         echo userAvatar($claimUser, label: true);
         echo "</td>";
-        echo "<td>";
+        echo "<td class='pr-0'>";
         echo gameAvatar($claim, label: false);
         echo "</td>";
         echo "<td class='w-full'>";
@@ -62,9 +62,9 @@ function renderFinishedClaimsComponent(int $count): void
     echo "<table class='mb-1'>";
     echo "<thead>";
     echo "<tr>";
-    echo "<th></th>";
+    echo "<th class='pr-0'></th>";
     echo "<th>User</th>";
-    echo "<th></th>";
+    echo "<th class='pr-0'></th>";
     echo "<th>Game</th>";
     echo "<th>Type</th>";
     echo "<th>Finished</th>";
@@ -73,13 +73,13 @@ function renderFinishedClaimsComponent(int $count): void
     foreach ($claimData as $claim) {
         $claimUser = $claim['User'];
         echo "<tr>";
-        echo "<td>";
+        echo "<td class='pr-0'>";
         echo userAvatar($claimUser, label: false);
         echo "</td>";
         echo "<td>";
         echo userAvatar($claimUser, icon: false);
         echo "</td>";
-        echo "<td>";
+        echo "<td class='pr-0'>";
         echo gameAvatar($claim, label: false);
         echo "</td>";
         echo "<td class='w-full'>";

--- a/public/achievementList.php
+++ b/public/achievementList.php
@@ -118,7 +118,7 @@ RenderContentStart("Achievement List" . $requestedConsole);
         $mark7 = ($sortBy % 10 == 7) ? '&nbsp;*' : '';
         $mark8 = ($sortBy % 10 == 8) ? '&nbsp;*' : '';
 
-        echo "<th></th>";
+        echo "<th class='pr-0'></th>";
         echo "<th>";
         echo "<a href='/achievementList.php?s=$sort1&p=$params$dev_param'>Title</a>$mark1";
         echo " / ";
@@ -168,7 +168,7 @@ RenderContentStart("Achievement List" . $requestedConsole);
 
             echo "<tr>";
 
-            echo "<td>";
+            echo "<td class='pr-0'>";
             echo achievementAvatar($achEntry, label: false);
             echo "</td>";
             echo "<td class='w-full'>";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -36,7 +36,7 @@ function ListGames($gamesList, $dev, $queryParams, $sortBy, $showTickets, $showC
     $sort6 = ($sortBy == 6) ? 16 : 6;
 
     echo "<tr>";
-    echo "<th></th>";
+    echo "<th class='pr-0'></th>";
     if ($dev == null) {
         echo "<th><a href='/gameList.php?s=$sort1&$queryParams'>Title</a></th>";
         echo "<th><a href='/gameList.php?s=$sort2&$queryParams'>Achievements</a></th>";
@@ -87,7 +87,7 @@ function ListGames($gamesList, $dev, $queryParams, $sortBy, $showTickets, $showC
 
         echo "<tr>";
 
-        echo "<td>";
+        echo "<td class='pr-0'>";
         echo gameAvatar($gameEntry, label: false);
         echo "</td>";
         echo "<td class='w-full'>";


### PR DESCRIPTION
Introducing the wrapper for game titles makes them break between icon and label when too long:
![Screenshot 2023-01-06 at 16 56 43](https://user-images.githubusercontent.com/1280590/211051262-5879fa5b-63d9-4cb0-939e-9ac002b3eefb.png)

Move icons to a separate column like in other places:
![Screenshot 2023-01-06 at 16 56 07](https://user-images.githubusercontent.com/1280590/211051511-6990e2ee-baf3-4830-a6f4-b536432d9f36.png)

Includes minor cleanups:
- Docblocks
- Only keep the last release instead of five