### PR TITLE
fix(shortcode): support timestamps in youtube embeds

### DIFF
--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -315,6 +315,9 @@ final class Shortcode
      */
     private function autoEmbedYouTube(string $text): string
     {
+        // Restore any ampersands escaped by sanitization.
+        $text = str_replace('&amp;', '&', $text);
+
         return preg_replace_callback(
             '~
                 (?:https?://)?      # Optional scheme. Either http or https.

--- a/tests/Unit/ShortcodeTest.php
+++ b/tests/Unit/ShortcodeTest.php
@@ -49,4 +49,42 @@ final class ShortcodeTest extends TestCase
             Shortcode::render('[code]test')
         );
     }
+
+    /**
+     * @dataProvider youtubeUrlProvider
+     */
+    public function testAutoEmbedYoutube(string $url, string $expected): void
+    {
+        $this->assertStringContainsString(
+            $expected,
+            Shortcode::render($url)
+        );
+    }
+
+    public function youtubeUrlProvider(): array
+    {
+        // ["given", "expected"]
+        return [
+            // A vanilla URL
+            ['https://www.youtube.com/v/YYOKMUTTDdA', '//www.youtube-nocookie.com/embed/YYOKMUTTDdA'],
+
+            // With explicit video ID "v"
+            ['https://www.youtube.com/watch?v=W3igStIUp8Y', '//www.youtube-nocookie.com/embed/W3igStIUp8Y'],
+            ['https://www.youtube.com/watch?v=SXuIABMlZKc&t=1m30s', '//www.youtube-nocookie.com/embed/SXuIABMlZKc?start=90'],
+            ['https://www.youtube.com/v/xwmHOLoCyHU?t=4s', '//www.youtube-nocookie.com/embed/xwmHOLoCyHU?start=4'],
+
+            // With shortened or embed formats
+            ['https://youtu.be/seESL1hsPas', '//www.youtube-nocookie.com/embed/seESL1hsPas'],
+            ['https://youtu.be/qnHoKgIh0gU?t=10s', '//www.youtube-nocookie.com/embed/qnHoKgIh0gU?start=10'],
+            ['https://www.youtube.com/embed/xbf2c0JBJic', '//www.youtube-nocookie.com/embed/xbf2c0JBJic'],
+
+            // Additional or complex query parameters
+            ['https://www.youtube.com/watch?v=5IsSpAOD6K8&feature=youtu.be', '//www.youtube-nocookie.com/embed/5IsSpAOD6K8'],
+            ['https://www.youtube.com/watch?v=bLaSXpqp__E&t=1h1m1s', '//www.youtube-nocookie.com/embed/bLaSXpqp__E?start=3661'],
+
+            // Without "www" or SSL
+            ['https://youtube.com/watch?v=_mSmOcmk7uQ', '//www.youtube-nocookie.com/embed/_mSmOcmk7uQ'],
+            ['http://www.youtube.com/watch?v=1tNKq6KWPhY', '//www.youtube-nocookie.com/embed/1tNKq6KWPhY'],
+        ];
+    }
 }


### PR DESCRIPTION
This PR remediates an issue where timestamps are ignored by YouTube video embeds, such as on achievement pages.

**Root Cause**
The privacy-enhanced YouTube embed URL at `youtube-nocookie.com` does not support the `&t` query parameter. Instead, `&t` must be converted to `&start` which an integer of seconds representing the timestamp.

For example, `&t=1m30s` must be converted to `&start=90`.