### PR TITLE
fix(admin): remediate 500 error on Get Achievement Unlocks

### DIFF
--- a/public/admin.php
+++ b/public/admin.php
@@ -41,10 +41,10 @@ if ($action === 'unlocks') {
 
         $keys = array_keys($winners);
         $winnersCount = count($winners);
-        for ($i = 0; $i < $winnersCount; $i++) {
-            $winnersCount = is_countable($winners[$keys[$i]]) ? count($winners[$keys[$i]]) : 0;
-            $message .= "<strong>" . number_format($winnersCount) . " Winners of " . $keys[$i] . " in " . ($hardcoreMode ? "Hardcore mode" : "Softcore mode") . "$dateString:</strong><br>";
-            $message .= implode(', ', $winners[$keys[$i]]) . "<br><br>";
+        foreach ($winners as $key => $winner) {
+            $winnersCount = is_countable($winner) ? count($winner) : 0;
+            $message .= "<strong>" . number_format($winnersCount) . " Winners of " . $key . " in " . ($hardcoreMode ? "Hardcore mode" : "Softcore mode") . "$dateString:</strong><br>";
+            $message .= implode(', ', $winner) . "<br><br>";
         }
     }
 }


### PR DESCRIPTION
A user has reported that the Get Achievement Unlocks tool on admin.php is consistently returning 500 errors. The changes in this PR should resolve the issue.

ref: https://discord.com/channels/476211979464343552/1110344645675864074

**Root Cause**
The original code used a for loop to iterate over the `$winners` array based on its count. However, inside the loop, `$winnersCount` was reassigned to the count of the current element in `$winners`. This led to a potential scenario where the loop could iterate beyond the size of `$keys` array, causing an "Undefined array key" error when trying to access an index in `$keys` that didn't exist.