### PR TITLE
Use blade's curly braces for data display to show better practice

### DIFF
--- a/resources/views/community/components/event/aotw.blade.php
+++ b/resources/views/community/components/event/aotw.blade.php
@@ -28,6 +28,6 @@ if (empty($achData)) {
         <div>
             {!! gameAvatar($achData, iconSize: 24) !!}
         </div>
-        <a class="btn mt-2" href="/viewtopic.php?t=<?= $forumTopicID ?>">Join this tournament!</a>
+        <a class="btn mt-2" href="/viewtopic.php?t={{ $forumTopicID }}">Join this tournament!</a>
     </div>
 </div>

--- a/resources/views/community/components/news/carousel.blade.php
+++ b/resources/views/community/components/news/carousel.blade.php
@@ -7,9 +7,9 @@ if ($newsData->isEmpty()) {
     return;
 }
 ?>
-<link type="text/css" rel="stylesheet" href="<?= asset('/vendor/rcarousel/rcarousel.css') ?>"/>
-<script src="<?= asset('/vendor/rcarousel/jquery.ui.widget.min.js') ?>"></script>
-<script src="<?= asset('/vendor/rcarousel/jquery.ui.rcarousel.min.js') ?>"></script>
+<link type="text/css" rel="stylesheet" href="{{ asset('vendor/rcarousel/rcarousel.css') }}"/>
+<script src="{{ asset('vendor/rcarousel/jquery.ui.widget.min.js') }}"></script>
+<script src="{{ asset('vendor/rcarousel/jquery.ui.rcarousel.min.js') }}"></script>
 <script>
     $(function () {
         function generatePages() {


### PR DESCRIPTION
https://laravel.com/docs/blade#displaying-data

This will ultimately allow us get rid of the `requestInputSanitized()` helper as soon as all views have been ported to blade views:

> Blade's {{ }} echo statements are automatically sent through PHP's htmlspecialchars function to prevent XSS attacks.

Ideally all those `echo` statements will be removed in the future, too.