### PR TITLE
ci: adjust vitest package.json commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install
         run: npm install
       - name: Test
-        run: npm run test:ci
+        run: npm run test
         env:
           VITE_BUILD_PATH: dist
           APP_URL: https://raweb.test

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
         "lint:eslint": "eslint public/js resources/js postcss.config.js tailwind.config.js vite.config.ts --cache",
         "fix": "npm run fix:eslint",
         "fix:eslint": "eslint public/js resources/js postcss.config.js tailwind.config.js vite.config.ts --fix",
-        "test": "vitest",
-        "test:ci": "vitest run",
+        "test": "vitest run",
+        "test:watch": "vitest",
         "analyze": "cross-env ANALYZE=true npm run prod",
         "apidoc": "npm run apidoc:connect",
         "apidoc:connect": "apidoc -i src/Connect/ -c docs/src/connect-api -t docs/src/connect-api/template -o docs/dist/api/connect"


### PR DESCRIPTION
Addresses https://github.com/RetroAchievements/RAWeb/pull/1528#issuecomment-1529133767

`npm run test` does a full pass of Vite/TypeScript code.
`npm run test:watch` puts Vitest into watch mode after a full pass.