### PR TITLE
fix(downloads): remediate broken duckstation link

### DIFF
--- a/storage/app/releases.dist.php
+++ b/storage/app/releases.dist.php
@@ -176,7 +176,7 @@ See <a href="https://docs.libretro.com/guides/retroachievements/#cores-compatibi
             'handle' => 'DuckStation',
             'active' => true,
             'link' => 'https://github.com/stenzek/duckstation/wiki',
-            'download_url' => 'duckstation.org',
+            'download_url' => 'https://duckstation.org',
             'systems' => [
                 12, // PlayStation
             ],


### PR DESCRIPTION
The link to download DuckStation on the Downloads page is currently broken. This PR fixes the broken link.