### PR TITLE
fix(globalRanking): Mastered column only displays a value of 1 or 0 when using Daily/Weekly filters

### DIFF
--- a/app_legacy/Helpers/render/leaderboard.php
+++ b/app_legacy/Helpers/render/leaderboard.php
@@ -580,7 +580,8 @@ function getGlobalRankingData(
                           $friendCondAward
                           $singleUserAwardCond
                           $untrackedCond
-                          GROUP BY sa.User, sa.AwardData, sa.AwardDate
+                          AND AwardType = " . AwardType::Mastery .
+                          "GROUP BY sa.User
                       )
                   ) AS Query
               GROUP BY User

--- a/app_legacy/Helpers/render/leaderboard.php
+++ b/app_legacy/Helpers/render/leaderboard.php
@@ -437,6 +437,8 @@ function getGlobalRankingData(
             break;
     }
 
+    $masteryCond = "AND AwardType = " . AwardType::Mastery;
+    
     $untrackedCond = match ($untracked) {
         0 => "AND Untracked = 0",
         1 => "AND Untracked = 1",
@@ -505,7 +507,7 @@ function getGlobalRankingData(
             // Get site award info for each user.
             $usersCount = count($users);
             for ($i = 0; $i < $usersCount; $i++) {
-                $query2 = "SELECT $totalAwards AS TotalAwards FROM SiteAwards WHERE User = '" . $users[$i] . "' AND AwardType = " . AwardType::Mastery;
+                $query2 = "SELECT $totalAwards AS TotalAwards FROM SiteAwards WHERE User = '" . $users[$i] . "' " . $masteryCond;
 
                 $dbResult2 = s_mysql_query($query2);
                 if ($dbResult2 !== false) {
@@ -579,9 +581,9 @@ function getGlobalRankingData(
                           WHERE TRUE $whereDateAward $typeCond
                           $friendCondAward
                           $singleUserAwardCond
+                          $masteryCond
                           $untrackedCond
-                          AND AwardType = " . AwardType::Mastery .
-                          "GROUP BY sa.User
+                          GROUP BY sa.User
                       )
                   ) AS Query
               GROUP BY User

--- a/app_legacy/Helpers/render/leaderboard.php
+++ b/app_legacy/Helpers/render/leaderboard.php
@@ -438,7 +438,7 @@ function getGlobalRankingData(
     }
 
     $masteryCond = "AND AwardType = " . AwardType::Mastery;
-    
+
     $untrackedCond = match ($untracked) {
         0 => "AND Untracked = 0",
         1 => "AND Untracked = 1",


### PR DESCRIPTION
**Highlights**
- This PR attempts to fix an issue with the Mastered column on the global ranking [page](https://retroachievements.org/globalRanking.php?s=9&t=1&d=2023-05-07&f=0) when certain filters are used.
- The issue was first described in [#1088](https://github.com/RetroAchievements/RAWeb/issues/1088) as quoted below.
> Mastered (and soon Completed) columns do not report accurate data for the Daily/Weekly filters and will at most display 1

![image](https://user-images.githubusercontent.com/94894395/236656126-c4423fcb-dc55-42ac-bb3f-4e058384d124.png)

**Considerations**
- Because my RAWeb test server is not fully set up, I'm submitting this untested on my part.  Any feedback/assistance would be greatly appreciated.
- As for the second issue described in [#1088](https://github.com/RetroAchievements/RAWeb/issues/1088) and relating to Friends, I haven't looked into it yet, because I haven't started using the Follow/Friend features yet.