### PR TITLE
fix(createmessage): remediate html structure issue

### DIFF
--- a/public/createmessage.php
+++ b/public/createmessage.php
@@ -65,11 +65,12 @@ $(document).ready(onUserChange);
             echo "<div class='comment'>$messageContextPayload</div>";
         }
 
+        echo "<form action='/request/message/send.php' method='post'>";
+        echo csrf_field();
+
         echo "<table>";
         echo "<tbody>";
 
-        echo "<form action='/request/message/send.php' method='post'>";
-        echo csrf_field();
         $destUser = mb_strlen($messageTo) > 2 ? $messageTo : '_User';
         echo "<tr>";
         echo "<td>User:</td>";
@@ -81,9 +82,9 @@ $(document).ready(onUserChange);
         RenderShortcodeButtons();
         echo "<textarea id='commentTextarea' class='w-full forum messageTextarea' style='height:160px' rows='5' cols='61' name='message' placeholder='Enter your message here...' required>$messageOutgoingPayload</textarea></td></tr>";
         echo "<tr><td></td><td colspan='2' class='w-full'><input style='float:right' type='submit' value='Send Message' size='37'/></td></tr>";
-        echo "</form>";
         echo "</tbody>";
         echo "</table>";
+        echo "</form>";
         ?>
     </div>
 </div>


### PR DESCRIPTION
This PR remediates an issue reported here: https://discord.com/channels/310192285306454017/1106029608408723486

**Root Cause**
The HTML structure for createmessage.php is invalid. Right now, the entire form renders outside its `<form>` tag.