### PR TITLE
Small fixes/adjustments for Inbox/Outbox pages

### DIFF
--- a/app_legacy/Helpers/render/layout.php
+++ b/app_legacy/Helpers/render/layout.php
@@ -235,6 +235,9 @@ function RenderPaginator($numItems, $perPage, $offset, $urlPrefix): void
 
     echo "Page <select class='gameselector' onchange='window.location=\"$urlPrefix\" + this.options[this.selectedIndex].value'>";
     $pages = floor(($numItems + $perPage - 1) / $perPage);
+    if ($pages < 1) {
+        $pages = 1;
+    }
     for ($i = 1; $i <= $pages; $i++) {
         $pageOffset = ($i - 1) * $perPage;
         echo "<option value='$pageOffset'" . (($offset == $pageOffset) ? " selected" : "") . ">$i</option>";

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -173,15 +173,10 @@ function MarkAsUnread(msgID) {
 
             echo "</tbody></table>";
 
-            // Get message count and build URL from current GET parameters
+            // Get message count and build paginator URL from current GET parameters
             $messageCount = $unreadOnly ? $unreadMessageCount : $totalMessageCount;
-            $urlPrefix = '/inbox.php?';
-            foreach ($_GET as $parameter => $value) {
-                if ($parameter !== 'o') {
-                    $urlPrefix .= "$parameter=$value&";
-                }
-            }
-            $urlPrefix .= 'o=';
+            unset($_GET['o']);
+            $urlPrefix = '/inbox.php?' . http_build_query($_GET) . '&o=';
 
             echo "<div class='float-right'>";
             RenderPaginator($messageCount, $displayCount, $offset, $urlPrefix);

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -2,10 +2,10 @@
 
 use App\Support\Shortcode\Shortcode;
 
+$outbox = requestInputSanitized('s', 0, 'integer');
+$unreadOnly = requestInputSanitized('u', 0, 'integer');
 $count = requestInputSanitized('c', 10, 'integer');
 $offset = requestInputSanitized('o', 0, 'integer');
-$unreadOnly = requestInputSanitized('u', 0, 'integer');
-$outbox = requestInputSanitized('s', 0, 'integer');
 
 if (!authenticateFromCookie($user, $permissions, $userDetails)) {
     abort(401);
@@ -76,7 +76,7 @@ function MarkAsUnread(msgID) {
                 echo "<a class='btn btn-link' href='/inbox.php?s=1'>Outbox</a>";
                 echo "<div class='flex gap-2'>";
                 if ($unreadOnly) {
-                    echo "<a class='btn btn-link' href='/inbox.php?u=0'>View All Messages</a>";
+                    echo "<a class='btn btn-link' href='/inbox.php'>View All Messages</a>";
                 } else {
                     echo "<a class='btn btn-link' href='/inbox.php?u=1'>View Unread Only</a>";
                 }
@@ -177,7 +177,7 @@ function MarkAsUnread(msgID) {
 
             if ($offset > 0) {
                 $newOffset = max($offset - $count, 0);
-                echo "<a class='btn btn-link' href='/inbox.php?c=$count&o=$newOffset&u=$unreadOnly&s=$outbox'>";
+                echo "<a class='btn btn-link' href='/inbox.php?s=$outbox&u=$unreadOnly&c=$count&o=$newOffset'>";
                 echo "&lt; Previous $count";
                 echo "</a>";
             }
@@ -186,7 +186,7 @@ function MarkAsUnread(msgID) {
             if ($messagesLeft > $count) {
                 $newOffset = $offset + $count;
                 $messagesNext = min($count, $messagesLeft - $count);
-                echo "<a class='btn btn-link' href='/inbox.php?c=$count&o=$newOffset&u=$unreadOnly&s=$outbox'>";
+                echo "<a class='btn btn-link' href='/inbox.php?s=$outbox&u=$unreadOnly&c=$count&o=$newOffset'>";
                 echo "Next $messagesNext &gt;";
                 echo "</a>";
             }

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -182,7 +182,7 @@ function MarkAsUnread(msgID) {
                 echo "</a>";
             }
 
-            $messagesLeft = $totalMessageCount - $offset;
+            $messagesLeft = ($unreadOnly ? $unreadMessageCount : $totalMessageCount) - $offset;
             if ($messagesLeft > $count) {
                 $newOffset = $offset + $count;
                 $messagesNext = min($count, $messagesLeft - $count);

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -2,10 +2,8 @@
 
 use App\Support\Shortcode\Shortcode;
 
-$maxCount = 10;
-
+$count = requestInputSanitized('c', 10, 'integer');
 $offset = requestInputSanitized('o', 0, 'integer');
-$count = requestInputSanitized('c', $maxCount, 'integer');
 $unreadOnly = requestInputSanitized('u', 0, 'integer');
 $outbox = requestInputSanitized('s', 0, 'integer');
 
@@ -178,14 +176,16 @@ function MarkAsUnread(msgID) {
             echo "<div class='float-right'>";
 
             if ($offset > 0) {
-                echo "<a class='btn btn-link' href='/inbox.php?o=" . ($offset - $maxCount) . "&amp;u=$unreadOnly&amp;s=$outbox'>";
-                echo "&lt; Previous $maxCount";
+                $newOffset = $offset - $count;
+                echo "<a class='btn btn-link' href='/inbox.php?c=$count&o=$newOffset&u=$unreadOnly&s=$outbox'>";
+                echo "&lt; Previous $count";
                 echo "</a>";
             }
 
-            if ($totalMessageCount - $offset > $maxCount) {
-                echo "<a class='btn btn-link' href='/inbox.php?o=" . ($offset + $maxCount) . "&amp;u=$unreadOnly&amp;s=$outbox'>";
-                echo "Next $maxCount &gt;";
+            if ($totalMessageCount - $offset > $count) {
+                $newOffset = $offset + $count;
+                echo "<a class='btn btn-link' href='/inbox.php?c=$count&o=$newOffset&u=$unreadOnly&s=$outbox'>";
+                echo "Next $count &gt;";
                 echo "</a>";
             }
 

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -182,10 +182,12 @@ function MarkAsUnread(msgID) {
                 echo "</a>";
             }
 
-            if ($totalMessageCount - $offset > $count) {
+            $messagesLeft = $totalMessageCount - $offset;
+            if ($messagesLeft > $count) {
                 $newOffset = $offset + $count;
+                $messagesNext = min($count, $messagesLeft - $count);
                 echo "<a class='btn btn-link' href='/inbox.php?c=$count&o=$newOffset&u=$unreadOnly&s=$outbox'>";
-                echo "Next $count &gt;";
+                echo "Next $messagesNext &gt;";
                 echo "</a>";
             }
 

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -176,7 +176,7 @@ function MarkAsUnread(msgID) {
             echo "<div class='float-right'>";
 
             if ($offset > 0) {
-                $newOffset = $offset - $count;
+                $newOffset = max($offset - $count, 0);
                 echo "<a class='btn btn-link' href='/inbox.php?c=$count&o=$newOffset&u=$unreadOnly&s=$outbox'>";
                 echo "&lt; Previous $count";
                 echo "</a>";

--- a/public/inbox.php
+++ b/public/inbox.php
@@ -183,7 +183,7 @@ function MarkAsUnread(msgID) {
                 echo "</a>";
             }
 
-            if ($totalMsgs == $maxCount) {
+            if ($totalMessageCount - $offset > $maxCount) {
                 echo "<a class='btn btn-link' href='/inbox.php?o=" . ($offset + $maxCount) . "&amp;u=$unreadOnly&amp;s=$outbox'>";
                 echo "Next $maxCount &gt;";
                 echo "</a>";


### PR DESCRIPTION
Fix #1373, plus a few more changes.

- Don't show `Next ... >` if there are no more messages ahead (corner case handling)
- Allow passing custom `c` parameter for messages-per-page amount instead of previously hardcoded 10 (no UI way of utilizing this yet; must be URL-modified)
- Fix server error due to occasional negative offset after clicking `< Previous` (defaults to 0; not an expected error, only happens when toying with URL)
- Shows true number of messages next if below max amount (e.g `Next 5 >` instead of `Next 10 >` when at offset 30 with 45 total, 10 per page)
