### PR TITLE
include game name in page titles for game subpages

### DIFF
--- a/public/codenotes.php
+++ b/public/codenotes.php
@@ -14,7 +14,7 @@ sanitize_outputs(
 
 getCodeNotes($gameID, $codeNotes);
 
-RenderContentStart('Code Notes');
+RenderContentStart('Code Notes - ' . $gameData['Title']);
 ?>
 <div id='mainpage'>
     <div id="fullcontainer">

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -21,18 +21,18 @@ $sortBy = requestInputSanitized('s', empty($gameID) ? 3 : 0, 'integer');
 
 $lbCount = getLeaderboardsList($consoleIDInput, $gameID, $sortBy, $count, $offset, $lbData);
 
-$pageTitle = "Leaderboard List";
+$pageTitle = "Leaderboards - ";
 
 $gameData = null;
 $codeNotes = [];
 if ($gameID != 0) {
     $gameData = getGameData($gameID);
     getCodeNotes($gameID, $codeNotes);
-    $pageTitle .= " - " . $gameData['Title'];
+    $pageTitle .= $gameData['Title'];
 }
 
 if ($consoleIDInput) {
-    $pageTitle .= " - " . $consoleList[$consoleIDInput];
+    $pageTitle .= $consoleList[$consoleIDInput];
 }
 
 if (empty($consoleIDInput) && empty($gameID)) {
@@ -99,17 +99,16 @@ function ReloadLBPageByGame() {
         echo " &raquo; <a href='/game/" . $gameData['ID'] . "'>" . $gameData['Title'] . "</a>";
         echo " &raquo; <b>Leaderboards</b>";
     } else {
-        echo "<b>Leaderboard List</b>";    // NB. This will be a stub page
+        echo "<b>Leaderboards</b>";    // NB. This will be a stub page
     }
     echo "</div>";
 
     echo "<div class='detaillist'>";
-    echo "<h3>Leaderboard List</h3>";
+    echo "<h3>Leaderboards</h3>";
 
     if (isset($gameData['ID'])) {
         echo "<div>";
-        echo "Displaying leaderboards for: ";
-        echo gameAvatar($gameData);
+        echo gameAvatar($gameData, iconSize: 64);
         echo "</div>";
     }
 

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -21,16 +21,18 @@ $sortBy = requestInputSanitized('s', empty($gameID) ? 3 : 0, 'integer');
 
 $lbCount = getLeaderboardsList($consoleIDInput, $gameID, $sortBy, $count, $offset, $lbData);
 
+$pageTitle = "Leaderboard List";
+
 $gameData = null;
 $codeNotes = [];
 if ($gameID != 0) {
     $gameData = getGameData($gameID);
     getCodeNotes($gameID, $codeNotes);
+    $pageTitle .= " - " . $gameData['Title'];
 }
 
-$requestedConsole = "";
 if ($consoleIDInput) {
-    $requestedConsole = " " . $consoleList[$consoleIDInput];
+    $pageTitle .= " - " . $consoleList[$consoleIDInput];
 }
 
 if (empty($consoleIDInput) && empty($gameID)) {
@@ -45,8 +47,6 @@ sanitize_outputs(
     $requestedConsole,
     $gameData['Title'],
 );
-
-$pageTitle = "Leaderboard List" . $requestedConsole;
 
 RenderContentStart($pageTitle);
 ?>
@@ -94,8 +94,10 @@ function ReloadLBPageByGame() {
     echo "<div>";
     echo "<div class='navpath'>";
     if ($gameID != 0) {
-        echo "<a href='/leaderboardList.php'>Leaderboard List</a>";
-        echo " &raquo; <b>" . $gameData['Title'] . "</b>";
+        echo "<a href='/gameList.php'>All Games</a>";
+        echo " &raquo; <a href='/gameList.php?c=?" . $gameData['ConsoleID'] . "'>" . $gameData['ConsoleName'] . "</a>";
+        echo " &raquo; <a href='/game/" . $gameData['ID'] . "'>" . $gameData['Title'] . "</a>";
+        echo " &raquo; <b>Leaderboards</b>";
     } else {
         echo "<b>Leaderboard List</b>";    // NB. This will be a stub page
     }

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -19,7 +19,7 @@ $gameIcon = $gameData['ImageIcon'];
 $forumTopicID = $gameData['ForumTopicID'];
 $hashes = getHashListByGameID($gameID);
 
-RenderContentStart("Linked Hashes");
+RenderContentStart("Linked Hashes - $gameTitle");
 ?>
 <div id="mainpage">
     <div id='fullcontainer'>

--- a/public/manageclaims.php
+++ b/public/manageclaims.php
@@ -24,7 +24,7 @@ $consoleName = $gameData['ConsoleName'];
 $gameTitle = $gameData['Title'];
 $gameIcon = $gameData['ImageIcon'];
 
-RenderContentStart("Manage Claims");
+RenderContentStart("Manage Claims - $gameTitle");
 ?>
 <link rel="stylesheet" href="/vendor/jquery.datetimepicker.min.css">
 <script src="/vendor/jquery.datetimepicker.full.min.js"></script>

--- a/public/managehashes.php
+++ b/public/managehashes.php
@@ -30,7 +30,7 @@ sanitize_outputs(
     $gameTitle,
 );
 
-RenderContentStart("Manage Game Hashes");
+RenderContentStart("Manage Game Hashes - $gameTitle");
 ?>
 <script>
 function UpdateHashDetails(user, hash) {


### PR DESCRIPTION
Affects the following game subpages:
* Code Notes
* Manage Leaderboards
* Linked Hashes
* Manage Hashes
* Manage Claims

Helps to differentiate subpages when creating bookmarks and linking in Discord