### PR TITLE
fix(codenotes): remediate issue with cancel restore linebreaks

### DIFF
--- a/public/codenotes.php
+++ b/public/codenotes.php
@@ -72,7 +72,10 @@ function cancelEditMode(rowIndex) {
     // Restore the original value so unsaved edits are not persisted.
     const noteDisplayEl = rowEl.querySelector('.note-display');
     const noteEditEl = rowEl.querySelector('.note-edit');
-    const originalValue = noteDisplayEl.innerHTML.replace(/<br>\n/g, '\n');
+
+    // "<br>" "<br />" "<br>\n"
+    const originalValue = noteDisplayEl.innerHTML.replace(/<br\s*\/?>\n?/g, '\n');
+    
     noteEditEl.value = originalValue;
 
     setRowEditingEnabled(rowEl, false);


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/1563.

In the original code, the `.replace()` function was looking for a `<br>` element followed by a newline character (`\n`). However, it is possible for the input string to contain `<br>` elements that are not always followed by a newline character. This inconsistency caused the line breaks to not be properly restored when the user cancelled editing a code note.