### PR TITLE
feat(game): require guide links to be from RAGuides repo

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -963,7 +963,7 @@ sanitize_outputs(
                     echo "<input type='hidden' name='genre' value='" . attributeEscape($genre) . "'>";
                     echo "<input type='hidden' name='release' value='" . attributeEscape($released) . "'>";
                     echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
-                    echo "<label for='guide_url'>Guide URL</label><input type='url' name='guide_url' id='guide_url' value='" . attributeEscape($guideURL) . "' class='w-full'>";
+                    echo "<label for='guide_url' class='cursor-help italic' title='Must be from https://github.com/RetroAchievements/guides'>Guide URL<sup>*</sup></label><input type='url' name='guide_url' id='guide_url' value='" . attributeEscape($guideURL) . "' class='w-full'>";
                     echo "<div class='text-right'><button class='btn'>Submit</button></div>";
                     echo "</div>";
                     echo "</form>";

--- a/public/request/game/update-meta.php
+++ b/public/request/game/update-meta.php
@@ -15,7 +15,13 @@ $input = Validator::validate(Arr::wrap(request()->post()), [
     'publisher' => 'nullable|string|max:50',
     'genre' => 'nullable|string|max:50',
     'release' => 'nullable|string|max:50',
-    'guide_url' => 'nullable|active_url',
+    'guide_url' => [
+        'nullable',
+        'active_url',
+        'regex:/^https?:\/\/(www\.)?github\.com\/RetroAchievements\/guides\//i'
+    ],
+], [
+    'guide_url.regex' => 'The guide URL must be from https://github.com/RetroAchievements/guides/.',
 ]);
 
 $gameId = (int) $input['game'];

--- a/public/request/game/update-meta.php
+++ b/public/request/game/update-meta.php
@@ -18,7 +18,7 @@ $input = Validator::validate(Arr::wrap(request()->post()), [
     'guide_url' => [
         'nullable',
         'active_url',
-        'regex:/^https?:\/\/(www\.)?github\.com\/RetroAchievements\/guides\//i'
+        'regex:/^https?:\/\/(www\.)?github\.com\/RetroAchievements\/guides\//i',
     ],
 ], [
     'guide_url.regex' => 'The guide URL must be from https://github.com/RetroAchievements/guides/.',


### PR DESCRIPTION
This PR implements the outcome of this community poll: https://discord.com/channels/310192285306454017/511718348178849792/1104087071460704286

Validation has been added to the "Guide URL" field in the devbox requiring URLs to come from the RAGuides repo. This will ensure content linked to via the "Guide" link is content directly under RA's control, which will make a future on-site migration easier.

<img width="255" alt="Screenshot 2023-05-06 at 9 52 19 AM" src="https://user-images.githubusercontent.com/3984985/236628528-41e0adda-04db-4d1e-910c-26362188002a.png">
