### PR TITLE
fix(statistics): round the corners on stats boxes

### DIFF
--- a/resources/css/statistics.css
+++ b/resources/css/statistics.css
@@ -5,4 +5,5 @@
   @apply text-[color:var(--link-color)] bg-[color:var(--embed-color)];
   @apply hover:text-white hover:border-[color:var(--menu-link-color)] hover:bg-[color:var(--embed-highlight-color)];
   @apply select-none;
+  @apply rounded;
 }


### PR DESCRIPTION
Per discussion prior to the 2.9.0 release, this PR adds some slight border radius to the stat boxes on the home page. The radius given matches the other buttons on the side bar.