### PR TITLE
feat(game): add mature content permanent bypass option

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -96,8 +96,9 @@ if ($v != 1 && $isFullyFeaturedGame) {
          * @param {number} currentPreferenceValue
          * @param {number} gameId
          */
-        function disableMatureContentWarningPreference(currentPreferenceValue, gameId) {
+        function disableMatureContentWarningPreference(currentPreferenceValue) {
             const newPreferencesValue = <?= $userDetails['websitePrefs'] | (1 << $matureContentPref) ?>;
+            const gameId = <?= $gameID ?>;
 
             fetch('/request/user/update-notification.php', {
                 method: 'POST',
@@ -139,10 +140,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
                     <?php if ($userWebsitePrefs): ?>
                         <button 
                             class='break-words whitespace-normal leading-normal' 
-                            onclick='disableMatureContentWarningPreference(
-                                <?= $userWebsitePrefs ?>,
-                                <?= $gameID ?>
-                            )'
+                            onclick='disableMatureContentWarningPreference(<?= $userWebsitePrefs ?>)'
                         >
                             Yes. Never ask me again for games with mature content.
                         </button>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -130,17 +130,24 @@ if ($v != 1 && $isFullyFeaturedGame) {
                 <div class="flex flex-col sm:flex-row gap-4 sm:gap-2">
                     <form id='escapeform' action='/gameList.php'>
                         <input type='hidden' name='c' value='<?= $consoleID ?>'/>
-                        <input type='submit' value='No, get me out of here.'/>
+                        <input type='submit' class='leading-normal' value='No, get me out of here.'/>
                     </form>
 
                     <form id='consentform' action='/game/<?= $gameID ?>'>
                         <input type='hidden' name='v' value='1'/>
-                        <input type='submit' value='Yes, I&apos;m an adult.'/>
+                        <input type='submit' class='leading-normal' value='Yes, I&apos;m an adult.'/>
                     </form>
 
                     <?php
                     if ($userWebsitePrefs) {
-                        echo "<button class='w-max' onclick='disableMatureContentWarningPreference({$userWebsitePrefs}, {$matureContentPref}, {$gameID})'>Yes, and never ask me again for games with mature content.</button>";
+                        echo "
+                            <button 
+                                class='break-words whitespace-normal leading-normal' 
+                                onclick='disableMatureContentWarningPreference({$userWebsitePrefs}, {$matureContentPref}, {$gameID})'
+                            >
+                                Yes, and never ask me again for games with mature content.
+                            </button>
+                        ";
                     }
                     ?>
                 </div>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -94,10 +94,9 @@ if ($v != 1 && $isFullyFeaturedGame) {
     <script>
         /**
          * @param {number} currentPreferenceValue
-         * @param {number} matureContentEnumValue
          * @param {number} gameId
          */
-        function disableMatureContentWarningPreference(currentPreferenceValue, matureContentEnumValue, gameId) {
+        function disableMatureContentWarningPreference(currentPreferenceValue, gameId) {
             const newPreferencesValue = <?= $userDetails['websitePrefs'] | (1 << $matureContentPref) ?>;
 
             fetch('/request/user/update-notification.php', {
@@ -142,7 +141,6 @@ if ($v != 1 && $isFullyFeaturedGame) {
                             class='break-words whitespace-normal leading-normal' 
                             onclick='disableMatureContentWarningPreference(
                                 <?= $userWebsitePrefs ?>,
-                                <?= $matureContentPref ?>,
                                 <?= $gameID ?>
                             )'
                         >

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -27,7 +27,6 @@ $userID = $userDetails['ID'] ?? 0;
 $userWebsitePrefs = $userDetails['websitePrefs'] ?? null;
 $matureContentPref = UserPreference::SiteMsgOff_MatureContent;
 
-
 $officialFlag = AchievementType::OfficialCore;
 $unofficialFlag = AchievementType::Unofficial;
 $flags = requestInputSanitized('f', $officialFlag, 'integer');

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -92,12 +92,13 @@ if ($v != 1 && $isFullyFeaturedGame) {
 <?php if ($gate): ?>
     <?php RenderContentStart($pageTitle) ?>
     <script>
-        /**
-         * @param {number} currentPreferenceValue
-         * @param {number} gameId
-         */
-        function disableMatureContentWarningPreference(currentPreferenceValue) {
-            const newPreferencesValue = <?= $userDetails['websitePrefs'] | (1 << $matureContentPref) ?>;
+        function disableMatureContentWarningPreference() {
+            const isLoggedIn = <?= isset($userDetails) ?>;
+            if (!isLoggedIn) {
+                throw new Error('Tried to modify settings for an unauthenticated user.');
+            }
+
+            const newPreferencesValue = <?= ($userDetails['websitePrefs'] ?? 0) | (1 << $matureContentPref) ?>;
             const gameId = <?= $gameID ?>;
 
             fetch('/request/user/update-notification.php', {
@@ -109,7 +110,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
                 body: `preferences=${newPreferencesValue}`,
                 credentials: 'same-origin'
             }).then(() => {
-                window.location = `/game/${gameId}`;
+                window.location = `/game/<?= $gameID ?>`;
             })
         }
     </script>
@@ -140,9 +141,9 @@ if ($v != 1 && $isFullyFeaturedGame) {
                     <?php if ($userWebsitePrefs): ?>
                         <button 
                             class='break-words whitespace-normal leading-normal' 
-                            onclick='disableMatureContentWarningPreference(<?= $userWebsitePrefs ?>)'
+                            onclick='disableMatureContentWarningPreference()'
                         >
-                            Yes. Never ask me again for games with mature content.
+                            Yes. And never ask me again for games with mature content.
                         </button>
                     <?php endif; ?>
                 </div>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -140,7 +140,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
 
                     <?php
                     if ($userWebsitePrefs) {
-                        echo "<button class='w-max' onclick='disableMatureContentWarningPreference({$userWebsitePrefs}, {$matureContentPref}, {$gameID})'>Yes, and never ask me again.</button>";
+                        echo "<button class='w-max' onclick='disableMatureContentWarningPreference({$userWebsitePrefs}, {$matureContentPref}, {$gameID})'>Yes, and never ask me again for games with mature content.</button>";
                     }
                     ?>
                 </div>

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -98,7 +98,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
          * @param {number} gameId
          */
         function disableMatureContentWarningPreference(currentPreferenceValue, matureContentEnumValue, gameId) {
-            // eslint-disable-next-line no-bitwise -- this must be calculate via bitwise operations
+            // eslint-disable-next-line no-bitwise -- this must be calculated via bitwise operations
             const newPreferencesValue = currentPreferenceValue + (1 << matureContentEnumValue);
 
             fetch('/request/user/update-notification.php', {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -98,8 +98,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
          * @param {number} gameId
          */
         function disableMatureContentWarningPreference(currentPreferenceValue, matureContentEnumValue, gameId) {
-            // eslint-disable-next-line no-bitwise -- this must be calculated via bitwise operations
-            const newPreferencesValue = currentPreferenceValue + (1 << matureContentEnumValue);
+            const newPreferencesValue = <?= $userDetails['websitePrefs'] | (1 << $matureContentPref) ?>;
 
             fetch('/request/user/update-notification.php', {
                 method: 'POST',
@@ -130,26 +129,26 @@ if ($v != 1 && $isFullyFeaturedGame) {
                 <div class="flex flex-col sm:flex-row gap-4 sm:gap-2">
                     <form id='escapeform' action='/gameList.php'>
                         <input type='hidden' name='c' value='<?= $consoleID ?>'/>
-                        <input type='submit' class='leading-normal' value='No, get me out of here.'/>
+                        <input type='submit' class='leading-normal' value='No. Get me out of here.'/>
                     </form>
 
                     <form id='consentform' action='/game/<?= $gameID ?>'>
                         <input type='hidden' name='v' value='1'/>
-                        <input type='submit' class='leading-normal' value='Yes, I&apos;m an adult.'/>
+                        <input type='submit' class='leading-normal' value='Yes. I&apos;m an adult.'/>
                     </form>
 
-                    <?php
-                    if ($userWebsitePrefs) {
-                        echo "
-                            <button 
-                                class='break-words whitespace-normal leading-normal' 
-                                onclick='disableMatureContentWarningPreference({$userWebsitePrefs}, {$matureContentPref}, {$gameID})'
-                            >
-                                Yes, and never ask me again for games with mature content.
-                            </button>
-                        ";
-                    }
-                    ?>
+                    <?php if ($userWebsitePrefs): ?>
+                        <button 
+                            class='break-words whitespace-normal leading-normal' 
+                            onclick='disableMatureContentWarningPreference(
+                                <?= $userWebsitePrefs ?>,
+                                <?= $matureContentPref ?>,
+                                <?= $gameID ?>
+                            )'
+                        >
+                            Yes. Never ask me again for games with mature content.
+                        </button>
+                    <?php endif; ?>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR adds a 3rd option to the mature content warning. When clicked, this option disables the notification setting for mature content, then redirects the user to the game page.

This change was motivated by some discussion in the #site-feedback channel.

![Screenshot 2023-02-15 at 4 43 49 PM](https://user-images.githubusercontent.com/3984985/219183830-693d57f5-ca1b-4c29-87cd-445391272499.png)

Also, "No" is now in the first position. If this content warning is continuously displayed we can now assume going forward this is no accident. Therefore it makes sense for "No" to be the primary action.