### PR TITLE
 Icons for claim set type (New/Revision) [reopened]

### DIFF
--- a/public/claimlist.php
+++ b/public/claimlist.php
@@ -181,6 +181,8 @@ RenderContentStart("Claim List");
         // Loop through the claims and display them in the table
         foreach ($claimData as $claim) {
             $claimUser = $claim['User'];
+            $claimSetType = $claim['SetType'];
+            
             echo "<tr>";
             echo "<td>";
             echo userAvatar($claimUser, label: false);
@@ -192,11 +194,7 @@ RenderContentStart("Claim List");
             echo gameAvatar($claim);
             echo "</td>";
             echo "<td>" . ($claim['ClaimType'] == ClaimType::Primary ? ClaimType::toString(ClaimType::Primary) : ClaimType::toString(ClaimType::Collaboration)) . "</td>";
-            echo "<td class='text-2xs whitespace-nowrap [word-spacing:.2em]'>"
-                . ($claim['SetType'] == ClaimSetType::NewSet ?
-                    ('💡 <b>' . ClaimSetType::toString(ClaimSetType::NewSet) . '</b>') :
-                    ('🗒️ ' . ClaimSetType::toString(ClaimSetType::Revision)))
-                . "</td>";
+            echo "<td>" . Blade::render("<x-claim-set-type :claimSetType=$claimSetType />") . "</td>";
             echo "<td>" . ClaimStatus::toString($claim['Status']) . "</td>";
             echo "<td>" . ClaimSpecial::toString($claim['Special']) . "</td>";
             echo "<td>" . getNiceDate(strtotime($claim['Created'])) . "</td>";

--- a/public/claimlist.php
+++ b/public/claimlist.php
@@ -192,7 +192,7 @@ RenderContentStart("Claim List");
             echo gameAvatar($claim);
             echo "</td>";
             echo "<td>" . ($claim['ClaimType'] == ClaimType::Primary ? ClaimType::toString(ClaimType::Primary) : ClaimType::toString(ClaimType::Collaboration)) . "</td>";
-            echo "<td class='text-2xs whitespace-nowrap'>"
+            echo "<td class='text-2xs whitespace-nowrap [word-spacing:.2em]'>"
                 . ($claim['SetType'] == ClaimSetType::NewSet ?
                     ('💡 <b>' . ClaimSetType::toString(ClaimSetType::NewSet) . '</b>') :
                     ('🗒️ ' . ClaimSetType::toString(ClaimSetType::Revision)))

--- a/public/claimlist.php
+++ b/public/claimlist.php
@@ -182,7 +182,7 @@ RenderContentStart("Claim List");
         foreach ($claimData as $claim) {
             $claimUser = $claim['User'];
             $claimSetType = $claim['SetType'];
-            
+
             echo "<tr>";
             echo "<td>";
             echo userAvatar($claimUser, label: false);

--- a/public/claimlist.php
+++ b/public/claimlist.php
@@ -192,7 +192,11 @@ RenderContentStart("Claim List");
             echo gameAvatar($claim);
             echo "</td>";
             echo "<td>" . ($claim['ClaimType'] == ClaimType::Primary ? ClaimType::toString(ClaimType::Primary) : ClaimType::toString(ClaimType::Collaboration)) . "</td>";
-            echo "<td>" . ($claim['SetType'] == ClaimSetType::NewSet ? ClaimSetType::toString(ClaimSetType::NewSet) : ClaimSetType::toString(ClaimSetType::Revision)) . "</td>";
+            echo "<td class='text-2xs whitespace-nowrap'>"
+                . ($claim['SetType'] == ClaimSetType::NewSet ?
+                    ('💡 <b>' . ClaimSetType::toString(ClaimSetType::NewSet) . '</b>') :
+                    ('🗒️ ' . ClaimSetType::toString(ClaimSetType::Revision)))
+                . "</td>";
             echo "<td>" . ClaimStatus::toString($claim['Status']) . "</td>";
             echo "<td>" . ClaimSpecial::toString($claim['Special']) . "</td>";
             echo "<td>" . getNiceDate(strtotime($claim['Created'])) . "</td>";

--- a/resources/views/community/components/claim-set-type-icon.blade.php
+++ b/resources/views/community/components/claim-set-type-icon.blade.php
@@ -1,1 +1,0 @@
-<x-pixelarticons-lock-open class="w-5 h-5" />

--- a/resources/views/community/components/claim-set-type-icon.blade.php
+++ b/resources/views/community/components/claim-set-type-icon.blade.php
@@ -1,0 +1,1 @@
+<x-pixelarticons-lock-open class="w-5 h-5" />

--- a/resources/views/community/components/claim-set-type.blade.php
+++ b/resources/views/community/components/claim-set-type.blade.php
@@ -4,9 +4,9 @@ use LegacyApp\Community\Enums\ClaimSetType;
 
 <div class="flex items-center gap-1 text-xs">
 @if ($claimSetType == ClaimSetType::NewSet)
-    <x-pixelarticons-card-plus class="w-4 h-4 text-green-500" />
+    <x-pixelarticons-card-plus class="w-4 h-3 text-green-500" />
 @else
-    <x-pixelarticons-edit class="w-4 h-4 text-cyan-400" />
+    <x-pixelarticons-edit class="w-4 h-3 text-cyan-400" />
 @endif
     <span>{{ ClaimSetType::toString($claimSetType) }}</span>
 </div>

--- a/resources/views/community/components/claim-set-type.blade.php
+++ b/resources/views/community/components/claim-set-type.blade.php
@@ -1,7 +1,6 @@
-<?php
-
+@php
 use LegacyApp\Community\Enums\ClaimSetType;
-?>
+@endphp
 
 <div class="flex items-center gap-1 text-xs">
 @if ($claimSetType == ClaimSetType::NewSet)

--- a/resources/views/community/components/claim-set-type.blade.php
+++ b/resources/views/community/components/claim-set-type.blade.php
@@ -4,9 +4,9 @@ use LegacyApp\Community\Enums\ClaimSetType;
 
 <div class="flex items-center gap-1 text-xs">
 @if ($claimSetType == ClaimSetType::NewSet)
-    <x-pixelarticons-check class="w-5 h-5 text-lime-500" />
+    <x-pixelarticons-check class="w-5 h-5 text-lime-400" />
 @else
-    <x-pixelarticons-check-double class="w-5 h-5 text-amber-600" />
+    <x-pixelarticons-check-double class="w-5 h-5 text-cyan-300" />
 @endif
     <span>{{ ClaimSetType::toString($claimSetType) }}</span>
 </div>

--- a/resources/views/community/components/claim-set-type.blade.php
+++ b/resources/views/community/components/claim-set-type.blade.php
@@ -7,7 +7,7 @@ use LegacyApp\Community\Enums\ClaimSetType;
 @if ($claimSetType == ClaimSetType::NewSet)
     <x-pixelarticons-check class="w-5 h-5 text-lime-500" />
 @else
-    <x-pixelarticons-check-double class="w-5 h-5 text-orange-500" />
+    <x-pixelarticons-check-double class="w-5 h-5 text-amber-600" />
 @endif
     <span>{{ ClaimSetType::toString($claimSetType) }}</span>
 </div>

--- a/resources/views/community/components/claim-set-type.blade.php
+++ b/resources/views/community/components/claim-set-type.blade.php
@@ -1,16 +1,13 @@
 <?php
 
 use LegacyApp\Community\Enums\ClaimSetType;
-
-[$claimSetTypeStr, $claimSetTypeIcon] = ['', ''];
-if ($claim['SetType'] === ClaimSetType::NewSet) {
-    $claimSetTypeStr = ClaimSetType::toString(ClaimSetType::NewSet);
-} else {
-    $claimSetTypeStr = ClaimSetType::toString(ClaimSetType::Revision);
-}
 ?>
 
 <div class="flex items-center gap-1 text-xs">
+@if ($claim['SetType'] == ClaimSetType::NewSet)    
     <x-pixelarticons-lock-open class="w-5 h-5" />
-    <span>{{ $claimSetTypeStr }}</span>
+@else
+    <x-pixelarticons-lock-open class="w-5 h-5" />
+@endif
+    <span>{{ ClaimSetType::toString($claim['SetType']) }}</span>
 </div>

--- a/resources/views/community/components/claim-set-type.blade.php
+++ b/resources/views/community/components/claim-set-type.blade.php
@@ -1,0 +1,16 @@
+<?php
+
+use LegacyApp\Community\Enums\ClaimSetType;
+
+[$claimSetTypeStr, $claimSetTypeIcon] = ['', ''];
+if ($claim['SetType'] === ClaimSetType::NewSet) {
+    $claimSetTypeStr = ClaimSetType::toString(ClaimSetType::NewSet);
+} else {
+    $claimSetTypeStr = ClaimSetType::toString(ClaimSetType::Revision);
+}
+?>
+
+<div class="flex items-center gap-1 text-xs">
+    <x-pixelarticons-lock-open class="w-5 h-5" />
+    <span>{{ $claimSetTypeStr }}</span>
+</div>

--- a/resources/views/community/components/claim-set-type.blade.php
+++ b/resources/views/community/components/claim-set-type.blade.php
@@ -4,10 +4,10 @@ use LegacyApp\Community\Enums\ClaimSetType;
 ?>
 
 <div class="flex items-center gap-1 text-xs">
-@if ($claim['SetType'] == ClaimSetType::NewSet)    
+@if ($claimSetType == ClaimSetType::NewSet)
     <x-pixelarticons-check class="w-5 h-5 text-lime-500" />
 @else
     <x-pixelarticons-check-double class="w-5 h-5 text-orange-500" />
 @endif
-    <span>{{ ClaimSetType::toString($claim['SetType']) }}</span>
+    <span>{{ ClaimSetType::toString($claimSetType) }}</span>
 </div>

--- a/resources/views/community/components/claim-set-type.blade.php
+++ b/resources/views/community/components/claim-set-type.blade.php
@@ -4,9 +4,9 @@ use LegacyApp\Community\Enums\ClaimSetType;
 
 <div class="flex items-center gap-1 text-xs">
 @if ($claimSetType == ClaimSetType::NewSet)
-    <x-pixelarticons-check class="w-5 h-5 text-lime-400" />
+    <x-pixelarticons-card-plus class="w-4 h-4 text-green-500" />
 @else
-    <x-pixelarticons-check-double class="w-5 h-5 text-cyan-300" />
+    <x-pixelarticons-edit class="w-4 h-4 text-cyan-400" />
 @endif
     <span>{{ ClaimSetType::toString($claimSetType) }}</span>
 </div>

--- a/resources/views/community/components/claim-set-type.blade.php
+++ b/resources/views/community/components/claim-set-type.blade.php
@@ -5,9 +5,9 @@ use LegacyApp\Community\Enums\ClaimSetType;
 
 <div class="flex items-center gap-1 text-xs">
 @if ($claim['SetType'] == ClaimSetType::NewSet)    
-    <x-pixelarticons-lock-open class="w-5 h-5" />
+    <x-pixelarticons-check class="w-5 h-5 text-lime-500" />
 @else
-    <x-pixelarticons-lock-open class="w-5 h-5" />
+    <x-pixelarticons-check-double class="w-5 h-5 text-orange-500" />
 @endif
     <span>{{ ClaimSetType::toString($claim['SetType']) }}</span>
 </div>

--- a/resources/views/community/components/claims/finished-claim-table-row.blade.php
+++ b/resources/views/community/components/claims/finished-claim-table-row.blade.php
@@ -18,6 +18,6 @@ $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->
     <td class="w-full">{!! gameAvatar($claim, icon: false, tooltip: false) !!}</td>
     <td class="pr-0">{!! userAvatar($claim['User'], label: false) !!}</td>
     <td>{!! userAvatar($claim['User'], icon: false) !!}</td>
-    <td class="text-xs whitespace-nowrap">{!! $claimSetTypeCopy !!}</td>
+    <td class="text-xs whitespace-nowrap [word-spacing:.2em]">{!! $claimSetTypeCopy !!}</td>
     <td class="smalldate">{{ $finishedTimeAgo }}</td>
 </tr>

--- a/resources/views/community/components/claims/finished-claim-table-row.blade.php
+++ b/resources/views/community/components/claims/finished-claim-table-row.blade.php
@@ -5,7 +5,9 @@ use LegacyApp\Community\Enums\ClaimSetType;
 
 $claimSetTypeCopy = ClaimSetType::toString(ClaimSetType::NewSet);
 if ($claim['SetType'] !== ClaimSetType::NewSet) {
-    $claimSetTypeCopy = ClaimSetType::toString(ClaimSetType::Revision);
+    $claimSetTypeCopy = '🗒️ ' . ClaimSetType::toString(ClaimSetType::Revision);
+} else {
+    $claimSetTypeCopy = "💡 <b>$claimSetTypeCopy</b>";
 }
 
 $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->diffForHumans();
@@ -16,6 +18,6 @@ $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->
     <td class="w-full">{!! gameAvatar($claim, icon: false, tooltip: false) !!}</td>
     <td class="pr-0">{!! userAvatar($claim['User'], label: false) !!}</td>
     <td>{!! userAvatar($claim['User'], icon: false) !!}</td>
-    <td>{{ $claimSetTypeCopy }}</td>
+    <td class="text-xs whitespace-nowrap">{!! $claimSetTypeCopy !!}</td>
     <td class="smalldate">{{ $finishedTimeAgo }}</td>
 </tr>

--- a/resources/views/community/components/claims/finished-claim-table-row.blade.php
+++ b/resources/views/community/components/claims/finished-claim-table-row.blade.php
@@ -1,14 +1,6 @@
 <?php
 
 use Illuminate\Support\Carbon;
-use LegacyApp\Community\Enums\ClaimSetType;
-
-[$claimSetTypeStr, $claimSetTypeIcon] = ['', ''];
-if ($claim['SetType'] === ClaimSetType::NewSet) {
-    $claimSetTypeStr = ClaimSetType::toString(ClaimSetType::NewSet);
-} else {
-    $claimSetTypeStr = ClaimSetType::toString(ClaimSetType::Revision);
-}
 
 $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->diffForHumans();
 ?>
@@ -18,11 +10,6 @@ $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->
     <td class="w-full">{!! gameAvatar($claim, icon: false, tooltip: false) !!}</td>
     <td class="pr-0">{!! userAvatar($claim['User'], label: false) !!}</td>
     <td>{!! userAvatar($claim['User'], icon: false) !!}</td>
-    <td>
-        <div class="flex items-center gap-1 text-xs">
-            <x-claim-set-type-icon />
-            <span>{{ $claimSetTypeStr }}</span>
-        </div>
-    </td>
+    <td><x-claim-set-type :claim=$claim /></td>
     <td class="smalldate">{{ $finishedTimeAgo }}</td>
 </tr>

--- a/resources/views/community/components/claims/finished-claim-table-row.blade.php
+++ b/resources/views/community/components/claims/finished-claim-table-row.blade.php
@@ -3,11 +3,11 @@
 use Illuminate\Support\Carbon;
 use LegacyApp\Community\Enums\ClaimSetType;
 
-$claimSetTypeCopy = ClaimSetType::toString(ClaimSetType::NewSet);
-if ($claim['SetType'] !== ClaimSetType::NewSet) {
-    $claimSetTypeCopy = '🗒️ ' . ClaimSetType::toString(ClaimSetType::Revision);
+[$claimSetTypeStr, $claimSetTypeIcon] = ['', ''];
+if ($claim['SetType'] === ClaimSetType::NewSet) {
+    $claimSetTypeStr = ClaimSetType::toString(ClaimSetType::NewSet);
 } else {
-    $claimSetTypeCopy = "💡 <b>$claimSetTypeCopy</b>";
+    $claimSetTypeStr = ClaimSetType::toString(ClaimSetType::Revision);
 }
 
 $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->diffForHumans();
@@ -18,6 +18,11 @@ $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->
     <td class="w-full">{!! gameAvatar($claim, icon: false, tooltip: false) !!}</td>
     <td class="pr-0">{!! userAvatar($claim['User'], label: false) !!}</td>
     <td>{!! userAvatar($claim['User'], icon: false) !!}</td>
-    <td class="text-xs whitespace-nowrap [word-spacing:.2em]">{!! $claimSetTypeCopy !!}</td>
+    <td>
+        <div class="flex items-center gap-1 text-xs">
+            <x-claim-set-type-icon />
+            <span>{{ $claimSetTypeStr }}</span>
+        </div>
+    </td>
     <td class="smalldate">{{ $finishedTimeAgo }}</td>
 </tr>

--- a/resources/views/community/components/claims/finished-claim-table-row.blade.php
+++ b/resources/views/community/components/claims/finished-claim-table-row.blade.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Carbon;
 
+$claimSetType = $claim['SetType'];
 $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->diffForHumans();
 ?>
 
@@ -10,6 +11,6 @@ $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->
     <td class="w-full">{!! gameAvatar($claim, icon: false, tooltip: false) !!}</td>
     <td class="pr-0">{!! userAvatar($claim['User'], label: false) !!}</td>
     <td>{!! userAvatar($claim['User'], icon: false) !!}</td>
-    <td><x-claim-set-type :claim=$claim /></td>
+    <td><x-claim-set-type :claimSetType=$claimSetType /></td>
     <td class="smalldate">{{ $finishedTimeAgo }}</td>
 </tr>


### PR DESCRIPTION
Icons for distinction between "New" and "Revision" claim set types.

![image](https://user-images.githubusercontent.com/22218549/235377564-299ce4f3-c123-4e3f-9dd8-cfbdc4347d46.png)

---

Sorry for opening this again. Had to close #1529 and do so in another branch as I managed to completely screw up the commit history for the other one. Taking notes...