### PR TITLE
Add a Derived Hacks section to game alternatives in the sidebar

### DIFF
--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -232,6 +232,7 @@ function getGameHacks(int $gameID, string $gameTitle): array
         FROM GameData AS gd
         LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
         WHERE gd.Publisher = "Hack - $gameTitle" AND gd.Title LIKE "~Hack~%"
+            AND gd.ID IN (SELECT gameID FROM Achievements AS ach WHERE ach.flags = $officialCore)
         GROUP BY gd.ID, gd.Title
     SQL;
 

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -220,13 +220,10 @@ function getGameAlternatives(int $gameID, ?int $sortBy = null): array
 function getGameHacks(int $gameID, string $gameTitle): array
 {
     $officialCore = AchievementType::OfficialCore;
-    $alternativeTitleQuery = '';
     if (str_contains($gameTitle, ': ')) {
-        $alternativeTitle = str_replace(': ', ' - ', $gameTitle);
-        sanitize_outputs($alternativeTitle);
-        $alternativeTitleQuery = "OR gd.Title = '[Hacks - $alternativeTitle]'";
+        $gameTitle = str_replace(': ', ' - ', $gameTitle);
     }
-    sanitize_outputs($gameTitle);
+    sanitize_outputs($gameTitle);    
 
     $query = <<<SQL
         SELECT gd.ID gameIDAlt, gd.Title, gd.ImageIcon, c.Name ConsoleName,
@@ -245,8 +242,9 @@ function getGameHacks(int $gameID, string $gameTitle): array
         WHERE gd.ID IN (
             SELECT gameID FROM GameAlternatives ga
             LEFT JOIN GameData gd ON ga.gameIDAlt = gd.ID
-            WHERE gd.Title = '[Hacks - $gameTitle]' $alternativeTitleQuery
-        ) AND gd.Title LIKE "~Hack~%" AND gd.TotalTruePoints > 0
+            WHERE gd.Title = '[Hacks - $gameTitle]'
+        ) OR gd.Publisher LIKE '%Hack - $gameTitle%'
+            AND gd.Title LIKE "~Hack~%" AND gd.TotalTruePoints > 0
         GROUP BY gd.ID, gd.Title
     SQL;
 

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -223,8 +223,10 @@ function getGameHacks(int $gameID, string $gameTitle): array
     $alternativeTitleQuery = '';
     if (str_contains($gameTitle, ': ')) {
         $alternativeTitle = str_replace(': ', ' - ', $gameTitle);
+        sanitize_outputs($alternativeTitle);
         $alternativeTitleQuery = "OR gd.Title = '[Hacks - $alternativeTitle]'";
     }
