### PR TITLE
feat(game): change copy for linked hashes

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1385,7 +1385,7 @@ sanitize_outputs(
             echo "</li>";
             if (isset($user)) {
                 if ($permissions >= Permissions::Registered) {
-                    echo "<li><a class='btn py-2 mb-2 block' href='/linkedhashes.php?g=$gameID'><span class='icon icon-md ml-1 mr-3'>🔗</span>Linked Hashes</a></li>";
+                    echo "<li><a class='btn py-2 mb-2 block' href='/linkedhashes.php?g=$gameID'><span class='icon icon-md ml-1 mr-3'>💾</span>Supported Game Files</a></li>";
                     echo "<li><a class='btn py-2 mb-2 block' href='/codenotes.php?g=$gameID'><span class='icon icon-md ml-1 mr-3'>📑</span>Code Notes</a></li>";
                     $numOpenTickets = countOpenTickets(
                         requestInputSanitized('f') == $unofficialFlag,

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -41,7 +41,7 @@ RenderContentStart("Supported Game Files - $gameTitle");
              "<a href='https://docs.retroachievements.org/Game-Identification/'>here</a>." .
              "</b></p>";
 
-        echo "<p class='mt-4 mb-1'>There are currently <span class='font-bold'>" . count((array) $hashes) . "</span> unique game file hashes registered for this game.</p>";
+        echo "<p class='mt-4 mb-1'>There are currently <span class='font-bold'>" . count((array) $hashes) . "</span> supported game file hashes registered for this game.</p>";
 
         echo "<ul>";
         $hasUnlabeledHashes = false;

--- a/public/linkedhashes.php
+++ b/public/linkedhashes.php
@@ -19,29 +19,29 @@ $gameIcon = $gameData['ImageIcon'];
 $forumTopicID = $gameData['ForumTopicID'];
 $hashes = getHashListByGameID($gameID);
 
-RenderContentStart("Linked Hashes - $gameTitle");
+RenderContentStart("Supported Game Files - $gameTitle");
 ?>
 <div id="mainpage">
     <div id='fullcontainer'>
         <div class='navpath'>
             <?= renderGameBreadcrumb($gameData) ?>
-            &raquo; <b>Linked Hashes</b>
+            &raquo; <b>Supported Game Files</b>
         </div>
 
-        <h3>List of Linked Hashes</h3>
+        <h3>List of Supported Game Files</h3>
 
         <?php
         echo gameAvatar($gameData, iconSize: 64);
         echo "<br><br>";
 
-        echo "<p class='embedded'><b>Hashes are used to confirm if two copies of a file are identical. " .
+        echo "<p class='embedded p-4'><b>Game file hashes are used to confirm if two copies of a game file are identical. " .
              "We use it to ensure the player is using the same ROM as the achievement developer, or a compatible one." .
-             "<br/><br/>RetroAchievements only hashes portions of larger games to minimize load times, and strips " .
+             "<br/><br/>RetroAchievements only hashes portions of larger game files to minimize load times, and strips " .
              "headers on smaller ones. Details on how the hash is generated for each system can be found " .
              "<a href='https://docs.retroachievements.org/Game-Identification/'>here</a>." .
              "</b></p>";
 
-        echo "\n<br>Currently this game has <b>" . count((array) $hashes) . "</b> unique hashes registered for it:<br><br>";
+        echo "<p class='mt-4 mb-1'>There are currently <span class='font-bold'>" . count((array) $hashes) . "</span> unique game file hashes registered for this game.</p>";
 
         echo "<ul>";
         $hasUnlabeledHashes = false;
@@ -53,7 +53,7 @@ RenderContentStart("Linked Hashes - $gameTitle");
 
             $hashName = $hash['Name'];
             sanitize_outputs($hashName);
-            echo "<li><p class='embedded'><b>$hashName</b>";
+            echo "<li><p class='embedded p-4'><b>$hashName</b>";
             if (!empty($hash['Labels'])) {
                 foreach (explode(',', $hash['Labels']) as $label) {
                     if (empty($label)) {
@@ -77,7 +77,7 @@ RenderContentStart("Linked Hashes - $gameTitle");
         }
 
         if ($hasUnlabeledHashes) {
-            echo '<li><p class="embedded"><b>Unlabeled</b><br/>';
+            echo '<li><p class="embedded p-4"><b>Unlabeled Game File Hashes</b><br/>';
             foreach ($hashes as $hash) {
                 if (!empty($hash['Name'])) {
                     continue;


### PR DESCRIPTION
Per https://discord.com/channels/310192285306454017/1082381537619738766/1083784110364958860, this PR changes the game page's "Linked Hashes" to "Supported Game Files".

The Manage > Latest Linked Hashes is intentionally left untouched because the linked hashes copy is certainly more relevant for that page.

There are also some minor stylistic changes to the game link hashes page.

![Screenshot 2023-03-11 at 7 30 10 PM](https://user-images.githubusercontent.com/3984985/224517746-6aed429d-d105-4726-a743-6c1fb6a00267.png)

![Screenshot 2023-03-11 at 7 34 19 PM](https://user-images.githubusercontent.com/3984985/224517782-7d893145-bdc7-4fe7-b8f5-35bc2611ecf4.png)