### PR TITLE
Move check for different achievement ID to before the switch case

### DIFF
--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -443,6 +443,11 @@ $prevID = 0;
 $userTicketInfo = getTicketsForUser($dev);
 $counted = false;
 foreach ($userTicketInfo as $ticketData) {
+    if ($prevID != $ticketData['AchievementID']) { // relies on getTicketsForUser sorting by ID
+        $prevID = $ticketData['AchievementID'];
+        $userTickets['uniqueTotal']++;
+        $counted = false;
+    }
     switch ($ticketData['ReportState']) {
         case TicketState::Closed:
             $userTickets['closed'] += $ticketData['TicketCount'];
@@ -472,11 +477,6 @@ foreach ($userTicketInfo as $ticketData) {
             $userTickets['total'] += $ticketData['TicketCount'];
             $userTickets['uniqueRequest']++;
             break;
-    }
-    if ($prevID != $ticketData['AchievementID']) { // relies on getTicketsForUser sorting by ID
-        $prevID = $ticketData['AchievementID'];
-        $userTickets['uniqueTotal']++;
-        $counted = false;
     }
 }
 


### PR DESCRIPTION
Fixes #1459 which was caused by the check for a new achievement happening after the Switch Case so if an achievement had multiple tickets associated to it with the last one being Open or Resolved and the next achievement with tickets was Open or Resolved then it would not count because $counted was not being set to false.

Example to reproduce:
User - [suspect15 stats](https://retroachievements.org/individualdevstats.php?u=suspect15)
Ticket - [53409](https://retroachievements.org/ticketmanager.php?i=53409) will not be counted in the total because the prior achievement ID 248867 has a Closed and Resolved ticket

Overall Effect:
Not a super uncommon scenario so a fair amount of Devs Unique totals will likely increase a bit