+    sanitize_outputs($gameTitle);
 
     $query = <<<SQL
         SELECT gd.ID gameIDAlt, gd.Title, gd.ImageIcon, c.Name ConsoleName,

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -221,11 +221,11 @@ function getGameHacks(int $gameID, string $gameTitle): array
 {
     $officialCore = AchievementType::OfficialCore;
     $alternativeTitleQuery = '';
-    if (str_contains($gameTitle, ': ')) { 
+    if (str_contains($gameTitle, ': ')) {
         $alternativeTitle = str_replace(': ', ' - ', $gameTitle);
         $alternativeTitleQuery = "OR gd.Title = '[Hacks - $alternativeTitle]'";
     }
-    
+
     $query = <<<SQL
         SELECT gd.ID gameIDAlt, gd.Title, gd.ImageIcon, c.Name ConsoleName,
         CASE

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -239,11 +239,11 @@ function getGameHacks(int $gameID, string $gameTitle): array
         ) AS Points, gd.TotalTruePoints
         FROM GameData gd
         LEFT JOIN Console c ON c.ID = gd.ConsoleID
-        WHERE gd.ID IN (
+        WHERE (gd.ID IN (
             SELECT gameID FROM GameAlternatives ga
             LEFT JOIN GameData gd ON ga.gameIDAlt = gd.ID
             WHERE gd.Title = '[Hacks - $gameTitle]'
-        ) OR gd.Publisher LIKE '%Hack - $gameTitle%'
+        ) OR gd.Publisher LIKE '%Hack - $gameTitle%')
             AND gd.Title LIKE "~Hack~%" AND gd.TotalTruePoints > 0
         GROUP BY gd.ID, gd.Title
     SQL;

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -220,6 +220,12 @@ function getGameAlternatives(int $gameID, ?int $sortBy = null): array
 function getGameHacks(int $gameID, string $gameTitle): array
 {
     $officialCore = AchievementType::OfficialCore;
+    $alternativeTitleQuery = '';
+    if (str_contains($gameTitle, ': ')) { 
+        $alternativeTitle = str_replace(': ', ' - ', $gameTitle);
+        $alternativeTitleQuery = "OR gd.Title = '[Hacks - $alternativeTitle]'";
+    }
+    
     $query = <<<SQL
         SELECT gd.ID gameIDAlt, gd.Title, gd.ImageIcon, c.Name ConsoleName,
         CASE
@@ -237,7 +243,7 @@ function getGameHacks(int $gameID, string $gameTitle): array
         WHERE gd.ID IN (
             SELECT gameID FROM GameAlternatives ga
             LEFT JOIN GameData gd ON ga.gameIDAlt = gd.ID
-            WHERE gd.Title = '[Hacks - $gameTitle]'
+            WHERE gd.Title = '[Hacks - $gameTitle]' $alternativeTitleQuery
         ) AND gd.Title LIKE "~Hack~%" AND gd.TotalTruePoints > 0
         GROUP BY gd.ID, gd.Title
     SQL;

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -221,7 +221,7 @@ function getGameHacks(int $gameID, string $gameTitle): array
 {
     $officialCore = AchievementType::OfficialCore;
     $query = <<<SQL
-        SELECT gd.ID AS gameIDAlt, gd.Title, gd.ImageIcon, c.Name AS ConsoleName,
+        SELECT gd.ID gameIDAlt, gd.Title, gd.ImageIcon, c.Name ConsoleName,
         CASE
             WHEN (
                 SELECT COUNT(*) FROM Achievements ach
@@ -232,10 +232,13 @@ function getGameHacks(int $gameID, string $gameTitle): array
             SELECT SUM(ach.Points) FROM Achievements ach
             WHERE ach.GameID = gd.ID AND ach.Flags = $officialCore
         ) AS Points, gd.TotalTruePoints
-        FROM GameData AS gd
-        LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-        WHERE gd.Publisher = "Hack - $gameTitle" AND gd.Title LIKE "~Hack~%"
-            AND gd.ID IN (SELECT gameID FROM Achievements AS ach WHERE ach.flags = $officialCore)
+        FROM GameData gd
+        LEFT JOIN Console c ON c.ID = gd.ConsoleID
+        WHERE gd.ID IN (
+            SELECT gameID FROM GameAlternatives ga
+            LEFT JOIN GameData gd ON ga.gameIDAlt = gd.ID
+            WHERE gd.Title = '[Hacks - $gameTitle]'
+        ) AND gd.Title LIKE "~Hack~%" AND gd.TotalTruePoints > 0
         GROUP BY gd.ID, gd.Title
     SQL;
 

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -246,6 +246,7 @@ function getGameHacks(int $gameID, string $gameTitle): array
         ) OR gd.Publisher LIKE '%Hack - $gameTitle%')
             AND gd.Title LIKE "~Hack~%" AND gd.TotalTruePoints > 0
         GROUP BY gd.ID, gd.Title
+        LIMIT 10
     SQL;
 
     $dbResult = s_mysql_query($query);

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -214,6 +214,9 @@ function getGameAlternatives(int $gameID, ?int $sortBy = null): array
     return $results;
 }
 
