### PR TITLE
fix(forum): remediate an issue where long strings dont wrap

### DIFF
--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -207,7 +207,7 @@ RenderContentStart($pageTitle);
             echo userAvatar($nextCommentAuthor, label: false, iconSize: 64);
             echo "</td>";
 
-            echo "<td class='w-full py-3 break-normal' id='$nextCommentID'>";
+            echo "<td class='w-full py-3 break-all' id='$nextCommentID'>";
 
             echo "<div class='flex justify-between mb-2'>";
             echo "<div>";

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -207,7 +207,7 @@ RenderContentStart($pageTitle);
             echo userAvatar($nextCommentAuthor, label: false, iconSize: 64);
             echo "</td>";
 
-            echo "<td class='w-full py-3' id='$nextCommentID'>";
+            echo "<td class='w-full py-3 break-normal' id='$nextCommentID'>";
 
             echo "<div class='flex justify-between mb-2'>";
             echo "<div>";


### PR DESCRIPTION
This PR remediates an issue where a long string, such as a very long URL, does not break properly on forum posts and instead overflows the x-axis of the container.

This can be reproduced by going here and scrolling horizontally:
https://retroachievements.org/viewtopic.php?t=13871&c=154476#154476

The post that is overflowing is by a user named ExTermi.

After this PR, the same post wraps correctly:
<img width="977" alt="Screenshot 2023-02-14 at 9 47 09 PM" src="https://user-images.githubusercontent.com/3984985/218914782-84d1721d-f3ac-4eac-9a13-3d6ef16e0c79.png">
