### PR TITLE
fix(reorderSiteAwards): remediate issue with hidden prechecked setting

### DIFF
--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -240,7 +240,7 @@ function postAllAwardsDisplayOrder(awards) {
                     $awardTitle = "Patreon Supporter";
                 }
 
-                $isHiddenPreChecked = $awardDisplayOrder === '-1';
+                $isHiddenPreChecked = $awardDisplayOrder === -1;
                 $subduedOpacityClassName = $isHiddenPreChecked ? 'opacity-40' : '';
                 $isDraggable = $isHiddenPreChecked ? 'false' : 'true';
 


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/1587.

**Root Cause**
A type coercion issue is causing the hidden checkbox not to be correctly set on the initial page render.