### PR TITLE
Fix `Latest Masters` not showing players correctly for sets with 0-pointers

### DIFF
--- a/app_legacy/Helpers/database/player-game.php
+++ b/app_legacy/Helpers/database/player-game.php
@@ -383,7 +383,7 @@ function getGameTopAchievers(int $gameID): array
                   AND gd.ID = $gameID
                   AND aw.HardcoreMode = " . UnlockMode::Hardcore . "
                 GROUP BY aw.User
-                ORDER BY TotalScore DESC, LastAward";
+                ORDER BY TotalScore DESC, NumAchievements DESC, LastAward";
 
     $dbResult = s_mysql_query($query);
 


### PR DESCRIPTION
Long due follow-up to #1350.

The `Latest Masters` / `High Scores` loop logic checks for the first 10 players returned by an SQL query. Since the query was previously ordered by score but _not_ by # of unlocked achievements, in sets with 0-pointers the loop would occasionally abort too early (i.e before it could find all masters). This PR simply amends things so they work as intended.