### PR TITLE
fix(achievement): remediate an issue where the memory cell contents wrap

### DIFF
--- a/app_legacy/Helpers/util/trigger.php
+++ b/app_legacy/Helpers/util/trigger.php
@@ -302,11 +302,11 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
             if ($lSize) {
                 $lNote = getNoteForAddress($memNotes, $lMemory);
                 if ($lNote) {
-                    $lTooltip = " class=\"cursor-help\" title=\"" . htmlspecialchars($lNote) . "\"";
+                    $lTooltip = " class=\"cursor-help whitespace-nowrap\" title=\"" . htmlspecialchars($lNote) . "\"";
                     $codeNotes[$lMemory] = '<strong><u>' . $lMemory . '</u></strong>: ' . htmlspecialchars($lNote);
                 }
             } elseif ($lType == 'Value') {
-                $lTooltip = " class=\"cursor-help\" title=\"" . hexdec($lMemory) . "\"";
+                $lTooltip = " class=\"cursor-help whitespace-nowrap\" title=\"" . hexdec($lMemory) . "\"";
             }
 
             $res .= "\n<tr>\n  <td class='whitespace-nowrap'>" . ($j + 1) . "</td>";
@@ -321,11 +321,11 @@ function getAchievementPatchReadableHTML($mem, $memNotes)
                 if ($rSize) {
                     $rNote = getNoteForAddress($memNotes, $rMemVal);
                     if ($rNote) {
-                        $rTooltip = " class=\"cursor-help\" title=\"" . htmlspecialchars($rNote) . "\"";
+                        $rTooltip = " class=\"cursor-help whitespace-nowrap\" title=\"" . htmlspecialchars($rNote) . "\"";
                         $codeNotes[$rMemVal] = '<strong><u>' . $rMemVal . '</u></strong>: ' . htmlspecialchars($rNote);
                     }
                 } elseif ($rType == 'Value') {
-                    $rTooltip = " class=\"cursor-help\" title=\"" . hexdec($rMemVal) . "\"";
+                    $rTooltip = " class=\"cursor-help whitespace-nowrap\" title=\"" . hexdec($rMemVal) . "\"";
                 }
 
                 $res .= "\n  <td class='whitespace-nowrap'> " . htmlspecialchars($cmp) . " </td>";


### PR DESCRIPTION
This PR fixes an issue on the achievement page where Memory and Mem/Val cell contents can wrap. This is reproducible currently on /achievement/80118 by opening the Dev menu.

**BEFORE**
![Screenshot 2023-02-17 at 5 20 37 PM](https://user-images.githubusercontent.com/3984985/219804812-046dc670-7363-4d3d-b4b0-d37da5b9923c.png)

**AFTER**
![Screenshot 2023-02-17 at 5 20 24 PM](https://user-images.githubusercontent.com/3984985/219804833-6f850fcd-71e0-473c-8f7c-4efdfc988ea4.png)