### PR TITLE
Fix progress bar completion icon alignment

### DIFF
--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -307,14 +307,16 @@ function RenderGameProgress(int $numAchievements, int $numEarnedCasual, int $num
     }
     $numEarnedTotal = $numEarnedCasual + $numEarnedHardcore;
 
-    echo "<div class='progress flex flex-col items-start md:items-center my-2'>";
-    echo "<div class='progressbar'>";
+    echo "<div class='w-40 my-2'>";
+    echo "<div class='flex w-full items-center'>";
+    echo "<div class='progressbar grow'>";
     echo "<div class='completion' style='width:$pctComplete%' title='$title'>";
     echo "<div class='completion-hardcore' style='width:$pctHardcoreProportion%'></div>";
     echo "</div>";
     echo "</div>";
     echo renderCompletionIcon($numEarnedTotal, $numAchievements, $pctHardcore);
-    echo "<div class='progressbar-label md:text-center'>";
+    echo "</div>";
+    echo "<div class='progressbar-label pr-5 -mt-1'>";
     if ($pctHardcore >= 100.0) {
         echo "Mastered";
     } else {
@@ -343,7 +345,6 @@ function renderCompletionIcon(
         $tooltipText = $hardcoreRatio == 100.0 ? 'Mastered (hardcore)' : 'Completed';
         $class .= ' tooltip';
     }
-    $html = "<div class='$class' title='$tooltipText'>$icon</div>";
 
-    return $html;
+    return "<div class='$class' title='$tooltipText'>$icon</div>";
 }

--- a/app_legacy/Helpers/render/site-award.php
+++ b/app_legacy/Helpers/render/site-award.php
@@ -133,7 +133,7 @@ function RenderAwardGroup($awards, $title): void
     }
 
     echo "<div id='" . strtolower(str_replace(' ', '', $title)) . "'>";
-    echo "<h3 class='flex justify-between'><span>$title</span>$counters</h3>";
+    echo "<h3 class='flex justify-between gap-2'><span class='grow'>$title</span>$counters</h3>";
     echo "<div class='component flex flex-wrap justify-start gap-2'>";
     $imageSize = 48;
     foreach ($awards as $award) {

--- a/app_legacy/Helpers/render/user.php
+++ b/app_legacy/Helpers/render/user.php
@@ -185,14 +185,16 @@ function RenderCompletedGamesList($userCompletedGamesList): void
         echo "</td>";
         echo "<td>";
 
-        echo "<div class='progress player'>";
-        echo "<div class='progressbar'>";
+        echo "<div class='w-24'>";
+        echo "<div class='flex w-full items-center'>";
+        echo "<div class='progressbar grow'>";
         echo "<div class='completion' style='width:$pctAwardedNormal%'>";
         echo "<div class='completion-hardcore' style='width:$pctAwardedHCProportional%' title='Hardcore: $nextNumAwardedHC/$nextMaxPossible'></div>";
         echo "</div>";
         echo "</div>";
         echo renderCompletionIcon($nextTotalAwarded, $nextMaxPossible, $pctAwardedHCProportional, tooltip: true);
-        echo "<div class='progressbar-label lg:text-center'>";
+        echo "</div>";
+        echo "<div class='progressbar-label pr-5 -mt-1'>";
         echo "$nextTotalAwarded of $nextMaxPossible";
         echo "</div>";
         echo "</div>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1255,13 +1255,13 @@ sanitize_outputs(
                             }
                             echo "</div>";
 
-                            echo "<div class='flex flex-col items-start md:items-center my-2'>";
-                            echo "<div class='progressbar global'>";
+                            echo "<div class='w-40 my-2'>";
+                            echo "<div class='progressbar'>";
                             echo "<div class='completion' style='width:$pctAwardedCasual%'>";
                             echo "<div class='completion-hardcore' style='width:$pctAwardedHardcore%'></div>";
                             echo "</div>";
                             echo "</div>";
