### PR TITLE
fix(globalRanking): Rank column shows your rank as being 0 when using the Followed Users filter and browsing pages past your actual rank

### DIFF
--- a/public/globalRanking.php
+++ b/public/globalRanking.php
@@ -45,7 +45,7 @@ $lbUsers = match ($friends) {
 if ($friends == 1) {
     // We do a maxCount + 1 so that if we get maxCount + 1 rows returned we know
     // there are more row to get and we can add a "Next X" link for page traversal
-    $data = getGlobalRankingData($type, $sort, $date, null, $user, $untracked, $offset, getFriendCount($user) + 1, 0);
+    $data = getGlobalRankingData($type, $sort, $date, null, $user, $untracked, 0, getFriendCount($user) + 1, 0);
 } else {
     $data = getGlobalRankingData($type, $sort, $date, null, null, $untracked, $offset, $maxCount + 1, 0);
 }
@@ -215,7 +215,12 @@ RenderContentStart($lbUsers . " Ranking - " . $lbType);
         $userListed = false;
         $userRank = 0;
         $findUserRank = false;
-        $rank = $offset + 1;
+        if ($friends == 1) {
+            $rank = 1;
+        }
+        else {
+            $rank = $offset + 1;
+        }
         $rowRank = $rank;
         $rankPoints = null;
         $userCount = 0;
@@ -239,7 +244,13 @@ RenderContentStart($lbUsers . " Ranking - " . $lbType);
                 $rankPoints = $dataPoint['Points'];
             }
 
-            if (!$findUserRank) {
+            if ($rowRank < $offset + 1 || $findUserRank) {
+                if ($dataPoint['User'] == $user) {
+                    $userRank = $rank;
+                }
+                $rowRank++;
+            }
+            else {
                 // Outline the currently logged in user in the table
                 if ($dataPoint['User'] == $user) {
                     $userListed = true;
@@ -279,11 +290,6 @@ RenderContentStart($lbUsers . " Ranking - " . $lbType);
 
                 $rowRank++;
                 $userCount++;
-            } else {
-                if ($dataPoint['User'] == $user) {
-                    $userRank = $rank;
-                }
-                $rowRank++;
             }
         }
 
@@ -293,7 +299,7 @@ RenderContentStart($lbUsers . " Ranking - " . $lbType);
                 // Get and display the information for the logged in user if applicable
                 $userData = getGlobalRankingData($type, $sort, $date, $user, null, $untracked, 0, 1);
                 if (!empty($userData)) {
-                    // Add dummy row to seperate the user from the rest of the table
+                    // Add dummy row to separate the user from the rest of the table
                     echo "<tr class='do-not-highlight'><td colspan='7'>&nbsp;</td></tr>";
                     echo "<tr style='outline: thin solid'>";
 


### PR DESCRIPTION
**Highlights**
- This PR attempts to fix an issue with the Rank column on the global ranking [page](https://retroachievements.org/globalRanking.php?s=5&t=2&d=2023-05-07&f=1&o=25) using the Followed Users filter and when browsing pages past your actual rank.
- The issue was first described in the latter part of [#1088](https://github.com/RetroAchievements/RAWeb/issues/1088) as quoted below.
> Self rank among followed users is not correctly displayed when you move to

![image](https://user-images.githubusercontent.com/94894395/236664555-99f6c67e-8e81-4a63-8146-2d60dfb95153.png)

**Considerations**
- Because my RAWeb test server is not fully set up, I'm submitting this untested on my part.  Any feedback/assistance would be greatly appreciated.
- The other issue described in the former part of [#1088](https://github.com/RetroAchievements/RAWeb/issues/1088) is addressed by [#1561](https://github.com/RetroAchievements/RAWeb/pull/1561).