### PR TITLE
Fix logout request

### DIFF
--- a/app_legacy/Site/Models/User.php
+++ b/app_legacy/Site/Models/User.php
@@ -44,6 +44,11 @@ class User extends BaseModel implements AuthenticatableContract, AuthorizableCon
         'SaltedPass',
     ];
 
+    public function getRememberTokenName(): ?string
+    {
+        return null;
+    }
+
     public function getAuthPassword()
     {
         return $this->Password;


### PR DESCRIPTION
Strict model rules apply (https://github.com/RetroAchievements/RAWeb/blob/master/app_legacy/Site/AppServiceProvider.php#L24).

Laravel tries to access `remember_token` on the legacy User model which does not exist.
Setting it to `null` resolves this for now.