### PR TITLE
Follow-up fixes for breadcrumb tags

### DIFF
--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -485,7 +485,7 @@ function getGameIDFromTitle($gameTitleIn, $consoleID): int
               FROM GameData AS gd
               WHERE gd.Title='$gameTitle' AND gd.ConsoleID='$consoleID'";
 
-    $dbResult = s_mysql_query($query);
+    $dbResult = s_mysql_sanitized_query($query);
     if ($retVal = mysqli_fetch_assoc($dbResult)) {
         settype($retVal['ID'], 'integer');
 
@@ -817,13 +817,18 @@ function submitNewGameTitleJSON($user, $md5, $gameIDin, $titleIn, $consoleID, $d
     return $retVal;
 }
 
+/**
+ * Slash-escape special title characters (`\`, `'` and `/`)
+ */
 function sanitizeTitle(string $titleIn): string
 {
-    // Remove single quotes, replace with double quotes:
-    $title = str_replace("'", "''", $titleIn);
-    $title = str_replace("/", "-", $title);
+    $title = $titleIn;
+    $tokens = ["\\", "'", "/"];
+    foreach ($tokens as $token) {
+        $title = str_replace($token, "\\$token", $title);
+    }
 
-    return str_replace("\\", "-", $title);
+    return $title;
 }
 
 function modifyGameRichPresence(string $user, int $gameID, string $dataIn): bool

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -815,20 +815,6 @@ function submitNewGameTitleJSON($user, $md5, $gameIDin, $titleIn, $consoleID, $d
     return $retVal;
 }
 
-/**
- * Slash-escape special title characters (`\`, `'` and `/`)
- */
-function sanitizeTitle(string $titleIn): string
-{
-    $title = $titleIn;
-    $tokens = ["\\", "'", "/"];
-    foreach ($tokens as $token) {
-        $title = str_replace($token, "\\$token", $title);
-    }
-
-    return $title;
-}
-
 function modifyGameRichPresence(string $user, int $gameID, string $dataIn): bool
 {
     getRichPresencePatch($gameID, $existingData);

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -475,10 +475,9 @@ function getGamesListDataNamesOnly($consoleID, $officialFlag = false): array
     return $retval;
 }
 
-function getGameIDFromTitle($gameTitleIn, $consoleID): int
+function getGameIDFromTitle($gameTitle, $consoleID): int
 {
-    sanitize_sql_inputs($consoleID);
-    $gameTitle = sanitizeTitle($gameTitleIn);
+    sanitize_sql_inputs($gameTitle, $consoleID);
     settype($consoleID, 'integer');
 
     $query = "SELECT gd.ID
@@ -690,11 +689,10 @@ function getGameListSearch($offset, $count, $method, $consoleID = null): array
     return $retval;
 }
 
-function createNewGame($titleIn, $consoleID): ?array
+function createNewGame($title, $consoleID): ?array
 {
-    sanitize_sql_inputs($consoleID);
+    sanitize_sql_inputs($title, $consoleID);
     settype($consoleID, 'integer');
-    $title = sanitizeTitle($titleIn);
     // $title = str_replace( "--", "-", $title );    // subtle non-comment breaker
 
     $query = "INSERT INTO GameData (Title, ConsoleID, ForumTopicID, Flags, ImageIcon, ImageTitle, ImageIngame, ImageBoxArt, Publisher, Developer, Genre, Released, IsFinal, RichPresencePatch, TotalTruePoints)

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -91,7 +91,7 @@ function renderGameTitle(?string $title, bool $tags = true): string
  * Format: `All Games » (console) » (game title)`.
  * If given data is for a subset, then `» Subset - (name)` is also added.
  */
-function renderGameBreadcrumb(array $data, bool $addLinkToLastCrumb = true)
+function renderGameBreadcrumb(array $data, bool $addLinkToLastCrumb = true): string
 {
     [$consoleID, $consoleName] = [$data['ConsoleID'], $data['ConsoleName']];
 

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -133,7 +133,7 @@ function renderGameBreadcrumb(array $data, bool $addLinkToLastCrumb = true): str
         . $nextCrumb($consoleName, "/gameList.php?c=$consoleID");
 
     [$mainID, $renderedMain, $subsetID, $renderedSubset] = $getSplitData($data);
-    $baseHref = ($addLinkToLastCrumb or $subsetID) ? "/game/$mainID" : '';
+    $baseHref = (($addLinkToLastCrumb or $subsetID) and $mainID) ? "/game/$mainID" : '';
     $html .= $nextCrumb($renderedMain, $baseHref);
     if ($subsetID) {
         $html .= $nextCrumb($renderedSubset, $addLinkToLastCrumb ? "/game/$subsetID" : '');

--- a/public/comments.php
+++ b/public/comments.php
@@ -26,12 +26,10 @@ switch ($articleTypeID)
         if ($gameData === null) {
             abort(404);
         }
-        $pageTitle = $gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')';
+        $pageTitle = renderGameTitle($gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')');
         $navPath =
         [
-            'All Games' => '/gameList.php',
-            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
-            $gameData['Title'] => '/game/' . $gameData['ID'],
+            '_GamePrefix' => renderGameBreadcrumb($gameData),
         ];
         break;
 
@@ -43,13 +41,11 @@ switch ($articleTypeID)
         if ($gameData === null) {
             abort(404);
         }
-        $pageTitle = $gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')';
+        $pageTitle = renderGameTitle($gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')');
         $commentsLabel = "Hash Comments";
         $navPath =
         [
-            'All Games' => '/gameList.php',
-            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
-            $gameData['Title'] => '/game/' . $gameData['ID'],
+            '_GamePrefix' => renderGameBreadcrumb($gameData),
             'Manage Hashes' => '/managehashes.php?g=' . $gameData['ID'],
         ];
         break;
@@ -62,13 +58,11 @@ switch ($articleTypeID)
         if ($gameData === null) {
             abort(404);
         }
-        $pageTitle = $gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')';
+        $pageTitle = renderGameTitle($gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')');
         $commentsLabel = "Modifications";
         $navPath =
         [
-            'All Games' => '/gameList.php',
-            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
-            $gameData['Title'] => '/game/' . $gameData['ID'],
+            '_GamePrefix' => renderGameBreadcrumb($gameData),
         ];
         break;
 
@@ -80,13 +74,11 @@ switch ($articleTypeID)
         if ($gameData === null) {
             abort(404);
         }
-        $pageTitle = $gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')';
+        $pageTitle = renderGameTitle($gameData['Title'] . ' (' . $gameData['ConsoleName'] . ')');
         $commentsLabel = "Claim Comments";
         $navPath =
         [
-            'All Games' => '/gameList.php',
-            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
-            $gameData['Title'] => '/game/' . $gameData['ID'],
+            '_GamePrefix' => renderGameBreadcrumb($gameData),
             'Manage Claims' => '/manageclaims.php?g=' . $gameData['ID'],
         ];
         break;
@@ -102,9 +94,7 @@ switch ($articleTypeID)
         }
         $navPath =
         [
-            'All Games' => '/gameList.php',
-            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
-            $gameData['Title'] => '/game/' . $gameData['ID'],
+            '_GamePrefix' => renderGameBreadcrumb($gameData),
             $pageTitle => '/achievement/' . $articleID,
         ];
         break;
@@ -120,9 +110,7 @@ switch ($articleTypeID)
         }
         $navPath =
         [
-            'All Games' => '/gameList.php',
-            $gameData['ConsoleName'] => '/gameList.php?c=' . $gameData['ConsoleID'],
-            $gameData['Title'] => '/game/' . $gameData['ID'],
+            '_GamePrefix' => renderGameBreadcrumb($gameData),
             $pageTitle => '/leaderboard/' . $articleID,
         ];
         break;
@@ -178,6 +166,11 @@ RenderContentStart("$commentsLabel: $pageTitle");
     <div id="fullcontainer">
         <?php
             echo "<div class='navpath'>";
+            if (array_key_first($navPath) === '_GamePrefix') {
+                // Render game breadcrumb prefix
+                echo $navPath['_GamePrefix'] . " &raquo; ";
+                array_shift($navPath);
+            }
             foreach ($navPath as $text => $link) {
                 echo "<a href='$link'>$text</a> &raquo; ";
             }


### PR DESCRIPTION
Follow-up to #1314, as per @RALordAndrew's report.

- Fix breadcrumb links not working for game titles with special characters (e.g `/`, `'` and `\`). Previously, sanitization was converting titles like `.hack//Infection` to `.hack--Infection`, which caused queries to fail. Solved by modifying `sanitizeTitle` to slash-escape text instead; then, `s_mysql_sanitized_query` is called (which is fine, I hope, since the dangerous parts have already been sanitized).

- Add tag rendering to `comments.php` breadcrumb + header:

![image](https://user-images.githubusercontent.com/22218549/213876639-f5800e4b-9d84-4774-85e2-2161814ae34f.png)

---

Furthermore, we have some breaking cases revolving around base game and subset naming; more precisely, when `$title` isn't actually the base game for the subset `$title [Subset - XYZ]`. However, I could find only two instances of it, which are ironically opposite in nature:
1. [This subset](https://retroachievements.org/game/16084) being derived from the Red part of [Pokemon Red / Blue](https://retroachievements.org/game/724), which is a merged set
2. [This other subset](https://retroachievements.org/game/12399) being derived both from [Zelda Oracle of Ages](https://retroachievements.org/game/710) and [Zelda Oracle of Seasons](https://retroachievements.org/game/676), which are split.

I couldn't think of a clever way to solve it, so I left the issue untouched. Ideas?