### PR TITLE
Add `100-Point Achievements` award section

### DIFF
--- a/app_legacy/Community/Enums/AwardType.php
+++ b/app_legacy/Community/Enums/AwardType.php
@@ -18,6 +18,8 @@ abstract class AwardType
 
     public const CertifiedLegend = 7;
 
+    public const HundredPointAchievement = 8;
+
     public static function cases(): array
     {
         return [
@@ -26,6 +28,7 @@ abstract class AwardType
             self::AchievementPointsYield,
             self::PatreonSupporter,
             self::CertifiedLegend,
+            self::HundredPointAchievement,
         ];
     }
 

--- a/app_legacy/Helpers/database/site-award.php
+++ b/app_legacy/Helpers/database/site-award.php
@@ -125,9 +125,12 @@ function getUsersSiteAwards($user, $showHidden = false): array
         $retVal = array_values(array_filter($retVal));
     }
 
-    $query = "SELECT ach.ID, ach.GameID, ach.Title, ach.BadgeName, UNIX_TIMESTAMP(aw.Date) AS AwardedAt
+    // Get unlocked 100-point achievements
+    $query = "SELECT ach.ID, ach.Title, ach.Description, ach.Points, ach.BadgeName,
+            gd.Title AS GameTitle, UNIX_TIMESTAMP(aw.Date) AS AwardedAt
         FROM Awarded aw
         LEFT JOIN Achievements ach ON aw.AchievementID = ach.ID
+        LEFT JOIN GameData gd ON ach.GameID = gd.ID
         WHERE aw.User = '$user' AND aw.HardcoreMode = 1 AND ach.Points = 100
         GROUP BY ach.ID";
 

--- a/app_legacy/Helpers/database/site-award.php
+++ b/app_legacy/Helpers/database/site-award.php
@@ -125,6 +125,22 @@ function getUsersSiteAwards($user, $showHidden = false): array
         $retVal = array_values(array_filter($retVal));
     }
 
+    $query = "SELECT ach.ID, ach.GameID, ach.Title, ach.BadgeName,
+            MAX(aw.HardcoreMode) AS HardcoreMode, UNIX_TIMESTAMP(aw.Date) AS AwardedAt
+        FROM Awarded aw
+        LEFT JOIN Achievements ach ON aw.AchievementID = ach.ID
+        WHERE aw.User = '$user' AND ach.Points = 100
+        GROUP BY ach.ID";
+    
+    $dbResult = mysqli_query($db, $query);
+    if ($dbResult !== false) {
+        while ($db_entry = mysqli_fetch_assoc($dbResult)) {
+            $db_entry['AwardType'] = AwardType::HundredPointAchievement;
+            $db_entry['DisplayOrder'] = 9999;
+            array_push($retVal, $db_entry);
+        }
+    }
+
     return $retVal;
 }
 

--- a/app_legacy/Helpers/database/site-award.php
+++ b/app_legacy/Helpers/database/site-award.php
@@ -132,7 +132,8 @@ function getUsersSiteAwards($user, $showHidden = false): array
         LEFT JOIN Achievements ach ON aw.AchievementID = ach.ID
         LEFT JOIN GameData gd ON ach.GameID = gd.ID
         WHERE aw.User = '$user' AND aw.HardcoreMode = 1 AND ach.Points = 100
-        GROUP BY ach.ID";
+        GROUP BY ach.ID
+        ORDER BY AwardedAt";
 
     $dbResult = mysqli_query($db, $query);
     if ($dbResult !== false) {

--- a/app_legacy/Helpers/database/site-award.php
+++ b/app_legacy/Helpers/database/site-award.php
@@ -125,13 +125,12 @@ function getUsersSiteAwards($user, $showHidden = false): array
         $retVal = array_values(array_filter($retVal));
     }
 
-    $query = "SELECT ach.ID, ach.GameID, ach.Title, ach.BadgeName,
-            MAX(aw.HardcoreMode) AS HardcoreMode, UNIX_TIMESTAMP(aw.Date) AS AwardedAt
+    $query = "SELECT ach.ID, ach.GameID, ach.Title, ach.BadgeName, UNIX_TIMESTAMP(aw.Date) AS AwardedAt
         FROM Awarded aw
         LEFT JOIN Achievements ach ON aw.AchievementID = ach.ID
-        WHERE aw.User = '$user' AND ach.Points = 100
+        WHERE aw.User = '$user' AND aw.HardcoreMode = 1 AND ach.Points = 100
         GROUP BY ach.ID";
