### PR TITLE
fix(devStats): Remediate an individual dev's cheevo stats from being polluted with zero-cheevo, some-LB game entries

### DIFF
--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -268,7 +268,8 @@ function getGamesListByDev(
     bool $ticketsFlag = false,
     ?int $filter = 0,
     int $offset = 0,
-    int $count = 0
+    int $count = 0,
+    bool $includeLBs = false // include games for which the dev made 0 cheevos but some LBs
 ): int {
     // Specify 0 for $consoleID to fetch games for all consoles, or an ID for just that console
 
@@ -289,7 +290,10 @@ function getGamesListByDev(
                            SUM(CASE WHEN ach.Author = :myRRDev THEN ach.TrueRatio ELSE 0 END) AS MyTrueRatio,
                            SUM(CASE WHEN ach.Author != :notMyAchDev THEN 1 ELSE 0 END) AS NotMyAchievements,
                            lbdi.MyLBs,";
-        $havingCond = "HAVING MyAchievements > 0 OR MyLBs > 0 ";
+        $havingCond = "HAVING MyAchievements > 0 ";
+        if ($includeLBs) {
+            $havingCond .= "OR MyLBs > 0 ";
+        }
     } else {
         if ($filter == 0) { // only with achievements
             $havingCond = "HAVING NumAchievements > 0 ";

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -8,7 +8,7 @@ $consoleIDInput = requestInputSanitized('c', 0, 'integer');
 $filter = requestInputSanitized('f', 0, 'integer'); // 0 = no filter, 1 = only complete, 2 = only incomplete
 $sortBy = requestInputSanitized('s', 0, 'integer');
 $dev = requestInputSanitized('d');
-$includeLBs = true;
+$includeLBs = true;  // include games for which the dev made 0 cheevos but some LBs
 
 if ($dev == null && ($consoleIDInput == 0 || $filter != 0)) {
     $maxCount = 50;

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -8,6 +8,7 @@ $consoleIDInput = requestInputSanitized('c', 0, 'integer');
 $filter = requestInputSanitized('f', 0, 'integer'); // 0 = no filter, 1 = only complete, 2 = only incomplete
 $sortBy = requestInputSanitized('s', 0, 'integer');
 $dev = requestInputSanitized('d');
+$includeLBs = true;
 
 if ($dev == null && ($consoleIDInput == 0 || $filter != 0)) {
     $maxCount = 50;
@@ -21,7 +22,7 @@ authenticateFromCookie($user, $permissions, $userDetails);
 
 $showTickets = (isset($user) && $permissions >= Permissions::Developer);
 $gamesList = [];
-$gamesCount = getGamesListByDev($dev, $consoleIDInput, $gamesList, (int) $sortBy, $showTickets, $filter, $offset, $maxCount);
+$gamesCount = getGamesListByDev($dev, $consoleIDInput, $gamesList, (int) $sortBy, $showTickets, $filter, $offset, $maxCount, $includeLBs);
 
 function ListGames(
     array $gamesList,


### PR DESCRIPTION
It has been reported via Discord that #1550 has caused other pages such as the individual dev stats page to inadvertently pollute the dev's cheevo statistics with zero-cheevo entries that only have leaderboards.

I've been asked to cease creating untested PRs.  Therefore, this one is only being made as a Draft PR to spearhead discussion.  If this is still not acceptable, just let me know.  Thank you for your patience.