### PR TITLE
fix(user): remediate x-axis overflow on completion progress

### DIFF
--- a/resources/css/legacy.css
+++ b/resources/css/legacy.css
@@ -104,6 +104,7 @@
 #usercompletedgamescomponent {
   max-height: 30.0em;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #devstatsscrollpane {


### PR DESCRIPTION
This PR remediates an issue on the user page where the completion progress div can overflow on the x-axis.

I believe this is occurring due to some operating systems having a slightly thicker native scrollbar than what the div was developed under. The issue does not occur in macOS, but it does occur if I add just a bit of right padding to the div.

**BEFORE**
![Screenshot 2023-02-24 at 6 20 41 AM](https://user-images.githubusercontent.com/3984985/221166863-47de29b4-3618-40b1-8b0a-b536d0b283d2.png)

**AFTER**
![Screenshot 2023-02-24 at 6 20 46 AM](https://user-images.githubusercontent.com/3984985/221166876-8f9d860a-35bf-452f-b68c-76d55ae59022.png)
