### PR TITLE
feat(game): require game icons to be 96x96 pixels

### DIFF
--- a/public/request/game/update-image.php
+++ b/public/request/game/update-image.php
@@ -21,7 +21,7 @@ if ($input['type'] === ImageType::GameIcon) {
     Validator::make(
         request()->all(),
         ['file' => ['dimensions:width=96,height=96']],
-        ['file.dimensions' => 'The game icon must be exactly 96x96 pixels.']
+        ['file.dimensions' => 'Game icons are required to have dimensions of 96x96 pixels.']
     )->validate();
 }
 

--- a/public/request/game/update-image.php
+++ b/public/request/game/update-image.php
@@ -14,8 +14,16 @@ if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Juni
 $input = Validator::validate(request()->post(), [
     'game' => 'required|integer|exists:mysql_legacy.GameData,ID',
     'type' => ['required', 'string', Rule::in(ImageType::cases())],
-    'file' => 'image',
+    'file' => ['image'],
 ]);
+
+if ($input['type'] === ImageType::GameIcon) {
+    Validator::make(
+        request()->all(), 
+        ['file' => ['dimensions:width=96,height=96']], 
+        ['file.dimensions' => 'The game icon must be exactly 96x96 pixels.']
+    )->validate();
+}
 
 $gameID = (int) $input['game'];
 $imageType = $input['type'];

--- a/public/request/game/update-image.php
+++ b/public/request/game/update-image.php
@@ -19,8 +19,8 @@ $input = Validator::validate(request()->post(), [
 
 if ($input['type'] === ImageType::GameIcon) {
     Validator::make(
-        request()->all(), 
-        ['file' => ['dimensions:width=96,height=96']], 
+        request()->all(),
+        ['file' => ['dimensions:width=96,height=96']],
         ['file.dimensions' => 'The game icon must be exactly 96x96 pixels.']
     )->validate();
 }


### PR DESCRIPTION
This PR adds validation to uploading game icons to game pages. An error message is now shown if the user attempts to upload an image that is not exactly 96x96.

<img width="696" alt="Screenshot 2023-03-09 at 5 42 39 PM" src="https://user-images.githubusercontent.com/3984985/224176915-37e9648a-319c-475a-9031-bf3e7c4f65f1.png">

https://discord.com/channels/310192285306454017/1082859674002522192