### PR TITLE
Add box shadows to main menu dropdowns and tooltips

### DIFF
--- a/resources/css/nav.css
+++ b/resources/css/nav.css
@@ -64,6 +64,7 @@
 
 #innermenu > ul > li:hover > div {
   background-color: var(--embed-highlight-color);
+  box-shadow: var(--box-shadow-color) 0 30px 60px -12px, var(--box-shadow-color) 0px 18px 36px -18px;
 }
 
 @media all and (max-width: 549px) {

--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -25,6 +25,7 @@ a:hover {
 :root {
   --bg-color: rgb(26, 26, 26); /*#1a1a1a*/
   --box-bg-color: rgb(35, 35, 35); /*#2a2a2a*/
+  --box-shadow-color: rgb(22, 22, 22);
   --embed-color: rgb(22, 22, 22); /*#161616*/
   --embed-highlight-color: rgb(42, 42, 42);
   --heading-color: rgb(210, 210, 210);
@@ -41,6 +42,7 @@ a:hover {
 [data-scheme="black"] {
   --bg-color: rgb(10, 10, 10);
   --box-bg-color: rgb(20, 20, 20);
+  --box-shadow-color: rgb(0, 0, 0);
   --embed-color: rgb(0, 0, 0);
   --embed-highlight-color: rgb(30, 30, 30);
   --heading-color: rgb(200, 200, 200);
@@ -51,6 +53,7 @@ a:hover {
 [data-scheme="light"] {
   --bg-color:rgb(248, 248, 248);
   --box-bg-color: rgb(255, 255, 255);
+  --box-shadow-color: rgb(22, 22, 22, .3);
   /*--box-bg-color:rgb(248, 248, 248);*/
   /*--bg-color: rgb(255, 255, 255);*/
   --embed-color:  rgb(240, 240, 240);

--- a/resources/css/tooltip.css
+++ b/resources/css/tooltip.css
@@ -1,5 +1,6 @@
 #WzTtDiV {
   width: auto !important;
+  box-shadow: var(--box-shadow-color) 0 30px 60px -12px, var(--box-shadow-color) 0px 18px 36px -18px;
 }
 
 #WzBoDy {


### PR DESCRIPTION
Add some depth to main menu dropdowns and tooltips:

![Screenshot 2023-01-07 at 14 02 49](https://user-images.githubusercontent.com/1280590/211152057-01f66497-83ea-4eb8-86ff-e234416e1df5.png)
![Screenshot 2023-01-07 at 14 03 06](https://user-images.githubusercontent.com/1280590/211152059-baf1b575-423a-4974-b1cf-ddfb560ef5a8.png)
![Screenshot 2023-01-07 at 14 03 29](https://user-images.githubusercontent.com/1280590/211152060-2f9ffba0-c44c-4025-9cc9-0aa953e1018d.png)
![Screenshot 2023-01-07 at 14 03 46](https://user-images.githubusercontent.com/1280590/211152061-84c0584f-b418-4839-90fa-dd274c4f95ca.png)
