### PR TITLE
docs(README.md): update required node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is a Laravel application ([TALL stack](https://tallstack.dev/)) including ind
 - [PHP 8.0](http://php.net/manual/en/)
 - [Composer v2](https://getcomposer.org/) PHP dependency manager
 - [MySQL 8](https://dev.mysql.com/doc/refman/8.0/en/)
-- [Node.js 16](https://nodejs.org/)
+- [Node.js 18](https://nodejs.org/)
  
 Validated to run on Windows, macOS, and Linux with any of the setup options below (Docker via Laravel Sail, VM with either nginx or Apache, Laravel Valet on macOS).
 


### PR DESCRIPTION
The README is currently incorrect. The required Node.js version is [enforced via the _package.json_ file](https://github.com/RetroAchievements/RAWeb/blob/219266ab104da7c74c236b67125ed6cb4e9340e1/package.json#L33):

```json
"engines": {
    "node": "v18.8.0",
    "npm": "8.18.0"
}
```