### PR TITLE
Adjust user account timstamps

### DIFF
--- a/app_legacy/Site/AppServiceProvider.php
+++ b/app_legacy/Site/AppServiceProvider.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\ServiceProvider;
+use LegacyApp\Site\Commands\UpdateUserTimestamps;
 use LegacyApp\Site\Models\User;
 
 class AppServiceProvider extends ServiceProvider
@@ -16,6 +17,7 @@ class AppServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
+                UpdateUserTimestamps::class,
             ]);
         }
 

--- a/app_legacy/Site/Commands/UpdateUserTimestamps.php
+++ b/app_legacy/Site/Commands/UpdateUserTimestamps.php
@@ -121,24 +121,30 @@ class UpdateUserTimestamps extends Command
             if ($forumTopicTimestamps->has($user->ID)) {
                 $forumTopicTimestamp = $forumTopicTimestamps->get($user->ID)['ForumTopicTimestamp'];
                 $timestampMemento = $timestampMemento->isAfter($forumTopicTimestamp) ? Carbon::parse($forumTopicTimestamp) : $timestampMemento;
+                // $this->line('[' . $user->ID . '] FTC! ' . $timestampMemento->format('Y-m-d H:i:s'));
             }
 
             // Take earlier comment timestamp if exists
             if ($commentTimestamps->has($user->ID)) {
                 $commentTimestamp = $commentTimestamps->get($user->ID)['CommentTimestamp'];
                 $timestampMemento = $timestampMemento->isAfter($commentTimestamp) ? Carbon::parse($commentTimestamp) : $timestampMemento;
+                // $this->line('[' . $user->ID . '] C! ' . $timestampMemento->format('Y-m-d H:i:s'));
             }
 
             // Apply previous timestamp if it's earlier than the current or no Created timestamp exists.
             if (!$user->Created || $user->Created->isAfter($timestampMemento)) {
-                // $this->line('Update ' . $user->User . ' from "' . $user->Created . '" to "' . $timestampMemento . '"');
                 $user->update([
                     'Created' => $timestampMemento,
                 ]);
                 $updated++;
-            } else {
-                $timestampMemento = $user->Created;
+                // $this->line('[' . $user->ID . '] Update ' . $user->User . ' from "' . $user->Created . '" to "' . $timestampMemento . '"');
             }
+
+            if ($user->Created && $user->Created->isBefore($timestampMemento)) {
+                $timestampMemento = $user->Created;
+                // $this->line('[' . $user->ID . '] Use ' . $timestampMemento->format('Y-m-d H:i:s'));
+            }
+
             $progressBar->advance();
         }
         $progressBar->finish();

--- a/app_legacy/Site/Commands/UpdateUserTimestamps.php
+++ b/app_legacy/Site/Commands/UpdateUserTimestamps.php
@@ -67,7 +67,7 @@ class UpdateUserTimestamps extends Command
                 'Updated' => DB::raw('Updated'),
             ]);
 
