### PR TITLE
Render `[m]` in achievement titles as a tag

### DIFF
--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -64,12 +64,11 @@ function renderAchievementTitle(string $title, bool $tags = true): string
     $span = '';
     if ($tags) {
         $span = "<span class='tag missable' title='Missable'>"
-            . "<div>[<span>m</span>]</div>"
+            . "<abbr>[<b>m</b>]</abbr>"
             . "</span>";
     }
-    $html = trim(str_replace('[m]', $span, $title));
 
-    return $html;
+    return trim(str_replace('[m]', $span, $title));
 }
 
 function renderAchievementCard(int|string|array $achievement, ?string $context = null): string

--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -53,13 +53,16 @@ function achievementAvatar(
     );
 }
 
-function renderAchievementTitle(string $title): string
-{   
+/**
+ * Render achievement title, parsing `[m]` (missable) as a tag
+ */
+function renderAchievementTitle(string $title, bool $tags = true): string
+{
     if (!str_contains($title, '[m]')) {
         return $title;
     }
-    $span = "<span class='tag missable' title='Missable'><span>m</span></span>";
-    $html = str_replace('[m]', $span, $title);
+    $span = $tags ? "<span class='tag missable' title='Missable'><span>m</span></span>" : '';
+    $html = trim(str_replace('[m]', $span, $title));
 
     return $html;
 }
@@ -86,7 +89,7 @@ function renderAchievementCard(int|string|array $achievement, ?string $context =
         });
     }
 
-    $title = $data['AchievementTitle'] ?? $data['Title'] ?? null;
+    $title = renderAchievementTitle($data['AchievementTitle'] ?? $data['Title'] ?? null);
     $description = $data['AchievementDesc'] ?? $data['Description'] ?? null;
     $achPoints = $data['Points'] ?? null;
     $badgeName = $data['BadgeName'] ?? null;

