### PR TITLE
fix(user): force locked achievement tooltips on user pages to grayscale

### DIFF
--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -101,10 +101,11 @@ function renderAchievementCard(int|string|array $achievement, ?string $context =
     $achPoints = $data['Points'] ?? null;
     $badgeName = $data['BadgeName'] ?? null;
     $unlock = $data['Unlock'] ?? null;
+    $badgeImgSrc = media_asset("Badge/{$badgeName}" . ($unlock ? '' : '_lock') . ".png");
     $gameTitle = renderGameTitle($data['GameTitle'] ?? null);
 
     $tooltip = "<div class='tooltip-body flex items-start gap-2 p-2' style='max-width: 400px'>";
-    $tooltip .= "<img src='" . media_asset("Badge/$badgeName.png") . "' width='64' height='64' />";
+    $tooltip .= "<img src='$badgeImgSrc' width='64' height='64' />";
     $tooltip .= "<div>";
     $tooltip .= "<div><b>$title</b></div>";
     $tooltip .= "<div class='mb-1'>$description</div>";

--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -50,7 +50,7 @@ function achievementAvatar(
         label: $label !== false && ($label || !$icon) ? $label : null,
         link: route('achievement.show', $id),
         tooltip: is_array($tooltip)
-            ? renderAchievementCard($tooltip, shouldForceLockedImage: str_contains($icon, '_lock'))
+            ? renderAchievementCard($tooltip, iconUrl: $icon)
             : $tooltip,
         iconUrl: $icon !== false && ($icon || !$label) ? $icon : null,
         iconSize: $iconSize,
@@ -81,7 +81,7 @@ function renderAchievementTitle(?string $title, bool $tags = true): string
     return trim(str_replace('[m]', $span, $title));
 }
 
-function renderAchievementCard(int|string|array $achievement, ?string $context = null, bool $shouldForceLockedImage = false): string
+function renderAchievementCard(int|string|array $achievement, ?string $context = null, ?string $iconUrl = null): string
 {
     $id = is_int($achievement) || is_string($achievement) ? (int) $achievement : ($achievement['AchievementID'] ?? $achievement['ID'] ?? null);
 
@@ -103,7 +103,7 @@ function renderAchievementCard(int|string|array $achievement, ?string $context =
     $achPoints = $data['Points'] ?? null;
     $badgeName = $data['BadgeName'] ?? null;
     $unlock = $data['Unlock'] ?? null;
-    $badgeImgSrc = media_asset("Badge/{$badgeName}" . ($shouldForceLockedImage ? '_lock' : '') . ".png");
+    $badgeImgSrc = $iconUrl ?? media_asset("Badge/{$badgeName}.png");
     $gameTitle = renderGameTitle($data['GameTitle'] ?? null);
 
     $tooltip = "<div class='tooltip-body flex items-start gap-2 p-2' style='max-width: 400px'>";

--- a/app_legacy/Helpers/render/achievement.php
+++ b/app_legacy/Helpers/render/achievement.php
@@ -49,7 +49,9 @@ function achievementAvatar(
         id: $id,
         label: $label !== false && ($label || !$icon) ? $label : null,
         link: route('achievement.show', $id),
-        tooltip: is_array($tooltip) ? renderAchievementCard($tooltip) : $tooltip,
+        tooltip: is_array($tooltip)
+            ? renderAchievementCard($tooltip, shouldForceLockedImage: str_contains($icon, '_lock'))
+            : $tooltip,
         iconUrl: $icon !== false && ($icon || !$label) ? $icon : null,
         iconSize: $iconSize,
         iconClass: $iconClass,
@@ -79,7 +81,7 @@ function renderAchievementTitle(?string $title, bool $tags = true): string
     return trim(str_replace('[m]', $span, $title));
 }
 
-function renderAchievementCard(int|string|array $achievement, ?string $context = null): string
+function renderAchievementCard(int|string|array $achievement, ?string $context = null, bool $shouldForceLockedImage = false): string
 {
     $id = is_int($achievement) || is_string($achievement) ? (int) $achievement : ($achievement['AchievementID'] ?? $achievement['ID'] ?? null);
 
@@ -101,7 +103,7 @@ function renderAchievementCard(int|string|array $achievement, ?string $context =
     $achPoints = $data['Points'] ?? null;
     $badgeName = $data['BadgeName'] ?? null;
     $unlock = $data['Unlock'] ?? null;
-    $badgeImgSrc = media_asset("Badge/{$badgeName}" . ($unlock ? '' : '_lock') . ".png");
+    $badgeImgSrc = media_asset("Badge/{$badgeName}" . ($shouldForceLockedImage ? '_lock' : '') . ".png");
     $gameTitle = renderGameTitle($data['GameTitle'] ?? null);
 
     $tooltip = "<div class='tooltip-body flex items-start gap-2 p-2' style='max-width: 400px'>";


### PR DESCRIPTION
This PR addresses an issue raised in https://github.com/RetroAchievements/RAWeb/pull/1487 where locked achievement badges shown in tooltips on user profile pages are not in grayscale.

I have come to believe this behavior is a bug, mostly due to badge artwork like what was created for [Myst on 3DO](http://retroachievements.org/game/16839).

This PR restores these images to be grayscale until the achievements are unlocked by the user.

https://user-images.githubusercontent.com/3984985/233530759-9cbc2a91-4ccc-4e4f-99a9-1ce4cd431aac.mp4