-        $this->line('Updated initial account creation timestamps');
+        $this->info('Updated initial account creation timestamps');
     }
 
     /**
@@ -130,7 +130,7 @@ class UpdateUserTimestamps extends Command
             }
 
             // Apply previous timestamp if it's earlier than the current or no Created timestamp exists.
-            if (!$user->Created || $user->Created > $timestampMemento) {
+            if (!$user->Created || $user->Created->isAfter($timestampMemento)) {
                 // $this->line('Update ' . $user->User . ' from "' . $user->Created . '" to "' . $timestampMemento . '"');
                 $user->update([
                     'Created' => $timestampMemento,

--- a/app_legacy/Site/Commands/UpdateUserTimestamps.php
+++ b/app_legacy/Site/Commands/UpdateUserTimestamps.php
@@ -6,6 +6,7 @@ namespace LegacyApp\Site\Commands;
 
 use Eloquent;
 use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use LegacyApp\Site\Models\User;
 
@@ -16,6 +17,13 @@ class UpdateUserTimestamps extends Command
     protected $description = 'Calculates missing and/or incorrect timestamps for users';
 
     public function handle(): void
+    {
+        $this->updateInitialAccountCreationDates();
+
+        $this->interpolateAccountCreationDates();
+    }
+
+    private function updateInitialAccountCreationDates(): void
     {
         // Scott's account was created on the day of the domain registration
         User::where('User', 'Scott')
@@ -59,21 +67,70 @@ class UpdateUserTimestamps extends Command
                 'Updated' => DB::raw('Updated'),
             ]);
 
-        // Iterate through user accounts by ID, descending, fill gaps and correct order of timestamps.
+        $this->line('Updated initial account creation timestamps');
+    }
+
+    /**
+     * Iterate through user accounts by ID, descending, fill gaps and correct order of timestamps.
+     */
+    private function interpolateAccountCreationDates(): void
+    {
         Eloquent::unguard();
-        $maxId = User::whereNull('Created')->max('ID') + 1; // 106605
+        // 106605, created on 2019-09-22 is the first user to have a real creation timestamp
+        $maxId = 106605;
+
+        $this->line('Fetching forum topic comment timestamps...');
+        $forumTopicTimestamps = User::withTrashed()
+            ->selectRaw('UserAccounts.ID, UserAccounts.User, UserAccounts.Created, MIN(ForumTopicComment.DateCreated) ForumTopicTimestamp')
+            ->leftJoin('ForumTopicComment', 'Author', '=', 'UserAccounts.User')
+            ->where('UserAccounts.ID', '<=', $maxId)
+            ->whereRaw('ForumTopicComment.DateCreated < UserAccounts.Created')
+            ->groupByRaw('UserAccounts.ID, UserAccounts.User, UserAccounts.Created')
+            ->orderByDesc('UserAccounts.ID')
+            ->get()
+            ->keyBy('ID');
+        $this->info('Found ' . $forumTopicTimestamps->count() . ' earlier forum topic comment timestamps');
+
+        $this->line('Fetching comment timestamps...');
+        $commentTimestamps = User::withTrashed()
+            ->selectRaw('UserAccounts.ID, UserAccounts.User, UserAccounts.Created, MIN(Comment.Submitted) CommentTimestamp')
+            ->leftJoin('Comment', 'UserID', '=', 'UserAccounts.ID')
+            ->where('UserAccounts.ID', '<=', $maxId)
+            ->whereRaw('Comment.Submitted < UserAccounts.Created')
+            ->groupByRaw('UserAccounts.ID, UserAccounts.User, UserAccounts.Created')
+            ->orderByDesc('UserAccounts.ID')
+            ->get()
+            ->keyBy('ID');
+        $this->info('Found ' . $commentTimestamps->count() . ' earlier comment timestamps');
+
+        $this->line('Interpolate account creation timestamps...');
         $users = User::withTrashed()
             ->where('ID', '<=', $maxId)
             ->orderByDesc('ID')
             ->get(['ID', 'User', 'Created']);
+
         $progressBar = $this->output->createProgressBar($users->count());
         $progressBar->start();
         $timestampMemento = null;
         $updated = 0;
         /** @var User $user */
         foreach ($users as $user) {
+            $timestampMemento ??= $user->Created;
+
+            // Take earlier forum topic comment timestamp if exists
+            if ($forumTopicTimestamps->has($user->ID)) {
+                $forumTopicTimestamp = $forumTopicTimestamps->get($user->ID)['ForumTopicTimestamp'];
+                $timestampMemento = $timestampMemento->isAfter($forumTopicTimestamp) ? Carbon::parse($forumTopicTimestamp) : $timestampMemento;
+            }
+
+            // Take earlier comment timestamp if exists
+            if ($commentTimestamps->has($user->ID)) {
+                $commentTimestamp = $commentTimestamps->get($user->ID)['CommentTimestamp'];
+                $timestampMemento = $timestampMemento->isAfter($commentTimestamp) ? Carbon::parse($commentTimestamp) : $timestampMemento;
+            }
+
             // Apply previous timestamp if it's earlier than the current or no Created timestamp exists.
-            if ($timestampMemento && (!$user->Created || $user->Created > $timestampMemento)) {
+            if (!$user->Created || $user->Created > $timestampMemento) {
                 // $this->line('Update ' . $user->User . ' from "' . $user->Created . '" to "' . $timestampMemento . '"');
                 $user->update([
                     'Created' => $timestampMemento,
@@ -86,6 +143,6 @@ class UpdateUserTimestamps extends Command
         }
         $progressBar->finish();
 
-        $this->line('Updated ' . $updated . ' timestamps');
+        $this->info(PHP_EOL . 'Updated ' . $updated . ' account creation timestamps');
     }
 }

--- a/app_legacy/Site/Commands/UpdateUserTimestamps.php
+++ b/app_legacy/Site/Commands/UpdateUserTimestamps.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LegacyApp\Site\Commands;
+
+use Eloquent;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use LegacyApp\Site\Models\User;
+
+class UpdateUserTimestamps extends Command
+{
+    protected $signature = 'ra-legacy:site:update-user-timestamps';
+
+    protected $description = 'Calculates missing and/or incorrect timestamps for users';
+
+    public function handle(): void
+    {
+        // Scott's account was created on the day of the domain registration
+        User::where('User', 'Scott')
+            ->update([
+                'Created' => '2012-10-03 13:37:00',
+                'Updated' => DB::raw('Updated'),
+            ]);
+
+        // https://web.archive.org/web/20121121150009/http://retroachievements.org/
+        User::whereIn('User', [
+            'Dave',
+            'Jimmy',
+            'Batman',
+            'Steve',
+            'Michael',
+            'poip',
+            'Sonic',
+            'qwer',
+            'Bob',
+            'Dan',
+            'Jim',
+            'qweqwe',
+            'qwe',
+        ])
+            ->update([
+                'Created' => '2012-11-21 13:37:00',
+                'Updated' => DB::raw('Updated'),
+            ]);
+
+        // Teario - first achievement unlock
+        User::where('User', 'Teario')
+            ->update([
+                'Created' => '2012-12-29 13:37:00',
+                'Updated' => DB::raw('Updated'),
+            ]);
+
+        // Same as nightgoat99
+        User::where('User', 'nightgoat')
+            ->update([
+                'Created' => '2013-03-02 04:17:05',
+                'Updated' => DB::raw('Updated'),
+            ]);
+
+        // Iterate through user accounts by ID, descending, fill gaps and correct order of timestamps.
+        Eloquent::unguard();
+        $maxId = User::whereNull('Created')->max('ID') + 1; // 106605
+        $users = User::withTrashed()
+            ->where('ID', '<=', $maxId)
+            ->orderByDesc('ID')
+            ->get(['ID', 'User', 'Created']);
+        $progressBar = $this->output->createProgressBar($users->count());
+        $progressBar->start();
+        $timestampMemento = null;
+        $updated = 0;
+        /** @var User $user */
+        foreach ($users as $user) {
+            // Apply previous timestamp if it's earlier than the current or no Created timestamp exists.
+            if ($timestampMemento && (!$user->Created || $user->Created > $timestampMemento)) {
+                // $this->line('Update ' . $user->User . ' from "' . $user->Created . '" to "' . $timestampMemento . '"');
+                $user->update([
+                    'Created' => $timestampMemento,
+                ]);
+                $updated++;
+            } else {
+                $timestampMemento = $user->Created;
+            }
+            $progressBar->advance();
+        }
+        $progressBar->finish();
+
+        $this->line('Updated ' . $updated . ' timestamps');
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,7 +16,7 @@ parameters:
         - '#Unsafe usage of new static#'
         # accessors to polymorphic relationships
         - '#Access to an undefined property [a-zA-Z0-9\&\\_]+::\$[trigger|subject]#'
-        #- '#Access to an undefined property LegacyApp\\Models\\.*#'
+        - '#Access to an undefined property LegacyApp\\Site\\Models\\.*#'
         # Builder::exists() is not private
         #- '#Call to private method exists\(\) of parent class Illuminate\\Database\\Eloquent\\Builder<Illuminate\\Database\\Eloquent\\Model>.#'
         - '#Parameter (.*) of function htmlentities expects#'


### PR DESCRIPTION
Add a command to derive more accurate creation timestamps for user accounts.

```shell
php artisan ra-legacy:site:update-user-timestamps
```

This fixes an issue where some accounts are allowed to request a high amount of sets due to their creation timestamp not existing.
Creation timestamps ("Member Since" on profile pages) used to be derived from the Activity table.
Activity entries were written when a user first logged in, not when the account was actually created. As some of the accounts never had any activity there is no date to go by. 
This command tries to interpolate missing and/or timestamps that are out of order.