### PR TITLE
Simplify breadcrumbs and separate main/subset links

### DIFF
--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -115,8 +115,8 @@ function renderGameBreadcrumb(array $data, bool $addLinkToLastCrumb = true)
             $gameID = $result->fetch_array()[0];
         }
 
-        // Include categories if an unofficial game shares an
-        // identical title with an official one
+        // In the rare case of a derived game sharing identical base title
+        // with another one, include category to solve ambiguity
         $renderedMain = renderGameTitle($gameTitle, tags: false);
         if ($renderedMain !== $gameTitle) {
             sanitize_sql_inputs($gameTitle);

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -100,7 +100,7 @@ function renderGameBreadcrumb(array $data, bool $addLinkToLastCrumb = true)
         return " &raquo; " . ($href ? "<a href='$href'>$text</a>" : "<b>$text</b>");
     };
 
-    // Retrieve separete IDs and titles for main game and subset (if any)
+    // Retrieve separate IDs and titles for main game and subset (if any)
     $getSplitData = function ($data) use ($consoleID): array {
         $gameID = $data['GameID'] ?? $data['ID'];
         $gameTitle = $data['GameTitle'] ?? $data['Title'];

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -58,8 +58,9 @@ function gameAvatar(
  */
 function renderGameTitle(?string $title, bool $tags = true): string
 {
-    $updateHtml = fn(&$html, $text, $replacement) =>
+    $updateHtml = function (&$html, $text, $replacement) {
         $html = trim(str_replace($text, '', $html) . $replacement);
+    };
 
     $html = (string) $title;
     $matches = [];
@@ -90,7 +91,7 @@ function renderGameBreadcrumb(array $data, bool $gameLink = true) {
     [$consoleID, $consoleName] = [$data['ConsoleID'], $data['ConsoleName']];
     $html = "<a href='/gameList.php'>All Games</a>"
         . " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
-    
+
     $taglessTitle = renderGameTitle($data['GameTitle'] ?? $data['Title'], tags: false);
     if ($gameLink) {
         $gameID = $data['GameID'] ?? $data['ID'];

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -72,12 +72,31 @@ function renderGameTitle(?string $title, bool $tags = true): string
     preg_match_all('/\[(Subset - (.+))\]/', $title, $matches);
     foreach ($matches[0] as $i => $match) {
         $subset = $matches[2][$i];
-        $span = "<span class='tag'>";
-        $span .= "<span class='tag-label'>Subset</span>";
-        $span .= "<span class='tag-arrow'></span>";
-        $span .= "<span>$subset</span>";
-        $span .= "</span>";
+        $span = "<span class='tag'>"
+            . "<span class='tag-label'>Subset</span>"
+            . "<span class='tag-arrow'></span>"
+            . "<span>$subset</span>"
+            . "</span>";
         $updateHtml($html, $match, $tags ? " $span" : '');
+    }
+
+    return $html;
+}
+
+/**
+ * Render breadcrumb prefix `All Games > (console) > (game title)`
+ */
+function renderGameBreadcrumb(array $data, bool $gameLink = true) {
+    [$consoleID, $consoleName] = [$data['ConsoleID'], $data['ConsoleName']];
+    $html = "<a href='/gameList.php'>All Games</a>"
+        . " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
+    
+    $taglessTitle = renderGameTitle($data['GameTitle'] ?? $data['Title'], tags: false);
+    if ($gameLink) {
+        $gameID = $data['GameID'] ?? $data['ID'];
+        $html .= " &raquo; <a href='/game/$gameID'>$taglessTitle</a>";
+    } else {
+        $html .= " &raquo; <b>$taglessTitle</b>";
     }
 
     return $html;

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -91,7 +91,7 @@ function renderGameTitle(?string $title, bool $tags = true): string
  * Format: `All Games » (console) » (game title)`.
  * If given data is for a subset, then `» Subset - (name)` is also added.
  */
-function renderGameBreadcrumb(array $data, bool $gameLink = true)
+function renderGameBreadcrumb(array $data, bool $addLinkToLastCrumb = true)
 {
     // Return next crumb (i.e `» text`), either as a link or not
     $nextCrumb = function ($text, $href = ''): string {
@@ -139,10 +139,10 @@ function renderGameBreadcrumb(array $data, bool $gameLink = true)
     $gameTitle = $data['GameTitle'] ?? $data['Title'];
     [$mainID, $renderedMain, $subsetID, $renderedSubset] = $getSplitData($gameID, $gameTitle);
 
-    $baseHref = ($gameLink or $subsetID) ? "/game/$mainID" : '';
+    $baseHref = ($addLinkToLastCrumb or $subsetID) ? "/game/$mainID" : '';
     $html .= $nextCrumb($renderedMain, $baseHref);
     if ($subsetID) {
-        $html .= $nextCrumb($renderedSubset, $gameLink ? "/game/$subsetID" : '');
+        $html .= $nextCrumb($renderedSubset, $addLinkToLastCrumb ? "/game/$subsetID" : '');
     }
 
     return $html;

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -56,15 +56,18 @@ function gameAvatar(
 /**
  * Render game title, wrapping categories for styling
  */
-function renderGameTitle(?string $title): string
+function renderGameTitle(?string $title, bool $tags = true): string
 {
+    $updateHtml = fn(&$html, $text, $replacement) =>
+        $html = trim(str_replace($text, '', $html) . $replacement);
+
     $html = (string) $title;
     $matches = [];
     preg_match_all('/~([^~]+)~/', $title, $matches);
     foreach ($matches[0] as $i => $match) {
         $category = $matches[1][$i];
         $span = "<span class='tag'><span>$category</span></span>";
-        $html = trim(str_replace($match, '', $html) . ' ' . $span);
+        $updateHtml($html, $match, $tags ? " $span" : '');
     }
     preg_match_all('/\[(Subset - (.+))\]/', $title, $matches);
     foreach ($matches[0] as $i => $match) {
@@ -74,7 +77,7 @@ function renderGameTitle(?string $title): string
         $span .= "<span class='tag-arrow'></span>";
         $span .= "<span>$subset</span>";
         $span .= "</span>";
-        $html = trim(str_replace($match, '', $html) . ' ' . $span);
+        $updateHtml($html, $match, $tags ? " $span" : '');
     }
 
     return $html;

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -168,7 +168,7 @@ RenderContentStart($pageTitle);
         echo "<div class='navpath'>";
         echo "<a href='/gameList.php'>All Games</a>";
         echo " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
-        echo " &raquo; <a href='/game/$gameID'>" . renderGameTitle($gameTitle) . "</a>";
+        echo " &raquo; <a href='/game/$gameID'>" . renderGameTitle($gameTitle, tags: false) . "</a>";
         echo " &raquo; <b>$achievementTitle</b>";
         echo "</div>"; // navpath
 

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -166,11 +166,9 @@ RenderContentStart($pageTitle);
         echo "<div id='achievement'>";
 
         echo "<div class='navpath'>";
-        echo "<a href='/gameList.php'>All Games</a>";
-        echo " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
-        echo " &raquo; <a href='/game/$gameID'>" . renderGameTitle($gameTitle, tags: false) . "</a>";
+        echo renderGameBreadcrumb($dataOut);
         echo " &raquo; <b>$achievementTitle</b>";
-        echo "</div>"; // navpath
+        echo "</div>";
 
         echo "<h3>" . renderGameTitle("$gameTitle ($consoleName)") . "</h3>";
 

--- a/public/codenotes.php
+++ b/public/codenotes.php
@@ -19,9 +19,7 @@ RenderContentStart('Code Notes - ' . $gameData['Title']);
 <div id='mainpage'>
     <div id="fullcontainer">
         <div class='navpath'>
-            <a href='/gameList.php'>All Games</a>
-            &raquo; <a href='/gameList.php?c=<?= $gameData['ConsoleID'] ?>'><?= $gameData['ConsoleName'] ?></a>
-            &raquo; <a href='/game/<?= $gameID ?>'><?= renderGameTitle($gameData['Title']) ?></a>
+            <?= renderGameBreadcrumb($gameData) ?>
             &raquo; <b>Code Notes</b>
         </div>
         <h3>Code Notes</h3>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -91,7 +91,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
     <div id='mainpage'>
         <div id='leftcontainer'>
             <div class='navpath'>
-                <?= renderGameBreadcrumb($gameData, gameLink: false) ?>
+                <?= renderGameBreadcrumb($gameData, addLinkToLastCrumb: false) ?>
             </div>
             <h3><?= renderGameTitle($pageTitle) ?></h3>
             <h4>WARNING: THIS GAME MAY CONTAIN CONTENT NOT APPROPRIATE FOR ALL AGES.</h4>
@@ -616,7 +616,7 @@ sanitize_outputs(
 
             if ($isFullyFeaturedGame) {
                 echo "<div class='navpath'>";
-                echo renderGameBreadcrumb($gameData, gameLink: $flags === $unofficialFlag);
+                echo renderGameBreadcrumb($gameData, addLinkToLastCrumb: $flags === $unofficialFlag);
                 if ($flags === $unofficialFlag) {
                     echo " &raquo; <b>Unofficial Achievements</b>";
                 }

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -91,9 +91,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
     <div id='mainpage'>
         <div id='leftcontainer'>
             <div class='navpath'>
-                <a href='/gameList.php'>All Games</a>
-                &raquo; <a href='/gameList.php?c=?<?= $consoleID ?>'><?= $consoleName ?></a>
-                &raquo; <b><?= renderGameTitle($gameTitle, tags: false) ?></b>
+                <?= renderGameBreadcrumb($gameData, gameLink: false) ?>
             </div>
             <h3><?= renderGameTitle($pageTitle) ?></h3>
             <h4>WARNING: THIS GAME MAY CONTAIN CONTENT NOT APPROPRIATE FOR ALL AGES.</h4>
@@ -618,13 +616,9 @@ sanitize_outputs(
 
             if ($isFullyFeaturedGame) {
                 echo "<div class='navpath'>";
-                echo "<a href='/gameList.php'>All Games</a>";
-                echo " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
-                if ($flags == $unofficialFlag) {
-                    echo " &raquo; <a href='/game/$gameID'>" . renderGameTitle($gameTitle) . "</a>";
+                echo renderGameBreadcrumb($gameData, gameLink: $flags === $unofficialFlag);
+                if ($flags === $unofficialFlag) {
                     echo " &raquo; <b>Unofficial Achievements</b>";
-                } else {
-                    echo " &raquo; <b>" . renderGameTitle($gameTitle, tags: false) . "</b>";
                 }
                 echo "</div>";
             }

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -93,7 +93,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
             <div class='navpath'>
                 <a href='/gameList.php'>All Games</a>
                 &raquo; <a href='/gameList.php?c=?<?= $consoleID ?>'><?= $consoleName ?></a>
-                &raquo; <b><?= renderGameTitle($gameTitle) ?></b>
+                &raquo; <b><?= renderGameTitle($gameTitle, tags: false) ?></b>
             </div>
             <h3><?= renderGameTitle($pageTitle) ?></h3>
             <h4>WARNING: THIS GAME MAY CONTAIN CONTENT NOT APPROPRIATE FOR ALL AGES.</h4>
@@ -624,7 +624,7 @@ sanitize_outputs(
                     echo " &raquo; <a href='/game/$gameID'>" . renderGameTitle($gameTitle) . "</a>";
                     echo " &raquo; <b>Unofficial Achievements</b>";
                 } else {
-                    echo " &raquo; <b>" . renderGameTitle($gameTitle) . "</b>";
+                    echo " &raquo; <b>" . renderGameTitle($gameTitle, tags: false) . "</b>";
                 }
                 echo "</div>";
             }

--- a/public/gamecompare.php
+++ b/public/gamecompare.php
@@ -65,9 +65,7 @@ RenderContentStart("Game Compare");
         <div id="gamecompare">
             <?php
             echo "<div class='navpath'>";
-            echo "<a href='/gameList.php'>All Games</a>";
-            echo " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
-            echo " &raquo; <a href='/game/$gameID'>" . renderGameTitle($gameTitle) . "</a>";
+            echo renderGameBreadcrumb($gameData);
             echo " &raquo; <b>Game Compare</b>";
             echo "</div>";
 

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -94,9 +94,7 @@ function ReloadLBPageByGame() {
     echo "<div>";
     echo "<div class='navpath'>";
     if ($gameID != 0) {
-        echo "<a href='/gameList.php'>All Games</a>";
-        echo " &raquo; <a href='/gameList.php?c=?" . $gameData['ConsoleID'] . "'>" . $gameData['ConsoleName'] . "</a>";
-        echo " &raquo; <a href='/game/" . $gameData['ID'] . "'>" . renderGameTitle($gameData['Title']) . "</a>";
+        echo renderGameBreadcrumb($gameData);
         echo " &raquo; <b>Leaderboards</b>";
     } else {
         echo "<b>Leaderboards</b>";    // NB. This will be a stub page

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -90,7 +90,8 @@ RenderContentStart('Leaderboard');
             echo " &raquo; <b>$lbTitle</b>";
             echo "</div>";
 
-            echo "<h3>$gameTitle ($consoleName)</h3>";
+            $renderedTitle = renderGameTitle("$gameTitle ($consoleName)");
+            echo "<h3>$renderedTitle</h3>";
 
             echo "<table class='nicebox'><tbody>";
 

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -84,9 +84,7 @@ RenderContentStart('Leaderboard');
         <div id="lbinfo">
             <?php
             echo "<div class='navpath'>";
-            echo "<a href='/gameList.php'>All Games</a>";
-            echo " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
-            echo " &raquo; <a href='/game/$gameID'>" . renderGameTitle($gameTitle) . "</a>";
+            echo renderGameBreadcrumb($lbData);
             echo " &raquo; <b>$lbTitle</b>";
             echo "</div>";
 

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -24,9 +24,7 @@ RenderContentStart("Linked Hashes - $gameTitle");
 <div id="mainpage">
     <div id='fullcontainer'>
         <div class='navpath'>
-            <a href='/gameList.php'>All Games</a>
-            &raquo; <a href='/gameList.php?c=<?= $consoleID ?>'><?= $consoleName ?></a>
-            &raquo; <a href='/game/<?= $gameID ?>'><?= renderGameTitle($gameTitle) ?></a>
+            <?= renderGameBreadcrumb($gameData) ?>
             &raquo; <b>Linked Hashes</b>
         </div>
 

--- a/public/manageclaims.php
+++ b/public/manageclaims.php
@@ -123,9 +123,7 @@ RenderContentStart("Manage Claims - $gameTitle");
 <div id='mainpage'>
     <div id='fullcontainer'>
         <div class='navpath'>
-            <a href='/gameList.php'>All Games</a>
-            &raquo; <a href='/gameList.php?c=<?= $gameData['ConsoleID'] ?>'><?= $gameData['ConsoleName'] ?></a>
-            &raquo; <a href='/game/<?= $gameID ?>'><?= renderGameTitle($gameTitle) ?></a>
+            <?= renderGameBreadcrumb($gameData) ?>
             &raquo; <b>Manage Claims</b>
         </div>
 

--- a/public/managehashes.php
+++ b/public/managehashes.php
@@ -80,9 +80,7 @@ function UnlinkHash(user, gameID, hash, elem) {
 <div id="mainpage">
     <div id="fullcontainer">
         <div class='navpath'>
-            <a href='/gameList.php'>All Games</a>
-            &raquo; <a href='/gameList.php?c=<?= $consoleID ?>'><?= $consoleName ?></a>
-            &raquo; <a href='/game/<?= $gameID ?>'><?= renderGameTitle($gameTitle) ?></a>
+            <?= renderGameBreadcrumb($gameData) ?>
             &raquo; <b>Manage Hashes</b>
         </div>
 

--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -8,7 +8,7 @@ if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     return redirect(route('achievement.show', $achievementID));
 }
 
-$dataOut = null;
+$dataOut = [];
 if ($achievementID == 0 || !getAchievementMetadata($achievementID, $dataOut)) {
     abort(404);
 }
@@ -52,10 +52,7 @@ function displayCore() {
 <div id="mainpage">
     <div id="fullcontainer">
         <div class="navpath">
-            <a href="/gameList.php">All Games</a>
-            &raquo; <a href="/gameList.php?c=<?= $consoleName ?>"><?= $consoleName ?></a>
-            &raquo; <a href="/game/<?= $gameID ?>"><?= renderGameTitle($gameTitle) ?></a>
-            &raquo; <a href="/achievement/<?= $achievementID ?>"><?= $achievementTitle ?></a>
+            <?= renderGameBreadcrumb($dataOut) ?>
             &raquo; <b>Issue Report</b>
         </div>
 

--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -53,6 +53,7 @@ function displayCore() {
     <div id="fullcontainer">
         <div class="navpath">
             <?= renderGameBreadcrumb($dataOut) ?>
+            &raquo; <a href="/achievement/<?= $achievementID ?>"><?= $achievementTitle ?></a>
             &raquo; <b>Issue Report</b>
         </div>
 

--- a/public/usergameactivity.php
+++ b/public/usergameactivity.php
@@ -44,9 +44,7 @@ RenderContentStart("$user2's activity for $gameTitle");
         <div id="gamecompare">
             <?php
             echo "<div class='navpath'>";
-            echo "<a href='/gameList.php'>All Games</a>";
-            echo " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
-            echo " &raquo; <a href='/game/$gameID'>" . renderGameTitle($gameTitle) . "</a>";
+            echo renderGameBreadcrumb($gameData);
             echo " &raquo; <b>$user2</b>";
             echo "</div>";
 


### PR DESCRIPTION
Since we're in the process of semantically separating tags from the actual game titles, and since there have been concerns about the visual clutter in breadcrumbs (either in the old or new formats), here are some changes I've implemented:

- Category tags won't be displayed (in general) when a game has one. 99.9% of the time its title is already unique for a given console, and the full tagged title usually appears right below in most pages anyway

![void](https://user-images.githubusercontent.com/22218549/212150180-7eded4c1-e996-4a5e-8f21-bff5dcdc6bd1.png)

- In the really rare case of a pair of games sharing the same base title, the category tag for the derived one is shown -- to avoid ambiguity. Unless I'm mistaken about my searches, this one below is currently the sole actual instance in... _5792_ sets

![1-in-5792](https://user-images.githubusercontent.com/22218549/212150174-32b70175-1f27-4c91-9c21-027304a635b6.png)

- Subsets get more interesting. I've separated the main title and subset tag into different crumbs. Clicking the first link sends you to the main set, while clicking the second one takes you to the subset page

![subsets](https://user-images.githubusercontent.com/22218549/212150221-a22e7e3a-6363-4a9f-b820-0f2935da39b2.png)

Once again, I'm not sure if I managed to catch every page that employs the navbar. Feel free to report missing ones.