### PR TITLE
fix(game): add console id check for parent game id

### DIFF
--- a/app_legacy/Helpers/database/game.php
+++ b/app_legacy/Helpers/database/game.php
@@ -23,11 +23,11 @@ function getGameData(int $gameID): ?array
 }
 
 // If the game is a subset, identify its parent game ID.
-function getParentGameIdFromGameTitle(string $title): ?int {
+function getParentGameIdFromGameTitle(string $title, int $consoleID): ?int {
     if (preg_match('/(.+)(\[Subset - .+\])/', $title, $matches)) {
         $baseSetTitle = trim($matches[1]);
-        $query = "SELECT ID FROM GameData WHERE Title = :title";
-        $result = legacyDbFetch($query, ['title' => $baseSetTitle]);
+        $query = "SELECT ID FROM GameData WHERE Title = :title AND ConsoleID = :consoleId";
+        $result = legacyDbFetch($query, ['title' => $baseSetTitle, 'consoleId' => $consoleID]);
 
         return $result ? $result['ID'] : null;
     }
@@ -38,7 +38,7 @@ function getParentGameIdFromGameTitle(string $title): ?int {
 function getParentGameIdFromGameId(int $gameID): ?int {
     $gameData = getGameData($gameID);
 
-    return getParentGameIdFromGameTitle($gameData['Title']);
+    return getParentGameIdFromGameTitle($gameData['Title'], $gameData['ConsoleID']);
 }
 
 function getGameMetadata(
@@ -166,7 +166,7 @@ function getGameMetadata(
     }
 
     if ($metrics) {
-        $parentGameId = getParentGameIdFromGameTitle($gameDataOut['Title']);
+        $parentGameId = getParentGameIdFromGameTitle($gameDataOut['Title'], $gameDataOut['ConsoleID']);
 
         $bindings = [
             'gameId' => $gameID,

--- a/public/API/API_GetAchievementOfTheWeek.php
+++ b/public/API/API_GetAchievementOfTheWeek.php
@@ -78,7 +78,7 @@ $forumTopic = [
     'ID' => $staticData['Event_AOTW_ForumID'] ?? null,
 ];
 
-$parentGameID = getParentGameIdFromGameTitle($game['Title']);
+$parentGameID = getParentGameIdFromGameTitle($game['Title'], $achievementData['ConsoleID']);
 
 $unlocks = getAchievementUnlocksData((int) $achievementID, null, $numWinners, $numPossibleWinners, $parentGameID, 0, 500);
 

--- a/public/API/API_GetAchievementUnlocks.php
+++ b/public/API/API_GetAchievementUnlocks.php
@@ -63,7 +63,7 @@ $console = [
     'Title' => $achievementData['ConsoleName'] ?? null,
 ];
 
-$parentGameID = getParentGameIdFromGameTitle($game['Title']);
+$parentGameID = getParentGameIdFromGameTitle($game['Title'], $achievementData['ConsoleID']);
 
 $unlocks = getAchievementUnlocksData($achievementID, null, $numWinners, $numPossibleWinners, $parentGameID, $offset, $count);
 

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -48,7 +48,7 @@ sanitize_outputs(
 );
 
 $numLeaderboards = getLeaderboardsForGame($gameID, $lbData, $user);
-$parentGameID = getParentGameIdFromGameTitle($gameTitle);
+$parentGameID = getParentGameIdFromGameTitle($gameTitle, $consoleID);
 
 $numWinners = 0;
 $numPossibleWinners = 0;


### PR DESCRIPTION
This PR resolves an issue where subsets are not inheriting their parent game player counts correctly.

**Root Cause**
The algorithmic check was not checking for console ID. Many of the games with issues were PS2 titles with GameCube ports, thus 0 players were detected from the parent.