+/**
+ * Get list of hacks derived from a given game (ignore empty official sets)
+ */
 function getGameHacks(int $gameID, string $gameTitle): array
 {
     $officialCore = AchievementType::OfficialCore;

--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -223,7 +223,7 @@ function getGameHacks(int $gameID, string $gameTitle): array
     if (str_contains($gameTitle, ': ')) {
         $gameTitle = str_replace(': ', ' - ', $gameTitle);
     }
-    sanitize_outputs($gameTitle);    
+    sanitize_outputs($gameTitle);
 
     $query = <<<SQL
         SELECT gd.ID gameIDAlt, gd.Title, gd.ImageIcon, c.Name ConsoleName,

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -237,12 +237,13 @@ function RenderGameSort(bool $isFullyFeaturedGame, ?int $flags, int $officialFla
     echo "<sup>&nbsp;</sup></span></div>";
 }
 
-function RenderGameAlts(array $gameAlts, ?string $headerText = null): void
+function RenderGameAlts(array $gameAlts, ?string $headerText = null, bool $scroll = false): void
 {
     echo "<div class='component gamealts'>";
     if ($headerText) {
         echo "<h2 class='text-h3'>$headerText</h2>";
     }
+    echo "<div " . ($scroll ? "class='max-h-[300px] overflow-y-auto'" : '' ) . ">";
     echo "<table class='table-highlight'><tbody>";
     foreach ($gameAlts as $nextGame) {
         echo "<tr>";
@@ -281,6 +282,7 @@ function RenderGameAlts(array $gameAlts, ?string $headerText = null): void
         echo "</tr>";
     }
     echo "</tbody></table>";
+    echo "</div>";
     echo "</div>";
 }
 

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -237,14 +237,17 @@ function RenderGameSort(bool $isFullyFeaturedGame, ?int $flags, int $officialFla
     echo "<sup>&nbsp;</sup></span></div>";
 }
 
-function RenderGameAlts(array $gameAlts, ?string $headerText = null): void
+function RenderGameAlts(array $gameAlts, ?string $headerText = null, ?string $linkFull = null): void
 {
     echo "<div class='component gamealts'>";
+
     if ($headerText) {
         echo "<h2 class='text-h3'>$headerText</h2>";
     }
     echo "<div class='max-h-[350px] overflow-y-auto'>";
     echo "<table class='table-highlight'><tbody>";
+
+    $count = 0;
     foreach ($gameAlts as $nextGame) {
         echo "<tr>";
         $consoleName = $nextGame['ConsoleName'];
@@ -280,9 +283,19 @@ function RenderGameAlts(array $gameAlts, ?string $headerText = null): void
         }
 
         echo "</tr>";
+
+        $count++;
+        if ($linkFull and $count === 8) {
+            break;
+        }
     }
     echo "</tbody></table>";
     echo "</div>";
+
+    if ($linkFull and $count < count($gameAlts)) {
+        echo "<a class='btn btn-link float-right mt-2' href='$linkFull'>more...</a>";
+    }
+
     echo "</div>";
 }
 

--- a/app_legacy/Helpers/render/game.php
+++ b/app_legacy/Helpers/render/game.php
@@ -237,13 +237,13 @@ function RenderGameSort(bool $isFullyFeaturedGame, ?int $flags, int $officialFla
     echo "<sup>&nbsp;</sup></span></div>";
 }
 
