### PR TITLE
use cards for game award tooltips

### DIFF
--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -33,7 +33,9 @@ function gameAvatar(
         }
 
         // pre-render tooltip
-        $tooltip = $tooltip !== false ? $game : false;
+        if (!is_string($tooltip)) {
+            $tooltip = $tooltip !== false ? $game : false;
+        }
     }
 
     return avatar(
@@ -114,6 +116,12 @@ function renderGameCard(int|string|array $game): string
     $tooltip .= "<div>";
     $tooltip .= "<b>$gameName</b><br>";
     $tooltip .= $consoleName;
+
+    $mastery = $game['Mastery'] ?? null;
+    if (!empty($mastery)) {
+        $tooltip .= "<div>$mastery</div>";
+    }
+
     $tooltip .= "</div>";
     $tooltip .= "</div>";
 

--- a/app_legacy/Helpers/render/site-award.php
+++ b/app_legacy/Helpers/render/site-award.php
@@ -174,16 +174,21 @@ function RenderAward($award, $imageSize, $clickable = true): void
 
     if ($awardType == AwardType::Mastery) {
         if ($awardDataExtra == '1') {
-            $tooltip = "MASTERED $awardGameTitle ($awardGameConsole)";
+            $awarded = "MASTERED on $awardDate";
             $imgclass = 'goldimage';
         } else {
-            $tooltip = "Completed $awardGameTitle ($awardGameConsole)";
+            $awarded = "Completed on $awardDate";
         }
         if ($awardButGameIsIncomplete) {
-            $tooltip .= "...<br>but more achievements have been added!<br>Click here to find out what you're missing!";
+            $awarded .= "...<br>but more achievements have been added!<br>Click here to find out what you're missing!";
         }
-        $imagepath = media_asset($awardGameImage);
-        $linkdest = "/game/$awardData";
+        $award['GameID'] = $award['AwardData'];
+        $award['Mastery'] = "<br clear=all>$awarded";
+        $tooltip = renderGameCard($award);
+
+        echo "<div>" . gameAvatar($award, label: false, iconSize: $imageSize, iconClass: $imgclass, tooltip: $tooltip) . "</div>";
+
+        return;
     } elseif ($awardType == AwardType::AchievementUnlocksYield) {
         // Developed a number of earned achievements
         $tooltip = "Awarded for being a hard-working developer and producing achievements that have been earned over " . PlayerBadge::getBadgeThreshold($awardType, $awardData) . " times!";

--- a/app_legacy/Helpers/render/site-award.php
+++ b/app_legacy/Helpers/render/site-award.php
@@ -174,7 +174,7 @@ function RenderAward($award, $imageSize, $clickable = true): void
 
     if ($awardType == AwardType::Mastery) {
         if ($awardDataExtra == '1') {
-            $awarded = "MASTERED on $awardDate";
+            $awarded = "Mastered on $awardDate";
             $imgclass = 'goldimage';
         } else {
             $awarded = "Completed on $awardDate";


### PR DESCRIPTION
Updates the tooltips on the game awards to use the game card.

Before:
![image](https://user-images.githubusercontent.com/32680403/211129519-cb1d63e8-ee2a-47de-ae6f-9c0bb43a04e5.png)

After:
![image](https://user-images.githubusercontent.com/32680403/211129528-724ce10b-4f3f-4fa3-9b45-9e2bed7890e9.png)

This does affect the event awards as they're game entries. It does not affect the contribution or patreon badges.