### PR TITLE
refactor: integrate app theming in tailwind

### DIFF
--- a/resources/css/statistics.css
+++ b/resources/css/statistics.css
@@ -1,8 +1,8 @@
 .stat-box {
-  @apply w-full h-20 border border-[color:var(--embed-highlight-color)];
+  @apply w-full h-20 border border-embed-highlight;
   @apply flex flex-col justify-center items-center;
   @apply cursor-pointer;
-  @apply text-[color:var(--link-color)] bg-[color:var(--embed-color)];
-  @apply hover:text-white hover:border-[color:var(--menu-link-color)] hover:bg-[color:var(--embed-highlight-color)];
+  @apply text-link bg-embed;
+  @apply hover:text-white hover:border-menu-link hover:bg-embed-highlight;
   @apply select-none;
 }

--- a/resources/views/content/static-data.blade.php
+++ b/resources/views/content/static-data.blade.php
@@ -56,7 +56,7 @@ if ($lastRegisteredUserAt) {
 
     <div>
         @if($staticData->lastRegisteredUser)
-            <hr class="mt-4 mb-5 border-[color:var(--embed-highlight-color)]">
+            <hr class="mt-4 mb-5 border-embed-highlight">
 
             <div class="w-full flex flex-col justify-center items-center">
                 <p>Newest user</p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
@@ -21,11 +22,23 @@ module.exports = {
     container: {
       center: true,
     },
-    // extend: {
-    //   fontFamily: {
-    //     sans: ['Verdana', ...defaultTheme.fontFamily.sans],
-    //   },
-    // },
+    extend: {
+      colors: {
+        bg: 'var(--bg-color)',
+        'box-bg': 'var(--box-bg-color)',
+        'box-shadow': 'var(--box-shadow-color)',
+        embed: 'var(--embed-color)',
+        'embed-highlight': 'var(--embed-highlight-color)',
+        heading: 'var(--heading-color)',
+        link: 'var(--link-color)',
+        'link-hover': 'var(--link-hover-color)',
+        'menu-link': 'var(--menu-link-color)',
+        'menu-link-hover': 'var(--menu-link-hover-color)',
+        text: 'var(--text-color)',
+        'text-danger': 'var(--text-color-danger)',
+        'text-muted': 'var(--text-color-muted)'
+      }
+    },
     fontSize: {
       '2xs': '.70rem',
       xs: '.75rem',


### PR DESCRIPTION
This PR adds the app color theme variables to the Tailwind configuration so we no longer need to use something like:

```html
<div class="hover:border-[color:var(--menu-link-color)]" />
```

Instead, we can now use:

```html
<div class="hover:border-menu-link" />
```

Existing styles for the new statistics UX have been refactored accordingly.