### PR TITLE
feat(game): only show expiration timeago copy to jr devs and up

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1146,16 +1146,16 @@ sanitize_outputs(
                         }
 
                         if ($claimExpiration) {
-                            $claimFormattedDate = $claimExpiration->format('d M Y, H:i');
                             $isAlreadyExpired = Carbon::parse($claimExpiration)->isPast();
+                            $isAlreadyExpiredCopy = $isAlreadyExpired ? "Expired" : "Expires";
 
-                            echo "<p>";
-                            if ($isAlreadyExpired) {
-                                echo "Expired on: $claimFormattedDate (" . $claimExpiration->diffForHumans() . ")";
-                            } else {
-                                echo "Expires on: $claimFormattedDate (" . $claimExpiration->diffForHumans() . ")";
-                            }
-                            echo "</p>";
+                            $claimFormattedDate = $claimExpiration->format('d M Y, H:i');
+                            $claimTimeAgoDate = $permissions >= Permissions::JuniorDeveloper 
+                                ? "(" . $claimExpiration->diffForHumans() . ")" 
+                                : null;
+
+                            // "Expires on: 12 Jun 2023, 01:28 (1 month from now)"
+                            echo "<p>$isAlreadyExpiredCopy on: $claimFormattedDate $claimTimeAgoDate</p>";
                         }
                     } else {
                         if ($numAchievements < 1) {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1150,8 +1150,8 @@ sanitize_outputs(
                             $isAlreadyExpiredCopy = $isAlreadyExpired ? "Expired" : "Expires";
 
                             $claimFormattedDate = $claimExpiration->format('d M Y, H:i');
-                            $claimTimeAgoDate = $permissions >= Permissions::JuniorDeveloper 
-                                ? "(" . $claimExpiration->diffForHumans() . ")" 
+                            $claimTimeAgoDate = $permissions >= Permissions::JuniorDeveloper
+                                ? "(" . $claimExpiration->diffForHumans() . ")"
                                 : null;
 
                             // "Expires on: 12 Jun 2023, 01:28 (1 month from now)"


### PR DESCRIPTION
This PR:

* Sets the game page's expiration timeago copy to visible only to Junior Developers and up.
* Slightly refactors the code to generate the copy for that area of the page.

This change is motivated by https://discord.com/channels/310192285306454017/310195377993416714/1096534286456340572.

Specifically, this is the area of the page affected:
<img width="380" alt="Screenshot 2023-04-15 at 7 51 23 AM" src="https://user-images.githubusercontent.com/3984985/232217699-47396f1c-35e8-4a06-9efd-8efb10022395.png">
