### PR TITLE
fix(layout): update sitenav Hardest Achievements url

### DIFF
--- a/app_legacy/Helpers/render/layout.php
+++ b/app_legacy/Helpers/render/layout.php
@@ -131,7 +131,7 @@ function RenderToolbar(): void
     echo "<li class='divider'></li>";
     // echo "<li><a href='/awardedList.php'>Commonly Won Achievements</a></li>";
     echo "<li><a href='/achievementList.php?s=4&p=2'>Easy Achievements</a></li>";
-    echo "<li><a href='/gameSearch.php?p=0'>Hardest Achievements</a></li>";
+    echo "<li><a href='/achievementList.php?s=14&p=2'>Hardest Achievements</a></li>";
     echo "</ul>";
     echo "</div>";
     echo "</li>";

--- a/app_legacy/Helpers/render/layout.php
+++ b/app_legacy/Helpers/render/layout.php
@@ -109,7 +109,7 @@ function RenderToolbar(): void
     echo "<ul>";
     echo "<li class='dropdown-header'>Miscellaneous</li>";
     echo "<li><a href='/gameList.php'>All Games</a></li>";
-    // echo "<li><a href='/popularGames.php'>Most Played</a></li>";
+    echo "<li><a href='/gameSearch.php?p=0'>Hardest Games</a></li>";
     echo "<li><a href='/setRequestList.php'>Most Requested</a></li>";
     echo "<li><a href='/claimlist.php?s=9&f=8109'>New Sets & Revisions</a></li>";
     echo "<li><a href='/claimlist.php'>Sets in Progress</a></li>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -845,7 +845,7 @@ sanitize_outputs(
                         echo "<form class='mb-2' method='post' action='/request/game/update-title.php'>";
                         echo csrf_field();
                         echo "<input type='hidden' name='game' value='$gameID' />";
-                        echo "<div class='grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
+                        echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
                         echo "<label for='game_title'>Name</label>";
                         echo "<input type='text' name='title' id='game_title' value='$escapedGameTitle' maxlength='80' class='w-full'>";
                         echo "<div class='text-right'><button class='btn'>Submit</button></div>";
