### PR TITLE
fix: remediate large layout shift on legacy pages

### DIFF
--- a/resources/css/legacy.css
+++ b/resources/css/legacy.css
@@ -3,8 +3,9 @@
   padding: 0;
   position: relative;
   min-height: 450px;
-  display: flex;
-  grid-gap: 1rem;
+  display: grid;
+  column-gap: 1rem;
+  grid-template-columns: 1.329fr 0.671fr;
 }
 
 @media only screen and (max-width: 1023px) {
@@ -28,6 +29,7 @@
   background: var(--box-bg-color);
   background: linear-gradient(180deg, var(--box-bg-color) 0%, var(--bg-color) 100%);
   overflow: auto; /* 1 */
+  grid-column: 1 / -1;
 }
 
 /*
@@ -40,7 +42,6 @@
   border: 2px solid var(--embed-color);
   border-radius: 4px;
   align-self: start;
-  flex-grow: 1;
   background: var(--box-bg-color);
   background: linear-gradient(180deg, var(--box-bg-color) 0%, var(--bg-color) 100%);
   overflow: auto; /* 1 */


### PR DESCRIPTION
This PR fixes an issue that I believe was introduced as part of the V2 rollout. There is now a substantial cumulative layout shift on legacy pages that have leftcolumn + rightcolumn layouts. 

I am still not totally clear on why this happens, much to my disappointment. I believe the right column renders in the DOM after the left column, but that is just my guess. Regardless, this should fix the issue while still preserving full-width layouts when they occur.

Note that this does not fix the issue on modern pages. I think only the home page and TOS fall under this umbrella presently. However since [layout shift is a core web vital](https://web.dev/cls/), this feels essential to fix for the sake of SEO.

**BEFORE**
![Broken3](https://user-images.githubusercontent.com/3984985/218292631-a7080f4e-a5c6-4134-8023-c43ec9dd5d5b.gif)

**AFTER**
![Fixed2](https://user-images.githubusercontent.com/3984985/218292636-86d959f7-95d3-4e88-8b51-711706e91bdd.gif)
