### PR TITLE
feat(gameList): show the count of leaderboards owned by the dev

### DIFF
--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -280,7 +280,8 @@ function getGamesListByDev(
         $moreSelectCond = "SUM(CASE WHEN ach.Author LIKE '$dev' THEN 1 ELSE 0 END) AS MyAchievements,
                            SUM(CASE WHEN ach.Author LIKE '$dev' THEN ach.Points ELSE 0 END) AS MyPoints,
                            SUM(CASE WHEN ach.Author LIKE '$dev' THEN ach.TrueRatio ELSE 0 END) AS MyTrueRatio,
-                           SUM(CASE WHEN ach.Author NOT LIKE '$dev' THEN 1 ELSE 0 END) AS NotMyAchievements,";
+                           SUM(CASE WHEN ach.Author NOT LIKE '$dev' THEN 1 ELSE 0 END) AS NotMyAchievements,
+                           lbdi.MyLBs,";
         $havingCond = "HAVING MyAchievements > 0 ";
     } else {
         if ($filter == 0) { // only with achievements
@@ -298,7 +299,10 @@ function getGamesListByDev(
                 FROM GameData AS gd
                 INNER JOIN Console AS c ON c.ID = gd.ConsoleID
                 LEFT JOIN Achievements AS ach ON gd.ID = ach.GameID AND ach.Flags = " . AchievementType::OfficialCore . "
-                LEFT JOIN ( SELECT lbd.GameID, COUNT( DISTINCT lbd.ID ) AS NumLBs FROM LeaderboardDef AS lbd GROUP BY lbd.GameID ) AS lbdi ON lbdi.GameID = gd.ID
+                LEFT JOIN ( SELECT lbd.GameID, COUNT( DISTINCT lbd.ID ) AS NumLBs,
+                                   SUM(CASE WHEN lbd.Author LIKE '$dev' THEN 1 ELSE 0 END) AS MyLBs
+                            FROM LeaderboardDef AS lbd
+                            GROUP BY lbd.GameID ) AS lbdi ON lbdi.GameID = gd.ID
                 $joinTicketsTable
                 $whereCond
                 GROUP BY gd.ID

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -80,6 +80,7 @@ function ListGames(
         $maxPoints = $gameEntry['MaxPointsAvailable'] ?? 0;
         $totalTrueRatio = $gameEntry['TotalTruePoints'];
         $totalAchievements = null;
+        $devLeaderboards = null;
         if ($dev == null) {
             $numAchievements = $gameEntry['NumAchievements'];
             $numPoints = $maxPoints;
@@ -89,7 +90,7 @@ function ListGames(
             $numPoints = $gameEntry['MyPoints'];
             $numTrueRatio = $gameEntry['MyTrueRatio'];
             $totalAchievements = $numAchievements + $gameEntry['NotMyAchievements'];
-            $myLBs = $gameEntry['MyLBs'];
+            $devLeaderboards = $gameEntry['MyLBs'];
         }
         $numLBs = $gameEntry['NumLBs'];
 
@@ -127,8 +128,8 @@ function ListGames(
                 echo "<a href=\"game/$gameID\">$numLBs</a>";
                 $lbCount += $numLBs;
             } else {
-                echo "<a href=\"game/$gameID\">$myLBs of $numLBs</a>";
-                $lbCount += $myLBs;
+                echo "<a href=\"game/$gameID\">$devLeaderboards of $numLBs</a>";
+                $lbCount += $devLeaderboards;
             }
         }
         echo "</td>";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -89,9 +89,9 @@ function ListGames(
             $numPoints = $gameEntry['MyPoints'];
             $numTrueRatio = $gameEntry['MyTrueRatio'];
             $totalAchievements = $numAchievements + $gameEntry['NotMyAchievements'];
+            $myLBs = $gameEntry['MyLBs'];
         }
         $numLBs = $gameEntry['NumLBs'];
-        $myLBs = $gameEntry['MyLBs'];
 
         sanitize_outputs($title);
 
@@ -123,8 +123,13 @@ function ListGames(
 
         echo "<td class=''>";
         if ($numLBs > 0) {
-            echo "<a href=\"game/$gameID\">$myLBs of $numLBs</a>";
-            $lbCount += $myLBs;
+            if ($dev == null) {
+                echo "<a href=\"game/$gameID\">$numLBs</a>";
+                $lbCount += $numLBs;
+            } else {
+                echo "<a href=\"game/$gameID\">$myLBs of $numLBs</a>";
+                $lbCount += $myLBs;
+            }
         }
         echo "</td>";
 

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -91,6 +91,7 @@ function ListGames(
             $totalAchievements = $numAchievements + $gameEntry['NotMyAchievements'];
         }
         $numLBs = $gameEntry['NumLBs'];
+        $myLBs = $gameEntry['MyLBs'];
 
         sanitize_outputs($title);
 
@@ -122,8 +123,8 @@ function ListGames(
 
         echo "<td class=''>";
         if ($numLBs > 0) {
-            echo "<a href=\"game/$gameID\">$numLBs</a>";
-            $lbCount += $numLBs;
+            echo "<a href=\"game/$gameID\">$myLBs of $numLBs</a>";
+            $lbCount += $myLBs;
         }
         echo "</td>";
 


### PR DESCRIPTION
This PR:
* Makes an update to dev-specific _gameList.php_ pages such that, in addition to a set's total loaderboard count being shown, the count of leaderboards worked on by the dev is also shown.
* Adjusts the total cell for leaderboards so it displays the sum of leaderboards specifically worked on by the dev.

**BEFORE**
<img width="1001" alt="Screenshot 2023-04-15 at 8 25 35 AM" src="https://user-images.githubusercontent.com/3984985/232223448-17429a10-0287-452f-b1bd-98e69e4c250e.png">

**AFTER**
<img width="1004" alt="Screenshot 2023-04-15 at 8 25 20 AM" src="https://user-images.githubusercontent.com/3984985/232223454-6a6e51a4-831e-41dc-8b66-b10ecfe141bb.png">