### PR TITLE
Grid-like section for top links

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -35,6 +35,7 @@
 @import "tag.css";
 @import "table.css";
 @import "tooltip.css";
+@import "top-links.css";
 
 /* TODO split into components or replace with utility classes */
 @import "active-players.css";

--- a/resources/css/top-links.css
+++ b/resources/css/top-links.css
@@ -1,0 +1,29 @@
+.top-links {
+    @apply mb-4;
+}
+
+.top-links a {
+    @apply btn;
+    @apply flex justify-center items-center gap-2;
+    @apply p-3 text-center text-xs rounded-none;
+}
+
+.top-links > a:first-child {
+    @apply rounded-t-lg;
+}
+
+.top-links div:last-child a {
+    @apply flex-col gap-3;
+}
+
+.top-links div:last-child a:first-child {
+    @apply rounded-bl-lg;
+}
+
+.top-links div:last-child a:last-child {
+    @apply rounded-br-lg;
+}
+
+.top-links div:last-child a > span {
+    @apply text-gray-400;
+}

--- a/resources/views/content/top-links.blade.php
+++ b/resources/views/content/top-links.blade.php
@@ -1,39 +1,39 @@
-<x-section class="mb-3 flex flex-col">
-    <a class="btn flex justify-center gap-1.5 p-3 text-xs" href="/globalRanking.php?s=5&t=2">
+<x-section class="top-links">
+    <a href="/globalRanking.php?s=5&t=2">
         <span class="text-yellow-500"><x-fas-medal/></span>
         Global Ranking
     </a>
-    <a class="btn flex justify-center gap-1.5 p-3 text-xs" href="{{ route('download.index') }}">
+    <a href="{{ route('download.index') }}">
         <span class="text-purple-400"><x-fas-gamepad/></span>
         Download Emulator
     </a>
     @if(config('services.discord.invite_id'))
-        <a class="btn flex justify-center gap-1.5 p-3 text-xs" href="https://discord.gg/{{ config('services.discord.invite_id') }}">
+        <a href="https://discord.gg/{{ config('services.discord.invite_id') }}">
             <span class="text-discord"><x-fab-discord/></span>
             Join us on Discord
         </a>
     @endif
     @if(config('services.patreon.user_id'))
-        <a class="btn flex justify-center gap-1.5 p-3 text-xs" href="https://www.patreon.com/bePatron?u={{ config('services.patreon.user_id') }}">
+        <a href="https://www.patreon.com/bePatron?u={{ config('services.patreon.user_id') }}">
             <span class="text-patreon"><x-fab-patreon/></span>
             Become a Patron
         </a>
     @endif
     <div class="grid grid-cols-4">
-        <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href="https://news.retroachievements.org/">
-            <span class="text-gray-400"><x-fas-newspaper/></span>
+        <a href="https://news.retroachievements.org/">
+            <span><x-fas-newspaper/></span>
             RANews
         </a>
-        <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href="https://www.youtube.com/channel/UCIGdJGxrzmNYMaAGPsk2sIA">
-            <span class="text-gray-400"><x-fas-microphone/></span>
+        <a href="https://www.youtube.com/channel/UCIGdJGxrzmNYMaAGPsk2sIA">
+            <span><x-fas-microphone/></span>
             RAPodcast
         </a>
-        <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href='https://docs.retroachievements.org/'>
-            <span class="text-gray-400"><x-fas-book/></span>
+        <a href='https://docs.retroachievements.org/'>
+            <span><x-fas-book/></span>
             Docs
         </a>
-        <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href='https://docs.retroachievements.org/FAQ/'>
-            <span class="text-gray-400"><x-fas-question-circle/></span>
+        <a href='https://docs.retroachievements.org/FAQ/'>
+            <span><x-fas-question-circle/></span>
             FAQ
         </a>
     </div>

--- a/resources/views/content/top-links.blade.php
+++ b/resources/views/content/top-links.blade.php
@@ -1,40 +1,38 @@
-<x-section class="mb-3 flex flex-col gap-2">
-    <a class="btn text-center py-2" href="/globalRanking.php?s=5&t=2">
+<x-section class="mb-3 flex flex-col">
+    <a class="btn flex justify-center gap-1.5 p-3" href="/globalRanking.php?s=5&t=2">
         <span class="text-yellow-400"><x-fas-medal/></span>
         Global Ranking
     </a>
-    <a class="btn text-center py-2" href="{{ route('download.index') }}">
+    <a class="btn flex justify-center gap-1.5 p-3" href="{{ route('download.index') }}">
         <span class="text-heading"><x-fas-gamepad/></span>
         Download Emulator
     </a>
     @if(config('services.discord.invite_id'))
-        <a class="btn text-center py-2" href="https://discord.gg/{{ config('services.discord.invite_id') }}">
+        <a class="btn flex justify-center gap-1.5 p-3" href="https://discord.gg/{{ config('services.discord.invite_id') }}">
             <span class="text-discord"><x-fab-discord/></span>
             Join us on Discord
         </a>
     @endif
     @if(config('services.patreon.user_id'))
-        <a class="btn text-center py-2" href="https://www.patreon.com/bePatron?u={{ config('services.patreon.user_id') }}">
+        <a class="btn flex justify-center gap-1.5 p-3" href="https://www.patreon.com/bePatron?u={{ config('services.patreon.user_id') }}">
             <span class="text-patreon"><x-fab-patreon/></span>
             Become a Patron
         </a>
     @endif
