### PR TITLE
fix(gameList): add missing td

### DIFF
--- a/public/gameList.php
+++ b/public/gameList.php
@@ -173,6 +173,7 @@ function ListGames(
         echo "<td><b>$achievementsTally</b></td>";
         echo "<td><b>$pointsTally</b><span class='TrueRatio'> ($truePointsTally)</span></td>";
         echo "<td></td>";
+        echo "<td></td>";
         echo "<td><b>$lbCount</b></td>";
         if ($showTickets) {
             echo "<td><b>$ticketsCount</b></td>";


### PR DESCRIPTION
Resolves a minor regression introduced in https://github.com/RetroAchievements/RAWeb/pull/1504 where the table footer is missing a td element.