### PR TITLE
fix(user): remediate issue where username casing can be wrong

### DIFF
--- a/app_legacy/Helpers/database/user.php
+++ b/app_legacy/Helpers/database/user.php
@@ -199,6 +199,7 @@ function getUserPageInfo(string $user, int $numGames = 0, int $numRecentAchievem
 
     $libraryOut = [];
 
+    $libraryOut['User'] = $userInfo['User'];
     $libraryOut['RecentlyPlayedCount'] = getRecentlyPlayedGames($user, 0, $numGames, $recentlyPlayedData);
     $libraryOut['RecentlyPlayed'] = $recentlyPlayedData;
     $libraryOut['MemberSince'] = $userInfo['Created'];

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -29,6 +29,7 @@ if ((int) $userMassData['Permissions'] < Permissions::Unregistered && $permissio
     abort(404);
 }
 
+$userPage = $userMassData['User'];
 $userMotto = $userMassData['Motto'];
 $userPageID = $userMassData['ID'];
 $setRequestList = getUserRequestList($userPage);


### PR DESCRIPTION
This PR resolves an issue where entering a user's profile page with their name casing incorrect causes all references of their username on the page to use the given incorrect casing.

**Reproduction**
https://retroachievements.org/user/toastlover