### PR TITLE
show "Invalid Credentials" error if current password is incorrect

### DIFF
--- a/public/request/auth/update-password.php
+++ b/public/request/auth/update-password.php
@@ -17,7 +17,7 @@ $input = Validator::validate(request()->post(), [
 $username = $user->User;
 
 if (!authenticateFromPassword($username, $input['password_current'])) {
-    return back()->withErrors(__('legacy.error.account'));
+    return back()->withErrors(__('legacy.error.credentials'));
 }
 
 RemovePasswordResetToken($username);


### PR DESCRIPTION
instead of "There appears to be a problem with your account".