### PR TITLE
fix(user): hide progress bars if a game has no achievements

### DIFF
--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -433,23 +433,25 @@ function RenderGameProgress(int $numAchievements, int $numEarnedCasual, int $num
         $fullWidthClassName = "md:w-40";
     }
 
-    echo "<div class='w-full my-2 $fullWidthClassName'>";
-    echo "<div class='flex w-full items-center'>";
-    echo "<div class='progressbar grow'>";
-    echo "<div class='completion' style='width:$pctComplete%' title='$title'>";
-    echo "<div class='completion-hardcore' style='width:$pctHardcoreProportion%'></div>";
-    echo "</div>";
-    echo "</div>";
-    echo renderCompletionIcon($numEarnedTotal, $numAchievements, $pctHardcore);
-    echo "</div>";
-    echo "<div class='progressbar-label -mt-1'>";
-    if ($pctHardcore >= 100.0) {
-        echo "Mastered";
-    } else {
-        echo "$pctComplete% complete";
+    if ($numAchievements) {
+        echo "<div class='w-full my-2 $fullWidthClassName'>";
+        echo "<div class='flex w-full items-center'>";
+        echo "<div class='progressbar grow'>";
+        echo "<div class='completion' style='width:$pctComplete%' title='$title'>";
+        echo "<div class='completion-hardcore' style='width:$pctHardcoreProportion%'></div>";
+        echo "</div>";
+        echo "</div>";
+        echo renderCompletionIcon($numEarnedTotal, $numAchievements, $pctHardcore);
+        echo "</div>";
+        echo "<div class='progressbar-label -mt-1'>";
+        if ($pctHardcore >= 100.0) {
+            echo "Mastered";
+        } else {
+            echo "$pctComplete% complete";
+        }
+        echo "</div>";
+        echo "</div>";
     }
-    echo "</div>";
-    echo "</div>";
 }
 
 /**


### PR DESCRIPTION
This PR fixes an issue on user pages where games in a user's recently played list show completion % progress bars even if the game itself has no achievements.

**BEFORE**
<img width="656" alt="Screenshot 2023-04-11 at 10 16 04 PM" src="https://user-images.githubusercontent.com/3984985/231330688-d7376e52-0ba4-48ac-bdb8-411c9da873df.png">


**AFTER**
<img width="660" alt="Screenshot 2023-04-11 at 10 16 21 PM" src="https://user-images.githubusercontent.com/3984985/231330695-92818ecb-84cd-45b9-aadc-401ecc3facc0.png">