### PR TITLE
don't calculate rank for highest followed user

### DIFF
--- a/public/globalRanking.php
+++ b/public/globalRanking.php
@@ -227,7 +227,7 @@ RenderContentStart($lbUsers . " Ranking - " . $lbType);
             }
 
             if ($dataPoint['Points'] != $rankPoints) {
-                if ($rankPoints === null) {
+                if ($rankPoints === null && $friends !== 1) {
                     $rankType = ($unlockMode == UnlockMode::Hardcore) ? RankType::Hardcore : RankType::Softcore;
                     $rank = getUserRank($dataPoint['User'], $rankType);
                 } else {


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1048299730670735421/1075113426105409646

Introduced by #1328. The rank of the first user on a page is looked up to ensure the shared rank is carried over between pages.

There's no easy way to do that for the following list, but there's less chance of users sharing ranks there, so I've removed the lookup. The 26th user on the following list will have rank 26, even if they should share a rank with whoever's at 25.