-    <div class="flex gap-1">
-        <a class="btn text-center py-2 grow" href="https://news.retroachievements.org/">
+    <div class="grid grid-cols-4">
+        <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href="https://news.retroachievements.org/">
             <span class="text-heading"><x-fas-newspaper/></span>
             RANews
         </a>
-        <a class="btn text-center py-2 grow" href="https://www.youtube.com/channel/UCIGdJGxrzmNYMaAGPsk2sIA">
+        <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href="https://www.youtube.com/channel/UCIGdJGxrzmNYMaAGPsk2sIA">
             <span class="text-heading"><x-fas-microphone/></span>
             RAPodcast
         </a>
-    </div>
-    <div class="flex gap-1">
-        <a class="btn text-center py-2 grow" href='https://docs.retroachievements.org/'>
+        <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href='https://docs.retroachievements.org/'>
             <span class="text-heading"><x-fas-book/></span>
-            Documentation
+            Docs
         </a>
-        <a class="btn text-center py-2 grow" href='https://docs.retroachievements.org/FAQ/'>
+        <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href='https://docs.retroachievements.org/FAQ/'>
             <span class="text-heading"><x-fas-question-circle/></span>
             FAQ
         </a>

--- a/resources/views/content/top-links.blade.php
+++ b/resources/views/content/top-links.blade.php
@@ -1,20 +1,20 @@
 <x-section class="mb-3 flex flex-col">
-    <a class="btn flex justify-center gap-1.5 p-3" href="/globalRanking.php?s=5&t=2">
+    <a class="btn flex justify-center gap-1.5 p-3 text-xs" href="/globalRanking.php?s=5&t=2">
         <span class="text-yellow-500"><x-fas-medal/></span>
         Global Ranking
     </a>
-    <a class="btn flex justify-center gap-1.5 p-3" href="{{ route('download.index') }}">
-        <span class="text-blue-400"><x-fas-gamepad/></span>
+    <a class="btn flex justify-center gap-1.5 p-3 text-xs" href="{{ route('download.index') }}">
+        <span class="text-purple-400"><x-fas-gamepad/></span>
         Download Emulator
     </a>
     @if(config('services.discord.invite_id'))
-        <a class="btn flex justify-center gap-1.5 p-3" href="https://discord.gg/{{ config('services.discord.invite_id') }}">
+        <a class="btn flex justify-center gap-1.5 p-3 text-xs" href="https://discord.gg/{{ config('services.discord.invite_id') }}">
             <span class="text-discord"><x-fab-discord/></span>
             Join us on Discord
         </a>
     @endif
     @if(config('services.patreon.user_id'))
-        <a class="btn flex justify-center gap-1.5 p-3" href="https://www.patreon.com/bePatron?u={{ config('services.patreon.user_id') }}">
+        <a class="btn flex justify-center gap-1.5 p-3 text-xs" href="https://www.patreon.com/bePatron?u={{ config('services.patreon.user_id') }}">
             <span class="text-patreon"><x-fab-patreon/></span>
             Become a Patron
         </a>

--- a/resources/views/content/top-links.blade.php
+++ b/resources/views/content/top-links.blade.php
@@ -1,10 +1,10 @@
 <x-section class="mb-3 flex flex-col">
     <a class="btn flex justify-center gap-1.5 p-3" href="/globalRanking.php?s=5&t=2">
-        <span class="text-yellow-400"><x-fas-medal/></span>
+        <span class="text-yellow-500"><x-fas-medal/></span>
         Global Ranking
     </a>
     <a class="btn flex justify-center gap-1.5 p-3" href="{{ route('download.index') }}">
-        <span class="text-heading"><x-fas-gamepad/></span>
+        <span class="text-blue-400"><x-fas-gamepad/></span>
         Download Emulator
     </a>
     @if(config('services.discord.invite_id'))
@@ -21,19 +21,19 @@
     @endif
     <div class="grid grid-cols-4">
         <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href="https://news.retroachievements.org/">
-            <span class="text-heading"><x-fas-newspaper/></span>
+            <span class="text-gray-400"><x-fas-newspaper/></span>
             RANews
         </a>
         <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href="https://www.youtube.com/channel/UCIGdJGxrzmNYMaAGPsk2sIA">
-            <span class="text-heading"><x-fas-microphone/></span>
+            <span class="text-gray-400"><x-fas-microphone/></span>
             RAPodcast
         </a>
         <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href='https://docs.retroachievements.org/'>
-            <span class="text-heading"><x-fas-book/></span>
+            <span class="text-gray-400"><x-fas-book/></span>
             Docs
         </a>
         <a class="btn flex flex-col items-center gap-3 p-3 text-xs" href='https://docs.retroachievements.org/FAQ/'>
-            <span class="text-heading"><x-fas-question-circle/></span>
+            <span class="text-gray-400"><x-fas-question-circle/></span>
             FAQ
         </a>
     </div>


### PR DESCRIPTION
This is a follow-up to a [previous discussion](https://github.com/RetroAchievements/RAWeb/pull/1334#discussion_r1089792205).

In place of having everything in a list or square grid, I opted for a mix of both; should feel less monotone and more heterogeneous this way. Bottom links are ideal for being displayed in a single row, as labels are small there. 

**Old:**

![before](https://user-images.githubusercontent.com/22218549/219258118-e53a271a-95dc-4c52-85ee-e0f66f7bc8ae.png)

**New:**

https://user-images.githubusercontent.com/22218549/219261010-29fdecaf-6cd3-46a0-a582-ff621b069dae.mp4

---
Gets rid of the margins between buttons in exchange for some more padding. Changes most icon colors too. Instead of every `btn` having round corners, those are applied in a way that styles the container itself.