### PR TITLE
fix(debug): don't render unless DEBUGBAR_ENABLED is true

### DIFF
--- a/resources/views/layouts/components/body-end.blade.php
+++ b/resources/views/layouts/components/body-end.blade.php
@@ -1,15 +1,6 @@
 {{-- TODO add livewire--}}
 {{--<livewire:scripts />--}}
-@if(!app()->environment('production'))
-    <script>
-        function hideDebugBar() {
-            const debugBarEl = document.querySelector('#debug');
-            if (debugBarEl) {
-                debugBarEl.classList.add('hidden');
-            }
-        }
-    </script>
-
+@if(!app()->environment('production') && env('DEBUGBAR_ENABLED'))
     <style nonce="{{ csp_nonce() }}">
         pre.xdebug-var-dump {
             background: #FFFFFF;
@@ -23,7 +14,7 @@
         }
     </style>
 
-    <div id="debug" role="button" x-init="{}" @click="hideDebugBar()">
+    <div id="debug">
         <b class="text-danger text-capitalize">{{ app()->environment() }}</b>
         <b>
             <span class="sm:hidden">XS</span>

--- a/resources/views/layouts/components/body-end.blade.php
+++ b/resources/views/layouts/components/body-end.blade.php
@@ -1,6 +1,15 @@
 {{-- TODO add livewire--}}
 {{--<livewire:scripts />--}}
 @if(!app()->environment('production'))
+    <script>
+        function hideDebugBar() {
+            const debugBarEl = document.querySelector('#debug');
+            if (debugBarEl) {
+                debugBarEl.classList.add('hidden');
+            }
+        }
+    </script>
+
     <style nonce="{{ csp_nonce() }}">
         pre.xdebug-var-dump {
             background: #FFFFFF;
@@ -13,7 +22,8 @@
             z-index: 100;
         }
     </style>
-    <div id="debug">
+
+    <div id="debug" role="button" x-init="{}" @click="hideDebugBar()">
         <b class="text-danger text-capitalize">{{ app()->environment() }}</b>
         <b>
             <span class="sm:hidden">XS</span>


### PR DESCRIPTION
This PR makes a minor adjustment to the debug element which shows env, breakpoint, locale, and language. Now, if the Laravel debug bar is disabled, the debug element is also disabled.

This is helpful for showing demo screenshots/videos on tiny displays, like the iPhone SE.

![Screenshot 2023-05-02 at 4 27 56 PM](https://user-images.githubusercontent.com/3984985/235778827-312e6dea-d7aa-451f-91f7-49dead482db1.png)
