### PR TITLE
Fix request input default not being passed when empty and string

### DIFF
--- a/app_legacy/Helpers/util/request.php
+++ b/app_legacy/Helpers/util/request.php
@@ -10,7 +10,7 @@ function requestInputSanitized(string $key, mixed $default = null, mixed $type =
     $input = request()->input($key, $default);
 
     if (!$type || $type === 'string') {
-        return !empty($input) ? htmlentities($input) : null;
+        return !empty($input) ? htmlentities((string) $input) : $default;
     }
 
     settype($input, $type);


### PR DESCRIPTION
Included in #1393  
https://github.com/RetroAchievements/RAWeb/pull/1393/files#diff-276f85cc7d9994b508613eab3ce641376786c6128138dedeb71adf41fcea444fR13

Fixes (among other occurences):
```
getRecentMasteryData(): Argument #1 ($date) must be of type string, null given, called in /public/recentMastery.php
```
when calling `recentMastery.php?d=` with an empty `d` parameter. It should default to the current date: https://github.com/RetroAchievements/RAWeb/blob/master/public/recentMastery.php#L12