### PR TITLE
fix(user): remediate mobile css issue with user following notice

### DIFF
--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -250,11 +250,14 @@ RenderContentStart($userPage);
             if ($areTheyFollowingMe) {
                 echo "<span class='hidden sm:block px-3'>Follows you</span>";
             }
-            echo "</div>";
-        }
 
-        if ($areTheyFollowingMe) {
-            echo "<p class='sm:hidden'>Follows you</p>";
+            echo "</div>";
+
+            // This needs to be a sibling to the user relationship div to prevent spacing
+            // issues with the user avatar.
+            if ($areTheyFollowingMe) {
+                echo "<p class='sm:hidden'>Follows you</p>";
+            }
         }
 
         echo "<br>";

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -206,15 +206,18 @@ RenderContentStart($userPage);
         }
 
         if (isset($user) && ($user !== $userPage)) {
-            echo "<div class='flex items-center gap-1'>";
-            $friendshipType = GetFriendship($user, $userPage);
-            switch ($friendshipType) {
+            echo "<div class='flex items-center sm:gap-1'>";
+
+            $myFriendshipType = GetFriendship($user, $userPage);
+            $areTheyFollowingMe = GetFriendship($userPage, $user) == UserRelationship::Following;
+
+            switch ($myFriendshipType) {
                 case UserRelationship::Following:
                     echo "<form class='inline-block' action='/request/user/update-relationship.php' method='post'>";
                     echo csrf_field();
                     echo "<input type='hidden' name='user' value='$userPage'>";
                     echo "<input type='hidden' name='action' value='" . UserRelationship::NotFollowing . "'>";
-                    echo "<button class='btn btn-link'>Unfollow</button>";
+                    echo "<button class='btn btn-link' style='padding-left: 0;'>Unfollow</button>";
                     echo "</form>";
                     break;
                 case UserRelationship::NotFollowing:
@@ -222,12 +225,12 @@ RenderContentStart($userPage);
                     echo csrf_field();
                     echo "<input type='hidden' name='user' value='$userPage'>";
                     echo "<input type='hidden' name='action' value='" . UserRelationship::Following . "'>";
-                    echo "<button class='btn btn-link'>Follow</button>";
+                    echo "<button class='btn btn-link' style='padding-left: 0;'>Follow" . ($areTheyFollowingMe ? ' Back' : '') . "</button>";
                     echo "</form>";
                     break;
             }
 
-            if ($friendshipType != UserRelationship::Blocked) {
+            if ($myFriendshipType != UserRelationship::Blocked) {
                 echo "<form class='inline-block' action='/request/user/update-relationship.php' method='post'>";
                 echo csrf_field();
                 echo "<input type='hidden' name='user' value='$userPage'>";
@@ -244,10 +247,14 @@ RenderContentStart($userPage);
             }
             echo "<a class='btn btn-link' href='/createmessage.php?t=$userPage'>Message</a>";
 
-            if (GetFriendship($userPage, $user) == UserRelationship::Following) {
-                echo "<span class='px-3'>Follows you</span>";
+            if ($areTheyFollowingMe) {
+                echo "<span class='hidden sm:block px-3'>Follows you</span>";
             }
             echo "</div>";
+        }
+
+        if ($areTheyFollowingMe) {
+            echo "<p class='sm:hidden'>Follows you</p>";
         }
 
         echo "<br>";


### PR DESCRIPTION
This PR resolves an issue visible when opening a user page on mobile if the user follows you. Right now, the "Follows you" text is clipping into the user avatar.

Additionally, if the user follows you and you don't follow them, the "Follow" button now says "Follow Back".

**Before**
![Screenshot 2023-04-25 at 4 55 28 PM](https://user-images.githubusercontent.com/3984985/234402589-7103a97e-074b-45f7-96a7-ca743ce34ca5.png)

**After**
![Screenshot 2023-04-25 at 4 55 06 PM](https://user-images.githubusercontent.com/3984985/234402727-433d0f2e-f27a-4c12-b296-0fd8e4a7b3ef.png)