### PR TITLE
Adjust column width in main nav

### DIFF
--- a/resources/css/nav.css
+++ b/resources/css/nav.css
@@ -103,7 +103,7 @@
   display: block;
   color: var(--menu-link-color);
   line-height: 1.4em;
-  width: 175px;
+  width: 200px;
   text-align: left;
   margin: 0;
   padding: 4px 12px;


### PR DESCRIPTION
With the addition of system icons in the main navigation the columns aren't wide enough anymore to prevent line breaks (PC Engine & 3DO entries).

This PR fixes that, should not have implications for smaller screens if i'm not mistaken.

**Before**

![Screenshot 2023-04-16 at 14 15 19](https://user-images.githubusercontent.com/1280590/232309380-946a66b2-ad3d-496b-8270-efd9b94d4b17.png)

**After**

![Screenshot 2023-04-16 at 14 15 46](https://user-images.githubusercontent.com/1280590/232309393-0eeb7740-08ff-49a6-94a8-4a10c7850233.png)
