### PR TITLE
Increase contrast for alternate table rows

### DIFF
--- a/resources/css/table.css
+++ b/resources/css/table.css
@@ -8,7 +8,7 @@ tbody tr {
 }
 
 tbody tr:nth-child(odd) {
-  background-color: rgba(50, 50, 50, .2);
+  background-color: rgba(50, 50, 50, .3);
 }
 
 [data-scheme="light"] tbody tr:nth-child(odd) {
@@ -17,7 +17,7 @@ tbody tr:nth-child(odd) {
 
 table.table-highlight tr:not(.do-not-highlight):hover {
   outline-color: rgba(128, 128, 128, .3);
-  background-color: rgba(128, 128, 128, .1);
+  background-color: rgba(128, 128, 128, .2);
 }
 
 [data-scheme="light"] table.table-highlight tr:not(.do-not-highlight):hover {


### PR DESCRIPTION
This PR lightly increases the background color contrast for table rows so they stand out more, as per some feedback. So far the visual difference was really subtle, almost invisible in some displays. The change was small, so the focus doesn't go away from the content.

Before / after:
![image](https://user-images.githubusercontent.com/22218549/236700826-23fcb1c7-9161-482b-b4f7-01fd3106e7de.png)
![image](https://user-images.githubusercontent.com/22218549/236700809-5c7fb911-f1dd-41af-8e08-8e051df646e4.png)

Likewise, highlight on hover was also increased a little bit.