### PR TITLE
feat(top-card): redesign guest login

### DIFF
--- a/resources/views/components/user/top-card.blade.php
+++ b/resources/views/components/user/top-card.blade.php
@@ -31,10 +31,6 @@ $user = request()->user();
                 <button type="submit" name="submit" class="lg:col-start-2 lg:row-span-2 flex items-center justify-center p-2 w-full lg:w-24">Log In</button>
             </div>
         </form>
-
-        <!-- <div class="grid grid-cols-2 lg:flex lg:justify-between text-center">
-            <a href="/createaccount.php">Register</a>
-        </div> -->
     @endguest
     @auth
         <div class="flex justify-between items-start gap-2">

--- a/resources/views/components/user/top-card.blade.php
+++ b/resources/views/components/user/top-card.blade.php
@@ -26,7 +26,7 @@ $user = request()->user();
             </div>
         </form>
 
-        <div class="grid grid-cols-2 text-center">
+        <div class="grid grid-cols-2 lg:flex lg:justify-between text-center">
             <a href="/createaccount.php">Register</a>
             <a href="/resetPassword.php">Forgot Password?</a>
         </div>

--- a/resources/views/components/user/top-card.blade.php
+++ b/resources/views/components/user/top-card.blade.php
@@ -12,24 +12,29 @@ $user = request()->user();
     @guest
         <form class="mb-2" action="/request/auth/login.php" method="post">
             @csrf
-            <div class="grid lg:flex gap-2 mb-2">
+            <div class="grid gap-1 mb-2">
                 <div>
                     <label for="username-input" class="sr-only">Username</label>
-                    <input class="w-full p-2" type="text" placeholder="Username" id="username-input" name="u">
+                    <input class="w-full py-[6px]" type="text" placeholder="Username" id="username-input" name="u">
                 </div>
-                <div>
+                <div class="lg:row-start-2">
                     <label for="password-input" class="sr-only">Password</label>
-                    <input class="w-full p-2" type="password" placeholder="Password" id="password-input" name="p">
+                    <input class="w-full py-[6px]" type="password" placeholder="Password" id="password-input" name="p">
                 </div>
+            </div>
 
-                <button type="submit" name="submit" class="flex items-center justify-center p-2">Log In</button>
+            <div class="flex lg:flex-row flex-col-reverse justify-between gap-y-2">
+                <div class="flex w-full justify-around lg:flex-col">
+                    <a href="/resetPassword.php">Forgot Password?</a>
+                    <a href="/createaccount.php">Register</a>
+                </div>
+                <button type="submit" name="submit" class="lg:col-start-2 lg:row-span-2 flex items-center justify-center p-2 w-full lg:w-24">Log In</button>
             </div>
         </form>
 
-        <div class="grid grid-cols-2 lg:flex lg:justify-between text-center">
-            <a href="/resetPassword.php">Forgot Password?</a>
+        <!-- <div class="grid grid-cols-2 lg:flex lg:justify-between text-center">
             <a href="/createaccount.php">Register</a>
-        </div>
+        </div> -->
     @endguest
     @auth
         <div class="flex justify-between items-start gap-2">

--- a/resources/views/components/user/top-card.blade.php
+++ b/resources/views/components/user/top-card.blade.php
@@ -8,19 +8,19 @@ use LegacyApp\Site\Models\User;
 /** @var ?User $user */
 $user = request()->user();
 ?>
-<div class="bg-embedded rounded lg:w-[340px] lg:my-4 px-5 py-3">
+<div class="bg-embedded rounded lg:w-[340px] lg:my-4 p-[1.125rem]">
     @guest
-        <form class="grid grid-cols-2 gap-2" action="/request/auth/login.php" method="post">
+        <form class="flex gap-[1.125rem]" action="/request/auth/login.php" method="post">
             @csrf
-            <div class="flex gap-2 flex-col w-full">
+            <div class="flex flex-col grow gap-2">
                 <label class="sr-only" for="username-input">Username</label>
