### PR TITLE
Achievement list polishing/fixes; single-line progressbar label

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1199,7 +1199,7 @@ sanitize_outputs(
                             echo "<tr>";
                             echo "<td>";
 
-                            echo "<div class='flex justify-between gap-3 items-start'>";
+                            echo "<div class='flex items-center gap-4 p-2'>";
 
                             echo "<div>";
 
@@ -1219,10 +1219,10 @@ sanitize_outputs(
                             );
                             echo "</div>";
 
-                            echo "<div class='md:flex justify-between items-center gap-3 grow'>";
+                            echo "<div class='md:flex grow justify-between items-center gap-4'>";
 
-                            echo "<div class='achievementdata'>";
-                            echo "<div class='mb-1 lg:mt-1'>";
+                            echo "<div class='flex flex-col grow gap-2'>";
+                            echo "<div>";
                             echo achievementAvatar(
                                 $nextAch,
                                 label: true,
@@ -1231,7 +1231,7 @@ sanitize_outputs(
                             );
                             echo " <span class='TrueRatio'>($achTrueRatio)</span>";
                             echo "</div>";
-                            echo "<div class='mb-2'>$achDesc</div>";
+                            echo "<div>$achDesc</div>";
                             if ($achieved) {
                                 echo "<div class='date smalltext italic'>Unlocked on $dateAch</div>";
                             }

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1183,6 +1183,7 @@ sanitize_outputs(
 
                             $wonBy = $nextAch['NumAwarded'];
                             $wonByHardcore = $nextAch['NumAwardedHardcore'];
+                            $wonByCasual = $wonBy - $wonByHardcore;
                             if ($numDistinctPlayersCasual == 0) {
                                 $completionPctCasual = "0";
                                 $completionPctHardcore = "0";
@@ -1214,27 +1215,8 @@ sanitize_outputs(
                             echo "</div>";
 
                             echo "<div class='md:flex justify-between items-start gap-3 grow'>";
-                            $pctAwardedCasual = 0;
-                            $pctAwardedHardcore = 0;
-                            $pctComplete = 0;
-                            if ($numDistinctPlayersCasual) {
-                                $pctAwardedCasual = $wonBy / $numDistinctPlayersCasual;
-                                $pctAwardedHardcore = $wonByHardcore / $numDistinctPlayersCasual;
-                                $pctAwardedHardcoreProportion = 0;
-                                if ($wonByHardcore > 0 && $wonBy > 0) {
-                                    $pctAwardedHardcoreProportion = $wonByHardcore / $wonBy;
-                                }
 
-                                $pctAwardedCasual = sprintf("%01.1f", $pctAwardedCasual * 100.0);
-                                $pctAwardedHardcore = sprintf("%01.1f", $pctAwardedHardcoreProportion * 100.0);
-
-                                $pctComplete = sprintf(
-                                    "%01.1f",
-                                    ($wonBy + $wonByHardcore) * 100.0 / $numDistinctPlayersCasual
-                                );
-                            }
                             echo "<div class='achievementdata'>";
-
                             echo "<div class='mb-1 lg:mt-1'>";
                             echo achievementAvatar(
                                 $nextAch,
@@ -1250,14 +1232,32 @@ sanitize_outputs(
                             }
                             echo "</div>";
 
+                            [$pctAwarded, $pctAwardedHardcore, $pctAwardedCasual] = [0, 0, 0];
+                            if ($numDistinctPlayersCasual) {
+                                $pctAwarded = $wonBy / $numDistinctPlayersCasual;
+                                $pctAwardedHardcore = $wonByHardcore / $numDistinctPlayersCasual;
+                                $pctAwardedHardcoreProportion = ($wonByHardcore > 0 && $wonBy > 0) ?
+                                    ($pctAwardedHardcoreProportion = $wonByHardcore / $wonBy) : 0;
+                                $pctAwardedCasual = $pctAwarded - $pctAwardedHardcore;
+
+                                $stringify = function (&$pct) {
+                                    $pct = sprintf("%01.1f", $pct * 100.0);
+                                };
+                                $stringify($pctAwardedHardcoreProportion);
+                                $stringify($pctAwardedCasual);
+                                $stringify($pctAwardedHardcore);
+                                $stringify($pctAwarded);
+                            }
+
                             echo "<div class='progress'>";
                             echo "<div class='progressbar'>";
-                            echo "<div class='completion' style='width:$pctAwardedCasual%'>";
-                            echo "<div class='completion-hardcore' style='width:$pctAwardedHardcore%'></div>";
+                            echo "<div class='completion' style='width:$pctAwarded%'>";
+                            echo "<div class='completion-hardcore' style='width:$pctAwardedHardcoreProportion%'></div>";
                             echo "</div>";
                             echo "</div>";
                             echo "<div class='progressbar-label mt-1'>";
-                            echo "<strong>$wonByHardcore</strong> of $numDistinctPlayersCasual players <small>($pctAwardedCasual%)</small>";
+                            echo "<strong title='+ $wonByCasual softcore unlocks'>$wonByHardcore</strong> of $numDistinctPlayersCasual players "
+                                . "<small title='+ $pctAwardedCasual% softcore unlocks'>($pctAwardedHardcore%)</small>";
                             echo "</div>";
                             echo "</div>";
                             

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1225,15 +1225,16 @@ sanitize_outputs(
                                     $pctAwardedHardcoreProportion = $wonByHardcore / $wonBy;
                                 }
 
-                                $pctAwardedCasual = sprintf("%01.2f", $pctAwardedCasual * 100.0);
-                                $pctAwardedHardcore = sprintf("%01.2f", $pctAwardedHardcoreProportion * 100.0);
+                                $pctAwardedCasual = sprintf("%01.1f", $pctAwardedCasual * 100.0);
+                                $pctAwardedHardcore = sprintf("%01.1f", $pctAwardedHardcoreProportion * 100.0);
 
                                 $pctComplete = sprintf(
-                                    "%01.2f",
+                                    "%01.1f",
                                     ($wonBy + $wonByHardcore) * 100.0 / $numDistinctPlayersCasual
                                 );
                             }
                             echo "<div class='achievementdata'>";
+
                             echo "<div class='mb-1 lg:mt-1'>";
                             echo achievementAvatar(
                                 $nextAch,
@@ -1256,14 +1257,10 @@ sanitize_outputs(
                             echo "</div>";
                             echo "</div>";
                             echo "<div class='progressbar-label mt-1'>";
-                            if ($wonByHardcore > 0) {
-                                echo "$wonBy <strong>($wonByHardcore)</strong> of $numDistinctPlayersCasual<br/>($pctAwardedCasual%) players";
-                            } else {
-                                echo "$wonBy of $numDistinctPlayersCasual<br>($pctAwardedCasual%) players";
-                            }
+                            echo "<strong>$wonByHardcore</strong> of $numDistinctPlayersCasual players <small>($pctAwardedCasual%)</small>";
                             echo "</div>";
                             echo "</div>";
-
+                            
                             echo "</div>";
 
                             echo "</div>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1214,7 +1214,7 @@ sanitize_outputs(
                             );
                             echo "</div>";
 
-                            echo "<div class='md:flex justify-between items-start gap-3 grow'>";
+                            echo "<div class='md:flex justify-between items-center gap-3 grow'>";
 
                             echo "<div class='achievementdata'>";
                             echo "<div class='mb-1 lg:mt-1'>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1249,8 +1249,8 @@ sanitize_outputs(
                             }
                             echo "</div>";
 
-                            echo "<div class='my-2'>";
-                            echo "<div class='progressbar w-40'>";
+                            echo "<div class='progress'>";
+                            echo "<div class='progressbar'>";
                             echo "<div class='completion' style='width:$pctAwardedCasual%'>";
                             echo "<div class='completion-hardcore' style='width:$pctAwardedHardcore%'></div>";
                             echo "</div>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1267,7 +1267,7 @@ sanitize_outputs(
                             echo "</div>";
 
                             echo "</div>";
-                            
+
                             echo "</div>";
 
                             echo "</div>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1256,12 +1256,14 @@ sanitize_outputs(
                             echo "</div>";
                             echo "</div>";
 
-                            $titleWonByCasual = ($wonByCasual > 0) ? " title='+ $wonByCasual softcore unlocks'" : "";
-                            $titlePctAwardedCasual = ($wonByCasual > 0) ? " title='+ $pctAwardedCasual% softcore unlocks'" : "";
+                            $titleWonByCasual = ($wonByCasual > 0) ?
+                                " title='+ $wonByCasual softcore unlock(s) — Total: $wonBy'" : "";
+                            $titlePctAwardedCasual = ($wonByCasual > 0) ?
+                                " title='+ $pctAwardedCasual% softcore unlocks — Total: $pctAwarded%'" : "";
                             echo "<div class='progressbar-label mt-1'>";
-                            echo "<strong class='hint-tooltip' $titleWonByCasual>$wonByHardcore</strong> "
+                            echo "<strong class='tooltip-hint' $titleWonByCasual>$wonByHardcore</strong> "
                                 . "of $numDistinctPlayersCasual players "
-                                . "<small class='hint-tooltip' $titlePctAwardedCasual>($pctAwardedHardcore%)</small>";
+                                . "<small class='tooltip-hint' $titlePctAwardedCasual>($pctAwardedHardcore%)</small>";
                             echo "</div>";
 
                             echo "</div>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1203,7 +1203,12 @@ sanitize_outputs(
 
                             echo "<div>";
 
-                            $nextAch['Unlock'] = $earnedOnHardcore ? '<br clear=all>Unlocked: ' . getNiceDate(strtotime($nextAch['DateEarnedHardcore'])) . '<br>HARDCORE' : null;
+                            $nextAch['Unlock'] = null;
+                            if ($earnedOnHardcore) {
+                                $dataEarned = getNiceDate(strtotime($nextAch['DateEarnedHardcore']));
+                                $nextAch['Unlock'] = "<br>Unlocked: $dataEarned<br>HARDCORE";
+                            }
+
                             echo achievementAvatar(
                                 $nextAch,
                                 label: false,
@@ -1228,7 +1233,7 @@ sanitize_outputs(
                             echo "</div>";
                             echo "<div class='mb-2'>$achDesc</div>";
                             if ($achieved) {
-                                echo "<div class='date smalltext'>Unlocked $dateAch</div>";
+                                echo "<div class='date smalltext italic'>Unlocked on $dateAch</div>";
                             }
                             echo "</div>";
 

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1255,10 +1255,15 @@ sanitize_outputs(
                             echo "<div class='completion-hardcore' style='width:$pctAwardedHardcoreProportion%'></div>";
                             echo "</div>";
                             echo "</div>";
+
+                            $titleWonByCasual = ($wonByCasual > 0) ? " title='+ $wonByCasual softcore unlocks'" : "";
+                            $titlePctAwardedCasual = ($wonByCasual > 0) ? " title='+ $pctAwardedCasual% softcore unlocks'" : "";
                             echo "<div class='progressbar-label mt-1'>";
-                            echo "<strong title='+ $wonByCasual softcore unlocks'>$wonByHardcore</strong> of $numDistinctPlayersCasual players "
-                                . "<small title='+ $pctAwardedCasual% softcore unlocks'>($pctAwardedHardcore%)</small>";
+                            echo "<strong class='hint-tooltip' $titleWonByCasual>$wonByHardcore</strong> "
+                                . "of $numDistinctPlayersCasual players "
+                                . "<small class='hint-tooltip' $titlePctAwardedCasual>($pctAwardedHardcore%)</small>";
                             echo "</div>";
+
                             echo "</div>";
                             
                             echo "</div>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1232,7 +1232,7 @@ sanitize_outputs(
                             }
                             echo "</div>";
 
-                            [$pctAwarded, $pctAwardedHardcore, $pctAwardedCasual] = [0, 0, 0];
+                            [$pctAwarded, $pctAwardedHardcore, $pctAwardedHardcoreProportion, $pctAwardedCasual] = [0, 0, 0, 0];
                             if ($numDistinctPlayersCasual) {
                                 $pctAwarded = $wonBy / $numDistinctPlayersCasual;
                                 $pctAwardedHardcore = $wonByHardcore / $numDistinctPlayersCasual;

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1199,7 +1199,7 @@ sanitize_outputs(
                             echo "<tr>";
                             echo "<td>";
 
-                            echo "<div class='flex items-center gap-4 p-2'>";
+                            echo "<div class='flex items-center gap-3.5 p-2'>";
 
                             echo "<div>";
 

--- a/resources/css/progress.css
+++ b/resources/css/progress.css
@@ -1,3 +1,9 @@
+.progress {
+  margin: .5em .2em;
+  min-width: 12em;
+  max-width: 12em;
+}
+
 .progressbar {
   overflow: hidden;
   height: 6px;

--- a/resources/css/progress.css
+++ b/resources/css/progress.css
@@ -1,7 +1,7 @@
 .progress {
-  margin: .5em .2em;
-  min-width: 12em;
-  max-width: 12em;
+  margin: .7em 0 0 .2em;
+  min-width: 13em;
+  max-width: 13em;
 }
 
 .progressbar {

--- a/resources/css/utilities.css
+++ b/resources/css/utilities.css
@@ -34,3 +34,8 @@
 span.smalldate {
   display: inline-block;
 }
+
+[title].tooltip-hint {
+  cursor: help;
+  border-bottom: 1px dotted #888a;
+}


### PR DESCRIPTION
- General CSS refinement (padding, alignment, italics on "Unlocked" text, etc)

![css](https://user-images.githubusercontent.com/22218549/213896478-27603c86-c673-4d70-ab90-739d7b5286a4.png)

- Progressbar label fits in a single line now. Moved softcore data to tooltips (both for amount and percentage)

![softcore-amount](https://user-images.githubusercontent.com/22218549/213896598-f69be549-c69b-4dd4-8302-f7c5071f8676.png)
![softcore-percentage](https://user-images.githubusercontent.com/22218549/213896590-4ded0b0d-5f07-426d-9df5-94f5af7db217.png)

- Fixed this label centering anomaly that happened on mobile:

[compact-broken.webm](https://user-images.githubusercontent.com/22218549/213896666-49ce7b59-0ff3-4022-bb54-ed89a08b5b32.webm)
