### PR TITLE
Console renders for game lists, game pages and avatars

### DIFF
--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -153,7 +153,7 @@ final class Shortcode
             return '';
         }
 
-        return gameAvatar($data, iconSize: 24);
+        return gameAvatar($data, iconSize: 28);
     }
 
     private function embedTicket(int $id): string

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -201,7 +201,7 @@ function getGameAlternatives(int $gameID, ?int $sortBy = null): array
         default => "ORDER BY HasAchievements DESC, gd.Title ",
     };
 
-    $query = "SELECT gameIDAlt, gd.Title, gd.ImageIcon, c.Name AS ConsoleName,
+    $query = "SELECT gameIDAlt, gd.Title, gd.ImageIcon, c.Name AS ConsoleName, c.ID AS ConsoleID,
               CASE
                 WHEN (SELECT COUNT(*) FROM Achievements ach WHERE ach.GameID = gd.ID AND ach.Flags = " . AchievementType::OfficialCore . ") > 0 THEN 1
                 ELSE 0

--- a/app_legacy/Helpers/render/avatar.php
+++ b/app_legacy/Helpers/render/avatar.php
@@ -34,7 +34,7 @@ function avatar(
         }
     }
 
-    return "<span class='$class' $tooltipTrigger><a class='inline-flex items-center gap-2 m-0.5' href='$link'>$label</a></span>";
+    return "<span class='$class' $tooltipTrigger><a class='inline-flex items-center gap-2 m-1 align-middle' href='$link'>$label</a></span>";
 }
 
 function tooltipEscape(string $input): string

--- a/app_legacy/Helpers/render/avatar.php
+++ b/app_legacy/Helpers/render/avatar.php
@@ -34,7 +34,7 @@ function avatar(
         }
     }
 
-    return "<span class='$class' $tooltipTrigger><a class='inline-block' href='$link'>$label</a></span>";
+    return "<span class='$class' $tooltipTrigger><a class='inline-flex items-center gap-2 m-0.5' href='$link'>$label</a></span>";
 }
 
 function tooltipEscape(string $input): string

--- a/app_legacy/Helpers/render/avatar.php
+++ b/app_legacy/Helpers/render/avatar.php
@@ -19,9 +19,10 @@ function avatar(
         sanitize_outputs($label);
     }
 
+    $margin = $label ? 'my-1' : '';
+
     if ($iconUrl) {
         $iconLabel = "<img loading='lazy' width='$iconSize' height='$iconSize' src='$iconUrl' alt='$escapedName' class='$iconClass'>";
-
         $label = $iconLabel . ' ' . $label;
     }
 
@@ -34,7 +35,7 @@ function avatar(
         }
     }
 
-    return "<span class='$class' $tooltipTrigger><a class='inline-flex items-center gap-2 my-1 align-middle' href='$link'>$label</a></span>";
+    return "<span class='$class' $tooltipTrigger><a class='inline-flex items-center gap-2 $margin align-middle' href='$link'>$label</a></span>";
 }
 
 function tooltipEscape(string $input): string

--- a/app_legacy/Helpers/render/avatar.php
+++ b/app_legacy/Helpers/render/avatar.php
@@ -34,7 +34,7 @@ function avatar(
         }
     }
 
