### PR TITLE
fix: add basic point pluralization to achievement tooltips

### DIFF
--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -111,7 +111,7 @@ function renderAchievementCard(int|string|array $achievement, ?string $context =
     $tooltip .= "<div><b>$title</b></div>";
     $tooltip .= "<div class='mb-1'>$description</div>";
     if ($achPoints) {
-        $tooltip .= "<div>$achPoints " . ($achPoints == 1 ? "Point" : "Points") . "</div>";
+        $tooltip .= "<div>$achPoints " . __res('point', $achPoints) . "</div>";
     }
     if ($gameTitle) {
         $tooltip .= "<div><i>$gameTitle</i></div>";

--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -111,7 +111,7 @@ function renderAchievementCard(int|string|array $achievement, ?string $context =
     $tooltip .= "<div><b>$title</b></div>";
     $tooltip .= "<div class='mb-1'>$description</div>";
     if ($achPoints) {
-        $tooltip .= "<div>$achPoints Points</div>";
+        $tooltip .= "<div>$achPoints " . ($achPoints == 1 ? "Point" : "Points") . "</div>";
     }
     if ($gameTitle) {
         $tooltip .= "<div><i>$gameTitle</i></div>";


### PR DESCRIPTION
This PR makes a very minor change to the "Points" label on achievement tooltips. If Points === 1, the label now displays "1 Point" instead of "1 Points".

![Screenshot 2023-03-04 at 4 11 37 PM](https://user-images.githubusercontent.com/3984985/222929012-7583b6f4-608d-4a64-9c2d-9379c9ee436c.png)
