### PR TITLE
collapse forum history by topic

### DIFF
--- a/app_legacy/Helpers/database/forum.php
+++ b/app_legacy/Helpers/database/forum.php
@@ -529,6 +529,55 @@ function getRecentForumPosts($offset, $count, $numMessageChars, $permissions, &$
     }
 }
 
+function getRecentForumTopics(int $offset, int $count, int $permissions, int $numMessageChars = 90): array
+{
+    $query = "
+        SELECT ft.ID as ForumTopicID, ft.Title as ForumTopicTitle,
+               f.ID as ForumID, f.Title as ForumTitle,
+               lc.CommentID, lftc.DateCreated as PostedAt, lftc.Author,
+               LEFT(lftc.Payload, $numMessageChars) AS ShortMsg,
+               LENGTH(lftc.Payload) > $numMessageChars AS IsTruncated,
+               d1.CommentID as CommentID_1d, d1.Count as Count_1d,
+               d7.CommentID as CommentID_7d, d7.Count as Count_7d
+        FROM ForumTopic AS ft
+        LEFT JOIN Forum AS f on f.ID = ft.ForumID
+        LEFT JOIN (
+            SELECT ftc.ForumTopicId, MAX(ftc.ID) as CommentID
+            FROM ForumTopicComment ftc
+            WHERE ftc.Authorised=1
+            GROUP BY ftc.ForumTopicId
+        ) AS lc ON lc.ForumTopicId = ft.ID
+        LEFT JOIN ForumTopicComment AS lftc ON lftc.ID = lc.CommentID
+        LEFT JOIN (
+            SELECT ftc.ForumTopicId, MIN(ftc.ID) as CommentID, COUNT(ftc.ID) as Count
+            FROM ForumTopicComment ftc
+            WHERE ftc.Authorised=1 AND DateCreated >= DATE_SUB(NOW(), INTERVAL 1 DAY)
+            GROUP BY ftc.ForumTopicId
+        ) AS d1 ON d1.ForumTopicId = ft.ID
+        LEFT JOIN (
+            SELECT ftc.ForumTopicId, MIN(ftc.ID) as CommentID, COUNT(ftc.ID) as Count
+            FROM ForumTopicComment ftc
+            WHERE ftc.Authorised=1 AND DateCreated >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+            GROUP BY ftc.ForumTopicId
+        ) AS d7 ON d7.ForumTopicId = ft.ID
+        WHERE ft.RequiredPermissions <= $permissions
+        ORDER BY PostedAt DESC
+        LIMIT $offset, $count";
+
+    $dataOut = [];
+
+    $dbResult = s_mysql_query($query);
+    if ($dbResult === false) {
+        log_sql_fail();
+    } else {
+        while ($db_entry = mysqli_fetch_assoc($dbResult)) {
+            $dataOut[] = $db_entry;
+        }
+    }
+
+    return $dataOut;
+}
+
 function updateTopicPermissions(int $topicId, int $permissions): bool
 {
     $query = "  UPDATE ForumTopic AS ft

--- a/app_legacy/Helpers/render/forum.php
+++ b/app_legacy/Helpers/render/forum.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Carbon;
+
 function RenderRecentForumPostsComponent($permissions, $numToFetch = 4): void
 {
     echo "<div class='component'>";
@@ -8,15 +10,7 @@ function RenderRecentForumPostsComponent($permissions, $numToFetch = 4): void
     if (getRecentForumPosts(0, $numToFetch, 100, $permissions, $recentPostData) != 0) {
         foreach ($recentPostData as $nextData) {
             $timestamp = strtotime($nextData['PostedAt']);
-            $datePosted = date("d M", $timestamp);
-
-            if (date("d", $timestamp) == date("d")) {
-                $datePosted = "Today";
-            } elseif (date("d", $timestamp) == (date("d") - 1)) {
-                $datePosted = "Y'day";
-            }
-
-            $postedAt = date("H:i", $timestamp);
+            $postedAt = Carbon::createFromTimeStamp($timestamp)->diffForHumans();
 
             $shortMsg = trim($nextData['ShortMsg']);
             if ($nextData['IsTruncated']) {
@@ -33,14 +27,14 @@ function RenderRecentForumPostsComponent($permissions, $numToFetch = 4): void
                 $forumTopicTitle,
             );
 
-            echo "<div class='embedded mb-1 flex justify-between items-center'>";
-            echo "<div>";
+            echo "<div class='embedded mb-1'>";
+            echo "<div class='flex justify-between items-center'><div>";
             echo userAvatar($author, iconSize: 16);
-            echo " <span class='smalldate'>$datePosted $postedAt</span><br>";
+            echo " <span class='smalldate'>$postedAt</span></div>";
+            echo "<div><a class='btn btn-link' href='/viewtopic.php?t=$forumTopicID&amp;c=$commentID#$commentID'>View</a></div>";
+            echo "</div>";
             echo "in <a href='/viewtopic.php?t=$forumTopicID&amp;c=$commentID#$commentID'>$forumTopicTitle</a><br>";
             echo "<div class='comment text-overflow-wrap'>$shortMsg</div>";
-            echo "</div>";
-            echo "<a class='btn btn-link' href='/viewtopic.php?t=$forumTopicID&amp;c=$commentID#$commentID'>View</a>";
             echo "</div>";
         }
     }

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -83,14 +83,14 @@ RenderContentStart("Forum Recent Posts");
                 echo "<span class='smalltext whitespace-nowrap'>";
 
                 if ($count_1d > 1) {
-                    echo "<a href='/viewtopic.php?t=$forumTopicID&c=$commentID_1d#$commentID_1d'>$count_1d posts in last 24 hours";
+                    echo "<a href='/viewtopic.php?t=$forumTopicID&c=$commentID_1d#$commentID_1d'>$count_1d posts in the last 24 hours";
                 }
 
                 if ($count_7d > $count_1d) {
                     if ($count_1d > 1) {
                         echo "<div class='mt-1'/>";
                     }
-                    echo "<a href='/viewtopic.php?t=$forumTopicID&c=$commentID_7d#$commentID_7d'>$count_7d posts in last 7 days";
+                    echo "<a href='/viewtopic.php?t=$forumTopicID&c=$commentID_7d#$commentID_7d'>$count_7d posts in the last 7 days";
                     if ($count_1d > 1) {
                         echo "</div>";
                     }

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Carbon;
+
 $maxCount = 25;
 
 $offset = requestInputSanitized('o', 0, 'integer');
@@ -8,7 +10,7 @@ $count = $maxCount;
 authenticateFromCookie($user, $permissions, $userDetails);
 
 $forUser = requestInputSanitized('u');
-$numPostsFound = getRecentForumPosts($offset, $count, 90, $permissions, $recentPostsData, $forUser);
+$recentPostsData = getRecentForumTopics($offset, $count, $permissions);
 
 RenderContentStart("Forum Recent Posts");
 ?>
@@ -38,34 +40,66 @@ RenderContentStart("Forum Recent Posts");
         echo "<tbody>";
 
         echo "<tr>";
-        echo "<th></th>";
-        echo "<th>Author</th>";
-        echo "<th class='w-full'>Message</th>";
-        echo "<th class='whitespace-nowrap'>Posted At</th>";
+        echo "<th>Last Post By</th>";
+        echo "<th>Message</th>";
+        echo "<th>Additional Posts</th>";
         echo "</tr>";
 
         foreach ($recentPostsData as $topicPostData) {
             $postMessage = $topicPostData['ShortMsg'];
+            if ($topicPostData['IsTruncated']) {
+                $postMessage .= '...';
+            }
             $postAuthor = $topicPostData['Author'];
+            $forumID = $topicPostData['ForumID'];
+            $forumTitle = $topicPostData['ForumTitle'];
             $forumTopicID = $topicPostData['ForumTopicID'];
             $forumTopicTitle = $topicPostData['ForumTopicTitle'];
-            $forumCommentID = $topicPostData['CommentID'];
-            $postTime = $topicPostData['PostedAt'];
-            $nicePostTime = getNiceDate(strtotime($postTime));
+            $commentID = $topicPostData['CommentID'];
+            $commentID_1d = $topicPostData['CommentID_1d'] ?? 0;
+            $count_1d = $topicPostData['Count_1d'] ?? 0;
+            $commentID_7d = $topicPostData['CommentID_7d'] ?? 0;
+            $count_7d = $topicPostData['Count_7d'] ?? 0;
 
-            sanitize_outputs($forumTopicTitle, $postMessage);
+            $timestamp = strtotime($topicPostData['PostedAt']);
+            $postedAt = Carbon::createFromTimeStamp($timestamp)->diffForHumans();
+
+            sanitize_outputs($forumTopicTitle, $forumTitle, $postMessage);
 
             echo "<tr>";
 
             echo "<td>";
-            echo userAvatar($postAuthor, label: false);
-            echo "</td>";
-            echo "<td>";
-            echo userAvatar($postAuthor, icon: false);
+            echo userAvatar($postAuthor, iconSize: 24);
             echo "</td>";
 
-            echo "<td><a href='/viewtopic.php?t=$forumTopicID&c=$forumCommentID#$forumCommentID'>$forumTopicTitle</a><br>$postMessage...</td>";
-            echo "<td class='smalldate'>$nicePostTime</td>";
+            echo "<td>";
+            echo "<a href='/viewtopic.php?t=$forumTopicID&c=$commentID#$commentID'>$forumTopicTitle</a>";
+            echo " <span class='smalldate'>$postedAt</span>";
+            echo "<div class='comment text-overflow-wrap'>$postMessage</div>";
+            echo "</td>";
+
+            echo "<td>";
+            if ($count_7d > 1) {
+                echo "<span class='smalltext whitespace-nowrap'>";
+
+                if ($count_1d > 1) {
+                    echo "<a href='/viewtopic.php?t=$forumTopicID&c=$commentID_1d#$commentID_1d'>$count_1d posts in last 24 hours";
+                }
+
+                if ($count_7d > $count_1d) {
+                    if ($count_1d > 1) {
+                        echo "<div class='mt-1'/>";
+                    }
+                    echo "<a href='/viewtopic.php?t=$forumTopicID&c=$commentID_7d#$commentID_7d'>$count_7d posts in last 7 days";
+                    if ($count_1d > 1) {
+                        echo "</div>";
+                    }
+                }
+
+                echo "</span>";
+            }
+            echo "</td>";
+
             echo "</tr>";
         }
 
@@ -82,7 +116,7 @@ RenderContentStart("Forum Recent Posts");
             $prevOffset = $offset - $maxCount;
             echo "<a href='$baseUrl$prevOffset'>&lt; Previous $maxCount</a> - ";
         }
-        if ($numPostsFound == $maxCount) {
+        if (count($recentPostsData) == $maxCount) {
             // Max number fetched, i.e. there are more. Can goto next 25.
             $nextOffset = $offset + $maxCount;
             echo "<a href='$baseUrl$nextOffset'>Next $maxCount &gt;</a>";

--- a/public/viewforum.php
+++ b/public/viewforum.php
@@ -29,7 +29,7 @@ if ($requestedForumID == 0 && $permissions >= Permissions::Admin) {
     $thisCategoryID = 0;
     $thisCategoryName = "Unauthorised Links";
 
-    $topicList = getUnauthorisedForumLinks();
+    $topicList = $unofficialLinks;
 
     $requestedForum = "Unauthorised Links";
 } else {


### PR DESCRIPTION
implements #727 

Only shows the most recent post to a forum topic on the Recent Posts page. If additional posts have been made in the last 24 hours or last 7 days, links will be provided to jump to the first post within the 24-hour or 7-day windows.

![image](https://user-images.githubusercontent.com/32680403/212741077-aeff83b3-d259-4a54-9ff9-2db82681630b.png)

This does not change the behavior of the Forum Activity widget because of the additional overhead in performing the query since the widget appears on the main page. If the four most recent posts are all part of the same Topic, they'll still all be shown.

I did, however, slightly modify the layout of the Forum Activity widget. The timestamp is changed from an absolute GMT time to an elapsed time, and the View link has been pulled into the header to allow more space in the body for the message content.

Before:
![image](https://user-images.githubusercontent.com/32680403/212741669-ec721c80-6d1f-42dc-832b-b887f2d7f402.png)

After:
![image](https://user-images.githubusercontent.com/32680403/212741690-8323e910-d394-4e59-a0e3-d752168ef97a.png)
