### PR TITLE
fix(downloads): add missing bizhawk supported systems

### DIFF
--- a/storage/app/releases.dist.php
+++ b/storage/app/releases.dist.php
@@ -143,6 +143,7 @@ See <a href="https://docs.libretro.com/guides/retroachievements/#cores-compatibi
                 12, // PlayStation
                 13, // Atari Lynx
                 14, // Neo Geo Pocket
+                15, // Game Gear
                 17, // Atari Jaguar
                 18, // Nintendo DS
                 23, // Magnavox Odyssey 2
@@ -150,6 +151,7 @@ See <a href="https://docs.libretro.com/guides/retroachievements/#cores-compatibi
                 28, // Virtual Boy
                 29, // MSX
                 33, // SG-1000
+                38, // Apple II
                 39, // Saturn
                 44, // ColecoVision
                 45, // IntelliVision
@@ -157,6 +159,7 @@ See <a href="https://docs.libretro.com/guides/retroachievements/#cores-compatibi
                 49, // PC-FX
                 51, // Atari 7800
                 53, // WonderSwan
+                76, // PC Engine CD
                 78, // Nintendo DSi
             ],
         ],


### PR DESCRIPTION
This PR adds three missing systems to Bizhawk on the downloads page:

* Apple II
* Game Gear
* PC Engine CD

All three of these systems have been confirmed as supporting RA, but are currently absent from the list.