### PR TITLE
fix(forum): inject shortcodes to the correct position

### DIFF
--- a/resources/js/utils/injectShortcode.test.ts
+++ b/resources/js/utils/injectShortcode.test.ts
@@ -23,7 +23,7 @@ describe('Util: injectShortcode', () => {
     expect(screen.getByRole('button', { name: /insert shortcode/i })).toBeVisible();
   });
 
-  it('given the user has no cursor position and no text selection', async () => {
+  it('given the user has no cursor position and no text selection, can insert a shortcode', async () => {
     // ARRANGE
     render('[shortcode]', '[/shortcode]');
 

--- a/resources/js/utils/injectShortcode.test.ts
+++ b/resources/js/utils/injectShortcode.test.ts
@@ -1,0 +1,102 @@
+import { screen } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+
+import { injectShortcode } from './injectShortcode';
+
+function render(start: string, end = '') {
+  (document as any).injectShortcode = injectShortcode;
+
+  document.body.innerHTML = /** @html */ `
+    <textarea id="commentTextarea"></textarea>
+    <button onclick="injectShortcode('${start}', '${end}')">Insert shortcode</button>
+  `;
+}
+
+describe('Util: injectShortcode', () => {
+  it('is defined #sanity', () => {
+    expect(injectShortcode).toBeDefined();
+  });
+
+  it('renders without crashing #sanity', () => {
+    render('[shortcode]', '[/shortcode]');
+    expect(screen.getByRole('button', { name: /insert shortcode/i })).toBeVisible();
+  });
+
+  it('given the user has no cursor position and no text selection', async () => {
+    // ARRANGE
+    render('[shortcode]', '[/shortcode]');
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: /insert shortcode/i }));
+
+    // ASSERT
+    const textareaEl = screen.getByRole<HTMLTextAreaElement>('textbox');
+    expect(textareaEl.value).toEqual('[shortcode][/shortcode]');
+  });
+
+  it('given the user has a cursor position and no text selected, should insert a shortcode at the cursor position', async () => {
+    // ARRANGE
+    render('[shortcode]', '[/shortcode]');
+
+    // ACT
+    const textareaEl = screen.getByRole<HTMLTextAreaElement>('textbox');
+
+    await userEvent.type(textareaEl, 'This is a test');
+
+    textareaEl.setSelectionRange(5, 5); // Set the cursor, but don't highlight any text.
+    await userEvent.click(screen.getByRole('button', { name: /insert shortcode/i }));
+
+    // ASSERT
+    expect(textareaEl.value).toEqual('This [shortcode][/shortcode]is a test');
+  });
+
+  it('given the cursor has a cursor position and text selected, wraps the text with the shortcode', async () => {
+    // ARRANGE
+    render('[shortcode]', '[/shortcode]');
+
+    // ACT
+    const textareaEl = screen.getByRole<HTMLTextAreaElement>('textbox');
+
+    await userEvent.type(textareaEl, 'This is a test');
+
+    textareaEl.setSelectionRange(5, 7); // Highlight the word "is".
+    await userEvent.click(screen.getByRole('button', { name: /insert shortcode/i }));
+
+    // ASSERT
+    expect(textareaEl.value).toEqual('This [shortcode]is[/shortcode] a test');
+  });
+
+  it('given a shortcode is injected, restores the cursor position after shortcode injection', async () => {
+    // ARRANGE
+    render('[shortcode]', '[/shortcode]');
+
+    // ACT
+    const textareaEl = screen.getByRole<HTMLTextAreaElement>('textbox');
+
+    await userEvent.type(textareaEl, 'This is a test');
+
+    textareaEl.setSelectionRange(5, 7); // Highlight the word "is".
+    await userEvent.click(screen.getByRole('button', { name: /insert shortcode/i }));
+
+    // ASSERT
+    expect(textareaEl.selectionStart).toEqual(16);
+    expect(textareaEl.selectionEnd).toEqual(18);
+  });
+
+  it('properly handles shortcodes that have single-character closing tags', async () => {
+    // ARRANGE
+    render('[ach=', ']');
+
+    // ACT
+    const textareaEl = screen.getByRole<HTMLTextAreaElement>('textbox');
+
+    await userEvent.type(textareaEl, 'I unlocked achievement 12345');
+
+    textareaEl.setSelectionRange(23, 28); // Highlight "12345".
+    await userEvent.click(screen.getByRole('button', { name: /insert shortcode/i }));
+
+    // ASSERT
+    expect(textareaEl.value).toEqual('I unlocked achievement [ach=12345]');
+  });
+});

--- a/resources/js/utils/injectShortcode.ts
+++ b/resources/js/utils/injectShortcode.ts
@@ -23,5 +23,9 @@ export function injectShortcode(start: string, end = ''): void {
   const newText = [beforeSelectedText, start, selectedText, end, afterSelectedText].join('');
 
   commentTextarea.value = newText;
+
+  // Restore the cursor position.
+  commentTextarea.selectionStart = startPosition + start.length;
+  commentTextarea.selectionEnd = endPosition + start.length;
   commentTextarea.focus();
 }

--- a/resources/js/utils/injectShortcode.ts
+++ b/resources/js/utils/injectShortcode.ts
@@ -15,16 +15,12 @@ export function injectShortcode(start: string, end = ''): void {
 
   const startPosition = commentTextarea.selectionStart;
   const endPosition = commentTextarea.selectionEnd;
-  const selectedText = commentTextarea.value.substring(
-    startPosition,
-    endPosition,
-  );
+  const selectedText = commentTextarea.value.substring(startPosition, endPosition);
 
-  const newText = (
-    selectedText === ''
-      ? `${commentTextarea.value}${start}${end}`
-      : `${commentTextarea.value.slice(0, startPosition)}${start}${selectedText}${end}${commentTextarea.value.slice(endPosition)}`
-  );
+  const beforeSelectedText = commentTextarea.value.slice(0, startPosition);
+  const afterSelectedText = commentTextarea.value.slice(endPosition);
+
+  const newText = [beforeSelectedText, start, selectedText, end, afterSelectedText].join('');
 
   commentTextarea.value = newText;
   commentTextarea.focus();


### PR DESCRIPTION
This PR fixes a longstanding issue with shortcode injection where if a shortcode button is clicked but no text is highlighted, the shortcode is appended to the end of the textarea's input rather than the current cursor position.

I have confirmed this behavior [was not a regression from this function's migration to TypeScript](https://github.com/wescopeland/RAWeb/commit/da3e9c56d775919b97103f78e657ef81adc88d86#diff-931ee85c19ae8eac66d195c307413252e54191fb71c05b9d2e45ec7b66169ad7L111). It seems to have been intentionally built this way, but I believe this is not a great user experience.

**Root Cause**
In the case where `selectedText === ''`, the code simply appends the shortcode to the end of the textarea value, which is incorrect. We need to change this line to properly insert the shortcode at the current cursor position.

**Fixed Behavior**

https://user-images.githubusercontent.com/3984985/233525452-4235d56a-4f90-4896-8869-c5aeb77ce7b6.mp4