-                            echo "<div class='progressbar-label md:text-center'>";
+                            echo "<div class='progressbar-label mt-1'>";
                             if ($wonByHardcore > 0) {
                                 echo "$wonBy <strong>($wonByHardcore)</strong> of $numDistinctPlayersCasual<br/>($pctAwardedCasual%) players";
                             } else {

--- a/resources/css/award-count.css
+++ b/resources/css/award-count.css
@@ -1,6 +1,7 @@
 .awardcounter {
   font-size: .65em;
   cursor: help;
+  white-space: nowrap;
 }
 
 .awardcounter > * {

--- a/resources/css/award-count.css
+++ b/resources/css/award-count.css
@@ -1,5 +1,4 @@
 .awardcounter {
-  margin: 0 .3em;
   font-size: .65em;
   cursor: help;
 }

--- a/resources/css/progress.css
+++ b/resources/css/progress.css
@@ -3,6 +3,7 @@
   height: 6px;
   border: 1px solid var(--embed-highlight-color);
   border-radius: .5em 0 0 .5em;
+  border-right: 0;
   background-color: var(--embed-color);
 }
 
@@ -34,6 +35,7 @@
   border-radius: 50%;
   font-size: 10px;
   line-height: 1em;
+  margin-left: -1px;
 }
 
 .completion-icon.tooltip {
@@ -41,12 +43,12 @@
 }
 
 .completion-icon.mastered {
-  border-color: #c90;
+  border-color: rgb(204, 153, 0);
   background-color: #606;
 }
 
 .completion-icon.completed {
-  border-color: #0b71c1;
+  border-color: rgb(11, 113, 193);
   background-color: #083171;
 }
 

--- a/resources/css/progress.css
+++ b/resources/css/progress.css
@@ -3,7 +3,7 @@
   height: 6px;
   border: 1px solid var(--embed-highlight-color);
   border-radius: .5em 0 0 .5em;
-  border-right: 0;
+  border-right: 0 none;
   background-color: var(--embed-color);
 }
 
@@ -35,7 +35,6 @@
   border-radius: 50%;
   font-size: 10px;
   line-height: 1em;
-  margin-left: -1px;
 }
 
 .completion-icon.tooltip {

--- a/resources/css/progress.css
+++ b/resources/css/progress.css
@@ -1,48 +1,14 @@
-.progress {
-  position: relative;
-  width: 130px;
-}
-
-.progress.player {
-  width: 100px;
-}
-
 .progressbar {
   overflow: hidden;
-  margin-right: auto;
   height: 6px;
-  width: calc(100% - 18px);
   border: 1px solid var(--embed-highlight-color);
   border-radius: .5em 0 0 .5em;
   background-color: var(--embed-color);
 }
 
-.progressbar.global {
-  width: 160px;
-  font-size: smaller;
-  line-height: 1.2em;
-}
-
-.progressbar.global .completion {
-  width: inherit;
-  background-color: rgb(11, 113, 193);
-}
-
-.progressbar.global .completion-hardcore {
-  height: 4px;
-  width: inherit;
-}
-
 .progressbar-label {
-  margin-top: .3em;
   text-align: center;
   font-size: 0.9em;
-}
-
-.progressbar:not(.global) ~ .progressbar-label {
-  margin-left: auto;
-  margin-right: auto;
-  transform: translateX(-8px);
 }
 
 .completion {
@@ -59,19 +25,15 @@
 }
 
 .completion-icon {
-  position: absolute;
-  top: -6.25px;
-  right: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 19px;
-  width: 19px;
+  height: 20px;
+  width: 20px;
   border: solid 2px;
   border-radius: 50%;
-  font-family: emoji;
-  font-size: 7pt;
-  cursor: default;
+  font-size: 10px;
+  line-height: 1em;
 }
 
 .completion-icon.tooltip {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,10 +5,10 @@ module.exports = {
     './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
     './storage/framework/views/*.php',
     './resources/views/**/*.blade.php',
-    './resources/js/**/*.vue',
+    //  legacy
+    './app_legacy/Helpers/render/*.php',
+    './app_legacy/Helpers/util/*.php',
     './public/*.php',
-    './lib/render/*.php',
-    './lib/util/*.php',
   ],
 
   corePlugins: {


### PR DESCRIPTION
Simplify progress CSS & tailwind class usage. Same result.

Revert the `.progress` container; a relative container is not needed when aligning progress bar a completion icon using flex. The global and player variants only set the width which can be replaced by reusable utility classes.

Progress bar labels can be aligned using utility classes, too, where needed.

All of this will be moved to a normalized view component eventually so we do not have to maintain it in three different places.

Fix tailwind content paths config.