### PR TITLE
feat(devStats): In Achievements section of individual dev stats page, show the count of leaderboards owned by the dev

### DIFF
--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -40,6 +40,8 @@ $anyDevEasiestGame = [];
 $anyDevRichPresenceCount = 0;
 $anyDevLeaderboardCount = 0;
 $anyDevLeaderboardTotal = 0;
+$anyDevLeaderboardCountByThisDev = 0;
+$anyDevLeaderboardTotalByThisDev = 0;
 
 // Initialise majority dev game variables
 $majorityDevGameIDs = [];
@@ -49,6 +51,8 @@ $majorityDevAchievementCount = 0;
 $majorityDevRichPresenceCount = 0;
 $majorityDevLeaderboardCount = 0;
 $majorityDevLeaderboardTotal = 0;
+$majorityDevLeaderboardCountByThisDev = 0;
+$majorityDevLeaderboardTotalByThisDev = 0;
 
 // Initialise sole dev game variables
 $onlyDevGameIDs = [];
@@ -58,6 +62,8 @@ $onlyDevAchievementCount = 0;
 $onlyDevRichPresenceCount = 0;
 $onlyDevLeaderboardCount = 0;
 $onlyDevLeaderboardTotal = 0;
+$onlyDevLeaderboardCountByThisDev = 0;
+$onlyDevLeaderboardTotalByThisDev = 0;
 
 // Get user game list data
 getGamesListByDev($dev, 0, $gamesList, 1, false);