-    
+
     $dbResult = mysqli_query($db, $query);
     if ($dbResult !== false) {
         while ($db_entry = mysqli_fetch_assoc($dbResult)) {

--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -11,6 +11,7 @@ function achievementAvatar(
     string $iconClass = 'badgeimg',
     bool|string|array $tooltip = true,
     ?string $context = null,
+    ?string $unlockDate = null,
 ): string {
     $id = $achievement;
     $title = null;
@@ -48,7 +49,7 @@ function achievementAvatar(
         id: $id,
         label: $label !== false && ($label || !$icon) ? $label : null,
         link: route('achievement.show', $id),
-        tooltip: is_array($tooltip) ? renderAchievementCard($tooltip) : $tooltip,
+        tooltip: is_array($tooltip) ? renderAchievementCard($tooltip, unlockDate: $unlockDate) : $tooltip,
         iconUrl: $icon !== false && ($icon || !$label) ? $icon : null,
         iconSize: $iconSize,
         iconClass: $iconClass,
@@ -76,7 +77,7 @@ function renderAchievementTitle(string $title, bool $tags = true): string
     return trim(str_replace('[m]', $span, $title));
 }
 
-function renderAchievementCard(int|string|array $achievement, ?string $context = null): string
+function renderAchievementCard(int|string|array $achievement, ?string $context = null, ?string $unlockDate = null): string
 {
     $id = is_int($achievement) || is_string($achievement) ? (int) $achievement : ($achievement['AchievementID'] ?? $achievement['ID'] ?? null);
 
@@ -102,7 +103,6 @@ function renderAchievementCard(int|string|array $achievement, ?string $context =
     $description = $data['AchievementDesc'] ?? $data['Description'] ?? null;
     $achPoints = $data['Points'] ?? null;
     $badgeName = $data['BadgeName'] ?? null;
-    $unlock = $data['Unlock'] ?? null;
     $gameTitle = renderGameTitle($data['GameTitle'] ?? null);
 
     $tooltip = "<div class='tooltip-body flex items-start gap-2 p-2' style='max-width: 400px'>";
@@ -117,8 +117,12 @@ function renderAchievementCard(int|string|array $achievement, ?string $context =
         $tooltip .= "<div><i>$gameTitle</i></div>";
     }
 
-    if ($unlock) {
-        $tooltip .= "<div>$unlock</div>";
+    if ($unlockDate) {
+        $unlockedStr = "<br clear=all>Unlocked on $unlockDate";
+        if (!array_key_exists('HardcoreMode', $achievement) or $achievement['HardcoreMode'] === 1) {
+            $unlockedStr .= "<br>HARDCORE";
+        }
+        $tooltip .= "<div>$unlockedStr</div>";
     }
 
     $tooltip .= "</div>";

--- a/app_legacy/Helpers/render/site-award.php
+++ b/app_legacy/Helpers/render/site-award.php
@@ -24,8 +24,11 @@ function SeparateAwards($userAwards): array
 
     $eventAwards = array_values(array_filter($eventAwards, fn ($award) => !in_array($award, $devEventAwards)));
 
-    $siteAwards = array_values(array_filter($userAwards, fn ($award) => ($award['AwardType'] != AwardType::Mastery && AwardType::isActive((int) $award['AwardType'])) ||
-        in_array($award, $devEventAwards)
+    $siteAwards = array_values(array_filter(
+        $userAwards,
+        fn ($award) => (!in_array($award['AwardType'], [AwardType::Mastery, AwardType::HundredPointAchievement])
+                && AwardType::isActive((int) $award['AwardType']))
+            || in_array($award, $devEventAwards)
     ));
 
     $hundredPointAchievements = array_values(array_filter($userAwards, fn ($award) => $award['AwardType'] == AwardType::HundredPointAchievement));
@@ -70,7 +73,7 @@ function RenderSiteAwards(array $userAwards): void
         }
     }
 
-    if (!empty($siteAwards)) {
+    if (!empty($hundredPointAchievements)) {
         $firstSiteAward = $firstVisibleIndex($hundredPointAchievements);
         if ($firstSiteAward >= 0) {
             $groups[] = [$firstSiteAward, $hundredPointAchievements, "100-point Achievements"];

--- a/app_legacy/Helpers/render/site-award.php
+++ b/app_legacy/Helpers/render/site-award.php
@@ -225,8 +225,8 @@ function RenderAward($award, $imageSize, $clickable = true): void
         $imgclass = 'goldimage';
         $linkdest = '';
     } elseif ($awardType == AwardType::HundredPointAchievement) {
-        $imgclass = $award['HardcoreMode'] ? 'goldimage' : 'badgeimg';
-        echo "<div>" . achievementAvatar($award, label: false, iconSize: $imageSize, iconClass: $imgclass) . "</div>";
+        echo "<div>" . achievementAvatar($award, label: false, iconSize: $imageSize, iconClass: 'goldimage') . "</div>";
+
         return;
     } else {
         // Unknown or inactive award type

--- a/app_legacy/Helpers/render/site-award.php
+++ b/app_legacy/Helpers/render/site-award.php
@@ -225,7 +225,8 @@ function RenderAward($award, $imageSize, $clickable = true): void
         $imgclass = 'goldimage';
         $linkdest = '';
     } elseif ($awardType == AwardType::HundredPointAchievement) {
-        echo "<div>" . achievementAvatar($award, label: false, iconSize: $imageSize, iconClass: 'goldimage') . "</div>";
+        $avatar = achievementAvatar($award, label: false, iconSize: $imageSize, iconClass: 'goldimage', unlockDate: $awardDate);
+        echo "<div>$avatar</div>";
 
         return;
     } else {

--- a/app_legacy/Helpers/render/site-award.php
+++ b/app_legacy/Helpers/render/site-award.php
@@ -76,7 +76,7 @@ function RenderSiteAwards(array $userAwards): void
     if (!empty($hundredPointAchievements)) {
         $firstSiteAward = $firstVisibleIndex($hundredPointAchievements);
         if ($firstSiteAward >= 0) {
-            $groups[] = [$firstSiteAward, $hundredPointAchievements, "100-point Achievements"];
+            $groups[] = [$firstSiteAward, $hundredPointAchievements, "100-Point Achievements"];
         }
     }
 
@@ -109,7 +109,7 @@ function RenderAwardGroup($awards, $title): void
         "Game Awards" => "👑🎖️",
         "Event Awards" => "🌱",
         "Site Awards" => "🌐",
-        "100-point Achievements" => "💯",
+        "100-Point Achievements" => "💯",
     ];
     if ($title == "Game Awards") {
         // Count and show # of completed/mastered games

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1215,7 +1215,6 @@ sanitize_outputs(
 
                             echo "<div>";
 
-                            $nextAch['Unlock'] = $earnedOnHardcore ? '<br clear=all>Unlocked: ' . getNiceDate(strtotime($nextAch['DateEarnedHardcore'])) . '<br>HARDCORE' : null;
                             echo achievementAvatar(
                                 $nextAch,
                                 label: false,

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -547,14 +547,9 @@ RenderContentStart($userPage);
                         $class = 'badgeimglarge';
 
                         if (!$achData['IsAwarded']) {
-                            $badgeName .= "_lock";
-                        } else {
-                            $unlockedStr = "<br clear=all>Unlocked: $achUnlockDate";
-                            if ($achHardcore == 1) {
-                                $unlockedStr .= "<br>HARDCORE";
-                                $class = 'goldimage';
-                            }
-                            $achData['Unlock'] = $unlockedStr;
+                            $badgeName .= '_lock';
+                        } elseif ($achHardcore == 1) {
+                            $class = 'goldimage';
                         }
 
                         echo achievementAvatar(
@@ -563,6 +558,7 @@ RenderContentStart($userPage);
                             icon: $badgeName,
                             iconSize: 48,
                             iconClass: $class,
+                            unlockDate: $achUnlockDate,
                         );
                     }
                 }


### PR DESCRIPTION
Add a new award section for displaying 100-point achievements unlocked by given player.

![100-point-achievements](https://user-images.githubusercontent.com/22218549/219224926-2d6aa22d-91d0-4eb1-87e4-0a97c17fa19c.png)
![tooltip](https://user-images.githubusercontent.com/22218549/219220214-67329d64-7168-4254-bd2b-5180d8ad631d.png)

**Why?**
Because such feats represent outstanding display of skill and are very rare in nature. Unlike masteries - than can easily go to the hundreds figures - 100-point achievements are far and few between. Milestones for those are also featured in _RANews_, giving yet another reason for them to be featured in the website.

For coherence and preventing abuse, only achievements unlocked on _hardcore_ are taken into account.

Since data for this can be easily fetched from the `Achievements` and `Awarded` tables, no interaction to `SiteAwards` is done. This, however, doesn't directly allow such awards to be reordered; which is why I opted for using a dummy display order (9999) and showing them below all others. I plan to tackle such issues in a future PR.