### PR TITLE
Fix completed games endpoint

### DIFF
--- a/app_legacy/Helpers/database/player-game.php
+++ b/app_legacy/Helpers/database/player-game.php
@@ -276,7 +276,7 @@ function getUsersCompletedGamesAndMax($user): array
     $minAchievementsForCompletion = 5;
 
     $query = "SELECT gd.ID AS GameID, c.Name AS ConsoleName, c.ID AS ConsoleID, gd.ImageIcon, gd.Title, inner1.MaxPossible,
-            MAX(aw.HardcoreMode), SUM(aw.HardcoreMode = 0) AS NumAwarded, SUM(aw.HardcoreMode = 1) AS NumAwardedHC,
+            MAX(aw.HardcoreMode) AS HardcoreMode, SUM(aw.HardcoreMode = 0) AS NumAwarded, SUM(aw.HardcoreMode = 1) AS NumAwardedHC,
             (SUM(aw.HardcoreMode = 0) / inner1.MaxPossible) AS PctWon,
             (SUM(aw.HardcoreMode = 1) / inner1.MaxPossible) AS PctWonHC
         FROM Awarded AS aw

--- a/public/API/API_GetUserCompletedGames.php
+++ b/public/API/API_GetUserCompletedGames.php
@@ -15,9 +15,9 @@
  *    string     ConsoleName      name of the console associated to the game
  *    string     MaxPossible      number of core achievements associated to the game
  *    string     NumAwarded       number of achievements earned by the user in softcore mode
- *    string.    NumAwardedHC     number of achievements earned by the user in hardcore mode
+ *    string     NumAwardedHC     number of achievements earned by the user in hardcore mode
  *    string     PctWon           NumAwarded divided by MaxPossible in softcore mode
- *    string.    PctWonHC         NumAwarded divided by MaxPossible in hardcore mode
+ *    string     PctWonHC         NumAwarded divided by MaxPossible in hardcore mode
  *    string     HardcoreMode     "1" if the data is for hardcore, otherwise "0"
  */
 

--- a/public/API/API_GetUserCompletedGames.php
+++ b/public/API/API_GetUserCompletedGames.php
@@ -14,8 +14,10 @@
  *    string     ConsoleID        unique identifier of the console associated to the game
  *    string     ConsoleName      name of the console associated to the game
  *    string     MaxPossible      number of core achievements associated to the game
- *    string     NumAwarded       number of achievements earned by the user
- *    string     PctWon           NumAwarded divided by MaxPossible
+ *    string     NumAwarded       number of achievements earned by the user in softcore mode
+ *    string.    NumAwardedHC     number of achievements earned by the user in hardcore mode
+ *    string     PctWon           NumAwarded divided by MaxPossible in softcore mode
+ *    string.    PctWonHC         NumAwarded divided by MaxPossible in hardcore mode
  *    string     HardcoreMode     "1" if the data is for hardcore, otherwise "0"
  */
 


### PR DESCRIPTION
Using endpoint https://retroachievements.org/API/API_GetUserCompletedGames.php
instead of receiving field HardcoreMode, is returned MAX(aw.HardcoreMode) wrongly.

```
[
	{
		"GameID": "11276",
		"ConsoleName": "PlayStation",
		"ConsoleID": "12",
		"ImageIcon": "\/Images\/035652.png",
		"Title": "Tomba! | Tombi! | Ore! Tomba",
		"MaxPossible": "53",
		"MAX(aw.HardcoreMode)": "1",
		"NumAwarded": "53",
		"NumAwardedHC": "53",
		"PctWon": "1.0000",
		"PctWonHC": "1.0000"
	},
	{
		"GameID": "10433",
		"ConsoleName": "PlayStation",
		"ConsoleID": "12",
		"ImageIcon": "\/Images\/031766.png",
		"Title": "Crash Bandicoot 3: Warped",
		"MaxPossible": "80",
		"MAX(aw.HardcoreMode)": "1",
		"NumAwarded": "38",
		"NumAwardedHC": "38",
		"PctWon": "0.4750",
		"PctWonHC": "0.4750"
	},

       {...}

]
```