### PR TITLE
Add validation to web api user summary and recently played games

### DIFF
--- a/public/API/API_GetUserCompletedGames.php
+++ b/public/API/API_GetUserCompletedGames.php
@@ -19,6 +19,14 @@
  *    string     HardcoreMode     "1" if the data is for hardcore, otherwise "0"
  */
 
+use App\Support\Rules\CtypeAlnum;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+
+$input = Validator::validate(Arr::wrap(request()->query()), [
+    'u' => ['required', 'min:2', 'max:20', new CtypeAlnum()],
+]);
+
 $user = request()->query('u');
 
 $result = [];

--- a/public/API/API_GetUserRecentlyPlayedGames.php
+++ b/public/API/API_GetUserRecentlyPlayedGames.php
@@ -22,11 +22,12 @@
  *    int        ScoreAchievedHardcore    number of points earned by the user in hardcore
  */
 
+use App\Support\Rules\CtypeAlnum;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 
 $input = Validator::validate(Arr::wrap(request()->query()), [
-    'u' => 'required',
+    'u' => ['required', 'min:2', 'max:20', new CtypeAlnum()],
     'c' => 'nullable|integer|min:0',
     'o' => 'nullable|integer|min:0',
 ]);

--- a/public/API/API_GetUserRecentlyPlayedGames.php
+++ b/public/API/API_GetUserRecentlyPlayedGames.php
@@ -22,15 +22,21 @@
  *    int        ScoreAchievedHardcore    number of points earned by the user in hardcore
  */
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+
+$input = Validator::validate(Arr::wrap(request()->query()), [
+    'u' => 'required',
+    'c' => 'nullable|integer|min:0',
+    'o' => 'nullable|integer|min:0',
+]);
+
 $user = request()->query('u');
 $count = min((int) request()->query('c', '10'), 50);
 $offset = (int) request()->query('o');
 
 $recentlyPlayedData = [];