-                <input class="w-full" type="text" placeholder="Username" id="username-input" name="u">
+                <input id="username-input" class="w-full" type="text" placeholder="Username" name="u">
 
                 <label class="sr-only" for="password-input">Password</label>
-                <input class="w-full" type="password" placeholder="Password" id="password-input" name="p">
+                <input id="password-input" class="w-full" type="password" placeholder="Password" name="p">
             </div>
             
-            <div class="flex flex-col items-center gap-2 w-full h-full">
+            <div class="flex flex-col items-center gap-2">
                 <div class="h-7 flex items-center justify-center gap-x-2">
                     <button class="flex items-center justify-center p-2" type="submit" name="submit">Log In</button>
                     <a class="btn btn-link p-2" href="/createaccount.php">Register</a>

--- a/resources/views/components/user/top-card.blade.php
+++ b/resources/views/components/user/top-card.blade.php
@@ -10,18 +10,25 @@ $user = request()->user();
 ?>
 <div class="bg-embedded rounded lg:w-[340px] lg:my-4 px-5 py-3">
     @guest
-        <form class="flex justify-center items-end gap-2" action="/request/auth/login.php" method="post">
+        <form class="mb-2" action="/request/auth/login.php" method="post">
             @csrf
-            <div class="flex flex-col gap-1">
-                <input class="w-full" type="text" placeholder="Username" name="u">
-                <input class="w-full" type="password" placeholder="Password" name="p">
-                <a href="/resetPassword.php">Forgot password?</a>
+            <div class="grid grid-cols-2 gap-2 mb-2">
+                <label for="username-input" class="sr-only">Username</label>
+                <input class="w-full p-2" type="text" placeholder="Username" id="username-input" name="u">
+
+                <label for="password-input" class="sr-only">Password</label>
+                <input class="w-full p-2" type="password" placeholder="Password" id="password-input" name="p">
             </div>
-            <div class="flex flex-col gap-1 flex-1">
-                <input type="submit" value="Login" name="submit">
-                <a href="/createaccount.php">Register</a>
+
+            <div class="flex flex-col gap-2">
+                <button type="submit" name="submit" class="flex justify-center p-2">Log In</button>
             </div>
         </form>
+
+        <div class="grid grid-cols-2 text-center">
+            <a href="/createaccount.php">Register</a>
+            <a href="/resetPassword.php">Forgot Password?</a>
+        </div>
     @endguest
     @auth
         <div class="flex justify-between items-start gap-2">

--- a/resources/views/components/user/top-card.blade.php
+++ b/resources/views/components/user/top-card.blade.php
@@ -27,8 +27,8 @@ $user = request()->user();
         </form>
 
         <div class="grid grid-cols-2 lg:flex lg:justify-between text-center">
-            <a href="/createaccount.php">Register</a>
             <a href="/resetPassword.php">Forgot Password?</a>
+            <a href="/createaccount.php">Register</a>
         </div>
     @endguest
     @auth

--- a/resources/views/components/user/top-card.blade.php
+++ b/resources/views/components/user/top-card.blade.php
@@ -12,16 +12,17 @@ $user = request()->user();
     @guest
         <form class="mb-2" action="/request/auth/login.php" method="post">
             @csrf
-            <div class="grid grid-cols-2 gap-2 mb-2">
-                <label for="username-input" class="sr-only">Username</label>
-                <input class="w-full p-2" type="text" placeholder="Username" id="username-input" name="u">
+            <div class="grid lg:flex gap-2 mb-2">
+                <div>
+                    <label for="username-input" class="sr-only">Username</label>
+                    <input class="w-full p-2" type="text" placeholder="Username" id="username-input" name="u">
+                </div>
+                <div>
+                    <label for="password-input" class="sr-only">Password</label>
+                    <input class="w-full p-2" type="password" placeholder="Password" id="password-input" name="p">
+                </div>
 
