### PR TITLE
Simplify labels

### DIFF
--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -54,7 +54,7 @@ function gameAvatar(
 /**
  * Render game title, wrapping categories for styling
  */
-function renderGameTitle(?string $title): string
+function renderGameTitle(?string $title, $append = true): string
 {
     $html = (string) $title;
     $matches = [];
@@ -63,18 +63,21 @@ function renderGameTitle(?string $title): string
         $category = $matches[1][$i];
         // $class = strtolower(str_replace(' ', '-', $category));
         $span = "<span class='tag achievement-set category'>$category</span>";
-        $html = str_replace($match, $span, $html);
+        if ($append) {
+            $html = trim(str_replace($match, '', $html) . ' ' . $span);
+        } else {
+            $html = str_replace($match, $span, $html);
+        }
     }
     preg_match_all('/\[(Subset - (.+))\]/', $title, $matches);
     foreach ($matches[0] as $i => $match) {
         [$text, $subset] = [$matches[1][$i], $matches[2][$i]];
         // $class = strtolower(str_replace(' ', '-', $subset));
         $span = "<span class='tag achievement-set subset'>$text</span>";
-        $html = str_replace($match, $span, $html);
+        $html = trim(str_replace($match, '', $html) . ' ' . $span);
     }
-    $html = "<div class='achievement-set title'>$html</div>";
 
-    return $html;
+    return "<div class='achievement-set title'>$html</div>";
 }
 
 function renderGameCard(int|string|array $game): string

--- a/resources/css/achievement-set.css
+++ b/resources/css/achievement-set.css
@@ -44,4 +44,5 @@
 
 .game-category.subset.multi {
     color: deepskyblue;
-} */
+}
+*/

--- a/resources/css/achievement-set.css
+++ b/resources/css/achievement-set.css
@@ -38,7 +38,7 @@
     color: #ddd;
 }
 
-/* .game-category.subset.bonus {
+.game-category.subset.bonus {
     color: crimson;
 }
 

--- a/resources/css/achievement-set.css
+++ b/resources/css/achievement-set.css
@@ -3,12 +3,13 @@
     margin-left: .1em;
 }
 
+/*
 .tag.achievement-set.category {
     background-color: rgba(32, 32, 32, .8);
     color: white;
 }
 
-/* .game-category.demo {
+.game-category.demo {
     background-color: teal;
 }
 
@@ -30,13 +31,9 @@
 
 .game-category.unlicensed {
     background-color: black;
-} */
+}
 
 .tag.achievement-set.subset {
-    border-radius: .2em;
-    line-height: 1.3em;
-    font-weight: bold;
-    font-size: 0.7em;
     background-color: rgb(12, 12, 56);
     color: #ddd;
 }

--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -1,10 +1,13 @@
 .tag {
-    display: inline-block;
-    opacity: .9;
-    margin: 0 .15em;
-    padding: .1em .4em;
-    border-radius: .4em;
-    vertical-align: text-bottom;
-    line-height: 1.1em;
-    font-size: .8em;
+  display: inline-block;
+  opacity: .9;
+  margin: 0 .15em;
+  padding: .1em .4em;
+  border-radius: .2em;
+  vertical-align: text-bottom;
+  line-height: 1.1em;
+  font-size: .8em;
+  background: var(--text-color);
+  border: 1px solid var(--embed-highlight-color);
+  color: var(--embed-color);
 }


### PR DESCRIPTION
A more unified, visually consistent inverted version of labels that does not have too many variants and uses existing color variables.

I know you wanted to make a distinction between types, @EmoonX, but i feel it's still to early to introduce such changes before the tag system is in place. Tags will have to then emulate every behaviour that's added until then. Hence why i wanted those colors to be gone previously; to keep it simple for now and make the transition easier.

![Screenshot 2023-01-07 at 02 57 49](https://user-images.githubusercontent.com/1280590/211126515-c2e97baf-8580-4c3b-88ec-af034201d005.png)
![Screenshot 2023-01-07 at 02 58 07](https://user-images.githubusercontent.com/1280590/211126523-1b99e3c4-64e2-4a79-83dd-8b8d2116858d.png)
![Screenshot 2023-01-07 at 02 57 58](https://user-images.githubusercontent.com/1280590/211126535-c08e56f2-d7c3-4395-a58e-ea30ea31d4d0.png)
![Screenshot 2023-01-07 at 03 05 05](https://user-images.githubusercontent.com/1280590/211126616-80b31909-4001-4bf5-af99-d51d91d180f4.png)
![Screenshot 2023-01-07 at 03 05 20](https://user-images.githubusercontent.com/1280590/211126617-8d441f0c-6da6-4452-a7a7-cd8ac95cffd7.png)