@@ -857,7 +857,7 @@ sanitize_outputs(
                     echo csrf_field();
                     echo "<input type='hidden' name='game' value='$gameID'>";
                     echo "<input type='hidden' name='guide_url' value='" . attributeEscape($guideURL) . "'>";
-                    echo "<div class='grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
+                    echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
                     echo "<label for='game_developer'>Developer</label><input type='text' name='developer' id='game_developer' value='" . attributeEscape($developer) . "' class='w-full'>";
                     echo "<div class='text-right'><button class='btn'>Submit</button></div>";
                     echo "<label for='game_publisher'>Publisher</label><input type='text' name='publisher' id='game_publisher' value='" . attributeEscape($publisher) . "' class='w-full'>";
@@ -874,9 +874,9 @@ sanitize_outputs(
                         echo csrf_field();
                         echo "<input type='hidden' name='game' value='$gameID'>";
                         echo "<input type='hidden' name='type' value='" . ImageType::GameTitle . "'>";
-                        echo "<div class='grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
+                        echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
                         echo "<label for='image_" . ImageType::GameTitle . "'>Title Screenshot</label>";
-                        echo "<input class='grow' type='file' name='file' id='image_" . ImageType::GameTitle . "'>";
+                        echo "<input type='file' name='file' id='image_" . ImageType::GameTitle . "' class='w-full'>";
                         echo "<div class='text-right'><button class='btn'>Submit</button></div>";
                         echo "</div>";
                         echo "</form>";
@@ -885,9 +885,9 @@ sanitize_outputs(
                         echo csrf_field();
                         echo "<input type='hidden' name='game' value='$gameID'>";
                         echo "<input type='hidden' name='type' value='" . ImageType::GameInGame . "'>";
-                        echo "<div class='grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
+                        echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
                         echo "<label for='image_" . ImageType::GameInGame . "'>In-game Screenshot</label>";
-                        echo "<input type='file' name='file' id='image_" . ImageType::GameInGame . "'>";
+                        echo "<input type='file' name='file' id='image_" . ImageType::GameInGame . "' class='w-full'>";
                         echo "<div class='text-right'><button class='btn'>Submit</button></div>";
                         echo "</div>";
                         echo "</form>";
@@ -897,9 +897,9 @@ sanitize_outputs(
                     echo csrf_field();
                     echo "<input type='hidden' name='game' value='$gameID'>";
                     echo "<input type='hidden' name='type' value='" . ImageType::GameIcon . "'>";
-                    echo "<div class='grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
+                    echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
                     echo "<label for='image_" . ImageType::GameIcon . "'>Icon</label>";
-                    echo "<input type='file' name='file' id='image_" . ImageType::GameIcon . "'>";
+                    echo "<input type='file' name='file' id='image_" . ImageType::GameIcon . "' class='w-full'>";
                     echo "<div class='text-right'><button class='btn'>Submit</button></div>";
                     echo "</div>";
                     echo "</form>";
@@ -909,9 +909,9 @@ sanitize_outputs(
                         echo csrf_field();
                         echo "<input type='hidden' name='game' value='$gameID'>";
                         echo "<input type='hidden' name='type' value='" . ImageType::GameBoxArt . "'>";
-                        echo "<div class='grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
+                        echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
                         echo "<label for='image_" . ImageType::GameBoxArt . "'>Box Art</label>";
-                        echo "<input type='file' name='file' id='image_" . ImageType::GameBoxArt . "'>";
+                        echo "<input type='file' name='file' id='image_" . ImageType::GameBoxArt . "' class='w-full'>";
                         echo "<div class='text-right'><button class='btn'>Submit</button></div>";
                         echo "</div>";
                         echo "</form>";
@@ -919,12 +919,12 @@ sanitize_outputs(
                 }
 
                 if ($permissions >= Permissions::Admin) {
-                    echo "<form class='mb-2' method='post' action='/request/game/update-forum-topic.php' style='margin-bottom:10px'>";
+                    echo "<form class='mb-2' method='post' action='/request/game/update-forum-topic.php'>";
                     echo csrf_field();
                     echo "<input type='hidden' name='game' value='$gameID'>";
-                    echo "<div class='grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
+                    echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
                     echo "<label for='game_forum_topic'>New Forum Topic ID</label>";
-                    echo "<input type='text' name='forum_topic' id='game_forum_topic' size='20'>";
+                    echo "<input type='text' name='forum_topic' id='game_forum_topic' class='w-full'>";
                     echo "<div class='text-right'><button class='btn'>Submit</button></div>";
                     echo "</div>";
                     echo "</form>";
@@ -938,7 +938,7 @@ sanitize_outputs(
                     echo "<input type='hidden' name='publisher' value='" . attributeEscape($publisher) . "'>";
                     echo "<input type='hidden' name='genre' value='" . attributeEscape($genre) . "'>";
                     echo "<input type='hidden' name='release' value='" . attributeEscape($released) . "'>";
-                    echo "<div class='grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
+                    echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
                     echo "<label for='guide_url'>Guide URL</label><input type='url' name='guide_url' id='guide_url' value='" . attributeEscape($guideURL) . "' class='w-full'>";
                     echo "<div class='text-right'><button class='btn'>Submit</button></div>";
                     echo "</div>";
@@ -949,9 +949,9 @@ sanitize_outputs(
                     echo "<form class='mb-2' method='post' action='/request/game-relation/create.php'>";
                     echo csrf_field();
                     echo "<input type='hidden' name='game' value='$gameID'>";
-                    echo "<div class='grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
+                    echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
                     echo "<label for='game_relation_add'>Add Related Games<br>(CSV of game IDs)</label>";
-                    echo "<input type='text' name='relations' id='game_relation_add' size='20'>";
+                    echo "<input type='text' name='relations' id='game_relation_add' class='w-full'>";
                     echo "<div class='text-right'><button class='btn'>Add</button></div>";
                     echo "</div>";
                     echo "</form>";


### PR DESCRIPTION
Currently, the "Hardest Achievements" URL does not link to a list of achievements. It takes the user to a game list sorted by retro ratio. This could be more accurately labeled as "Hardest Games", but then it wouldn't belong under the "Achievements" menu.

This PR updates the URL to instead go to the site's global achievement list, pre-sorted by highest retro ratio.

https://discord.com/channels/310192285306454017/511718348178849792/1083779531065806929