### PR TITLE
fix(achievementInfo): resolve an issue where player counts are incorrect

### DIFF
--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -39,6 +39,8 @@ $achievementTitleRaw = $dataOut['AchievementTitle'];
 $achievementDescriptionRaw = $dataOut['Description'];
 $gameTitleRaw = $dataOut['GameTitle'];
 
+$parentGameID = getParentGameIdFromGameTitle($gameTitle, $consoleID);
+
 sanitize_outputs(
     $achievementTitle,
     $desc,
@@ -48,7 +50,6 @@ sanitize_outputs(
 );
 
 $numLeaderboards = getLeaderboardsForGame($gameID, $lbData, $user);
-$parentGameID = getParentGameIdFromGameTitle($gameTitle, $consoleID);
 
 $numWinners = 0;
 $numPossibleWinners = 0;


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1107095778167619584.

**Root Cause**
Game titles on achievementInfo pages are being sanitized before being passed to the parentId checking function. This causing the matching algorithm to break.