-                <label for="password-input" class="sr-only">Password</label>
-                <input class="w-full p-2" type="password" placeholder="Password" id="password-input" name="p">
-            </div>
-
-            <div class="flex flex-col gap-2">
-                <button type="submit" name="submit" class="flex justify-center p-2">Log In</button>
+                <button type="submit" name="submit" class="flex items-center justify-center p-2">Log In</button>
             </div>
         </form>
 

--- a/resources/views/components/user/top-card.blade.php
+++ b/resources/views/components/user/top-card.blade.php
@@ -10,25 +10,23 @@ $user = request()->user();
 ?>
 <div class="bg-embedded rounded lg:w-[340px] lg:my-4 px-5 py-3">
     @guest
-        <form class="mb-2" action="/request/auth/login.php" method="post">
+        <form class="grid grid-cols-2 gap-2" action="/request/auth/login.php" method="post">
             @csrf
-            <div class="grid gap-1 mb-2">
-                <div>
-                    <label for="username-input" class="sr-only">Username</label>
-                    <input class="w-full py-[6px]" type="text" placeholder="Username" id="username-input" name="u">
-                </div>
-                <div class="lg:row-start-2">
-                    <label for="password-input" class="sr-only">Password</label>
-                    <input class="w-full py-[6px]" type="password" placeholder="Password" id="password-input" name="p">
-                </div>
-            </div>
+            <div class="flex gap-2 flex-col w-full">
+                <label class="sr-only" for="username-input">Username</label>
+                <input class="w-full" type="text" placeholder="Username" id="username-input" name="u">
 
-            <div class="flex lg:flex-row flex-col-reverse justify-between gap-y-2">
-                <div class="flex w-full justify-around lg:flex-col">
-                    <a href="/resetPassword.php">Forgot Password?</a>
-                    <a href="/createaccount.php">Register</a>
+                <label class="sr-only" for="password-input">Password</label>
+                <input class="w-full" type="password" placeholder="Password" id="password-input" name="p">
+            </div>
+            
+            <div class="flex flex-col items-center gap-2 w-full h-full">
+                <div class="h-7 flex items-center justify-center gap-x-2">
+                    <button class="flex items-center justify-center p-2" type="submit" name="submit">Log In</button>
+                    <a class="btn btn-link p-2" href="/createaccount.php">Register</a>
                 </div>
-                <button type="submit" name="submit" class="lg:col-start-2 lg:row-span-2 flex items-center justify-center p-2 w-full lg:w-24">Log In</button>
+
+                <a class="btn btn-link p-2 text-xs" href="/resetPassword.php">Forgot password?</a>
             </div>
         </form>
     @endguest


### PR DESCRIPTION
This PR makes minor design and a11y changes to the guest login component displayed on the top right of the site. 

The component now responds better to all screen widths. 

A longstanding a11y bug in the existing component was also fixed: the input fields were confusing to screen readers. Up to now, screen readers have only been able to determine that the password field was, in fact, a password field. The username field was undeterminable, so easily confused for username / email address / etc. To fix this, I have attached invisible semantic labels to both fields.

**BEFORE**
_Mobile_
![Mobile Before](https://user-images.githubusercontent.com/3984985/218335548-2ab6c3dd-624b-4247-83f2-bc8fa3feef34.png)

_Desktop_
![Desktop Before](https://user-images.githubusercontent.com/3984985/218335558-c2cf4f37-f3b5-4b88-83a4-39a8b68ce9f1.png)

**AFTER**
_Mobile_
![Mobile After](https://user-images.githubusercontent.com/3984985/218335823-427fc1d2-bd29-41ca-a3a7-fa7525a601d1.png)

_Desktop_
![Desktop After](https://user-images.githubusercontent.com/3984985/218335827-b1fb60fc-55ff-4f1e-911e-125205a4244d.png)
