### PR TITLE
fix(game): rename Collections to Hubs

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1438,7 +1438,7 @@ sanitize_outputs(
             }
 
             if (!empty($gameHubs)) {
-                RenderGameAlts($gameHubs, 'Collections');
+                RenderGameAlts($gameHubs, 'Hubs');
             }
 
             if ($user !== null && $numAchievements > 0) {


### PR DESCRIPTION
Per https://discord.com/channels/310192285306454017/1103984823040737280, renames "Collections" on game pages to "Hubs". They referred to as Hubs everywhere else on the site, so this brings the game pages in line for consistency's sake.

<img width="347" alt="Screenshot 2023-05-06 at 8 25 56 PM" src="https://user-images.githubusercontent.com/3984985/236651728-b40ad16f-6a83-4b84-adca-544b89404904.png">
