### PR TITLE
perf(active-players): reduce processing overhead by 70%

### DIFF
--- a/public/js/activePlayersBootstrap.js
+++ b/public/js/activePlayersBootstrap.js
@@ -105,10 +105,10 @@ var ActivePlayersViewModel = function () {
     self.isLoading(true);
     $.post('/request/user/list-currently-active.php')
       .done(function (data) {
-        self.players([]);
-        data.forEach((player) => {
-          self.players.push(self.ConvertToObservablePlayer(player));
-        });
+        self.players(data.reduce(function (result, player) {
+          return result.concat(self.ConvertToObservablePlayer(player));
+        }, []));
+
         self.lastUpdate(new Date());
         self.hasError(false);
         self.isLoading(false);
@@ -119,8 +119,21 @@ var ActivePlayersViewModel = function () {
       });
   };
 
-  this.RefreshActivePlayers();
-  setInterval(this.RefreshActivePlayers, 5000 * 60);
+  this.init = function () {
+    const FIVE_MINUTES = 5000 * 60;
+
+    this.RefreshActivePlayers();
+    setInterval(this.RefreshActivePlayers, FIVE_MINUTES);
+  };
+
+  // This check will fail in Safari.
+  if ('requestIdleCallback' in window) {
+    requestIdleCallback(() => {
+      this.init();
+    });
+  } else {
+    this.init();
+  }
 };
 
 ko.applyBindings(new ActivePlayersViewModel(), document.getElementById('active-players-component'));


### PR DESCRIPTION
This PR is an initial stopgap fix for addressing a performance issue in the Active Players list (https://github.com/RetroAchievements/RAWeb/issues/1387). It would be ideal for this component not to use Knockout.js and probably to use infinite & virtual scrolling, however until that migration happens this can address a perf issue impacting the site's homepage.

When the component loads, it fetches all of the active players on RA and loads them into an array. Unfortunately this is done using `Array.prototype.forEach()`, which is quite slow when trying to iteratively add this much content to the DOM.

I have made two refactors here to greatly improve performance:
1. `forEach()` has been replaced with `reduce()`. Generally, I do not like using `reduce()` because I find it difficult to read, however there is no denying that it's the fastest native way to map long lists of objects like what this component is doing.
2. I've added a `requestIdleCallback()` check (and graceful degradation for Safari) to further prohibit this component from blocking the main UI thread.

During my local testing, I did something like:

```ts
const perfA = performance.now();

// ... map code here ...

const perfB = performance.now();
console.log("Total processing duration", perfB - perfA);
```

to get the time in ms and have some kind of measurement of the impact of these changes. My measurements were taken against a snapshot of a response containing 1000+ active players. Here is a before and after:

|         | Before | After  |
|---------|--------|--------|
| 1       | 2972ms | 890ms  |
| 2       | 2854ms | 953ms  |
| 3       | 3031ms | 965ms  |
| 4       | 2873ms | 935ms  |
| 5       | 2981ms | 1081ms |
| 6       | 2496ms | 991ms  |
| 7       | 2822ms | 917ms  |
| 8       | 2785ms | 942ms  |
| 9       | 2890ms | 1095ms |
| 10      | 2850ms | 1002ms |
| Average | 2855ms | 887ms  |

On average, the loop finishes 60-70% faster. Anything above 500ms is still painful, but this is much less so than what exists on prod today.

If this goes out to prod and it's still causing the page to hang for a bit, I have another idea for how to optimize this further, but I'd like to see how much this lever changes things first.