### PR TITLE
hide game progress if game has no achievements

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -958,7 +958,7 @@ sanitize_outputs(
                     echo "There are <b>$numAchievements</b> achievements worth <b>$totalPossible</b> <span class='TrueRatio'>($totalPossibleTrueRatio)</span> points.<br>";
                 }
 
-                if (isset($user)) {
+                if (isset($user) && $numAchievements > 0) {
                     echo "<div class='float-right'>";
                     RenderGameProgress($numAchievements, $numEarnedCasual, $numEarnedHardcore);
                     echo "</div>";


### PR DESCRIPTION
The new progress widget really stands out on game pages with no achievements compared to before.

Current:
![image](https://user-images.githubusercontent.com/32680403/211129930-79e2fa2b-22d2-4633-8af0-b14b4e576059.png)

Before:
![image](https://user-images.githubusercontent.com/32680403/211129935-81afb92a-173b-4f19-8d8a-04a75a39a26c.png)

But there's no reason for it to be there. The Set Request widget really should just replace it. So that's what I did.

After:
![image](https://user-images.githubusercontent.com/32680403/211129954-2e8f3dbc-86ee-4594-b935-32ffb2fc573c.png)
