### PR TITLE
fix(code-notes): use monospace font for both the mem and note columns

### DIFF
--- a/app_legacy/Helpers/render/code-note.php
+++ b/app_legacy/Helpers/render/code-note.php
@@ -24,11 +24,11 @@ function RenderCodeNotes($codeNotes): void
         $memNote = nl2br($memNote);
 
         echo "<td style='width: 25%;'>";
-        echo "<code>0x$addrFormatted</code>";
+        echo "<span class='font-mono'>0x$addrFormatted</span>";
         echo "</td>";
 
         echo "<td>";
-        echo "<div style='word-break:break-word'>$memNote</div>";
+        echo "<div class='font-mono' style='word-break:break-word'>$memNote</div>";
         echo "</td>";
 
         echo "<td>";


### PR DESCRIPTION
This PR makes a change to the code notes table so the note itself is also in monospace font. For improved readability, the monospace font has been changed to use the Tailwind `font-mono` rather than what the `<code>` tag is using.

**BEFORE**
![Screenshot 2023-02-19 at 12 43 02 PM](https://user-images.githubusercontent.com/3984985/219965322-70faf834-2569-4ff1-a160-a24ff1b4189e.png)

**AFTER**
![Screenshot 2023-02-19 at 12 26 40 PM](https://user-images.githubusercontent.com/3984985/219965331-259f47f1-b862-4486-9e28-74142fcead76.png)
