### PR TITLE
fix(following): remediate issue with Message link

### DIFF
--- a/public/friends.php
+++ b/public/friends.php
@@ -125,7 +125,7 @@ RenderContentStart("Following");
                 echo "<td style='vertical-align:middle;'>";
                 echo "<div class='flex justify-end gap-2'>";
 
-                echo "<a class='btn btn-link' href='/createmessage.php?t=$user'>Message</a>";
+                echo "<a class='btn btn-link' href='/createmessage.php?t=$followingUser'>Message</a>";
 
                 echo "<form class='inline-block' action='/request/user/update-relationship.php' method='post'>";
                 echo csrf_field();


### PR DESCRIPTION
This PR fixes an issue on /friends.php.

Previously, when clicking the "Message" link, the recipient of the new message opened on the subsequent page would be yourself. Now it is changed to the user you clicked the "Message" link for.