### PR TITLE
fix(game): remediate copy issue on zero earn rate achievements

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1337,7 +1337,7 @@ sanitize_outputs(
                             if ($wonByHardcore > 0) {
                                 echo "<p>" . number_format($wonBy) . " <strong>(" . number_format($wonByHardcore) . ")</strong> of " . number_format($numDistinctPlayersCasual) . "</p>";
                             } else {
-                                echo "<p>" . number_format($wonBy) . " of " . number_format($numDistinctPlayersCasual) . "<br>($pctAwardedCasual%)</p>";
+                                echo "<p>" . number_format($wonBy) . " of " . number_format($numDistinctPlayersCasual) . "</p>";
                             }
                             echo "<p class='text-2xs'>$pctAwardedCasual% earn rate</p>";
                             echo "</div>";


### PR DESCRIPTION
This PR remediates a minor copy issue from the game page UX updates. When an achievement on a game page has zero hardcore unlocks, there is an extraneous line of text that is displayed for the earn rate. After this PR, the line is removed.

**BEFORE**
![Screenshot 2023-04-09 at 11 35 30 AM](https://user-images.githubusercontent.com/3984985/230782209-26f9d7fe-3e89-4dbc-977e-d3a78ec4f48a.png)

**AFTER**
![Screenshot 2023-04-09 at 11 35 47 AM](https://user-images.githubusercontent.com/3984985/230782220-ad9c66b3-b490-4828-bf44-7d594566c090.png)