--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -55,10 +55,10 @@ function achievementAvatar(
 
 function renderAchievementTitle(string $title): string
 {   
-    if (! str_contains($title, '[m]')) {
+    if (!str_contains($title, '[m]')) {
         return $title;
     }
-    $span = "<span class='missable'>[m]</span>";
+    $span = "<span class='tag missable' title='Missable'><span>m</span></span>";
     $html = str_replace('[m]', $span, $title);
 
     return $html;

--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -12,6 +12,7 @@ function achievementAvatar(
     ?string $context = null,
 ): string {
     $id = $achievement;
+    $title = null;
 
     if (is_array($achievement)) {
         $id = $achievement['AchievementID'] ?? $achievement['ID'];
@@ -20,6 +21,8 @@ function achievementAvatar(
             $title = $achievement['AchievementTitle'] ?? $achievement['Title'];
             $points = $achievement['Points'] ?? null;
             $label = $title . ($points ? ' (' . $points . ')' : '');
+            sanitize_outputs($label);   // sanitize before rendering HTML
+            $label = renderAchievementTitle($label);
         }
 
         if ($icon !== false) {
@@ -45,7 +48,20 @@ function achievementAvatar(
         iconSize: $iconSize,
         iconClass: $iconClass,
         context: $context,
+        sanitize: $title === null,
+        altText: $title ?? $label,
     );
+}
+
+function renderAchievementTitle(string $title): string
+{   
+    if (! str_contains($title, '[m]')) {
+        return $title;
+    }
+    $span = "<span class='missable'>[m]</span>";
+    $html = str_replace('[m]', $span, $title);
+
+    return $html;
 }
 
 function renderAchievementCard(int|string|array $achievement, ?string $context = null): string

--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -64,7 +64,7 @@ function renderAchievementTitle(string $title, bool $tags = true): string
     $span = '';
     if ($tags) {
         $span = "<span class='tag missable' title='Missable'>"
-            . "<p>[<span>m</span>]</p>"
+            . "<div>[<span>m</span>]</div>"
             . "</span>";
     }
     $html = trim(str_replace('[m]', $span, $title));

--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -61,7 +61,12 @@ function renderAchievementTitle(string $title, bool $tags = true): string
     if (!str_contains($title, '[m]')) {
         return $title;
     }
-    $span = $tags ? "<span class='tag missable' title='Missable'><span>m</span></span>" : '';
+    $span = '';
+    if ($tags) {
+        $span = "<span class='tag missable' title='Missable'>"
+            . "<p>[<span>m</span>]</p>"
+            . "</span>";
+    }
     $html = trim(str_replace('[m]', $span, $title));
 
     return $html;

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -13,7 +13,7 @@ if (empty($achievementID)) {
     abort(404);
 }
 
-$dataOut = null;
+$dataOut = [];
 getAchievementMetadata($achievementID, $dataOut);
 if (empty($dataOut)) {
     abort(404);
@@ -167,7 +167,7 @@ RenderContentStart($pageTitle);
 
         echo "<div class='navpath'>";
         echo renderGameBreadcrumb($dataOut);
-        echo " &raquo; <b>$achievementTitle</b>";
+        echo " &raquo; <b>" . renderAchievementTitle($achievementTitle, tags: false) . "</b>";
         echo "</div>";
 
         echo "<h3>" . renderGameTitle("$gameTitle ($consoleName)") . "</h3>";

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -169,7 +169,7 @@ RenderContentStart($pageTitle);
         echo "<a href='/gameList.php'>All Games</a>";
         echo " &raquo; <a href='/gameList.php?c=$consoleID'>$consoleName</a>";
         echo " &raquo; <a href='/game/$gameID'>" . renderGameTitle($gameTitle) . "</a>";
-        echo " &raquo; <b>$achievementTitle</b>";
+        echo " &raquo; <b>" . renderAchievementTitle($achievementTitle, tags: false) . "</b>";
         echo "</div>"; // navpath
 
         echo "<h3>" . renderGameTitle("$gameTitle ($consoleName)") . "</h3>";
@@ -190,9 +190,10 @@ RenderContentStart($pageTitle);
         echo "<td>";
         echo "<div id='achievemententry'>";
 
+        $renderedTitle = renderAchievementTitle($achievementTitle);
         echo "<div class='flex justify-between'>";
         echo "<div>";
-        echo "<a href='/achievement/$achievementID'><strong>$achievementTitle</strong></a> ($achPoints)<span class='TrueRatio'> ($achTruePoints)</span><br>";
+        echo "<a href='/achievement/$achievementID'><strong>$renderedTitle</strong></a> ($achPoints)<span class='TrueRatio'> ($achTruePoints)</span><br>";
         echo "$desc";
         echo "</div>";
         if ($achievedLocal) {

--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -55,7 +55,8 @@ function displayCore() {
             <a href="/gameList.php">All Games</a>
             &raquo; <a href="/gameList.php?c=<?= $consoleName ?>"><?= $consoleName ?></a>
             &raquo; <a href="/game/<?= $gameID ?>"><?= renderGameTitle($gameTitle) ?></a>
-            &raquo; <a href="/achievement/<?= $achievementID ?>"><?= $achievementTitle ?></a>
+            &raquo; <a href="/achievement/<?= $achievementID ?>"><?=
+                renderAchievementTitle($achievementTitle, tags: false) ?></a>
             &raquo; <b>Issue Report</b>
         </div>
 

--- a/public/reportissue.php
+++ b/public/reportissue.php
@@ -53,7 +53,8 @@ function displayCore() {
     <div id="fullcontainer">
         <div class="navpath">
             <?= renderGameBreadcrumb($dataOut) ?>
-            &raquo; <a href="/achievement/<?= $achievementID ?>"><?= $achievementTitle ?></a>
+            &raquo; <a href="/achievement/<?= $achievementID ?>"><?=
+                renderAchievementTitle($achievementTitle, tags: false) ?></a>
             &raquo; <b>Issue Report</b>
         </div>
 

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -133,7 +133,7 @@ RenderContentStart($pageTitle);
                 if (!empty($gameIDGiven)) {
                     echo " &raquo; <a href='/ticketmanager.php?g=$gameIDGiven'>$gameTitle ($consoleName)</a>";
                     if (!empty($achievementIDGiven)) {
-                        echo " &raquo; $achievementTitle";
+                        echo " &raquo; " . renderAchievementTitle($achievementTitle, tags: false);
                     }
                 }
             } else {

--- a/resources/css/legacy.css
+++ b/resources/css/legacy.css
@@ -84,6 +84,10 @@
   color: rgb(140,140,140);
 }
 
+.missable {
+  filter: brightness(1);
+}
+
 .message-unread {
   font-weight: bold;
 }

--- a/resources/css/legacy.css
+++ b/resources/css/legacy.css
@@ -84,10 +84,6 @@
   color: rgb(140,140,140);
 }
 
-.missable {
-  filter: brightness(1);
-}
-
 .message-unread {
   font-weight: bold;
 }

--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -33,15 +33,14 @@
 
 .tag.missable {
   opacity: .8;
-  font-weight: bold;
-  cursor: help;
 }
 
-.tag.missable div {
+.tag.missable abbr {
   padding: .14em .15em .16em;
+  font-weight: normal;
   color: currentColor;
 }
 
-.tag.missable div span, a:hover .tag.missable div {
+.tag.missable abbr b, a:hover .tag.missable abbr {
   color: var(--bg-color);
 }

--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -38,7 +38,7 @@
 }
 
 .tag.missable div {
-  padding: .15em;
+  padding: .14em .15em .16em;
   color: currentColor;
 }
 

--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -30,3 +30,8 @@
   border-left-color: rgba(255, 255, 255, 0.5);
   border-right-width: 0;
 }
+
+.tag.missable {
+  opacity: .8;
+  cursor: help;
+}

--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -35,3 +35,12 @@
   opacity: .8;
   cursor: help;
 }
+
+.tag.missable p {
+  padding: .15em;
+  color: currentColor;
+}
+
+.tag.missable p span, a:hover .tag.missable p {
+  color: var(--bg-color);
+}

--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -33,14 +33,15 @@
 
 .tag.missable {
   opacity: .8;
+  font-weight: bold;
   cursor: help;
 }
 
-.tag.missable p {
+.tag.missable div {
   padding: .15em;
   color: currentColor;
 }
 
-.tag.missable p span, a:hover .tag.missable p {
+.tag.missable div span, a:hover .tag.missable div {
   color: var(--bg-color);
 }

--- a/resources/css/typography.css
+++ b/resources/css/typography.css
@@ -32,6 +32,10 @@ pre, code, .code {
   white-space: pre-wrap;
 }
 
+abbr {
+  cursor: help;
+}
+
 .text-overflow-wrap {
   overflow-wrap: anywhere;
   word-break: normal;


### PR DESCRIPTION
Self-explanatory. Should be able to be eventually expanded to other kinds of achievement tags.

![normal](https://user-images.githubusercontent.com/22218549/212196597-14d3c5d7-4ad8-4b66-998b-598593061358.png)
![hover](https://user-images.githubusercontent.com/22218549/212196603-6903a746-389a-45bf-a5ee-44986c1e24e9.png)
![tooltip](https://user-images.githubusercontent.com/22218549/212196764-dec41621-6f13-4acd-8711-ce0d1decbe09.png)