### PR TITLE
feat(home): redesign Statistics section

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -30,6 +30,7 @@
 @import "progress.css";
 @import "rating.css";
 @import "search.css";
+@import "statistics.css";
 @import "status-message.css";
 @import "tab.css";
 @import "tag.css";

--- a/resources/css/statistics.css
+++ b/resources/css/statistics.css
@@ -1,5 +1,5 @@
 .stat-box {
-  @apply w-full h-24 border border-[color:var(--embed-highlight-color)];
+  @apply w-full h-20 border border-[color:var(--embed-highlight-color)];
   @apply flex flex-col justify-center items-center;
   @apply cursor-pointer;
   @apply text-[color:var(--link-color)] bg-[color:var(--embed-color)];

--- a/resources/css/statistics.css
+++ b/resources/css/statistics.css
@@ -1,0 +1,8 @@
+.stat-box {
+  @apply w-full h-24 border border-[color:var(--embed-highlight-color)];
+  @apply flex flex-col justify-center items-center;
+  @apply cursor-pointer;
+  @apply text-[color:var(--link-color)] bg-[color:var(--embed-color)];
+  @apply hover:text-white hover:border-[color:var(--menu-link-color)] hover:bg-[color:var(--embed-highlight-color)];
+  @apply select-none;
+}

--- a/resources/views/components/home-stats-embed.blade.php
+++ b/resources/views/components/home-stats-embed.blade.php
@@ -1,0 +1,4 @@
+<a class="stat-box" href="{{ $href }}">
+    <span class="text-xl">{{ number_format($count) }}</span>
+    <span class="text-xs">{{ $label }}</span>
+</a>

--- a/resources/views/components/home-stats-embed.blade.php
+++ b/resources/views/components/home-stats-embed.blade.php
@@ -1,4 +1,4 @@
 <a class="stat-box" href="{{ $href }}">
-    <span class="text-xl">{{ number_format($count) }}</span>
     <span class="text-xs">{{ $label }}</span>
+    <span class="text-xl">{{ number_format($count) }}</span>
 </a>

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -1,7 +1,7 @@
 <?php
 
-use LegacyApp\Site\Models\StaticData;
 use Illuminate\Support\Carbon;
+use LegacyApp\Site\Models\StaticData;
 
 /** @var ?StaticData $staticData */
 $staticData = StaticData::with('lastRegisteredUser')

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -24,7 +24,7 @@ $lastRegisteredUser = $staticData['LastRegisteredUser'];
 $lastRegisteredUserAt = $staticData['LastRegisteredUserAt'];
 $totalPointsEarned = $staticData['TotalPointsEarned'];
 
-$lastRegisteredUserAtDate = new DateTime('2020-05-21 06:05:10');
+$lastRegisteredUserAtDate = new DateTime($lastRegisteredUserAt);
 $now = new DateTime();
 $interval = $lastRegisteredUserAtDate->diff($now);
 
@@ -38,7 +38,7 @@ $timeUnits = [
 ];
 foreach ($timeUnits as $format => $unit) {
     if ($interval->$format >= 1) {
-        $unit = $interval->$format > 1 ? "$unit"."s" : $unit;
+        $unit = $interval->$format > 1 ? $unit . "s" : $unit;
         // "%$format $unit ago" --> "5 minutes ago"
         $lastRegisteredUserTimeAgo = $interval->format("%$format $unit ago");
         break;

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -49,30 +49,37 @@ if ($lastRegisteredUser == null) {
     $lastRegisteredUser = 'unknown';
 }
 ?>
-<div class="component statistics">
+<div class="component statistics !mb-0">
     <h3>Statistics</h3>
 
-    <div class="infobox mb-4">
+    <div class="infobox">
         <div class="w-full">
-            <div class="w-full h-16 mb-2 flex flex-col justify-center items-center">
-                <span class="text-2xl">{{ number_format($totalPointsEarned) }}</span>
-                <span>Points earned since 2nd March 2013</span>
-            </div>
-
-            <div class="grid grid-cols-2 gap-px">
+            <div class="grid grid-cols-2 gap-px mb-2">
                 <x-home-stats-embed label="Games" :count="$numGames" href="/gameList.php?s=1" />
                 <x-home-stats-embed label="Achievements" :count="$numAchievements" href="/gameList.php?s=2" />
                 <x-home-stats-embed label="Achievement Unlocks" :count="$numAwarded" href="/achievementList.php" />
                 <x-home-stats-embed label="Registered Players" :count="$numRegisteredPlayers" href="/userList.php" />
+            </div>
+
+            <div class="w-full h-16 flex flex-col justify-center items-center">
+                <span>Points earned since 2nd March 2013</span>
+                <span class="text-2xl">{{ number_format($totalPointsEarned) }}</span>
             </div>
         </div>
     </div>
 
     <div>
         @if($staticData->lastRegisteredUser)
-            The newest registered user is
-            <x-user.avatar :user="$staticData->lastRegisteredUser" />, 
-            who joined {{ $lastRegisteredUserTimeAgo }}.
+            <hr class="mt-4 mb-5 border-[color:var(--embed-highlight-color)]">
+
+            <div class="w-full flex flex-col justify-center items-center">
+                <p>Newest user</p>
+
+                <div>
+                    <x-user.avatar :user="$staticData->lastRegisteredUser" /> 
+                    <span class="text-2xs">({{ $lastRegisteredUserTimeAgo }})</span>
+                </div>
+            </div>
         @endif
     </div>
 </div>

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -34,16 +34,16 @@ if ($lastRegisteredUser == null) {
     <h3>Statistics</h3>
     <div class="infobox">
         There are
-        <a title="Achievement List" href="/gameList.php?s=2">{{ $numAchievements }}</a>
+        <a title="Achievement List" href="/gameList.php?s=2">{{ number_format($numAchievements) }}</a>
         achievements registered for
-        <a title="Game List" href="/gameList.php?s=1">{{ $numGames }}</a> games.
-        <a title="Achievement List" href="/achievementList.php">{{ $numAwarded }}</a>
+        <a title="Game List" href="/gameList.php?s=1">{{ number_format($numGames) }}</a> games.
+        <a title="Achievement List" href="/achievementList.php">{{ number_format($numAwarded) }}</a>
         achievements have been awarded to the
-        <a title="User List" href="/userList.php">{{ $numRegisteredPlayers }}</a>
+        <a title="User List" href="/userList.php">{{ number_format($numRegisteredPlayers) }}</a>
         registered players (average: {{ $avAwardedPerPlayer }} per player)<br>
         <br>
         Since 2nd March 2013, a total of
-        <span title="Awesome!"><strong>{{ $totalPointsEarned }}</strong></span>
+        <span title="Awesome!"><strong>{{ number_format($totalPointsEarned) }}</strong></span>
         points have been earned by users on RetroAchievements.org.<br>
         <br>
         @if($staticData->lastRegisteredUser)

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -57,8 +57,8 @@ if ($lastRegisteredUser == null) {
             <div class="grid grid-cols-2 gap-px mb-2">
                 <x-home-stats-embed label="Games" :count="$numGames" href="/gameList.php?s=1" />
                 <x-home-stats-embed label="Achievements" :count="$numAchievements" href="/gameList.php?s=2" />
-                <x-home-stats-embed label="Achievement Unlocks" :count="$numAwarded" href="/achievementList.php" />
                 <x-home-stats-embed label="Registered Players" :count="$numRegisteredPlayers" href="/userList.php" />
+                <x-home-stats-embed label="Achievement Unlocks" :count="$numAwarded" href="/achievementList.php" />
             </div>
 
             <div class="w-full h-16 flex flex-col justify-center items-center">

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -24,7 +24,26 @@ $lastRegisteredUser = $staticData['LastRegisteredUser'];
 $lastRegisteredUserAt = $staticData['LastRegisteredUserAt'];
 $totalPointsEarned = $staticData['TotalPointsEarned'];
 
-$niceRegisteredAt = date("d M\nH:i", strtotime($lastRegisteredUserAt));
+$lastRegisteredUserAtDate = new DateTime('2020-05-21 06:05:10');
+$now = new DateTime();
+$interval = $lastRegisteredUserAtDate->diff($now);
+
+$timeUnits = [
+    "y" => "year",
+    "m" => "month",
+    "d" => "day",
+    "h" => "hour",
+    "i" => "minute",
+    "s" => "second",
+];
+foreach ($timeUnits as $format => $unit) {
+    if ($interval->$format >= 1) {
+        $unit = $interval->$format > 1 ? "$unit"."s" : $unit;
+        // "%$format $unit ago" --> "5 minutes ago"
+        $lastRegisteredUserTimeAgo = $interval->format("%$format $unit ago");
+        break;
+    }
+}
 
 if ($lastRegisteredUser == null) {
     $lastRegisteredUser = 'unknown';
@@ -32,24 +51,28 @@ if ($lastRegisteredUser == null) {
 ?>
 <div class="component statistics">
     <h3>Statistics</h3>
-    <div class="infobox">
-        There are
-        <a title="Achievement List" href="/gameList.php?s=2">{{ number_format($numAchievements) }}</a>
-        achievements registered for
-        <a title="Game List" href="/gameList.php?s=1">{{ number_format($numGames) }}</a> games.
-        <a title="Achievement List" href="/achievementList.php">{{ number_format($numAwarded) }}</a>
-        achievements have been awarded to the
-        <a title="User List" href="/userList.php">{{ number_format($numRegisteredPlayers) }}</a>
-        registered players (average: {{ $avAwardedPerPlayer }} per player)<br>
-        <br>
-        Since 2nd March 2013, a total of
-        <span title="Awesome!"><strong>{{ number_format($totalPointsEarned) }}</strong></span>
-        points have been earned by users on RetroAchievements.org.<br>
-        <br>
+
+    <div class="infobox mb-4">
+        <div class="w-full">
+            <div class="w-full h-16 mb-2 flex flex-col justify-center items-center">
+                <span class="text-2xl">{{ number_format($totalPointsEarned) }}</span>
+                <span>Points earned since 2nd March 2013</span>
+            </div>
+
+            <div class="grid grid-cols-2 gap-px">
+                <x-home-stats-embed label="Games" :count="$numGames" href="/gameList.php?s=1" />
+                <x-home-stats-embed label="Achievements" :count="$numAchievements" href="/gameList.php?s=2" />
+                <x-home-stats-embed label="Achievement Unlocks" :count="$numAwarded" href="/achievementList.php" />
+                <x-home-stats-embed label="Registered Players" :count="$numRegisteredPlayers" href="/userList.php" />
+            </div>
+        </div>
+    </div>
+
+    <div>
         @if($staticData->lastRegisteredUser)
-            The last registered user was
-            <x-user.avatar :user="$staticData->lastRegisteredUser"/>
-            on {{ $niceRegisteredAt }}.
+            The newest registered user is
+            <x-user.avatar :user="$staticData->lastRegisteredUser" />, 
+            who joined {{ $lastRegisteredUserTimeAgo }}.
         @endif
     </div>
 </div>

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -56,9 +56,9 @@ if ($lastRegisteredUser == null) {
         <div class="w-full">
             <div class="grid grid-cols-2 gap-px mb-2">
                 <x-home-stats-embed label="Games" :count="$numGames" href="/gameList.php?s=1" />
-                <x-home-stats-embed label="Achievements" :count="$numAchievements" href="/gameList.php?s=2" />
+                <x-home-stats-embed label="Achievements" :count="$numAchievements" href="/achievementList.php" />
                 <x-home-stats-embed label="Registered Players" :count="$numRegisteredPlayers" href="/userList.php" />
-                <x-home-stats-embed label="Achievement Unlocks" :count="$numAwarded" href="/achievementList.php" />
+                <x-home-stats-embed label="Achievement Unlocks" :count="$numAwarded" href="/recentMastery.php" />
             </div>
 
             <div class="w-full h-16 flex flex-col justify-center items-center">

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use LegacyApp\Site\Models\StaticData;
+use Illuminate\Support\Carbon;
 
 /** @var ?StaticData $staticData */
 $staticData = StaticData::with('lastRegisteredUser')
@@ -24,26 +25,7 @@ $lastRegisteredUser = $staticData['LastRegisteredUser'];
 $lastRegisteredUserAt = $staticData['LastRegisteredUserAt'];
 $totalPointsEarned = $staticData['TotalPointsEarned'];
 
-$lastRegisteredUserAtDate = new DateTime($lastRegisteredUserAt);
-$now = new DateTime();
-$interval = $lastRegisteredUserAtDate->diff($now);
-
-$timeUnits = [
-    "y" => "year",
-    "m" => "month",
-    "d" => "day",
-    "h" => "hour",
-    "i" => "minute",
-    "s" => "second",
-];
-foreach ($timeUnits as $format => $unit) {
-    if ($interval->$format >= 1) {
-        $unit = $interval->$format > 1 ? $unit . "s" : $unit;
-        // "%$format $unit ago" --> "5 minutes ago"
-        $lastRegisteredUserTimeAgo = $interval->format("%$format $unit ago");
-        break;
-    }
-}
+$lastRegisteredUserTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $lastRegisteredUserAt)->diffForHumans();
 
 if ($lastRegisteredUser == null) {
     $lastRegisteredUser = 'unknown';

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -25,10 +25,14 @@ $lastRegisteredUser = $staticData['LastRegisteredUser'];
 $lastRegisteredUserAt = $staticData['LastRegisteredUserAt'];
 $totalPointsEarned = $staticData['TotalPointsEarned'];
 
-$lastRegisteredUserTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $lastRegisteredUserAt)->diffForHumans();
-
 if ($lastRegisteredUser == null) {
     $lastRegisteredUser = 'unknown';
+}
+
+if ($lastRegisteredUserAt) {
+    $lastRegisteredUserTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $lastRegisteredUserAt)->diffForHumans();
+} else {
+    $lastRegisteredUserTimeAgo = null;
 }
 ?>
 <div class="component statistics !mb-0">
@@ -59,7 +63,9 @@ if ($lastRegisteredUser == null) {
 
                 <div>
                     <x-user.avatar :user="$staticData->lastRegisteredUser" /> 
-                    <span class="text-2xs">({{ $lastRegisteredUserTimeAgo }})</span>
+                    @if($lastRegisteredUserTimeAgo)
+                        <span class="text-2xs">({{ $lastRegisteredUserTimeAgo }})</span>
+                    @endif
                 </div>
             </div>
         @endif

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,7 @@ module.exports = {
     //   },
     // },
     fontSize: {
+      '2xs': '.70rem',
       xs: '.75rem',
       sm: '.875rem',
       base: '1rem',

--- a/vite.config.js
+++ b/vite.config.js
@@ -29,6 +29,9 @@ export default defineConfig(({ mode }) => {
           'resources/css/app.css',
           'resources/js/app.js',
         ],
+        refresh: [
+          'resources/views/**'
+        ]
       }),
     ],
     resolve: {


### PR DESCRIPTION
This PR redesigns the Statistics section on the home page.

**Why?**
The section provides interesting data, but I have always found it difficult to read. Originally, I was just going to add number separators, but I pushed a bit further to use this as an exercise to get more comfortable with the dev experience available on RAWeb.

Notable changes:
- Rather than a paragraph, content is displayed in a small 4x4 grid view.
- Numbers now have separators (ie: 1,000,000 instead of 1000000).
- The latest registered user now is using a timeago-style relative date, so instead of showing a hard date like "11 Feb 02:31", something more approachable like "5 minutes ago" is displayed.

**BEFORE**
![Screenshot 2023-02-10 at 9 52 36 PM](https://user-images.githubusercontent.com/3984985/218236412-817d66ab-8f11-4cf5-8e07-31e586da2f49.png)

**AFTER**
![Screenshot 2023-02-10 at 9 52 26 PM](https://user-images.githubusercontent.com/3984985/218236418-060490a4-df79-4d35-9666-585f0bccd68c.png)
