### PR TITLE
fix(ticket): dont show closed by meta for tickets in request status

### DIFF
--- a/app_legacy/Helpers/render/ticket.php
+++ b/app_legacy/Helpers/render/ticket.php
@@ -57,13 +57,17 @@ function renderTicketCard(int|Ticket $ticket): string
         default => '',
     };
 
+    $closedByInfo = $ticket->closedBy
+        ? "<div class='tooltip-closer'>Closed by $ticket->closedBy, " . getNiceDate(strtotime($ticket->closedOn)) . "</div>"
+        : '';
+
     return "<div class='tooltip-body flex items-start' style='max-width: 400px'>" .
         "<img style='margin-right:5px' src='" . media_asset('/Badge/' . $ticket->badgeName . '.png') . "' width='64' height='64' />" .
         "<div class='ticket-tooltip-info $ticketStateClass'>" .
         "<div><b>" . $ticket->achievementTitle . "</b> <i>(" . $ticket->gameTitle . ")</i></div>" .
         "<div>Reported by $ticket->createdBy</div>" .
         "<div>Issue: " . TicketType::toString($ticket->ticketType) . "</div>" .
-        "<div class='tooltip-closer'>Closed by $ticket->closedBy, " . getNiceDate(strtotime($ticket->closedOn)) . "</div>" .
+        $closedByInfo .
         "<div class='tooltip-opened-date'> Opened " . getNiceDate(strtotime($ticket->createdOn)) . "</div>" .
         "</div>" .
         "<div class='ticket-tooltip-state'>" . TicketState::toString($ticket->ticketState) . "</div>" .

--- a/app_legacy/Helpers/render/ticket.php
+++ b/app_legacy/Helpers/render/ticket.php
@@ -52,14 +52,10 @@ function renderTicketCard(int|Ticket $ticket): string
     }
 
     $ticketStateClass = match ($ticket->ticketState) {
-        TicketState::Open => 'open',
+        TicketState::Open, TicketState::Request => 'open',
         TicketState::Closed, TicketState::Resolved => 'closed',
         default => '',
     };
-
-    $closedByInfo = $ticket->closedBy
-        ? "<div class='tooltip-closer'>Closed by $ticket->closedBy, " . getNiceDate(strtotime($ticket->closedOn)) . "</div>"
-        : '';
 
     return "<div class='tooltip-body flex items-start' style='max-width: 400px'>" .
         "<img style='margin-right:5px' src='" . media_asset('/Badge/' . $ticket->badgeName . '.png') . "' width='64' height='64' />" .
@@ -67,7 +63,7 @@ function renderTicketCard(int|Ticket $ticket): string
         "<div><b>" . $ticket->achievementTitle . "</b> <i>(" . $ticket->gameTitle . ")</i></div>" .
         "<div>Reported by $ticket->createdBy</div>" .
         "<div>Issue: " . TicketType::toString($ticket->ticketType) . "</div>" .
-        $closedByInfo .
+        "<div class='tooltip-closer'>Closed by $ticket->closedBy, " . getNiceDate(strtotime($ticket->closedOn)) . "</div>" .
         "<div class='tooltip-opened-date'> Opened " . getNiceDate(strtotime($ticket->createdOn)) . "</div>" .
         "</div>" .
         "<div class='ticket-tooltip-state'>" . TicketState::toString($ticket->ticketState) . "</div>" .

--- a/app_legacy/Helpers/render/ticket.php
+++ b/app_legacy/Helpers/render/ticket.php
@@ -22,7 +22,7 @@ function ticketAvatar(
     }
 
     $ticketStateClass = match ($ticket->ticketState) {
-        TicketState::Open => 'open',
+        TicketState::Open, TicketState::Request => 'open',
         TicketState::Closed, TicketState::Resolved => 'closed',
         default => '',
     };


### PR DESCRIPTION
This pull request addresses a bug in the renderTicketCard function, which caused an incorrect display when the closedBy value of a ticket was not truthy. The issue resulted in an empty "Closed by" name and a close date showing"01 Jan 1970".

ref: https://discord.com/channels/310192285306454017/1098327873686880276/1098327873686880276