### PR TITLE
fix: address more word wrap issues

### DIFF
--- a/app_legacy/Helpers/render/content.php
+++ b/app_legacy/Helpers/render/content.php
@@ -26,7 +26,7 @@ function RenderActivePlayersComponent(): void
                         <tr>
                             <td data-bind='html: playerHtml'></td>
                             <td data-bind='html: gameHtml'></td>
-                            <td data-bind='text: richPresence' class="w-full break-all"></td>
+                            <td data-bind='text: richPresence' class="w-full" style="word-break: normal; overflow-wrap: anywhere;"></td>
                         </tr>
                         <!-- /ko -->
 

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -246,7 +246,7 @@ RenderContentStart($pageTitle);
             echo "</div>";
             echo "</div>";
 
-            echo "<div class='comment'>";
+            echo "<div class='comment' style='word-break: normal; overflow-wrap: anywhere;'>";
             echo Shortcode::render($nextCommentPayload);
             echo "</div>";
 


### PR DESCRIPTION
This PR addresses word wrap regressions on active players and the forum.

With recent changes in 2.9.0, long strings (such as URLs) are correctly wrapped, however now words are wrapped without regard for if the whole word should be moved to a new line.

This PR corrects this, while also still wrapping extraordinarily long strings correctly.

**BEFORE**
![Screenshot 2023-03-01 at 7 09 13 PM](https://user-images.githubusercontent.com/3984985/222296170-ab38acbc-16b7-4a5e-b17a-ece5515ebd7f.png)

![Screenshot 2023-03-01 at 7 11 50 PM](https://user-images.githubusercontent.com/3984985/222296313-8235bcc3-579b-4301-80e8-bdcb47835f8d.png)


**AFTER**
![Screenshot 2023-03-01 at 7 09 39 PM](https://user-images.githubusercontent.com/3984985/222296157-4734650b-e949-4088-80cc-a0f54f53446d.png)

![Screenshot 2023-03-01 at 7 11 39 PM](https://user-images.githubusercontent.com/3984985/222296326-22bc605b-7a9f-4026-ae7c-fe5a567158f7.png)
