### PR TITLE
feat: throw an error on forum/comment double posts

### DIFF
--- a/app_legacy/Helpers/database/forum.php
+++ b/app_legacy/Helpers/database/forum.php
@@ -301,7 +301,8 @@ function submitTopicComment(
     $userID = getUserIDFromUser($user);
 
     if (getIsForumDoublePost($userID, $topicID, $commentPayload)) {
-        return false;
+        // Fail silently.
+        return true;
     }
 
     // Replace inverted commas, Remove HTML

--- a/app_legacy/Helpers/database/forum.php
+++ b/app_legacy/Helpers/database/forum.php
@@ -268,6 +268,28 @@ function editTopicComment(int $commentID, string $newPayload): bool
     return false;
 }
 
+function getIsForumDoublePost(
+    int $authorID,
+    int $topicID,
+    string $commentPayload,
+): bool {
+    $query = "SELECT ftc.Payload, ftc.ForumTopicID
+        FROM ForumTopicComment AS ftc
+        WHERE AuthorID = :authorId
+        ORDER BY ftc.DateCreated DESC
+        LIMIT 1";
+
+    $dbResult = legacyDbFetch($query, ['authorId' => $authorID]);
+
+    $retrievedPayload = $dbResult['Payload'];
+    $retrievedTopicID = $dbResult['ForumTopicID'];
+
+    return
+        $retrievedPayload === $commentPayload
+        && $retrievedTopicID === $topicID
+    ;
+}
+
 function submitTopicComment(
     string $user,
     int $topicID,
@@ -277,6 +299,10 @@ function submitTopicComment(
 ): bool {
     sanitize_sql_inputs($user);
     $userID = getUserIDFromUser($user);
+
+    if (getIsForumDoublePost($userID, $topicID, $commentPayload)) {
+        return false;
+    }
 
     // Replace inverted commas, Remove HTML
     $commentPayload = str_replace("'", "''", $commentPayload);

--- a/app_legacy/Helpers/database/user-activity.php
+++ b/app_legacy/Helpers/database/user-activity.php
@@ -340,7 +340,8 @@ function addArticleComment(
     }
 
     if ($user !== "Server" && getIsCommentDoublePost($userID, $articleID, $commentPayload)) {
-        return false;
+        // Fail silently.
+        return true;
     }
 
     // Replace all single quotes with double quotes (to work with MYSQL DB)

--- a/app_legacy/Helpers/database/user-activity.php
+++ b/app_legacy/Helpers/database/user-activity.php
@@ -339,7 +339,7 @@ function addArticleComment(
         return false;
     }
 
-    if (getIsCommentDoublePost($userID, $articleID, $commentPayload)) {
+    if ($user !== "Server" && getIsCommentDoublePost($userID, $articleID, $commentPayload)) {
         return false;
     }
 


### PR DESCRIPTION
This PR adjusts the function calls for submitting comments and forum topic replies.

If the user submits a duplicate payload on the same article/comment ID, the function now returns an error and the duplicate post is blocked.

This issue can occur when the site doesn't instantly respond to a post submit and the user repeatedly spams the button click. After this change, only the first post will be preserved and all subsequent duplicates are blocked.

<img width="626" alt="Screenshot 2023-05-06 at 9 49 03 PM" src="https://user-images.githubusercontent.com/3984985/236653562-70fe7eb8-bcba-4c7e-ad71-cdabb93ccee8.png">
