### PR TITLE
fix(expiring-claims): remediate broken header row

### DIFF
--- a/public/expiringclaims.php
+++ b/public/expiringclaims.php
@@ -66,7 +66,7 @@ RenderContentStart("Expiring Claims");
 
         echo "<div class='table-wrapper'><table class='table-highlight'><tbody>";
 
-        echo "<tr class='do-not-highlight>";
+        echo "<tr class='do-not-highlight'>";
         echo "<th colspan='2'>" . ClaimSorting::toString(ClaimSorting::UserDescending) . "</th>";
         echo "<th>" . ClaimSorting::toString(ClaimSorting::GameDescending) . "</th>";
         echo "<th>" . ClaimSorting::toString(ClaimSorting::ClaimTypeDescending) . "</th>";


### PR DESCRIPTION
There is currently a typo when applying the `do-not-highlight` class to the table heading row on the expiring claims page. This is causing the table heading itself to break.

**BEFORE**
![Screenshot 2023-02-19 at 1 40 28 PM](https://user-images.githubusercontent.com/3984985/219968298-5d16b444-a289-46db-a136-bfa10e82138a.png)

**AFTER**
![Screenshot 2023-02-19 at 1 39 09 PM](https://user-images.githubusercontent.com/3984985/219968307-e9308fa4-1af5-4db5-9d9a-8fa1d709669a.png)
