### PR TITLE
Require 0-point achievements for `Latest Masters` table

### DIFF
--- a/app_legacy/Helpers/database/player-game.php
+++ b/app_legacy/Helpers/database/player-game.php
@@ -393,18 +393,20 @@ function getGameTopAchievers(int $gameID): array
 
     $high_scores = [];
     $masters = [];
-    $mastery_score = 0;
+    $numAchievementsInSet = 0;
 
-    $query = "SELECT SUM(Points) AS Points FROM Achievements WHERE GameID = $gameID AND Flags = " . AchievementType::OfficialCore;
+    $query = "SELECT COUNT(*) AS NumAchievementsInSet
+        FROM Achievements
+        WHERE GameID = $gameID AND Flags = " . AchievementType::OfficialCore;
     $dbResult = s_mysql_query($query);
 
     if ($dbResult !== false) {
         if ($data = mysqli_fetch_assoc($dbResult)) {
-            $mastery_score = $data['Points'];
+            $numAchievementsInSet = $data['NumAchievementsInSet'];
         }
     }
 
-    $query = "SELECT aw.User, SUM(ach.points) AS TotalScore, MAX(aw.Date) AS LastAward
+    $query = "SELECT aw.User, COUNT(*) AS NumAchievements, SUM(ach.points) AS TotalScore, MAX(aw.Date) AS LastAward
                 FROM Awarded AS aw
                 LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
                 LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
@@ -425,7 +427,7 @@ function getGameTopAchievers(int $gameID): array
                 $high_scores[] = $data;
             }
 
-            if ($data['TotalScore'] == $mastery_score) {
+            if ($data['NumAchievements'] == $numAchievementsInSet) {
                 if (count($masters) == 10) {
                     array_shift($masters);
                 }


### PR DESCRIPTION
Address #1349.

So far, the "Latest Masters" table only checked for 100% points, not accounting for cases where the player missed one or more 0-point achievements (thus not 100% cheevos). This is in disagreement with other instances for showing mastery, e.g the "Completion Progress" table. As a side effect, one could possibly even repeatedly "update" their table spot by earning 0-point cheevos.

Fixed by simply changing the check from _total points_ to _amount of achievements_.