### PR TITLE
fix(localized_number): use en_US as a fallback locale

### DIFF
--- a/app/Helpers/formatters.php
+++ b/app/Helpers/formatters.php
@@ -33,7 +33,7 @@ if (!function_exists('localized_number')) {
         int $fractionDigits = 0,
         string $pattern = null
     ): string {
-        $locale ??= session('number_locale');
+        $locale = $locale ?? session('number_locale', 'en_US');
 
         $formatter = new NumberFormatter($locale, $format, $pattern);
         $formatter->setAttribute($formatter::FRACTION_DIGITS, $fractionDigits);


### PR DESCRIPTION
This PR remediates an exception thrown in dorequest.php with `VALUE`-kind leaderboard submission.

**Root Cause**
```php
$locale ??= session('number_locale');
```

This null coalescing assignment operator has nowhere to safely navigate to if there isn't a `number_locale` value in the session, which will always happen in the case of calls made through rcheevos. Now, it will fall back to "en_US".