### PR TITLE
fix(hubs): remediate subset sorting issues

### DIFF
--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -214,8 +214,8 @@ function getGameAlternatives(int $gameID, ?int $sortBy = null): array
         11 => "ORDER BY HasAchievements ASC, gd.Title DESC",
         2 => "ORDER BY gd.TotalTruePoints DESC, gd.Title ASC ",
         12 => "ORDER BY gd.TotalTruePoints, gd.Title ASC ",
-            // 1 or unspecified
-        default => "ORDER BY HasAchievements DESC, gd.Title ",
+        // 1 or unspecified
+        default => "ORDER BY HasAchievements DESC, SUBSTRING_INDEX(gd.Title, ' [', 1) COLLATE latin1_general_ci, c.Name COLLATE latin1_general_ci, gd.Title COLLATE latin1_general_ci ",
     };
 
     $query = "SELECT gameIDAlt, gd.Title, gd.ImageIcon, c.Name AS ConsoleName,


### PR DESCRIPTION
This PR resolves an issue on hub pages where subsets are not alphabetically sorted in the list correctly. The new sort order is achieved by modifying the `default` orderBy case.

ref: https://discord.com/channels/310192285306454017/1104562789307121764

**Before**
<img width="1015" alt="Screenshot 2023-05-06 at 8 46 09 PM" src="https://user-images.githubusercontent.com/3984985/236652181-b052df62-cf01-489d-a9e8-35c24dee4c36.png">

**After**
<img width="1003" alt="Screenshot 2023-05-06 at 8 45 45 PM" src="https://user-images.githubusercontent.com/3984985/236652182-dda900da-2721-4281-b88f-a1a69b317b8d.png">
