### PR TITLE
fix: prevent iOS Safari from detecting numeric sequences as phone numbers

### DIFF
--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -9,7 +9,7 @@
     <meta name="copyright" content="Copyright 2014-{{ date('Y') }}">
     <meta name="description" content="{{ $pageDescription ?? __('app.description') }}">
     <meta name="keywords" content="games, achievements, retro, emulator">
-    <meta name="format-detection" content="telephone=no" />
+    <meta name="format-detection" content="telephone=no">
     @if(config('services.facebook.client_id'))
         <meta property="fb:app_id" content="{{ config('services.facebook.client_id') }}">
     @endif

--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -9,6 +9,7 @@
     <meta name="copyright" content="Copyright 2014-{{ date('Y') }}">
     <meta name="description" content="{{ $pageDescription ?? __('app.description') }}">
     <meta name="keywords" content="games, achievements, retro, emulator">
+    <meta name="format-detection" content="telephone=no" />
     @if(config('services.facebook.client_id'))
         <meta property="fb:app_id" content="{{ config('services.facebook.client_id') }}">
     @endif


### PR DESCRIPTION
iOS Safari is currently detecting several sequences of numbers on the site as being phone numbers. When these values are tapped, the user is prompted to initiate a phone call.

This change mitigates this undesirable behavior.

ref: https://discord.com/channels/310192285306454017/1087759281299914843