@@ -82,6 +88,10 @@ foreach ($gamesList as $game) {
         if (isset($game['NumLBs'])) {
             $anyDevLeaderboardCount++;
         }
+        $anyDevLeaderboardTotalByThisDev += $game['MyLBs'];
+        if (isset($game['MyLBs'])) {
+            $anyDevLeaderboardCountByThisDev++;
+        }
 
         // Majority developer
         if ($game['MyAchievements'] >= $game['NotMyAchievements']) {
@@ -102,6 +112,10 @@ foreach ($gamesList as $game) {
             $majorityDevLeaderboardTotal += $game['NumLBs'];
             if (isset($game['NumLBs'])) {
                 $majorityDevLeaderboardCount++;
+            }
+            $majorityDevLeaderboardTotalByThisDev += $game['MyLBs'];
+            if (isset($game['MyLBs'])) {
+                $majorityDevLeaderboardCountByThisDev++;
             }
         }
 
@@ -124,6 +138,10 @@ foreach ($gamesList as $game) {
             $onlyDevLeaderboardTotal += $game['NumLBs'];
             if (isset($game['NumLBs'])) {
                 $onlyDevLeaderboardCount++;
+            }
+            $onlyDevLeaderboardTotalByThisDev += $game['MyLBs'];
+            if (isset($game['MyLBs'])) {
+                $onlyDevLeaderboardCountByThisDev++;
             }
         }
     }
@@ -707,7 +725,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr></tr><tr class='do-not-highlight'><td colspan='2' align='center'>Stats below are for games that $dev has published at least one achievement for.</td></tr>";
 
             // Any Development - Games developed for
-            echo "<tr><td width='50%'>Games Developed For:</td><td>" . count($anyDevGameIDs) . "</td></tr>";
+            echo "<tr><td width='50%'>Games Developed for:</td><td>" . count($anyDevGameIDs) . "</td></tr>";
 
             // Any Development - Games with Rich Presence
             echo "<tr><td>Games with Rich Presence:</td><td>";
@@ -719,9 +737,9 @@ RenderContentStart("$dev's Developer Stats");
             echo "</td></tr>";
 
             // Any Development - Games with Leaderboards and Leaderboard count
-            echo "<tr><td>Games with Leaderboards:</td><td>";
+            echo "<tr><td>Games with Leaderboards also Developed for:</td><td>";
             if (!empty($anyDevGameIDs)) {
-                echo $anyDevLeaderboardCount . " - " . number_format($anyDevLeaderboardCount / count($anyDevGameIDs) * 100, 2, '.', '') . "%</br>" . $anyDevLeaderboardTotal . " Unique Leaderboards";
+                echo $anyDevLeaderboardCountByThisDev . " of " . $anyDevLeaderboardCount . " - " . number_format($anyDevLeaderboardCountByThisDev / count($anyDevGameIDs) * 100, 2, '.', '') . "% of Games</br>" . $anyDevLeaderboardTotalByThisDev . " of " . $anyDevLeaderboardTotal . " Unique Leaderboards";
             } else {
                 echo "N/A";
             }
@@ -817,7 +835,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "<tr></tr><tr class='do-not-highlight'><td colspan='2' align='center'>Stats below are for games that $dev has published at least half the achievements for.</td></tr>";
 
             // Majority Developer - Games developed for
-            echo "<tr><td width='50%'>Games Developed For:</td><td>" . count($majorityDevGameIDs) . "</td></tr>";
+            echo "<tr><td width='50%'>Games Developed for:</td><td>" . count($majorityDevGameIDs) . "</td></tr>";
 
             // Majority Developer - Games with Rich Presence
             echo "<tr><td>Games with Rich Presence:</td><td>";
@@ -829,9 +847,9 @@ RenderContentStart("$dev's Developer Stats");
             echo "</td></tr>";
 
             // Majority Developer - Games with Leaderboards and Leaderboard count
-            echo "<tr><td>Games with Leaderboards:</td><td>";
+            echo "<tr><td>Games with Leaderboards also Developed for:</td><td>";
             if (!empty($majorityDevGameIDs)) {
-                echo $majorityDevLeaderboardCount . " - " . number_format($majorityDevLeaderboardCount / count($majorityDevGameIDs) * 100, 2, '.', '') . "%</br>" . $majorityDevLeaderboardTotal . " Unique Leaderboards";
+                echo $majorityDevLeaderboardCountByThisDev . " of " . $majorityDevLeaderboardCount . " - " . number_format($majorityDevLeaderboardCountByThisDev / count($majorityDevGameIDs) * 100, 2, '.', '') . "% of Games</br>" . $majorityDevLeaderboardTotalByThisDev . " of " . $majorityDevLeaderboardTotal . " Unique Leaderboards";
             } else {
                 echo "N/A";
             }
@@ -939,9 +957,9 @@ RenderContentStart("$dev's Developer Stats");
             echo "</td></tr>";
 
             // Sole Developer - Games with Leaderboards and Leaderboard count
-            echo "<tr><td>Games with Leaderboards:</td><td>";
+            echo "<tr><td>Games with Leaderboards also Developed For:</td><td>";
             if (!empty($onlyDevGameIDs)) {
-                echo $onlyDevLeaderboardCount . " - " . number_format($onlyDevLeaderboardCount / count($onlyDevGameIDs) * 100, 2, '.', '') . "%</br>" . $onlyDevLeaderboardTotal . " Unique Leaderboards";
+                echo $onlyDevLeaderboardCountByThisDev . " of " . $onlyDevLeaderboardCount . " - " . number_format($onlyDevLeaderboardCountByThisDev / count($onlyDevGameIDs) * 100, 2, '.', '') . "% of Games</br>" . $onlyDevLeaderboardTotalByThisDev . " of " . $onlyDevLeaderboardTotal . " Unique Leaderboards";
             } else {
                 echo "N/A";
             }

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -957,7 +957,7 @@ RenderContentStart("$dev's Developer Stats");
             echo "</td></tr>";
 
             // Sole Developer - Games with Leaderboards and Leaderboard count
-            echo "<tr><td>Games with Leaderboards also Developed For:</td><td>";
+            echo "<tr><td>Games with Leaderboards also Developed for:</td><td>";
             if (!empty($onlyDevGameIDs)) {
                 echo $onlyDevLeaderboardCountByThisDev . " of " . $onlyDevLeaderboardCount . " - " . number_format($onlyDevLeaderboardCountByThisDev / count($onlyDevGameIDs) * 100, 2, '.', '') . "% of Games</br>" . $onlyDevLeaderboardTotalByThisDev . " of " . $onlyDevLeaderboardTotal . " Unique Leaderboards";
             } else {


### PR DESCRIPTION
**Highlights**
- This PR seeks update the individual dev stats page so that its achievements section can show _counts of leaderboards owned by the dev_ alongside the existing counts of leaderboards by any dev.
- Can be considered a companion to [#1474](https://github.com/RetroAchievements/RAWeb/pull/1474).
- The difference is that this PR applies the same improvement but to the dev stats page rather than to the dev game listing.
- The following test case is also provided.

For context, here's the dev game [listing](https://retroachievements.org/gameList.php?d=amine456) following #1474 (emphasis mine showing what that PR added):
![image](https://user-images.githubusercontent.com/94894395/236649157-c2b9e5a6-de9b-45fe-9157-242b64ce3fbd.png)

Add here's what this PR looks to add to the dev stats [page](https://retroachievements.org/individualdevstats.php?u=amine456) (emphasis mine):
![image](https://user-images.githubusercontent.com/94894395/236649423-84ac3c5a-b8e9-4a8c-b9c2-115726832f32.png)

**Considerations**
- The achievement figures already do this kind of differentiation (the "6 of 54" depicted).  With this PR, we can also a similar differentiation for the leaderboard figures.
- This PR relies on the changes to the legacy database helper game.php by that PR (getGamesListByDev), so no further changes are needed to that file for purposes of this PR.
- Related Discord [topic](https://discord.com/channels/310192285306454017/1096532922267344988).
- Because my RAWeb test server is not fully set up, I'm submitting this untested on my part. Any feedback/assistance would be greatly appreciated.