-$numRecentlyPlayed = 0;
-if (!empty($user)) {
-    $numRecentlyPlayed = getRecentlyPlayedGames($user, $offset, $count, $recentlyPlayedData);
-}
+$numRecentlyPlayed = getRecentlyPlayedGames($user, $offset, $count, $recentlyPlayedData);
 
 if (!empty($recentlyPlayedData)) {
     $gameIDsCSV = $recentlyPlayedData[0]['GameID'];

--- a/public/API/API_GetUserSummary.php
+++ b/public/API/API_GetUserSummary.php
@@ -78,11 +78,12 @@
  *  string     ContribYield            points awarded to others
  */
 
+use App\Support\Rules\CtypeAlnum;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 
 $input = Validator::validate(Arr::wrap(request()->query()), [
-    'u' => 'required',
+    'u' => ['required', 'min:2', 'max:20', new CtypeAlnum()],
     'g' => 'nullable|integer|min:0',
     'a' => 'nullable|integer|min:0',
 ]);

--- a/public/API/API_GetUserSummary.php
+++ b/public/API/API_GetUserSummary.php
@@ -78,6 +78,15 @@
  *  string     ContribYield            points awarded to others
  */
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+
+$input = Validator::validate(Arr::wrap(request()->query()), [
+    'u' => 'required',
+    'g' => 'nullable|integer|min:0',
+    'a' => 'nullable|integer|min:0',
+]);
+
 $user = request()->query('u');
 $recentGamesPlayed = (int) request()->query('g', '5');
 $recentAchievementsEarned = (int) request()->query('a', '10');

--- a/tests/Feature/Api/V1/UserCompletedGamesTest.php
+++ b/tests/Feature/Api/V1/UserCompletedGamesTest.php
@@ -19,7 +19,7 @@ class UserCompletedGamesTest extends TestCase
 
     public function testItValidates(): void
     {
-        $this->get($this->apiUrl('GetUserSummary'))
+        $this->get($this->apiUrl('GetUserCompletedGames'))
             ->assertJsonValidationErrors([
                 'u',
             ]);

--- a/tests/Feature/Api/V1/UserCompletedGamesTest.php
+++ b/tests/Feature/Api/V1/UserCompletedGamesTest.php
@@ -17,6 +17,14 @@ class UserCompletedGamesTest extends TestCase
     use RefreshDatabase;
     use BootstrapsApiV1;
 
+    public function testItValidates(): void
+    {
+        $this->get($this->apiUrl('GetUserSummary'))
+            ->assertJsonValidationErrors([
+                'u',
+            ]);
+    }
+
     public function testGetUserCompletedGamesUnknownUser(): void
     {
         $this->get($this->apiUrl('GetUserCompletedGames', ['u' => 'nonExistant']))

--- a/tests/Feature/Api/V1/UserRecentlyPlayedGamesTest.php
+++ b/tests/Feature/Api/V1/UserRecentlyPlayedGamesTest.php
@@ -20,6 +20,20 @@ class UserRecentlyPlayedGamesTest extends TestCase
     use RefreshDatabase;
     use BootstrapsApiV1;
 
+    public function testItValidates(): void
+    {
+        $this->get($this->apiUrl('GetUserRecentlyPlayedGames', [
+            'u' => null,
+            'c' => 'nope',
+            'o' => -1,
+        ]))
+            ->assertJsonValidationErrors([
+                'u',
+                'c',
+                'o',
+            ]);
+    }
+
     public function testGetUserRecentlyPlayedGamesUnknownUser(): void
     {
         $this->get($this->apiUrl('GetUserRecentlyPlayedGames', ['u' => 'nonExistant']))

--- a/tests/Feature/Api/V1/UserRecentlyPlayedGamesTest.php
+++ b/tests/Feature/Api/V1/UserRecentlyPlayedGamesTest.php
@@ -23,7 +23,6 @@ class UserRecentlyPlayedGamesTest extends TestCase
     public function testItValidates(): void
     {
         $this->get($this->apiUrl('GetUserRecentlyPlayedGames', [
-            'u' => null,
             'c' => 'nope',
             'o' => -1,
         ]))

--- a/tests/Feature/Api/V1/UserSummaryTest.php
+++ b/tests/Feature/Api/V1/UserSummaryTest.php
@@ -21,6 +21,20 @@ class UserSummaryTest extends TestCase
     use RefreshDatabase;
     use BootstrapsApiV1;
 
+    public function testItValidates(): void
+    {
+        $this->get($this->apiUrl('GetUserSummary', [
+            'u' => null,
+            'g' => 'nope',
+            'a' => -1,
+        ]))
+            ->assertJsonValidationErrors([
+                'u',
+                'g',
+                'a',
+            ]);
+    }
+
     public function testGetUserSummaryUnknownUser(): void
     {
         $this->get($this->apiUrl('GetUserSummary', ['u' => 'nonExistant']))

--- a/tests/Feature/Api/V1/UserSummaryTest.php
+++ b/tests/Feature/Api/V1/UserSummaryTest.php
@@ -24,7 +24,6 @@ class UserSummaryTest extends TestCase
     public function testItValidates(): void
     {
         $this->get($this->apiUrl('GetUserSummary', [
-            'u' => null,
             'g' => 'nope',
             'a' => -1,
         ]))


### PR DESCRIPTION
This PR acts as a template for other web api endpoint validation.

It applies Laravel's validation to `API_GetUserSummary` and `API_GetUserRecentlyPlayedGames`, comparable to request files in `public/request/`, without making too many assumptions about how our endpoints are used. Adding basic validation to them however might reduce resource usage caused by invalid requests (cpu, db hits, ...) and logging useless errors.

Calling `/API/API_GetUserSummary.php?y=API_KEY&u=&g=nope&a=-1` results in:

```
{
  "message": "The u field is required. (and 2 more errors)",
  "errors": {
    "u": [
      "The u field is required."
    ],
    "g": [
      "The g must be an integer."
    ],
    "a": [
      "The a must be at least 0."
    ]
  }
}
```

Fixes 
```
getUserPageInfo(): Argument #1 ($user) must be of type string, null given, called in public/API/API_GetUserSummary.php on line 85 {"userId":24699,"exception":"[object] (TypeError(code: 0): getUserPageInfo(): Argument #1 ($user) must be of type string, null given, called in public/API/API_GetUserSummary.php on line 85 at app_legacy/Helpers/database/user.php:226)
```