### PR TITLE
fix(home): remediate issue where active players table overflows

### DIFF
--- a/app_legacy/Helpers/database/player-game.php
+++ b/app_legacy/Helpers/database/player-game.php
@@ -390,9 +390,9 @@ function getGameTopAchievers(int $gameID): array
 {
     $cacheKey = "game:$gameID:topachievers";
     $retval = Cache::get($cacheKey);
-    // if ($retval !== null) {
-    //     return $retval;
-    // }
+    if ($retval !== null) {
+        return $retval;
+    }
 
     sanitize_sql_inputs($gameID);
 

--- a/app_legacy/Helpers/database/player-game.php
+++ b/app_legacy/Helpers/database/player-game.php
@@ -390,9 +390,9 @@ function getGameTopAchievers(int $gameID): array
 {
     $cacheKey = "game:$gameID:topachievers";
     $retval = Cache::get($cacheKey);
-    if ($retval !== null) {
-        return $retval;
-    }
+    // if ($retval !== null) {
+    //     return $retval;
+    // }
 
     sanitize_sql_inputs($gameID);
 

--- a/app_legacy/Helpers/render/content.php
+++ b/app_legacy/Helpers/render/content.php
@@ -26,7 +26,7 @@ function RenderActivePlayersComponent(): void
                         <tr>
                             <td data-bind='html: playerHtml'></td>
                             <td data-bind='html: gameHtml'></td>
-                            <td data-bind='text: richPresence' class="w-full"></td>
+                            <td data-bind='text: richPresence' class="w-full break-words"></td>
                         </tr>
                         <!-- /ko -->
 

--- a/app_legacy/Helpers/render/content.php
+++ b/app_legacy/Helpers/render/content.php
@@ -26,7 +26,7 @@ function RenderActivePlayersComponent(): void
                         <tr>
                             <td data-bind='html: playerHtml'></td>
                             <td data-bind='html: gameHtml'></td>
-                            <td data-bind='text: richPresence' class="w-full break-words"></td>
+                            <td data-bind='text: richPresence' class="w-full break-all"></td>
                         </tr>
                         <!-- /ko -->
 


### PR DESCRIPTION
This PR fixes an issue reported in #site-feedback where long strings don't properly break in the table, resulting in a horizontal scrollbar and weird formatting for rich presence if a single one of these strings overflows.

![chrome_QvCMy9A7TZ](https://user-images.githubusercontent.com/3984985/219371210-2f996575-3817-48e1-be9a-4cd460650ebc.png)