### PR TITLE
Event Awards Add Set Requests

### DIFF
--- a/app_legacy/Community/Models/UserGameListEntry.php
+++ b/app_legacy/Community/Models/UserGameListEntry.php
@@ -94,6 +94,9 @@ class UserGameListEntry extends BaseModel
         // adding the number of years the user is here
         $requests['total'] += Carbon::now()->diffInYears($user->Created);
 
+        // adding the number of event awards
+        $requests['total'] += getUserEventAwardCount($user->User);
+
         settype($requests['total'], 'integer');
         settype($requests['pointsForNext'], 'integer');
 

--- a/app_legacy/Helpers/database/site-award.php
+++ b/app_legacy/Helpers/database/site-award.php
@@ -210,3 +210,26 @@ function getRecentMasteryData(string $date, string $friendsOf = null, int $offse
 
     return $retVal;
 }
+
+/**
+ * Gets the number of event awards a user has earned
+ */
+function getUserEventAwardCount(string $user): int
+{
+    $bindings = [
+        'user' => $user,
+        'type' => AwardType::Mastery,
+        'event' => 101,
+    ];
+
+    $query = "SELECT COUNT(DISTINCT AwardData) AS TotalAwards 
+              FROM SiteAwards sa
+              INNER JOIN GameData gd ON gd.ID = sa.AwardData
+              WHERE User = :user              
+              AND AwardType = :type
+              AND gd.ConsoleID = :event";
+
+    $dataOut = legacyDbFetch($query, $bindings);
+
+    return $dataOut['TotalAwards'];
+}

--- a/app_legacy/Helpers/database/user.php
+++ b/app_legacy/Helpers/database/user.php
@@ -1,6 +1,5 @@
 <?php
 
-use LegacyApp\Community\Enums\AwardType;
 use LegacyApp\Community\Enums\ClaimStatus;
 use LegacyApp\Community\Enums\TicketState;
 use LegacyApp\Site\Enums\Permissions;
@@ -462,27 +461,4 @@ function getMostAwardedGames(array $gameIDs): array
     }
 
     return $retVal;
-}
-
-/**
- * Gets the number of event awards a user has earned
- */
-function getUserEventAwardCount(string $user): int
-{
-    $bindings = [
-        'user' => $user,
-        'type' => AwardType::Mastery,
-        'event' => 101,
-    ];
-
-    $query = "SELECT COUNT(DISTINCT AwardData) AS TotalAwards 
-              FROM SiteAwards sa
-              INNER JOIN GameData gd ON gd.ID = sa.AwardData
-              WHERE User = :user              
-              AND AwardType = :type
-              AND gd.ConsoleID = :event";
-
-    $dataOut = legacyDbFetch($query, $bindings);
-
-    return $dataOut['TotalAwards'];
 }

--- a/app_legacy/Helpers/database/user.php
+++ b/app_legacy/Helpers/database/user.php
@@ -1,5 +1,6 @@
 <?php
 
+use LegacyApp\Community\Enums\AwardType;
 use LegacyApp\Community\Enums\ClaimStatus;
 use LegacyApp\Community\Enums\TicketState;
 use LegacyApp\Site\Enums\Permissions;
@@ -461,4 +462,27 @@ function getMostAwardedGames(array $gameIDs): array
     }
 
     return $retVal;
+}
+
+/**
+ * Gets the number of event awards a user has earned
+ */
+function getUserEventAwardCount(string $user): int
+{
+    $bindings = [
+        'user' => $user,
+        'type' => AwardType::Mastery,
+        'event' => 101,
+    ];
+
+    $query = "SELECT COUNT(DISTINCT AwardData) AS TotalAwards 
+              FROM SiteAwards sa
+              INNER JOIN GameData gd ON gd.ID = sa.AwardData
+              WHERE User = :user              
+              AND AwardType = :type
+              AND gd.ConsoleID = :event";
+
+    $dataOut = legacyDbFetch($query, $bindings);
+
+    return $dataOut['TotalAwards'];
 }

--- a/tests/Feature/Community/UserGameListTest.php
+++ b/tests/Feature/Community/UserGameListTest.php
@@ -12,6 +12,7 @@ use LegacyApp\Community\Enums\UserGameListType;
 use LegacyApp\Community\Models\UserGameListEntry;
 use LegacyApp\Platform\Models\Achievement;
 use LegacyApp\Platform\Models\Game;
+use LegacyApp\Platform\Models\PlayerBadge;
 use LegacyApp\Site\Models\User;
 use Tests\TestCase;
 
@@ -39,6 +40,36 @@ class UserGameListTest extends TestCase
         $user = User::factory()->create(['RAPoints' => 0, 'RASoftcorePoints' => 0,
             'Created' => Carbon::now()->subDays(370),
         ]);
+
+        $requestInfo = UserGameListEntry::getUserSetRequestsInformation($user);
+
+        $this->assertEquals($requestInfo, [
+            'total' => 1,
+            'pointsForNext' => 1250,
+            'maxSoftcoreReached' => false,
+        ]);
+    }
+
+    public function testSetRequestLimitFromAwards(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create(['RAPoints' => 0, 'RASoftcorePoints' => 0]);
+
+        /** @var Game $game */
+        $game = Game::factory()->create(['ConsoleID' => 101]);
+
+        /** @var Achievement $publishedAchievements */
+        $publishedAchievements = Achievement::factory()->published()->count(10)->create(['GameID' => $game->ID]);
+
+        /** @var PlayerBadge $badge */
+        $badge = new PlayerBadge([
+            'User' => $user->User,
+            'AwardType' => 1,
+            'AwardData' => $game->ID,
+            'AwardDataExtra' => 1,
+            'AwardDate' => Carbon::now(),
+        ]);
+        $user->playerBadges()->save($badge);
 
         $requestInfo = UserGameListEntry::getUserSetRequestsInformation($user);
 


### PR DESCRIPTION
Provides one extra set request per Event Award the user has earned. This includes Site Award Developer Events (DevQuest, Devember, Junior Dev, etc) and Event Awards (AotW, Challenge League, Daily DistRActions, etc). This does **not** include the tiered developer achievements and points awards, Patreon or RA Legend badges.

ref: https://discord.com/channels/310192285306454017/1103455623288475748/1103455623288475748

Example with a mix of points and each type of award
Before
![image](https://user-images.githubusercontent.com/4047771/236655169-b95085b7-8ac4-4e39-9870-7ed67dcc2efd.png)
After (4 Site awards excluded as stated above so a total of 20 added)
![image](https://user-images.githubusercontent.com/4047771/236655180-8a4e9e13-8608-458d-bbf7-0dc4ff1c72a0.png)

Example where a dev that completes a lot of developer events will see benefit
Before
![image](https://user-images.githubusercontent.com/4047771/236655354-ba270d38-d309-45d2-9a14-754038bd856f.png)
After (2 Site awards excluded so a total of 18 added)
![image](https://user-images.githubusercontent.com/4047771/236655356-d9a60e86-3d7c-420a-b1dc-323ea354320d.png)


Reasoning is to help promote both player and developer events by providing some extra small reward to earning these badges in the form of set requests.
