### PR TITLE
Fix recalculation of true ratio not ignoring untracked users

### DIFF
--- a/app_legacy/Helpers/database/achievement-points.php
+++ b/app_legacy/Helpers/database/achievement-points.php
@@ -6,11 +6,12 @@ function recalculateTrueRatio($gameID): bool
 {
     sanitize_sql_inputs($gameID);
 
-    $query = "SELECT ach.ID, ach.Points, COUNT(aw.HardcoreMode) AS NumAchieved
+    $query = "SELECT ach.ID, ach.Points, SUM(aw.HardcoreMode) AS NumAchieved
               FROM Achievements AS ach
-              LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID AND aw.HardcoreMode = 1
-              LEFT JOIN UserAccounts AS ua ON ua.User = aw.User AND NOT ua.Untracked
-              WHERE ach.GameID = $gameID AND ach.Flags = " . AchievementType::OfficialCore . "
+              LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID
+              LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
+              WHERE ach.GameID = $gameID AND NOT ua.Untracked
+              AND ach.Flags = " . AchievementType::OfficialCore . "
               GROUP BY ach.ID";
 
     $dbResult = s_mysql_query($query);

--- a/app_legacy/Helpers/database/player-game.php
+++ b/app_legacy/Helpers/database/player-game.php
@@ -323,9 +323,8 @@ function getTotalUniquePlayers($gameID, $requestedBy, $hardcoreOnly = false, $fl
         SELECT COUNT(DISTINCT aw.User) As UniquePlayers
         FROM Awarded AS aw
         LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
-        LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
         LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
-        WHERE gd.ID = $gameID
+        WHERE ach.GameID = $gameID
         $hardcoreCond $achievementStateCond
         AND (NOT ua.Untracked" . (isset($requestedBy) ? " OR ua.User = '$requestedBy'" : "") . ")
     ";


### PR DESCRIPTION
fixes #1320

Changes made in #1286 moved the Untracked filter into the JOIN clause. This results in the Untracked users still being counted for the number of hardcore unlocks associated to an achievement when doing the true ratio calculation. I've moved it back, and provided an alternate solution to the original problem.