-function RenderGameAlts(array $gameAlts, ?string $headerText = null, bool $scroll = false): void
+function RenderGameAlts(array $gameAlts, ?string $headerText = null): void
 {
     echo "<div class='component gamealts'>";
     if ($headerText) {
         echo "<h2 class='text-h3'>$headerText</h2>";
     }
-    echo "<div " . ($scroll ? "class='max-h-[300px] overflow-y-auto'" : '' ) . ">";
+    echo "<div class='max-h-[350px] overflow-y-auto'>";
     echo "<table class='table-highlight'><tbody>";
     foreach ($gameAlts as $nextGame) {
         echo "<tr>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -77,7 +77,7 @@ foreach ($relatedGames as $gameAlt) {
         $gameHacks,
         fn ($hack) => $hack['gameIDAlt'] === $gameAlt['gameIDAlt']
     )) {
-        // Games in Hacks section are ignored here
+        // Games already in Hacks are ignored in Similar Games
         $gameAlts[] = $gameAlt;
     }
 }

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1439,8 +1439,12 @@ sanitize_outputs(
 
             if (!empty($gameHacks)) {
                 $hubID = getGameIDFromTitle("[Hacks - $gameTitle]", 100);
-                $headerText = "Hacks <a class='btn float-right text-sm' href='/game/$hubID'>Visit Hub</a>";
-                RenderGameAlts($gameHacks, $headerText);
+                $linkHub = $hubID ? "/game/$hubID" : null;
+                $headerText = "Derived Hacks";
+                if ($hubID) {
+                    $headerText .= " <a class='btn float-right text-sm' href='$linkHub'>Visit Hub</a>";
+                }
+                RenderGameAlts($gameHacks, $headerText, linkFull: $linkHub);
             }
 
             if (!empty($gameAlts)) {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1436,7 +1436,7 @@ sanitize_outputs(
             }
 
             if (!empty($gameHacks)) {
-                RenderGameAlts($gameHacks, 'Hacks');
+                RenderGameAlts($gameHacks, 'Hacks', scroll: true);
             }
 
             if (!empty($gameAlts)) {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1436,7 +1436,9 @@ sanitize_outputs(
             }
 
             if (!empty($gameHacks)) {
-                RenderGameAlts($gameHacks, 'Hacks');
+                $hubID = getGameIDFromTitle("[Hacks - $gameTitle]", 100);
+                $headerText = "Hacks <a class='btn float-right text-sm' href='/game/$hubID'>Visit Hub</a>";
+                RenderGameAlts($gameHacks, $headerText);
             }
 
             if (!empty($gameAlts)) {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -61,7 +61,9 @@ $isEventGame = $consoleName == 'Events';
 
 $pageTitle = "$gameTitle ($consoleName)";
 
+$gameHacks = $isFullyFeaturedGame ? getGameHacks($gameID, $gameTitle) : [];
 $relatedGames = $isFullyFeaturedGame ? getGameAlternatives($gameID) : getGameAlternatives($gameID, $sortBy);
+
 $gameAlts = [];
 $gameHubs = [];
 $gameSubsets = [];
@@ -69,16 +71,16 @@ $subsetPrefix = $gameData['Title'] . " [Subset - ";
 foreach ($relatedGames as $gameAlt) {
     if ($gameAlt['ConsoleName'] == 'Hubs') {
         $gameHubs[] = $gameAlt;
-    } else {
-        if (str_starts_with($gameAlt['Title'], $subsetPrefix)) {
-            $gameSubsets[] = $gameAlt;
-        } elseif (!str_starts_with($gameAlt['Title'], '~Hack~')) {
-            $gameAlts[] = $gameAlt;
-        }
+    } elseif (str_starts_with($gameAlt['Title'], $subsetPrefix)) {
+        $gameSubsets[] = $gameAlt;
+    } elseif (!array_filter(
+        $gameHacks,
+        fn ($hack) => $hack['gameIDAlt'] === $gameAlt['gameIDAlt']
+    )) {
+        // Games in Hacks section are ignored here
+        $gameAlts[] = $gameAlt;
     }
 }
-
-$gameHacks = $isFullyFeaturedGame ? getGameHacks($gameID, $gameTitle) : [];
 
 $v = requestInputSanitized('v', 0, 'integer');
 $gate = false;

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -72,7 +72,7 @@ foreach ($relatedGames as $gameAlt) {
     } else {
         if (str_starts_with($gameAlt['Title'], $subsetPrefix)) {
             $gameSubsets[] = $gameAlt;
-        } else {
+        } elseif (!str_starts_with($gameAlt['Title'], '~Hack~')) {
             $gameAlts[] = $gameAlt;
         }
     }

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -78,6 +78,8 @@ foreach ($relatedGames as $gameAlt) {
     }
 }
 
+$gameHacks = $isFullyFeaturedGame ? getGameHacks($gameID, $gameTitle) : [];
+
 $v = requestInputSanitized('v', 0, 'integer');
 $gate = false;
 if ($v != 1 && $isFullyFeaturedGame) {
@@ -1431,6 +1433,10 @@ sanitize_outputs(
 
             if (!empty($gameSubsets)) {
                 RenderGameAlts($gameSubsets, 'Subsets');
+            }
+
+            if (!empty($gameHacks)) {
+                RenderGameAlts($gameHacks, 'Hacks');
             }
 
             if (!empty($gameAlts)) {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1436,7 +1436,7 @@ sanitize_outputs(
             }
 
             if (!empty($gameHacks)) {
-                RenderGameAlts($gameHacks, 'Hacks', scroll: true);
+                RenderGameAlts($gameHacks, 'Hacks');
             }
 
             if (!empty($gameAlts)) {


### PR DESCRIPTION
Add a new section to go along with the other ones. Inspired by [this suggestion](https://github.com/RetroAchievements/RAWeb/discussions/1453).

![image](https://user-images.githubusercontent.com/22218549/236075486-21f487e5-a033-4da5-9563-482a8132b088.png)

Results are fetched by a query for the publisher `Hack - $gameTitle`. **EDIT**: and also by searching for `[Hacks - ...` hubs among game alternatives.

A few points of notice:
- Empty sets aren't shown (due to cases like e.g Super Mario World, which has 30% of 0-pointer hacks)
- "Similar Games" doesn't include hacks anymore, to avoid redundancy
- A scrollbar was added to when content gets past a certain height, so sidebar isn't polluted with endless lists.