### PR TITLE
add Contact Us page

### DIFF
--- a/app/Site/Controllers/ContentController.php
+++ b/app/Site/Controllers/ContentController.php
@@ -21,6 +21,11 @@ class ContentController extends Controller
     //     return view('docs');
     // }
 
+    public function contacts(): View
+    {
+        return view('contacts');
+    }
+
     public function terms(): View
     {
         return view('terms');

--- a/app/Site/RouteServiceProvider.php
+++ b/app/Site/RouteServiceProvider.php
@@ -67,6 +67,7 @@ class RouteServiceProvider extends ServiceProvider
             Route::get('demo', [ContentController::class, 'demo'])->name('demo');
             Route::get('demo/error/{code}', [ContentController::class, 'errorDemo'])->name('demo.error');
 
+            Route::get('contacts', [ContentController::class, 'contacts'])->name('contacts');
             Route::get('terms', [ContentController::class, 'terms'])->name('terms');
             // Route::get('downloads', [DownloadController::class, 'index'])->name('download.index');
             // Route::get('feed', [FeedController::class, 'index'])->name('feed.index');

--- a/resources/views/components/menu/footer.blade.php
+++ b/resources/views/components/menu/footer.blade.php
@@ -4,45 +4,6 @@ use Illuminate\Support\Facades\Route;
 
 $menu = collect([
     [
-        'title' => config('app.name'),
-        'items' => [
-            [
-                'active' => Route::is('achievement*'),
-                'label' => __res('achievement'),
-                'url' => url('achievementList.php'),
-                // 'url' => route('achievement.index'),
-                // 'visible' => Gate::allows('viewAny', App\Platform\Models\Achievement::class),
-            ],
-            // [
-            //     'active' => Route::is('leaderboard*'),
-            //     'label' => __res('leaderboard'),
-            //     'url' => url('leaderboardList.php'),
-            //     // 'url' => route('leaderboard.index'),
-            //     // 'visible' => Gate::allows('viewAny', App\Platform\Models\Leaderboard::class),
-            // ],
-            // [
-            //     'active' => Route::is('system*'),
-            //     'label' => __res('system'),
-            //     'url' => route('system.index'),
-            //     'visible' => Gate::allows('viewAny', App\Platform\Models\System::class),
-            // ],
-            [
-                'active' => Route::is('game*'),
-                'label' => __res('game'),
-                'url' => url('gameList.php'),
-                // 'url' => route('game.index'),
-                // 'visible' => Gate::allows('viewAny', App\Platform\Models\Game::class),
-            ],
-            [
-                'active' => Route::is('downloads*'),
-                'label' => __res('emulator'),
-                'url' => url('download.php'),
-                // 'url' => route('download.index'),
-                'visible' => true,
-            ],
-        ],
-    ],
-    [
         'title' => __('Documentation'),
         'items' => [
             [
@@ -107,8 +68,14 @@ $menu = collect([
         ],
     ],
     [
-        'title' => __('About'),
+        'title' => config('app.name'),
         'items' => [
+            [
+                'active' => Route::is('contacts'),
+                'label' => __('Contact Us'),
+                'url' => route('contacts'),
+                'visible' => true,
+            ],
             [
                 'active' => Route::is('terms'),
                 'label' => __('Privacy Policy'),

--- a/resources/views/contacts.blade.php
+++ b/resources/views/contacts.blade.php
@@ -1,0 +1,100 @@
+<x-app-layout :page-title="__('Contact Us')">
+    <div class="lg:grid grid-cols-2 gap-5">
+        <div>
+            <x-section>
+                <h2>Admins and Moderators</h2>
+
+                <p class="mb-3">
+                    <a href='/createmessage.php?t=RAdmin'>Send a message to RAdmin</a> for:
+                    <ul>
+                        <li>&#x2022; Reporting offensive behavior.</li>
+                        <li>&#x2022; Reporting copyrighted material.</li>
+                        <li>&#x2022; Reporting cheating to be investigated.</li>
+                        <li>&#x2022; Requesting to be untracked.</li>
+                    </ul>
+                </p>
+            </x-section>
+
+            <x-section>
+                <h2>Developer Compliance</h2>
+
+                <p class="mb-3">
+                    <a href='/createmessage.php?t=DevCompliance'>Send a message to DevCompliance</a> for:
+                    <ul>
+                        <li>&#x2022; Requesting set approval or early set release.</li>
+                        <li>&#x2022; Reporting achievements or sets with unwelcome concepts.</li>
+                        <li>&#x2022; Reporting sets failing to cover basic progression.</li>
+                    </ul>
+                </p>
+            </x-section>
+
+            <x-section>
+                <h2>Quality Assurance</h2>
+
+                <p class="mb-3">
+                    <a href='/createmessage.php?t=QATeam'>Send a message to QATeam</a> for:
+                    <ul>
+                        <li>&#x2022; Reporting a broken set, leaderboard, or rich presence.</li>
+                        <li>&#x2022; Reporting achievements with grammatical mistakes.</li>
+                        <li>&#x2022; Requesting a set be playtested.</li>
+                        <li>&#x2022; Hash compatibility questions.</li>
+                        <li>&#x2022; Hub organizational questions.</li>
+                        <li>&#x2022; Getting involved in a QA sub-team.</li>
+                    </ul>
+                </p>
+            </x-section>
+        </div>
+
+        <div>
+            <x-section>
+                <h2>RANews</h2>
+
+                <p class="mb-3">
+                    <a href='/createmessage.php?t=RANews'>Send a message to RANews</a> for:
+                    <ul>
+                        <li>&#x2022; Submitting a Play This Set, Wish This Set, or RAdvantage entry.</li>
+                        <li>&#x2022; Submitting a retrogaming article.</li>
+                        <li>&#x2022; Proposing a new article idea.</li>
+                        <li>&#x2022; Getting involved with RANews.</li>
+                    </ul>
+                </p>
+            </x-section>
+            
+            <x-section>
+                <h2>RAEvents</h2>
+
+                <p class="mb-3">
+                    <a href='/createmessage.php?t=RAEvents'>Send a message to RAEvents</a> for
+                    submissions, questions, ideas, or reporting issues related to
+                    <a href='/game/3105'>community events</a>.
+                </p>
+
+                <p class="mb-3">
+                    <a href='/createmessage.php?t=RAEvents'>Send a message to TheUnwanted</a> for
+                    submissions, questions, ideas, or reporting issues specifically related to
+                    <a href='/game/4271'>The Unwanted</a>.
+                </p>
+            </x-section>
+
+            <x-section>
+                <h2>DevQuest</h2>
+
+                <p class="mb-3">
+                    <a href='/createmessage.php?t=DevQuest'>Send a message to DevQuest</a> for
+                    submissions, questions, ideas, or reporting issues related to
+                    <a href='/game/5686'>DevQuest</a>.
+                </p>
+            </x-section>
+
+            <x-section>
+                <h2>Quality Quest</h2>
+
+                <p class="mb-3">
+                    <a href='/createmessage.php?t=QualityQuest'>Send a message to QualityQuest</a> for
+                    submissions, questions, ideas, or reporting issues related to
+                    <a href='/game/18999'>Quality Quest</a>.
+                </p>
+            </x-section>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/contacts.blade.php
+++ b/resources/views/contacts.blade.php
@@ -6,11 +6,11 @@
 
                 <p class="mb-3">
                     <a href='/createmessage.php?t=RAdmin'>Send a message to RAdmin</a> for:
-                    <ul>
-                        <li>&#x2022; Reporting offensive behavior.</li>
-                        <li>&#x2022; Reporting copyrighted material.</li>
-                        <li>&#x2022; Reporting cheating to be investigated.</li>
-                        <li>&#x2022; Requesting to be untracked.</li>
+                    <ul class="list-disc list-inside">
+                        <li>Reporting offensive behavior.</li>
+                        <li>Reporting copyrighted material.</li>
+                        <li>Reporting cheating to be investigated.</li>
+                        <li>Requesting to be untracked.</li>
                     </ul>
                 </p>
             </x-section>
@@ -20,10 +20,10 @@
 
                 <p class="mb-3">
                     <a href='/createmessage.php?t=DevCompliance'>Send a message to DevCompliance</a> for:
-                    <ul>
-                        <li>&#x2022; Requesting set approval or early set release.</li>
-                        <li>&#x2022; Reporting achievements or sets with unwelcome concepts.</li>
-                        <li>&#x2022; Reporting sets failing to cover basic progression.</li>
+                    <ul class="list-disc list-inside">
+                        <li>Requesting set approval or early set release.</li>
+                        <li>Reporting achievements or sets with unwelcome concepts.</li>
+                        <li>Reporting sets failing to cover basic progression.</li>
                     </ul>
                 </p>
             </x-section>
@@ -33,13 +33,13 @@
 
                 <p class="mb-3">
                     <a href='/createmessage.php?t=QATeam'>Send a message to QATeam</a> for:
-                    <ul>
-                        <li>&#x2022; Reporting a broken set, leaderboard, or rich presence.</li>
-                        <li>&#x2022; Reporting achievements with grammatical mistakes.</li>
-                        <li>&#x2022; Requesting a set be playtested.</li>
-                        <li>&#x2022; Hash compatibility questions.</li>
-                        <li>&#x2022; Hub organizational questions.</li>
-                        <li>&#x2022; Getting involved in a QA sub-team.</li>
+                    <ul class="list-disc list-inside">
+                        <li>Reporting a broken set, leaderboard, or rich presence.</li>
+                        <li>Reporting achievements with grammatical mistakes.</li>
+                        <li>Requesting a set be playtested.</li>
+                        <li>Hash compatibility questions.</li>
+                        <li>Hub organizational questions.</li>
+                        <li>Getting involved in a QA sub-team.</li>
                     </ul>
                 </p>
             </x-section>
@@ -51,11 +51,11 @@
 
                 <p class="mb-3">
                     <a href='/createmessage.php?t=RANews'>Send a message to RANews</a> for:
-                    <ul>
-                        <li>&#x2022; Submitting a Play This Set, Wish This Set, or RAdvantage entry.</li>
-                        <li>&#x2022; Submitting a retrogaming article.</li>
-                        <li>&#x2022; Proposing a new article idea.</li>
-                        <li>&#x2022; Getting involved with RANews.</li>
+                    <ul class="list-disc list-inside">
+                        <li>Submitting a Play This Set, Wish This Set, or RAdvantage entry.</li>
+                        <li>Submitting a retrogaming article.</li>
+                        <li>Proposing a new article idea.</li>
+                        <li>Getting involved with RANews.</li>
                     </ul>
                 </p>
             </x-section>

--- a/resources/views/contacts.blade.php
+++ b/resources/views/contacts.blade.php
@@ -4,44 +4,47 @@
             <x-section>
                 <h2>Admins and Moderators</h2>
 
-                <p class="mb-3">
+                <p class="mb-0">
                     <a href='/createmessage.php?t=RAdmin'>Send a message to RAdmin</a> for:
-                    <ul class="list-disc list-inside">
-                        <li>Reporting offensive behavior.</li>
-                        <li>Reporting copyrighted material.</li>
-                        <li>Reporting cheating to be investigated.</li>
-                        <li>Requesting to be untracked.</li>
-                    </ul>
                 </p>
+
+                <ul class="mb-3 list-disc list-inside">
+                    <li>Reporting offensive behavior.</li>
+                    <li>Reporting copyrighted material.</li>
+                    <li>Reporting cheating to be investigated.</li>
+                    <li>Requesting to be untracked.</li>
+                </ul>
             </x-section>
 
             <x-section>
                 <h2>Developer Compliance</h2>
 
-                <p class="mb-3">
+                <p class="mb-0">
                     <a href='/createmessage.php?t=DevCompliance'>Send a message to DevCompliance</a> for:
-                    <ul class="list-disc list-inside">
-                        <li>Requesting set approval or early set release.</li>
-                        <li>Reporting achievements or sets with unwelcome concepts.</li>
-                        <li>Reporting sets failing to cover basic progression.</li>
-                    </ul>
                 </p>
+
+                <ul class="mb-3 list-disc list-inside">
+                    <li>Requesting set approval or early set release.</li>
+                    <li>Reporting achievements or sets with unwelcome concepts.</li>
+                    <li>Reporting sets failing to cover basic progression.</li>
+                </ul>
             </x-section>
 
             <x-section>
                 <h2>Quality Assurance</h2>
 
-                <p class="mb-3">
+                <p class="mb-0">
                     <a href='/createmessage.php?t=QATeam'>Send a message to QATeam</a> for:
-                    <ul class="list-disc list-inside">
-                        <li>Reporting a broken set, leaderboard, or rich presence.</li>
-                        <li>Reporting achievements with grammatical mistakes.</li>
-                        <li>Requesting a set be playtested.</li>
-                        <li>Hash compatibility questions.</li>
-                        <li>Hub organizational questions.</li>
-                        <li>Getting involved in a QA sub-team.</li>
-                    </ul>
                 </p>
+
+                <ul class="mb-3 list-disc list-inside">
+                    <li>Reporting a broken set, leaderboard, or rich presence.</li>
+                    <li>Reporting achievements with grammatical mistakes.</li>
+                    <li>Requesting a set be playtested.</li>
+                    <li>Hash compatibility questions.</li>
+                    <li>Hub organizational questions.</li>
+                    <li>Getting involved in a QA sub-team.</li>
+                </ul>
             </x-section>
         </div>
 
@@ -49,15 +52,16 @@
             <x-section>
                 <h2>RANews</h2>
 
-                <p class="mb-3">
+                <p class="mb-0">
                     <a href='/createmessage.php?t=RANews'>Send a message to RANews</a> for:
-                    <ul class="list-disc list-inside">
-                        <li>Submitting a Play This Set, Wish This Set, or RAdvantage entry.</li>
-                        <li>Submitting a retrogaming article.</li>
-                        <li>Proposing a new article idea.</li>
-                        <li>Getting involved with RANews.</li>
-                    </ul>
                 </p>
+
+                <ul class="mb-3 list-disc list-inside">
+                    <li>Submitting a Play This Set, Wish This Set, or RAdvantage entry.</li>
+                    <li>Submitting a retrogaming article.</li>
+                    <li>Proposing a new article idea.</li>
+                    <li>Getting involved with RANews.</li>
+                </ul>
             </x-section>
             
             <x-section>

--- a/resources/views/terms.blade.php
+++ b/resources/views/terms.blade.php
@@ -55,7 +55,7 @@
                     such cases.
                 </p>
 
-                <ul class="mb-3">
+                <ul class="mb-3 list-disc list-inside">
                     <li>Without your explicit consent or a legal basis, your personal data is not passed on to third parties.</li>
                     <li>Before or at the time of collecting personal information, we will identify the purposes for which information is being collected.</li>
                     <li>We will only retain personal information as long as necessary for the fulfillment of those purposes.</li>


### PR DESCRIPTION
Provides a more detailed interaction with the unique accounts over the proposed dropdown menu in #1352.

Removes the "RetroAchievements" section from the footer, as it just linked to the "All Games", "All Achievements", and "Downloads" pages, which are readily accessible from the main menu.

Replaces the "About" header for the Legal/Privacy Policy links with "RetroAchievements", and adds a "Contact Us" link there.

![image](https://user-images.githubusercontent.com/32680403/218330138-787f8deb-52a5-4454-92b1-c2f5ad26e55d.png)

Clicking on the "Contact Us" link goes to a page with links to contact each of the unique accounts, and reasons why those individual accounts should be contacted.

![image](https://user-images.githubusercontent.com/32680403/218330122-a518df52-737b-47b6-b008-a335bb606fcc.png)
