### PR TITLE
fix: enable mobile tooltips on Android only

### DIFF
--- a/app_legacy/Helpers/render/avatar.php
+++ b/app_legacy/Helpers/render/avatar.php
@@ -27,10 +27,10 @@ function avatar(
 
     $tooltipTrigger = '';
     if ($tooltip) {
-        $tooltipTrigger = "ontouchstart=\"mobileSafeTipEvents.touchStart()\" onmouseover=\"mobileSafeTipEvents.mouseOver(loadCard(this, '$resource', '$id', '$context'))\" onmouseout=\"UnTip()\"";
+        $tooltipTrigger = "onmouseover=\"mobileSafeTipEvents.mouseOver(loadCard(this, '$resource', '$id', '$context'))\" onmouseout=\"UnTip()\"";
         if (is_string($tooltip)) {
             $escapedTooltip = tooltipEscape($tooltip);
-            $tooltipTrigger = "ontouchstart=\"mobileSafeTipEvents.touchStart()\" onmouseover=\"mobileSafeTipEvents.mouseOver(useCard('$resource', '$id', '$context', '$escapedTooltip'))\" onmouseout=\"UnTip()\"";
+            $tooltipTrigger = "onmouseover=\"mobileSafeTipEvents.mouseOver(useCard('$resource', '$id', '$context', '$escapedTooltip'))\" onmouseout=\"UnTip()\"";
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
             "name": "raweb",
             "dependencies": {
                 "alpinejs": "^3.0.6",
-                "js-cookie": "^3.0.1"
+                "js-cookie": "^3.0.1",
+                "ua-parser-js": "^1.0.33"
             },
             "devDependencies": {
                 "@defstudio/vite-livewire-plugin": "^1.0.0",
@@ -17,6 +18,7 @@
                 "@tailwindcss/typography": "^0.5.0",
                 "@types/alpinejs": "^3.7.1",
                 "@types/js-cookie": "^3.0.3",
+                "@types/ua-parser-js": "^0.7.36",
                 "@typescript-eslint/eslint-plugin": "^5.53.0",
                 "@typescript-eslint/parser": "^5.53.0",
                 "autoprefixer": "^10.4.7",
@@ -659,6 +661,12 @@
             "version": "7.3.13",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
             "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "dev": true
+        },
+        "node_modules/@types/ua-parser-js": {
+            "version": "0.7.36",
+            "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+            "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3807,6 +3815,24 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/ua-parser-js": {
+            "version": "1.0.33",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
+            "integrity": "sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/ua-parser-js"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/faisalman"
+                }
+            ],
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -4413,6 +4439,12 @@
             "version": "7.3.13",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
             "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+            "dev": true
+        },
+        "@types/ua-parser-js": {
+            "version": "0.7.36",
+            "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+            "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
@@ -6611,6 +6643,11 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
+        },
+        "ua-parser-js": {
+            "version": "1.0.33",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
+            "integrity": "sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ=="
         },
         "unbox-primitive": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     },
     "dependencies": {
         "alpinejs": "^3.0.6",
-        "js-cookie": "^3.0.1"
+        "js-cookie": "^3.0.1",
+        "ua-parser-js": "^1.0.33"
     },
     "devDependencies": {
         "@defstudio/vite-livewire-plugin": "^1.0.0",
@@ -23,6 +24,7 @@
         "@tailwindcss/typography": "^0.5.0",
         "@types/alpinejs": "^3.7.1",
         "@types/js-cookie": "^3.0.3",
+        "@types/ua-parser-js": "^0.7.36",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
         "@typescript-eslint/parser": "^5.53.0",
         "autoprefixer": "^10.4.7",

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1044,7 +1044,7 @@ sanitize_outputs(
                     echo "</div>";
 
                     echo "<script>var {$containername}tooltip = \"$tooltip\";</script>";
-                    echo "<div style='float: left; clear: left' ontouchstart=\"mobileSafeTipEvents.touchStart()\" onmouseover=\"mobileSafeTipEvents.mouseOver({$containername}tooltip)\" onmouseout=\"UnTip()\">";
+                    echo "<div style='float: left; clear: left' onmouseover=\"mobileSafeTipEvents.mouseOver({$containername}tooltip)\" onmouseout=\"UnTip()\">";
                     echo "<span class='$labelname'>$labelcontent</span>";
                     echo "</div>";
 

--- a/public/js/activePlayersBootstrap.js
+++ b/public/js/activePlayersBootstrap.js
@@ -1,6 +1,6 @@
 function CreateCardIconDiv(type, id, title, icon, url) {
   return '<div class=\'inline\' '
-    + 'ontouchstart="mobileSafeTipEvents.touchStart()" onmouseover="mobileSafeTipEvents.mouseOver(loadCard(this, \'' + type + '\', \'' + id + '\'))" onmouseout="UnTip()" >'
+    + 'onmouseover="mobileSafeTipEvents.mouseOver(loadCard(this, \'' + type + '\', \'' + id + '\'))" onmouseout="UnTip()" >'
     + '<a href=\'' + url + '\'>'
     + '<img src=\'' + mediaAsset(icon) + '\' width=\'32\' height=\'32\' '
     + ' alt="' + title + '" title="' + title + '" class=\'badgeimg\' loading=\'lazy\' />'

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -121,27 +121,6 @@ function replaceAll(find, replace, str) {
   return str.replace(new RegExp(find, 'g'), replace);
 }
 
-let wasTouchDeviceDetected = false;
-const mobileSafeTipEvents = {
-  touchStart: () => {
-    wasTouchDeviceDetected = true;
-  },
-  mouseOver: (tipArgs) => {
-    /**
-     * wz_tooltip.js causes issues with touch events on
-     * mobile devices.
-     * @see https://github.com/RetroAchievements/RAWeb/issues/1365
-     */
-    if (wasTouchDeviceDetected) {
-      return;
-    }
-
-    if (window.Tip) {
-      window.Tip(tipArgs);
-    }
-  }
-};
-
 var cardsCache = {};
 
 function useCard(type, id, context = null, html = '') {

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -2,9 +2,11 @@ import Alpine from 'alpinejs';
 // eslint-disable-next-line camelcase,import/no-unresolved
 // import { livewire_hot_reload } from 'virtual:livewire-hot-reload';
 
-import { clipboard, themeChange } from './utils';
+import { clipboard, mobileSafeTipEvents, themeChange } from './utils';
 
 // livewire_hot_reload();
+
+window.mobileSafeTipEvents = mobileSafeTipEvents;
 
 window.Alpine = Alpine;
 Alpine.start();

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -1,8 +1,11 @@
 import type { Alpine } from 'alpinejs';
+import type { mobileSafeTipEvents as MobileSafeTipEvents } from '../utils/tooltip';
 
 declare global {
     var Alpine: Alpine;
     var cfg: Record<string, unknown> | undefined;
     var clipboard: (text: string) => void;
+    var mobileSafeTipEvents: typeof MobileSafeTipEvents;
     var showStatusSuccess: (message: string) => void;
+    var Tip: (...args: unknown[]) => void;
 }

--- a/resources/js/utils/index.ts
+++ b/resources/js/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './cookie';
 export * from './helpers';
 export * from './theme';
+export * from './tooltip';

--- a/resources/js/utils/tooltip.ts
+++ b/resources/js/utils/tooltip.ts
@@ -1,0 +1,37 @@
+import { UAParser } from 'ua-parser-js';
+
+let wasMobileIosDetected: boolean | null = null;
+
+function detectMobileIos() {
+  if ('userAgent' in navigator) {
+    const { getOS, getDevice } = new UAParser(navigator.userAgent);
+
+    const { name: osName } = getOS();
+    const { type: deviceType } = getDevice();
+
+    if (osName === 'iOS' && deviceType === 'mobile') {
+      wasMobileIosDetected = true;
+    } else {
+      wasMobileIosDetected = false;
+    }
+  }
+}
+
+function handleMouseOver(tipArgs: unknown) {
+  /**
+   * wz_tooltip.js causes issues with touch events on
+   * iOS devices. Android devices are okay.
+   * @see https://github.com/RetroAchievements/RAWeb/issues/1365
+   */
+  if (wasMobileIosDetected === null) {
+    detectMobileIos();
+  }
+
+  if (wasMobileIosDetected === false && window.Tip) {
+    window.Tip(tipArgs);
+  }
+}
+
+export const mobileSafeTipEvents = {
+  mouseOver: handleMouseOver
+};


### PR DESCRIPTION
This PR addresses some discussion that recently came up in #site-feedback regarding recent changes to mobile tooltips, specifically in the case of Android users.

It seems Android and iOS handle "hover" gestures differently, and things were not broken on Android as they are on iOS for tooltips.

```
Hey yall, Jamiras directed me here. Just wanted to voice that I liked / used site tooltips on mobile quite a bit (android chrome). not sure if it can be disabled for one browser and not another, or via user profile settings, but it never seemed to cause any issues on my platform. minor thing but wanted to pass it on, thanks for all the hard work :pray~1:

Same here, I was trying to pull them up the other day while looking at a ticket to see the description of an achievement by tap holding it but can't do that now. I used it fairly often for other things as well :pray~1:

I'll throw my hat in for having it reenabled on Android also. It is t perfect since it usually pops up the menu when I press, but it still allows me to see info that is useful
```

Changes in this PR:
* The `mobileSafeTipEvents` code has been migrated from _all.js_ to a TypeScript util.
* `onTouchStart` is no longer needed, as we are no longer basing this conditional on the presence of user touch. Therefore, this code has been deleted.
* Mobile tooltips now gracefully degrade if iOS and mobile are both detected. Otherwise, tooltips will always display. This is handled by user agent sniffing. I have chosen `ua-parser-js` to take care of this lift, as my impression is we don't want to be rolling our own method of sniffing the user agent.

I have tested this on desktop, the iOS simulator, emulated iOS, and emulated Android. This seems to achieve the effect we want. Tooltips are enabled for desktop and Android, but they are disabled on iOS.