### PR TITLE
fix(reorderSiteAwards): force stop autoscroll on row drop

### DIFF
--- a/resources/js/dynamic/reorderSiteAwards/cancelAutoscroll.ts
+++ b/resources/js/dynamic/reorderSiteAwards/cancelAutoscroll.ts
@@ -1,0 +1,9 @@
+import { reorderSiteAwardsStore as store } from './reorderSiteAwardsStore';
+
+export function cancelAutoscroll() {
+  store.autoscrollDirection = null;
+  if (store.autoscrollAnimationId) {
+    cancelAnimationFrame(store.autoscrollAnimationId);
+    store.autoscrollAnimationId = null;
+  }
+}

--- a/resources/js/dynamic/reorderSiteAwards/handleRowDragOver.ts
+++ b/resources/js/dynamic/reorderSiteAwards/handleRowDragOver.ts
@@ -1,4 +1,5 @@
 import { autoscroll } from './autoscroll';
+import { cancelAutoscroll } from './cancelAutoscroll';
 import { reorderSiteAwardsStore as store } from './reorderSiteAwardsStore';
 
 export function handleRowDragOver(event: DragEvent) {
@@ -29,11 +30,7 @@ export function handleRowDragOver(event: DragEvent) {
   } else {
     // If the cursor is not near the edges of the screen,
     // set autoscrollDirection to null and stop scrolling.
-    store.autoscrollDirection = null;
-    if (store.autoscrollAnimationId) {
-      cancelAnimationFrame(store.autoscrollAnimationId);
-      store.autoscrollAnimationId = null;
-    }
+    cancelAutoscroll();
   }
 
   return false;

--- a/resources/js/dynamic/reorderSiteAwards/index.ts
+++ b/resources/js/dynamic/reorderSiteAwards/index.ts
@@ -1,3 +1,4 @@
+import { cancelAutoscroll } from './cancelAutoscroll';
 import { reorderSiteAwardsStore as store } from './reorderSiteAwardsStore';
 
 /**
@@ -112,6 +113,9 @@ export function handleRowDrop(event: DragEvent) {
   if (dropTargetEl) {
     setRowOutlineVisibility(dropTargetEl, false);
   }
+
+  // If we're autoscrolling, immediately halt.
+  cancelAutoscroll();
 }
 
 /**


### PR DESCRIPTION
This PR resolves a minor issue with the new window edge autoscroll functionality on the reorder site awards page.

**Before**
When a row is dropped while autoscroll is running, autoscroll keeps running and the page keeps scrolling.

**Now**
Autoscroll is immediately stopped on a row drop.