### PR TITLE
fix(reorderSiteAwards): disable invisible manual move buttons

### DIFF
--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -61,6 +61,7 @@ function generateManualMoveButtons(
     string $downLabel = '',
     bool $autoScroll = false,
     string $orientation = 'vertical',
+    bool $isHiddenPreChecked = false,
 ): string {
     $downValue = $moveValue;
     $upValue = $moveValue * -1;
@@ -83,6 +84,7 @@ function generateManualMoveButtons(
                 aria-label="$upA11yLabel" 
                 class="text-2xs"
                 onclick="reorderSiteAwards.moveRow($awardCounter, $upValue, $autoScroll)"
+                disabled="$isHiddenPreChecked"
             >
                 ↑$upLabel
             </button>
@@ -92,6 +94,7 @@ function generateManualMoveButtons(
                 aria-label="$downA11yLabel"
                 class="text-2xs"
                 onclick="reorderSiteAwards.moveRow($awardCounter, $downValue, $autoScroll)"
+                disabled="$isHiddenPreChecked"
             >
                 ↓$downLabel
             </button>
@@ -245,14 +248,14 @@ function postAllAwardsDisplayOrder(awards) {
                 echo "<td>";
                 echo "<div class='award-movement-buttons flex justify-end transition " . ($isHiddenPreChecked ? 'opacity-0' : 'opacity-100') . "'>";
                 if (count($awards) > 50) {
-                    echo generateManualMoveButtons($awardCounter, 99999, upLabel: ' Top', downLabel: ' Bottom', autoScroll: true);
-                    echo generateManualMoveButtons($awardCounter, 50, upLabel: '50', downLabel: '50', autoScroll: true);
-                    echo generateManualMoveButtons($awardCounter, 1);
+                    echo generateManualMoveButtons($awardCounter, 99999, upLabel: ' Top', downLabel: ' Bottom', autoScroll: true, isHiddenPreChecked: $isHiddenPreChecked);
+                    echo generateManualMoveButtons($awardCounter, 50, upLabel: '50', downLabel: '50', autoScroll: true, isHiddenPreChecked: $isHiddenPreChecked);
+                    echo generateManualMoveButtons($awardCounter, 1, isHiddenPreChecked: $isHiddenPreChecked);
                 } elseif (count($awards) > 15) {
-                    echo generateManualMoveButtons($awardCounter, 10, upLabel: '10', downLabel: '10', autoScroll: true);
-                    echo generateManualMoveButtons($awardCounter, 1);
+                    echo generateManualMoveButtons($awardCounter, 10, upLabel: '10', downLabel: '10', autoScroll: true, isHiddenPreChecked: $isHiddenPreChecked);
+                    echo generateManualMoveButtons($awardCounter, 1, isHiddenPreChecked: $isHiddenPreChecked);
                 } else {
-                    echo generateManualMoveButtons($awardCounter, 1, orientation: 'horizontal');
+                    echo generateManualMoveButtons($awardCounter, 1, orientation: 'horizontal', isHiddenPreChecked: $isHiddenPreChecked);
                 }
                 echo "</div>";
                 echo "</td>";

--- a/resources/js/dynamic/reorderSiteAwards.ts
+++ b/resources/js/dynamic/reorderSiteAwards.ts
@@ -313,7 +313,7 @@ export function handleRowHiddenCheckedChange(event: MouseEvent, rowIndex: number
         buttonsContainerEl.style.opacity = '100';
 
         buttonsContainerEl.querySelectorAll('button').forEach((buttonEl) => {
-          buttonEl.disabled = false;
+          buttonEl.removeAttribute('disabled');
         });
       }
     }

--- a/resources/js/dynamic/reorderSiteAwards.ts
+++ b/resources/js/dynamic/reorderSiteAwards.ts
@@ -303,10 +303,18 @@ export function handleRowHiddenCheckedChange(event: MouseEvent, rowIndex: number
         targetRowEl.classList.remove('cursor-grab');
         targetRowEl.setAttribute('draggable', 'false');
         buttonsContainerEl.style.opacity = '0';
+
+        buttonsContainerEl.querySelectorAll('button').forEach((buttonEl) => {
+          buttonEl.disabled = true;
+        });
       } else {
         targetRowEl.classList.add('cursor-grab');
         targetRowEl.setAttribute('draggable', 'true');
         buttonsContainerEl.style.opacity = '100';
+
+        buttonsContainerEl.querySelectorAll('button').forEach((buttonEl) => {
+          buttonEl.disabled = false;
+        });
       }
     }
 


### PR DESCRIPTION
This PR addresses a bug on the Reorder Site Awards page. 

When a row is checked to be hidden, the buttons are given an opacity of 0 but are not disabled, so they are still clickable. The changes in this PR disable them when they are hidden, and reenable them when they are unhidden.