-    return "<span class='$class' $tooltipTrigger><a class='inline-flex items-center gap-2 m-1 align-middle' href='$link'>$label</a></span>";
+    return "<span class='$class' $tooltipTrigger><a class='inline-flex items-center gap-2 my-1 align-middle' href='$link'>$label</a></span>";
 }
 
 function tooltipEscape(string $input): string

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -22,7 +22,14 @@ function gameAvatar(
             $title = $game['GameTitle'] ?? $game['Title'] ?? null;
             $consoleName = $game['Console'] ?? $game['ConsoleName'] ?? null;
             sanitize_outputs($title);   // sanitize before rendering HTML
-            $label = renderGameTitle($title, console: $consoleName);
+
+            $label = "<div class='inline-flex flex-col gap-0.5'>";
+            $label .= renderGameTitle($title);
+            if ($consoleName) {
+                $consoleID = $game['ConsoleID'] ?? 1;
+                $label .= renderGameConsole($consoleName, $consoleID);
+            }
+            $label .= "</div>";
         }
 
         if ($icon === null) {
@@ -53,9 +60,7 @@ function gameAvatar(
 /**
  * Render game title, wrapping categories for styling
  */
-function renderGameTitle(
-    ?string $title = null, bool $tags = true, ?string $console = null
-): string
+function renderGameTitle(?string $title = null, bool $tags = true): string
 {
     // Update $html by appending text
     $updateHtml = function (&$html, $text, $append) {
@@ -64,15 +69,6 @@ function renderGameTitle(
 
     $title ??= '';
     $html = $title;
-
-    if ($console) {
-        $iconSrc = asset("assets/images/system/nes.png");
-        $span = "<span class='tag console'>"
-            . "<img src='$iconSrc' alt=''>"
-            . "<span>$console</span>"
-            . "</span>";
-        $html .= " $span";
-    }
 
     $matches = [];
     preg_match_all('/~([^~]+)~/', $title, $matches);
@@ -92,7 +88,17 @@ function renderGameTitle(
         $updateHtml($html, $matches[0], $tags ? " $span" : '');
     }
 
-    return $html;
+    return "<div>$html</div>";
+}
+
+function renderGameConsole(string $consoleName, int $consoleID): string
+{
+    $iconSrc = getConsoleIconSrc($consoleID);
+
+    return "<div class='tag console'>"
+        . "<img src='$iconSrc' width='22' height='22' alt=''>"
+        . "<span>$consoleName</span>"
+        . "</div>";
 }
 
 /**
@@ -483,4 +489,12 @@ function renderCompletionIcon(
     }
 
     return "<div class='$class' title='$tooltipText'>$icon</div>";
+}
+
+function getConsoleIconSrc(int $consoleID): string
+{
+    $cleanConsoleShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
+    $iconName = Str::kebab($cleanConsoleShortName);
+
+    return asset("assets/images/system/$iconName.png");
 }

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -99,7 +99,16 @@ function renderConsoleIcon(string $consoleName, int $consoleID): string {
     $iconName = Str::kebab($cleanSystemShortName);
     $iconSrc = asset("assets/images/system/$iconName.png");
 
-    return "<img class='console-icon' src='$iconSrc' alt='$consoleName icon' onerror='this.src=\"$fallBackConsoleIcon\"'>";
+    return <<<HTML
+        <img class='console-icon'
+            src='$iconSrc'
+            alt='$consoleName icon'
+            onerror='this.src="$fallBackConsoleIcon"'>
+    HTML;
+}
+
+function renderGameTitleAndConsole(string $gameTitle, string $consoleName, int $consoleID): string {
+
 }
 
 /**

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -107,10 +107,6 @@ function renderConsoleIcon(string $consoleName, int $consoleID): string {
     HTML;
 }
 
-function renderGameTitleAndConsole(string $gameTitle, string $consoleName, int $consoleID): string {
-
-}
-
 /**
  * Render game breadcrumb prefix, with optional link on last crumb
  *

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -27,7 +27,7 @@ function gameAvatar(
             $label .= renderGameTitle($title);
             if ($consoleName) {
                 $consoleID = $game['ConsoleID'] ?? 1;
-                $label .= renderGameConsole($consoleName, $consoleID, size: 22, avatar: true);
+                $label .= renderGameConsole($consoleName, $consoleID, size: 15, avatar: true);
             }
             $label .= "</div>";
         }
@@ -92,29 +92,29 @@ function renderGameTitle(?string $title = null, bool $tags = true): string
 }
 
 /**
- * Render game console with icon of specified size
+ * Render game console with icon of specified size.
+ * Font size is calculated dynamically from icon size.
  */
 function renderGameConsole(
     string $consoleName, int $consoleID, int $size, bool $avatar = false
 ): string {
-    $iconSrc = getConsoleIconSrc($consoleID);
+    // Get console icon URL path based on given ID
+    $getConsoleIconSrc = function ($consoleID) {
+        $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
+        $iconName = Str::kebab($cleanSystemShortName);
+
+        return asset("assets/images/system/$iconName.png");
+    };
+
+    $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
+    $iconSrc = $getConsoleIconSrc($consoleID);
     $class = $avatar ? ' avatar' : '';
+    $textSize = round(.65 * $size);
 
     return "<div class='console$class'>"
-        . "<img src='$iconSrc' width='$size' height='$size' alt=''>"
-        . "<span>$consoleName</span>"
+        . "<img src='$iconSrc' width='$size' height='$size' alt='' onerror='this.src=\"$fallBackConsoleIcon\"'>"
+        . "<span style='font-size: ${textSize}px'>$consoleName</span>"
         . "</div>";
-}
-
-/**
- * Get console icon URL path based on given ID
- */
-function getConsoleIconSrc(int $consoleID): string
-{
-    $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
-    $iconName = Str::kebab($cleanSystemShortName);
-
-    return asset("assets/images/system/$iconName.png");
 }
 
 /**

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -26,7 +26,7 @@ function gameAvatar(
             $label = "<div class='inline-flex flex-col gap-0.5'>";
             $label .= renderGameTitle($title);
             if ($consoleName) {
-                $consoleID = $game['ConsoleID'] ?? 1;
+                $consoleID = $game['ConsoleID'];
                 $label .= renderGameConsole($consoleName, $consoleID, size: 14, avatar: true);
             }
             $label .= "</div>";
@@ -292,6 +292,7 @@ function RenderGameAlts(array $gameAlts, ?string $headerText = null): void
             'Title' => $nextGame['Title'],
             'ImageIcon' => $nextGame['ImageIcon'],
             'ConsoleName' => $consoleName,
+            'ConsoleID' => $nextGame['ConsoleID'],
         ];
 
         echo "<td>";

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -113,7 +113,7 @@ function renderGameConsole(
 
     return "<div class='console$class'>"
         . "<img src='$iconSrc' width='$size' height='$size' alt='' onerror='this.src=\"$fallBackConsoleIcon\"'>"
-        . "<span style='font-size: ${textSize}px'>$consoleName</span>"
+        . "<span style='font-size: {$textSize}px'>$consoleName</span>"
         . "</div>";
 }
 

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -109,7 +109,7 @@ function renderGameConsole(
     $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
     $iconSrc = $getConsoleIconSrc($consoleID);
     $class = $avatar ? ' avatar' : '';
-    $textSize = round(($avatar ? .7 : .6) * $size);
+    $textSize = round(($avatar ? .75 : .6) * $size);
 
     return "<div class='console$class'>"
         . "<img src='$iconSrc' width='$size' height='$size' alt='' onerror='this.src=\"$fallBackConsoleIcon\"'>"

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -95,10 +95,18 @@ function renderGameConsole(string $consoleName, int $consoleID): string
 {
     $iconSrc = getConsoleIconSrc($consoleID);
 
-    return "<div class='tag console'>"
+    return "<div class='console'>"
         . "<img src='$iconSrc' width='22' height='22' alt=''>"
         . "<span>$consoleName</span>"
         . "</div>";
+}
+
+function getConsoleIconSrc(int $consoleID): string
+{
+    $cleanConsoleShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
+    $iconName = Str::kebab($cleanConsoleShortName);
+
+    return asset("assets/images/system/$iconName.png");
 }
 
 /**
@@ -489,12 +497,4 @@ function renderCompletionIcon(
     }
 
     return "<div class='$class' title='$tooltipText'>$icon</div>";
-}
-
-function getConsoleIconSrc(int $consoleID): string
-{
-    $cleanConsoleShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
-    $iconName = Str::kebab($cleanConsoleShortName);
-
-    return asset("assets/images/system/$iconName.png");
 }

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -27,7 +27,7 @@ function gameAvatar(
             $label .= renderGameTitle($title);
             if ($consoleName) {
                 $consoleID = $game['ConsoleID'] ?? 1;
-                $label .= renderGameConsole($consoleName, $consoleID, size: 16, avatar: true);
+                $label .= renderGameConsole($consoleName, $consoleID, size: 14, avatar: true);
             }
             $label .= "</div>";
         }
@@ -109,7 +109,7 @@ function renderGameConsole(
     $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
     $iconSrc = $getConsoleIconSrc($consoleID);
     $class = $avatar ? ' avatar' : '';
-    $textSize = round(.6 * $size);
+    $textSize = round(($avatar ? .7 : .6) * $size);
 
     return "<div class='console$class'>"
         . "<img src='$iconSrc' width='$size' height='$size' alt='' onerror='this.src=\"$fallBackConsoleIcon\"'>"

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -21,11 +21,8 @@ function gameAvatar(
         if ($label !== false) {
             $title = $game['GameTitle'] ?? $game['Title'] ?? null;
             $consoleName = $game['Console'] ?? $game['ConsoleName'] ?? null;
-            if ($consoleName) {
-                $title .= " ($consoleName)";
-            }
             sanitize_outputs($title);   // sanitize before rendering HTML
-            $label = renderGameTitle($title);
+            $label = renderGameTitle($title, console: $consoleName);
         }
 
         if ($icon === null) {
@@ -56,16 +53,27 @@ function gameAvatar(
 /**
  * Render game title, wrapping categories for styling
  */
-function renderGameTitle(?string $title = null, bool $tags = true): string
+function renderGameTitle(
+    ?string $title = null, bool $tags = true, ?string $console = null
+): string
 {
-    $title ??= '';
-
     // Update $html by appending text
     $updateHtml = function (&$html, $text, $append) {
         $html = trim(str_replace($text, '', $html) . $append);
     };
 
+    $title ??= '';
     $html = $title;
+
+    if ($console) {
+        $iconSrc = asset("assets/images/system/nes.png");
+        $span = "<span class='tag console'>"
+            . "<img src='$iconSrc' alt=''>"
+            . "<span>$console</span>"
+            . "</span>";
+        $html .= " $span";
+    }
+
     $matches = [];
     preg_match_all('/~([^~]+)~/', $title, $matches);
     foreach ($matches[0] as $i => $match) {

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -23,7 +23,7 @@ function gameAvatar(
             $consoleName = $game['Console'] ?? $game['ConsoleName'] ?? null;
             sanitize_outputs($title);   // sanitize before rendering HTML
 
-            $label = "<div class='inline-flex flex-col gap-1'>";
+            $label = "<div class='flex flex-col items-start gap-1'>";
             $label .= renderGameTitle($title);
             if ($consoleName) {
                 $label .= "<div class='console-name'>$consoleName</div>";

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -26,7 +26,7 @@ function gameAvatar(
             $label = "<div class='inline-flex flex-col gap-1'>";
             $label .= renderGameTitle($title);
             if ($consoleName) {
-                $label .= "<div class='console'>$consoleName</div>";
+                $label .= "<div class='console-name'>$consoleName</div>";
             }
             $label .= "</div>";
         }
@@ -93,12 +93,14 @@ function renderGameTitle(?string $title = null, bool $tags = true): string
 /**
  * Render console icon based on given system ID
  */
-function renderConsoleIcon(string $consoleName, int $consoleID, int $size) {
+function renderConsoleIcon(string $consoleName, int $consoleID): string {
+    $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
     $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
     $iconName = Str::kebab($cleanSystemShortName);
+    $iconSrc = asset("assets/images/system/$iconName.png");
 
-    return asset("assets/images/system/$iconName.png");
-};
+    return "<img class='console-icon' src='$iconSrc' alt='$consoleName icon' onerror='this.src=\"$fallBackConsoleIcon\"'>";
+}
 
 /**
  * Render game breadcrumb prefix, with optional link on last crumb

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -91,18 +91,24 @@ function renderGameTitle(?string $title = null, bool $tags = true): string
     return "<div>$html</div>";
 }
 
+/**
+ * Render game console with icon of specified size.
+ */
 function renderGameConsole(
     string $consoleName, int $consoleID, int $size, bool $avatar = false
 ): string {
     $iconSrc = getConsoleIconSrc($consoleID);
-    $class = $avatar ? 'avatar' : '';
+    $class = $avatar ? ' avatar' : '';
 
-    return "<div class='console $class'>"
+    return "<div class='console$class'>"
         . "<img src='$iconSrc' width='$size' height='$size' alt=''>"
         . "<span>$consoleName</span>"
         . "</div>";
 }
 
+/**
+ * Get console icon URL path based on given ID.
+ */
 function getConsoleIconSrc(int $consoleID): string
 {
     $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -27,7 +27,7 @@ function gameAvatar(
             $label .= renderGameTitle($title);
             if ($consoleName) {
                 $consoleID = $game['ConsoleID'] ?? 1;
-                $label .= renderGameConsole($consoleName, $consoleID);
+                $label .= renderGameConsole($consoleName, $consoleID, size: 22, avatar: true);
             }
             $label .= "</div>";
         }
@@ -91,20 +91,22 @@ function renderGameTitle(?string $title = null, bool $tags = true): string
     return "<div>$html</div>";
 }
 
-function renderGameConsole(string $consoleName, int $consoleID): string
-{
+function renderGameConsole(
+    string $consoleName, int $consoleID, int $size, bool $avatar = false
+): string {
     $iconSrc = getConsoleIconSrc($consoleID);
+    $class = $avatar ? 'avatar' : '';
 
-    return "<div class='console'>"
-        . "<img src='$iconSrc' width='22' height='22' alt=''>"
+    return "<div class='console $class'>"
+        . "<img src='$iconSrc' width='$size' height='$size' alt=''>"
         . "<span>$consoleName</span>"
         . "</div>";
 }
 
 function getConsoleIconSrc(int $consoleID): string
 {
-    $cleanConsoleShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
-    $iconName = Str::kebab($cleanConsoleShortName);
+    $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
+    $iconName = Str::kebab($cleanSystemShortName);
 
     return asset("assets/images/system/$iconName.png");
 }

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -23,12 +23,16 @@ function gameAvatar(
             $consoleName = $game['Console'] ?? $game['ConsoleName'] ?? null;
             sanitize_outputs($title);   // sanitize before rendering HTML
 
-            $label = "<div class='flex flex-col items-start gap-1'>";
-            $label .= renderGameTitle($title);
-            if ($consoleName) {
-                $label .= "<div class='console-name'>$consoleName</div>";
+            if ($iconSize > 24) {
+                $label = "<div class='flex flex-col items-start gap-1'>";
+                $label .= renderGameTitle($title);
+                if ($consoleName) {
+                    $label .= "<div class='console-name'>$consoleName</div>";
+                }
+                $label .= "</div>";
+            } else {
+                $label = renderGameTitle($title . ($consoleName ? " ($consoleName)" : ''));
             }
-            $label .= "</div>";
         }
 
         if ($icon === null) {

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -25,7 +25,7 @@ function gameAvatar(
 
             $flexDirection = $iconSize >= 32 ? 'col' : 'row';
             $alignItems = $flexDirection == 'col' ? 'start' : 'center';
-            
+
             $label = "<div class='flex flex-$flexDirection items-$alignItems gap-1'>";
             $label .= renderGameTitle($title);
             if ($consoleName) {

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -99,16 +99,19 @@ function renderGameTitle(?string $title = null, bool $tags = true): string
 
 /**
  * Render console icon based on given system ID
+ * 
+ * Fallback to a default image if icon not found on server
  */
 function renderConsoleIcon(string $consoleName, int $consoleID): string {
     $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
     $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
     $iconName = Str::kebab($cleanSystemShortName);
-    $iconSrc = asset("assets/images/system/$iconName.png");
+    $iconPath = public_path("assets/images/system/$iconName.png");
+    $iconUrl = file_exists($iconPath) ? asset("assets/images/system/$iconName.png") : $fallBackConsoleIcon;
 
     return <<<HTML
         <img class='console-icon'
-            src='$iconSrc'
+            src='$iconUrl'
             alt='$consoleName icon'
             onerror='this.src="$fallBackConsoleIcon"'>
     HTML;

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -23,16 +23,19 @@ function gameAvatar(
             $consoleName = $game['Console'] ?? $game['ConsoleName'] ?? null;
             sanitize_outputs($title);   // sanitize before rendering HTML
 
-            if ($iconSize > 24) {
-                $label = "<div class='flex flex-col items-start gap-1'>";
-                $label .= renderGameTitle($title);
-                if ($consoleName) {
-                    $label .= "<div class='console-name'>$consoleName</div>";
+            $flexDirection = $iconSize >= 32 ? 'col' : 'row';
+            $alignItems = $flexDirection == 'col' ? 'start' : 'center';
+            
+            $label = "<div class='flex flex-$flexDirection items-$alignItems gap-1'>";
+            $label .= renderGameTitle($title);
+            if ($consoleName) {
+                $label .= "<div class='console-name";
+                if ($flexDirection == 'row') {
+                    $label .= " mx-0.5 border-l-2 border-white/[.25] pl-1.5";
                 }
-                $label .= "</div>";
-            } else {
-                $label = renderGameTitle($title . ($consoleName ? " ($consoleName)" : ''));
+                $label .= "'>$consoleName</div>";
             }
+            $label .= "</div>";
         }
 
         if ($icon === null) {

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -99,7 +99,7 @@ function renderGameTitle(?string $title = null, bool $tags = true): string
 
 /**
  * Render console icon based on given system ID
- * 
+ *
  * Fallback to a default image if icon not found on server
  */
 function renderConsoleIcon(string $consoleName, int $consoleID): string {

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -100,7 +100,7 @@ function renderGameTitle(?string $title = null, bool $tags = true): string
 /**
  * Render console icon based on given system ID
  *
- * Fallback to a default image if icon not found on server
+ * Fallback to a default image if icon fails to be found on server
  */
 function renderConsoleIcon(string $consoleName, int $consoleID): string {
     $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
@@ -109,12 +109,7 @@ function renderConsoleIcon(string $consoleName, int $consoleID): string {
     $iconPath = public_path("assets/images/system/$iconName.png");
     $iconUrl = file_exists($iconPath) ? asset("assets/images/system/$iconName.png") : $fallBackConsoleIcon;
 
-    return <<<HTML
-        <img class='console-icon'
-            src='$iconUrl'
-            alt='$consoleName icon'
-            onerror='this.src="$fallBackConsoleIcon"'>
-    HTML;
+    return "<img class='console-icon' src='$iconUrl' alt='$consoleName icon'>";
 }
 
 /**

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -23,11 +23,10 @@ function gameAvatar(
             $consoleName = $game['Console'] ?? $game['ConsoleName'] ?? null;
             sanitize_outputs($title);   // sanitize before rendering HTML
 
-            $label = "<div class='inline-flex flex-col gap-0.5'>";
+            $label = "<div class='inline-flex flex-col gap-1'>";
             $label .= renderGameTitle($title);
             if ($consoleName) {
-                $consoleID = $game['ConsoleID'];
-                $label .= renderGameConsole($consoleName, $consoleID, size: 14, avatar: true);
+                $label .= "<div class='console'>$consoleName</div>";
             }
             $label .= "</div>";
         }
@@ -92,30 +91,14 @@ function renderGameTitle(?string $title = null, bool $tags = true): string
 }
 
 /**
- * Render game console with icon of specified size.
- * Font size is calculated dynamically from icon size.
+ * Render console icon based on given system ID
  */
-function renderGameConsole(
-    string $consoleName, int $consoleID, int $size, bool $avatar = false
-): string {
-    // Get console icon URL path based on given ID
-    $getConsoleIconSrc = function ($consoleID) {
-        $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
-        $iconName = Str::kebab($cleanSystemShortName);
+function renderConsoleIcon(string $consoleName, int $consoleID, int $size) {
+    $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
+    $iconName = Str::kebab($cleanSystemShortName);
 
-        return asset("assets/images/system/$iconName.png");
-    };
-
-    $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
-    $iconSrc = $getConsoleIconSrc($consoleID);
-    $class = $avatar ? ' avatar' : '';
-    $textSize = round(($avatar ? .75 : .6) * $size);
-
-    return "<div class='console$class'>"
-        . "<img src='$iconSrc' width='$size' height='$size' alt='' onerror='this.src=\"$fallBackConsoleIcon\"'>"
-        . "<span style='font-size: {$textSize}px'>$consoleName</span>"
-        . "</div>";
-}
+    return asset("assets/images/system/$iconName.png");
+};
 
 /**
  * Render game breadcrumb prefix, with optional link on last crumb

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -92,7 +92,7 @@ function renderGameTitle(?string $title = null, bool $tags = true): string
 }
 
 /**
- * Render game console with icon of specified size.
+ * Render game console with icon of specified size
  */
 function renderGameConsole(
     string $consoleName, int $consoleID, int $size, bool $avatar = false
@@ -107,7 +107,7 @@ function renderGameConsole(
 }
 
 /**
- * Get console icon URL path based on given ID.
+ * Get console icon URL path based on given ID
  */
 function getConsoleIconSrc(int $consoleID): string
 {

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -27,7 +27,7 @@ function gameAvatar(
             $label .= renderGameTitle($title);
             if ($consoleName) {
                 $consoleID = $game['ConsoleID'] ?? 1;
-                $label .= renderGameConsole($consoleName, $consoleID, size: 15, avatar: true);
+                $label .= renderGameConsole($consoleName, $consoleID, size: 16, avatar: true);
             }
             $label .= "</div>";
         }
@@ -109,7 +109,7 @@ function renderGameConsole(
     $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
     $iconSrc = $getConsoleIconSrc($consoleID);
     $class = $avatar ? ' avatar' : '';
-    $textSize = round(.65 * $size);
+    $textSize = round(.6 * $size);
 
     return "<div class='console$class'>"
         . "<img src='$iconSrc' width='$size' height='$size' alt='' onerror='this.src=\"$fallBackConsoleIcon\"'>"

--- a/app_legacy/Helpers/render/layout.php
+++ b/app_legacy/Helpers/render/layout.php
@@ -114,8 +114,9 @@ function RenderToolbar(): void
                 $systemName = $system['systemName'];
                 $listID = $system['listID'];
 
-                echo "<li><a href='/gameList.php?c=$listID' class='!flex items-center gap-x-2' >"; // the flex class needs to be forced here
-                echo renderGameConsole($systemName, $listID, size: 16);
+                echo "<li><a href='/gameList.php?c=$listID' class='!flex items-center gap-x-2'>"; // the flex class needs to be forced here
+                echo renderConsoleIcon($systemName, $listID);
+                echo "<span class='console-name'>$systemName</span>";
                 echo "</a></li>";
             }
         }

--- a/app_legacy/Helpers/render/layout.php
+++ b/app_legacy/Helpers/render/layout.php
@@ -113,7 +113,7 @@ function RenderToolbar(): void
             foreach ($systems as $system) {
                 $systemName = $system['systemName'];
                 $listID = $system['listID'];
-                
+
                 echo "<li><a href='/gameList.php?c=$listID' class='!flex items-center gap-x-2' >"; // the flex class needs to be forced here
                 echo renderGameConsole($systemName, $listID, size: 16);
                 echo "</a></li>";

--- a/app_legacy/Helpers/render/layout.php
+++ b/app_legacy/Helpers/render/layout.php
@@ -114,9 +114,13 @@ function RenderToolbar(): void
                 $systemName = $system['systemName'];
                 $listID = $system['listID'];
 
+                $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$listID.name_short")));
+                $iconName = Str::kebab($cleanSystemShortName);
+                $iconSrc = asset("assets/images/system/$iconName.png");
+
                 echo "<li><a href='/gameList.php?c=$listID' class='!flex items-center gap-x-2'>"; // the flex class needs to be forced here
-                echo renderConsoleIcon($systemName, $listID);
-                echo "<span class='console-name'>$systemName</span>";
+                echo " <img src='$iconSrc' width='16' height='16' alt='$systemName icon'>";
+                echo " <span class='console-name' style='font-size: 1em'>$systemName</span>";
                 echo "</a></li>";
             }
         }

--- a/app_legacy/Helpers/render/layout.php
+++ b/app_legacy/Helpers/render/layout.php
@@ -106,19 +106,16 @@ function RenderToolbar(): void
     echo "<ul class='flex-1'>";
     echo "<li><a href='#'>Games</a>";
     echo "<div>";
-    foreach ($menuSystemsList as $column){
+    foreach ($menuSystemsList as $column) {
         echo "<ul>";
         foreach ($column as $brand => $systems) {
             echo "<li class='dropdown-header'>$brand</li>";
-            foreach ($systems as $system){
-
+            foreach ($systems as $system) {
                 $systemName = $system['systemName'];
-                $listId = $system['listID'];
-                $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$listId.name_short")));
-                $iconName = Str::kebab($cleanSystemShortName);
-                echo "<li><a href='/gameList.php?c=$listId' class='!flex items-center gap-x-2' >"; // the flex class needs to be forced here
-                echo " <img src='" . asset("assets/images/system/$iconName.png") . "' width='16' height='16' alt=''>";
-                echo " <span>$systemName</span>";
+                $listID = $system['listID'];
+                
+                echo "<li><a href='/gameList.php?c=$listID' class='!flex items-center gap-x-2' >"; // the flex class needs to be forced here
+                echo renderGameConsole($systemName, $listID, size: 16);
                 echo "</a></li>";
             }
         }

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -168,9 +168,12 @@ RenderContentStart($pageTitle);
         echo " &raquo; <b>" . renderAchievementTitle($achievementTitle, tags: false) . "</b>";
         echo "</div>";
 
-        echo "<h1 class='text-h3'>";
-        echo renderGameTitle("$gameTitle");
-        echo renderGameConsole($consoleName, $consoleID, size: 26);
+        echo "<h1 class='text-h3 flex items-center'>";
+        echo renderConsoleIcon($consoleName, $consoleID);
+        echo " <div>";
+        echo "  <span class='block'>$gameTitle</span>";
+        echo "  <span class='console-name'>$consoleName</span>";
+        echo " </div>";
         echo "</h1>";
 
         $fileSuffix = ($user == "" || !$achievedLocal) ? '_lock' : '';

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -171,7 +171,7 @@ RenderContentStart($pageTitle);
         echo "<h1 class='text-h3 flex items-center'>";
         echo renderConsoleIcon($consoleName, $consoleID);
         echo " <div>";
-        echo "  <span class='block'>$gameTitle</span>";
+        echo "  <span class='block'>" . renderGameTitle($gameTitle) . "</span>";
         echo "  <span class='console-name'>$consoleName</span>";
         echo " </div>";
         echo "</h1>";

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -168,7 +168,10 @@ RenderContentStart($pageTitle);
         echo " &raquo; <b>" . renderAchievementTitle($achievementTitle, tags: false) . "</b>";
         echo "</div>";
 
-        echo "<h3>" . renderGameTitle("$gameTitle ($consoleName)") . "</h3>";
+        echo "<h1 class='text-h3'>";
+        echo renderGameTitle("$gameTitle");
+        echo renderGameConsole($consoleName, $consoleID, size: 26);
+        echo "</h1>";
 
         $fileSuffix = ($user == "" || !$achievedLocal) ? '_lock' : '';
         $badgeFullPath = media_asset("Badge/$badgeName$fileSuffix.png");

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -675,17 +675,11 @@ sanitize_outputs(
             $imageTitle = media_asset($gameData['ImageTitle']);
             $imageIngame = media_asset($gameData['ImageIngame']);
             $pageTitleAttr = attributeEscape($pageTitle);
-
-            $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
-            $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleID.name_short")));
-            $iconName = Str::kebab($cleanSystemShortName);
+            // $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
 
             echo "<h1 class='text-h3'>";
-            echo " <span class='block mb-1'>$renderedTitle</span>";
-            echo " <div class='flex items-center gap-x-1'>";
-            echo "  <img src='" . asset("assets/images/system/$iconName.png") . "' width='24' height='24' alt='Console icon' onerror='this.src=\"$fallBackConsoleIcon\"'>";
-            echo "  <span class='block text-sm tracking-tighter'>$consoleName</span>";
-            echo " </div>";
+            echo " <span class='block'>$renderedTitle</span>";
+            echo renderGameConsole($consoleName, $consoleID, size: 30);
             echo "</h1>";
 
             echo "<div class='flex flex-col sm:flex-row sm:w-full gap-x-4 gap-y-2 items-center mb-4'>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -679,7 +679,7 @@ sanitize_outputs(
 
             echo "<h1 class='text-h3'>";
             echo " <span class='block'>$renderedTitle</span>";
-            echo renderGameConsole($consoleName, $consoleID, size: 30);
+            echo renderGameConsole($consoleName, $consoleID, size: 26);
             echo "</h1>";
 
             echo "<div class='flex flex-col sm:flex-row sm:w-full gap-x-4 gap-y-2 items-center mb-4'>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -121,7 +121,10 @@ if ($v != 1 && $isFullyFeaturedGame) {
             <div class='navpath'>
                 <?= renderGameBreadcrumb($gameData, addLinkToLastCrumb: false) ?>
             </div>
-            <h1 class="text-h3"><?= renderGameTitle($pageTitle) ?></h1>
+            <h1 class="text-h3">
+                <?= renderGameTitle($gameTitle) ?>
+                <?= renderGameConsole($consoleName, $consoleID, size: 26) ?>
+            </h1>
             <h4>WARNING: THIS GAME MAY CONTAIN CONTENT NOT APPROPRIATE FOR ALL AGES.</h4>
             <br/>
             <div id="confirmation">

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -121,9 +121,12 @@ if ($v != 1 && $isFullyFeaturedGame) {
             <div class='navpath'>
                 <?= renderGameBreadcrumb($gameData, addLinkToLastCrumb: false) ?>
             </div>
-            <h1 class="text-h3">
-                <?= renderGameTitle($gameTitle) ?>
+            <h1 class="text-h3 flex items-center">
                 <?= renderConsoleIcon($consoleName, $consoleID) ?>
+                <div>
+                    <?= renderGameTitle($gameTitle) ?>
+                    <div class='console-name'><?= $consoleName ?></div>
+                </div>
             </h1>
             <h4>WARNING: THIS GAME MAY CONTAIN CONTENT NOT APPROPRIATE FOR ALL AGES.</h4>
             <br/>
@@ -683,8 +686,8 @@ sanitize_outputs(
             echo "<h1 class='text-h3 flex items-center'>";
             echo renderConsoleIcon($consoleName, $consoleID);
             echo " <div>";
-            echo "  <span class='block'>$renderedTitle</span>";
-            echo "  <span class='console-name'>$consoleName</span>";
+            echo "  <div>$renderedTitle</div>";
+            echo "  <div class='console-name'>$consoleName</div>";
             echo " </div>";
             echo "</h1>";
 

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -123,7 +123,7 @@ if ($v != 1 && $isFullyFeaturedGame) {
             </div>
             <h1 class="text-h3">
                 <?= renderGameTitle($gameTitle) ?>
-                <?= renderGameConsole($consoleName, $consoleID, size: 26) ?>
+                <?= renderConsoleIcon($consoleName, $consoleID) ?>
             </h1>
             <h4>WARNING: THIS GAME MAY CONTAIN CONTENT NOT APPROPRIATE FOR ALL AGES.</h4>
             <br/>
@@ -680,9 +680,12 @@ sanitize_outputs(
             $pageTitleAttr = attributeEscape($pageTitle);
             // $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
 
-            echo "<h1 class='text-h3'>";
-            echo " <span class='block'>$renderedTitle</span>";
-            echo renderGameConsole($consoleName, $consoleID, size: 26);
+            echo "<h1 class='text-h3 flex items-center'>";
+            echo renderConsoleIcon($consoleName, $consoleID);
+            echo " <div>";
+            echo "  <span class='block'>$renderedTitle</span>";
+            echo "  <span class='console-name'>$consoleName</span>";
+            echo " </div>";
             echo "</h1>";
 
             echo "<div class='flex flex-col sm:flex-row sm:w-full gap-x-4 gap-y-2 items-center mb-4'>";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -209,7 +209,7 @@ RenderContentStart($requestedConsole . " Games");
                 }
             } else {
                 echo "<h2 class='flex gap-x-2'>";
-                echo renderGameConsole($consoleName, $consoleIDInput, size: 36);
+                echo renderConsoleIcon($consoleName, $consoleIDInput);
                 echo "</h2>";
 
                 echo "<div style='float:left'>$gamesCount Games</div>";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -208,14 +208,8 @@ RenderContentStart($requestedConsole . " Games");
                     echo "<br/>";
                 }
             } else {
-                $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
-                $cleanSystemShortName = Str::lower(str_replace("/", "", config("systems.$consoleIDInput.name_short")));
-                $iconName = Str::kebab($cleanSystemShortName);
-
                 echo "<h2 class='flex gap-x-2'>";
-                echo " <img src='" . asset("assets/images/system/$iconName.png") . "' alt='' width='32' height='32'";
-                echo " onerror='this.src=\"$fallBackConsoleIcon\"'></img>"; // fallback
-                echo " <span>$consoleName</span>";
+                echo renderGameConsole($consoleName, $consoleIDInput, size: 30);
                 echo "</h2>";
 
                 echo "<div style='float:left'>$gamesCount Games</div>";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -208,7 +208,7 @@ RenderContentStart($requestedConsole . " Games");
                     echo "<br/>";
                 }
             } else {
-                echo "<h2 class='flex'>";
+                echo "<h2 class='flex items-center'>";
                 echo renderConsoleIcon($consoleName, $consoleIDInput);
                 echo " <div class='console-name'>$consoleName</div>";
                 echo "</h2>";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -208,8 +208,9 @@ RenderContentStart($requestedConsole . " Games");
                     echo "<br/>";
                 }
             } else {
-                echo "<h2 class='flex gap-x-2'>";
+                echo "<h2 class='flex'>";
                 echo renderConsoleIcon($consoleName, $consoleIDInput);
+                echo " <div class='console-name'>$consoleName</div>";
                 echo "</h2>";
 
                 echo "<div style='float:left'>$gamesCount Games</div>";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -209,7 +209,7 @@ RenderContentStart($requestedConsole . " Games");
                 }
             } else {
                 echo "<h2 class='flex gap-x-2'>";
-                echo renderGameConsole($consoleName, $consoleIDInput, size: 30);
+                echo renderGameConsole($consoleName, $consoleIDInput, size: 36);
                 echo "</h2>";
 
                 echo "<div style='float:left'>$gamesCount Games</div>";

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -88,8 +88,14 @@ RenderContentStart('Leaderboard');
             echo " &raquo; <b>$lbTitle</b>";
             echo "</div>";
 
-            $renderedTitle = renderGameTitle("$gameTitle ($consoleName)");
-            echo "<h3>$renderedTitle</h3>";
+            $renderedTitle = renderGameTitle($gameTitle);
+            echo "<h1 class='text-h3 flex items-center'>";
+            echo renderConsoleIcon($consoleName, $consoleID);
+            echo " <div>";
+            echo "  <div>$renderedTitle</div>";
+            echo "  <div class='console-name'>$consoleName</div>";
+            echo " </div>";
+            echo "</h1>";
 
             echo "<table class='nicebox'><tbody>";
 

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -321,7 +321,7 @@ RenderContentStart($userPage);
         if (!empty($userMassData['RichPresenceMsg']) && $userMassData['RichPresenceMsg'] !== 'Unknown') {
             echo "<div class='mottocontainer'>Last seen ";
             if (!empty($userMassData['LastGame'])) {
-                echo ' in ' . gameAvatar($userMassData['LastGame'], iconSize: 22) . '<br>';
+                echo " in <div class='inline-block mx-1'>" . gameAvatar($userMassData['LastGame'], iconSize: 28) . "</div><br>";
             }
             echo "<code>" . $userMassData['RichPresenceMsg'] . "</code></div>";
         }
@@ -361,8 +361,8 @@ RenderContentStart($userPage);
                     'ImageIcon' => $claim['GameIcon'],
                     'ConsoleName' => $claim['ConsoleName'],
                 ];
-                echo gameAvatar($claim, iconSize: 22);
-                echo $details . '<br>';
+                echo gameAvatar($claim, iconSize: 28);
+                echo " $details<br>";
             }
             echo "* Counts against reservation limit</br></br>";
         }
@@ -510,7 +510,7 @@ RenderContentStart($userPage);
                 echo "<div class='md:flex justify-between mb-3'>";
 
                 echo "<div>";
-                echo gameAvatar($userMassData['RecentlyPlayed'][$i], iconSize: 24);
+                echo gameAvatar($userMassData['RecentlyPlayed'][$i], iconSize: 32);
                 echo "<br>";
                 echo "Last played $gameLastPlayed<br>";
                 if ($numPossibleAchievements) {

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -510,7 +510,7 @@ RenderContentStart($userPage);
                 echo "<div class='md:flex justify-between mb-3'>";
 
                 echo "<div>";
-                echo gameAvatar($userMassData['RecentlyPlayed'][$i], iconSize: 32);
+                echo gameAvatar($userMassData['RecentlyPlayed'][$i], iconSize: 42);
                 echo "<br>";
                 echo "Last played $gameLastPlayed<br>";
                 if ($numPossibleAchievements) {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -21,6 +21,7 @@
 @import "card.css";
 @import "carousel.css";
 @import "chart.css";
+@import "console.css";
 @import "embed.css";
 @import "footer.css";
 @import "form.css";

--- a/resources/css/console.css
+++ b/resources/css/console.css
@@ -2,6 +2,10 @@
   margin-left: .05em;
   color: var(--menu-link-color);
   font-size: .8em;
+
+  /* Font smoothing issue on Safari etc */
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
 }
 
 .console-icon {

--- a/resources/css/console.css
+++ b/resources/css/console.css
@@ -1,15 +1,16 @@
 .console {
   display: flex;
   align-items: center;
-  margin: .1em .05em;
   background: none;
 }
 
 .console.avatar {
+  margin-left: .05em;
   border-left: solid 2px #fff3;
 }
 
 .console > img {
+  padding: .15em 0;
   margin: 0 .5em;
 }
 

--- a/resources/css/console.css
+++ b/resources/css/console.css
@@ -1,7 +1,7 @@
 .console-name {
   margin-left: .05em;
   color: var(--menu-link-color);
-  font-size: .8em;
+  font-size: .85em;
 
   /* Font smoothing issue on Safari etc */
   -webkit-font-smoothing: auto;

--- a/resources/css/console.css
+++ b/resources/css/console.css
@@ -1,0 +1,19 @@
+.console {
+  display: flex;
+  align-items: center;
+  margin: 0 .15em;
+  padding: 0 .2em;
+  border-left: solid 2px #fff3;
+  background: none;
+  font-size: .8em;
+}
+
+.console > img {
+  padding: .3em;
+  padding-left: .45em;
+}
+
+.console > span {
+  padding-left: .3em;
+  color: var(--menu-link-color);
+}

--- a/resources/css/console.css
+++ b/resources/css/console.css
@@ -1,30 +1,18 @@
 .console {
   display: flex;
   align-items: center;
-  padding: 0 .2em;
+  margin: .1em .05em;
   background: none;
 }
 
 .console.avatar {
-  margin: 0 .1em;
-  padding-left: .45em;
   border-left: solid 2px #fff3;
-  font-size: .8em;
-}
-
-.console:not(.avatar) {
-  font-size: .7em;
 }
 
 .console > img {
-  padding: .3em;
-}
-
-.console:not(.avatar) > img {
-  padding: .3em .15em;
+  margin: 0 .5em;
 }
 
 .console > span {
-  padding-left: .3em;
   color: var(--menu-link-color);
 }

--- a/resources/css/console.css
+++ b/resources/css/console.css
@@ -1,19 +1,12 @@
-.console {
-  display: flex;
-  align-items: center;
-  background: none;
-}
-
-.console.avatar {
+.console-name {
   margin-left: .05em;
-  border-left: solid 2px #fff3;
-}
-
-.console > img {
-  padding: .15em 0;
-  margin: 0 .5em;
-}
-
-.console > span {
   color: var(--menu-link-color);
+  font-size: .8em;
+}
+
+.console-icon {
+  margin: 0 .5em;
+  object-fit: cover;
+  height: 36px;
+  image-rendering: pixelated;
 }

--- a/resources/css/console.css
+++ b/resources/css/console.css
@@ -9,8 +9,10 @@
 }
 
 .console-icon {
-  margin: 0 .5em;
-  object-fit: cover;
-  height: 36px;
-  image-rendering: pixelated;
+  margin: 0 .55em;
+  height: 26px;
+}
+
+.console-icon + * .console-name {
+  font-size: .8em;
 }

--- a/resources/css/console.css
+++ b/resources/css/console.css
@@ -3,13 +3,17 @@
   align-items: center;
   padding: 0 .2em;
   background: none;
-  font-size: .8em;
 }
 
 .console.avatar {
   margin: 0 .1em;
   padding-left: .45em;
   border-left: solid 2px #fff3;
+  font-size: .8em;
+}
+
+.console:not(.avatar) {
+  font-size: .7em;
 }
 
 .console > img {

--- a/resources/css/console.css
+++ b/resources/css/console.css
@@ -1,16 +1,23 @@
 .console {
   display: flex;
   align-items: center;
-  margin: 0 .15em;
   padding: 0 .2em;
-  border-left: solid 2px #fff3;
   background: none;
   font-size: .8em;
 }
 
+.console.avatar {
+  margin: 0 .1em;
+  padding-left: .45em;
+  border-left: solid 2px #fff3;
+}
+
 .console > img {
   padding: .3em;
-  padding-left: .45em;
+}
+
+.console:not(.avatar) > img {
+  padding: .3em .15em;
 }
 
 .console > span {

--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -32,14 +32,16 @@
 }
 
 .tag.console {
+  opacity: 1;
+  width: fit-content;
   padding: 0 .2em;
-  border-radius: 1em;
-  background-color: rgba(255, 255, 255, .1);
+  background: none;
+  border-left: solid 2px #fff3;
 }
 
 .tag.console > img {
-  width: 20px;
-  padding-right: .3em;
+  padding: .3em;
+  padding-left: .45em;
 }
 
 .tag.console > span {

--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -31,6 +31,22 @@
   border-right-width: 0;
 }
 
+.tag.console {
+  padding: 0 .2em;
+  border-radius: 1em;
+  background-color: rgba(255, 255, 255, .1);
+}
+
+.tag.console > img {
+  width: 20px;
+  padding-right: .3em;
+}
+
+.tag.console > span {
+  padding-left: .3em;
+  color: var(--menu-link-color);
+}
+
 .tag.missable {
   opacity: .8;
 }

--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -31,24 +31,6 @@
   border-right-width: 0;
 }
 
-.tag.console {
-  opacity: 1;
-  width: fit-content;
-  padding: 0 .2em;
-  background: none;
-  border-left: solid 2px #fff3;
-}
-
-.tag.console > img {
-  padding: .3em;
-  padding-left: .45em;
-}
-
-.tag.console > span {
-  padding-left: .3em;
-  color: var(--menu-link-color);
-}
-
 .tag.missable {
   opacity: .8;
 }

--- a/resources/views/community/components/event/aotw.blade.php
+++ b/resources/views/community/components/event/aotw.blade.php
@@ -24,7 +24,7 @@ if (empty($achData)) {
         </div>
         in
         <div>
-            {!! gameAvatar($achData, iconSize: 24) !!}
+            {!! gameAvatar($achData, iconSize: 32) !!}
         </div>
         <a class="btn mt-2" href="/viewtopic.php?t={{ $forumTopicID }}">Join this tournament!</a>
     </div>


### PR DESCRIPTION
Parses and stylizes console names (e.g `(Game Boy)`, `(PlayStation 2)` etc) so those are rendered in a separate line and with the respective icons.

![image](https://user-images.githubusercontent.com/22218549/233613126-f48906d8-44ac-4e78-9e7c-71e969c476a8.png)
![image](https://user-images.githubusercontent.com/22218549/233614005-21c269f1-a2f2-4b49-8ed8-2a26821081ba.png)

A similar style is also reflected now in game/achievement pages, for the sake of consistency:

![image](https://user-images.githubusercontent.com/22218549/233615185-0c7ae23b-a3b0-4761-8b1e-c0ab3abd5efc.png)
![image](https://user-images.githubusercontent.com/22218549/233615253-6075574b-9d18-4d4e-9a48-beaaf91a6a1f.png)
