### PR TITLE
fix(user): add conditional rendering for hide completed sets checkbox

### DIFF
--- a/app_legacy/Helpers/render/user.php
+++ b/app_legacy/Helpers/render/user.php
@@ -147,23 +147,52 @@ function renderUserCard(string|array $user): string
     return $tooltip;
 }
 
+function getCompletedAndIncompletedSetsCounts(array $userCompletedGamesList): array
+{
+    $completedSetsCount = 0;
+    $incompletedSetsCount = 0;
+
+    $numItems = count($userCompletedGamesList);
+    for ($i = 0; $i < $numItems; $i++) {
+        $nextMaxPossible = $userCompletedGamesList[$i]['MaxPossible'];
+        $nextNumAwarded = $userCompletedGamesList[$i]['NumAwarded'];
+
+        // Don't divide by 0.
+        if ($nextNumAwarded == 0 || $nextMaxPossible == 0) {
+            continue;
+        }
+
+        $pctAwardedNormal = ($nextNumAwarded / $nextMaxPossible) * 100.0;
+        if ($pctAwardedNormal == 100) {
+            $completedSetsCount++;
+        } else {
+            $incompletedSetsCount++;
+        }
+    }
+
+    return ['completedSetsCount' => $completedSetsCount, 'incompletedSetsCount' => $incompletedSetsCount];
+}
+
 function RenderCompletedGamesList(array $userCompletedGamesList): void
 {
     echo "<div id='completedgames' class='component' >";
 
     echo "<h3>Completion Progress</h3>";
 
-    echo <<<HTML
-        <label class="flex items-center gap-x-1 mb-2">
-            <input 
-                type="checkbox" 
-                id="hide-user-completed-sets-checkbox" 
-                onchange="toggleUserCompletedSetsVisibility.toggleUserCompletedSetsVisibility()"
-            >
-                Hide completed sets
-            </input>
-        </label>
-    HTML;
+    $setsCounts = getCompletedAndIncompletedSetsCounts($userCompletedGamesList);
+    if ($setsCounts['completedSetsCount'] > 0 && $setsCounts['incompletedSetsCount'] > 0) {
+        echo <<<HTML
+            <label class="flex items-center gap-x-1 mb-2">
+                <input 
+                    type="checkbox" 
+                    id="hide-user-completed-sets-checkbox" 
+                    onchange="toggleUserCompletedSetsVisibility.toggleUserCompletedSetsVisibility()"
+                >
+                    Hide completed sets
+                </input>
+            </label>
+        HTML;
+    }
 
     echo "<div id='usercompletedgamescomponent'>";
 

--- a/app_legacy/Helpers/render/user.php
+++ b/app_legacy/Helpers/render/user.php
@@ -152,18 +152,11 @@ function getCompletedAndIncompletedSetsCounts(array $userCompletedGamesList): ar
     $completedSetsCount = 0;
     $incompletedSetsCount = 0;
 
-    $numItems = count($userCompletedGamesList);
-    for ($i = 0; $i < $numItems; $i++) {
-        $nextMaxPossible = $userCompletedGamesList[$i]['MaxPossible'];
-        $nextNumAwarded = $userCompletedGamesList[$i]['NumAwarded'];
+    foreach ($userCompletedGamesList as $game) {
+        $nextMaxPossible = $game['MaxPossible'];
+        $nextNumAwarded = $game['NumAwarded'];
 
-        // Don't divide by 0.
-        if ($nextNumAwarded == 0 || $nextMaxPossible == 0) {
-            continue;
-        }
-
-        $pctAwardedNormal = ($nextNumAwarded / $nextMaxPossible) * 100.0;
-        if ($pctAwardedNormal == 100) {
+        if ($nextNumAwarded == $nextMaxPossible) {
             $completedSetsCount++;
         } else {
             $incompletedSetsCount++;


### PR DESCRIPTION
This PR addresses feedback left by @Jamiras in https://github.com/RetroAchievements/RAWeb/pull/1477#pullrequestreview-1392714663 for the "Hide completed sets" checkbox.

With this branch's changes, the new checkbox will no longer appear unless the user has at least 1 completed set and 1 non-completed set.