### PR TITLE
fix: turn off tooltips for touch events

### DIFF
--- a/app_legacy/Helpers/render/avatar.php
+++ b/app_legacy/Helpers/render/avatar.php
@@ -27,10 +27,10 @@ function avatar(
 
     $tooltipTrigger = '';
     if ($tooltip) {
-        $tooltipTrigger = "onmouseover=\"Tip(loadCard(this, '$resource', '$id', '$context'))\" onmouseout=\"UnTip()\"";
+        $tooltipTrigger = "ontouchstart=\"mobileSafeTipEvents.touchStart()\" onmouseover=\"mobileSafeTipEvents.mouseOver(loadCard(this, '$resource', '$id', '$context'))\" onmouseout=\"UnTip()\"";
         if (is_string($tooltip)) {
             $escapedTooltip = tooltipEscape($tooltip);
-            $tooltipTrigger = "onmouseover=\"Tip(useCard('$resource', '$id', '$context', '$escapedTooltip'))\" onmouseout=\"UnTip()\"";
+            $tooltipTrigger = "ontouchstart=\"mobileSafeTipEvents.touchStart()\" onmouseover=\"mobileSafeTipEvents.mouseOver(useCard('$resource', '$id', '$context', '$escapedTooltip'))\" onmouseout=\"UnTip()\"";
         }
     }
 

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1006,7 +1006,7 @@ sanitize_outputs(
                     echo "</div>";
 
                     echo "<script>var {$containername}tooltip = \"$tooltip\";</script>";
-                    echo "<div style='float: left; clear: left' onmouseover=\"Tip({$containername}tooltip)\" onmouseout=\"UnTip()\">";
+                    echo "<div style='float: left; clear: left' ontouchstart=\"mobileSafeTipEvents.touchStart()\" onmouseover=\"mobileSafeTipEvents.mouseOver({$containername}tooltip)\" onmouseout=\"UnTip()\">";
                     echo "<span class='$labelname'>$labelcontent</span>";
                     echo "</div>";
 

--- a/public/js/activePlayersBootstrap.js
+++ b/public/js/activePlayersBootstrap.js
@@ -1,6 +1,6 @@
 function CreateCardIconDiv(type, id, title, icon, url) {
   return '<div class=\'inline\' '
-    + 'onmouseover="Tip(loadCard(this, \'' + type + '\', \'' + id + '\'))" onmouseout="UnTip()" >'
+    + 'ontouchstart="mobileSafeTipEvents.touchStart()" onmouseover="mobileSafeTipEvents.mouseOver(loadCard(this, \'' + type + '\', \'' + id + '\'))" onmouseout="UnTip()" >'
     + '<a href=\'' + url + '\'>'
     + '<img src=\'' + mediaAsset(icon) + '\' width=\'32\' height=\'32\' '
     + ' alt="' + title + '" title="' + title + '" class=\'badgeimg\' loading=\'lazy\' />'

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -121,6 +121,31 @@ function replaceAll(find, replace, str) {
   return str.replace(new RegExp(find, 'g'), replace);
 }
 
+let wasTouchDeviceDetected = false;
+function mobileSafeTipTouchStart() {
+  wasTouchDeviceDetected = true;
+}
+
+const mobileSafeTipEvents = {
+  touchStart: () => {
+    wasTouchDeviceDetected = true;
+  },
+  mouseOver: (tipArgs) => {
+    /**
+     * wz_tooltip.js causes issues with touch events on
+     * mobile devices.
+     * @see https://github.com/RetroAchievements/RAWeb/issues/1365
+     */
+    if (wasTouchDeviceDetected) {
+      return;
+    }
+
+    if (window.Tip) {
+      window.Tip(tipArgs);
+    }
+  }
+};
+
 var cardsCache = {};
 
 function useCard(type, id, context = null, html = '') {

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -121,6 +121,7 @@ function replaceAll(find, replace, str) {
   return str.replace(new RegExp(find, 'g'), replace);
 }
 
+let wasTouchDeviceDetected = false;
 const mobileSafeTipEvents = {
   touchStart: () => {
     wasTouchDeviceDetected = true;

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -121,11 +121,6 @@ function replaceAll(find, replace, str) {
   return str.replace(new RegExp(find, 'g'), replace);
 }
 
-let wasTouchDeviceDetected = false;
-function mobileSafeTipTouchStart() {
-  wasTouchDeviceDetected = true;
-}
-
 const mobileSafeTipEvents = {
   touchStart: () => {
     wasTouchDeviceDetected = true;


### PR DESCRIPTION
This PR resolves https://github.com/RetroAchievements/RAWeb/issues/1365. There are various issues with tooltips on mobile because taps are interpreted as hover events. I have confirmed these issues occur not only on iOS, but occur on some Android browsers as well.

A new event listener, `ontouchstart`, is attached to DOM elements responsible for opening tooltips. This listener will always fire before `onmouseover`. If it does fire, a flag is set and tooltips will not open on tap.

This solution has the benefit of not breaking mobile devices that are using trackpads (which is increasingly common with iPads).