### PR TITLE
exclude sets for rollout consoles from new sets widget on main page

### DIFF
--- a/app_legacy/Helpers/database/set-claim.php
+++ b/app_legacy/Helpers/database/set-claim.php
@@ -363,6 +363,7 @@ function getFilteredClaims(
         sc.GameID AS GameID,
         gd.Title AS GameTitle,
         gd.ImageIcon AS GameIcon,
+        c.ID AS ConsoleID,
         c.Name AS ConsoleName,
         sc.ClaimType AS ClaimType,
         sc.SetType AS SetType,

--- a/app_legacy/Helpers/render/set-claim.php
+++ b/app_legacy/Helpers/render/set-claim.php
@@ -60,8 +60,6 @@ function renderFinishedClaimsComponent(int $count): void
     echo "<div class='component'>";
     echo "<h3>New Sets/Revisions</h3>";
 
-    $claimData = getFilteredClaims(null, ClaimFilters::AllCompletedPrimaryClaims, ClaimSorting::FinishedDateDescending, false, null, 0, $count);
-
     echo "<table class='table-highlight mb-1'>";
     echo "<thead>";
     echo "<tr class='do-not-highlight'>";
@@ -74,25 +72,47 @@ function renderFinishedClaimsComponent(int $count): void
     echo "</tr>";
     echo "</thead>";
     echo "<tbody>";
-    foreach ($claimData as $claim) {
-        $claimUser = $claim['User'];
-        echo "<tr>";
-        echo "<td class='pr-0'>";
-        echo userAvatar($claimUser, label: false);
-        echo "</td>";
-        echo "<td>";
-        echo userAvatar($claimUser, icon: false);
-        echo "</td>";
-        echo "<td class='pr-0'>";
-        echo gameAvatar($claim, label: false);
-        echo "</td>";
-        echo "<td class='w-full'>";
-        echo gameAvatar($claim, icon: false);
-        echo "</td>";
-        echo "<td>" . ($claim['SetType'] == ClaimSetType::NewSet ? ClaimSetType::toString(ClaimSetType::NewSet) : ClaimSetType::toString(ClaimSetType::Revision)) . "</td>";
-        echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['DoneTime'])) . "</td>";
-        echo "</tr>";
-    }
+
+    $remaining = $count;
+    $offset = 0;
+    do {
+        $claimData = getFilteredClaims(null, ClaimFilters::AllCompletedPrimaryClaims, ClaimSorting::FinishedDateDescending, false, null, $offset, $count);
+        if ($claimData->isEmpty()) {
+            break;
+        }
+
+        foreach ($claimData as $claim) {
+            if (!isValidConsoleId($claim['ConsoleID'])) {
+                continue;
+            }
+
+            $claimUser = $claim['User'];
+            echo "<tr>";
+            echo "<td class='pr-0'>";
+            echo userAvatar($claimUser, label: false);
+            echo "</td>";
+            echo "<td>";
+            echo userAvatar($claimUser, icon: false);
+            echo "</td>";
+            echo "<td class='pr-0'>";
+            echo gameAvatar($claim, label: false);
+            echo "</td>";
+            echo "<td class='w-full'>";
+            echo gameAvatar($claim, icon: false);
+            echo "</td>";
+            echo "<td>" . ($claim['SetType'] == ClaimSetType::NewSet ? ClaimSetType::toString(ClaimSetType::NewSet) : ClaimSetType::toString(ClaimSetType::Revision)) . "</td>";
+            echo "<td class='smalldate'>" . getNiceDate(strtotime($claim['DoneTime'])) . "</td>";
+            echo "</tr>";
+
+            $remaining--;
+            if ($remaining === 0) {
+                break;
+            }
+        }
+
+        $offset += $count;
+    } while ($remaining > 0);
+
     echo "</tbody></table>";
 
     echo "<div class='text-right'><a class='btn btn-link' href='/claimlist.php?s=" . ClaimSorting::FinishedDateDescending . "&f=" . ClaimFilters::AllCompletedPrimaryClaims . "'>more...</a></div>";


### PR DESCRIPTION
Claims for games for rollout consoles can be completed from Unofficial, but not played by users yet. This filters completed claims for rollout consoles from the main page. They'll still appear in the page that loads when clicking the "more..." link, and users who have requested the set will still be notified that the claim was completed.

https://discord.com/channels/310192285306454017/1067638638919307414/1081271680833429604
