### PR TITLE
Validate Jaguar CD on site

### DIFF
--- a/app_legacy/Helpers/database/release.php
+++ b/app_legacy/Helpers/database/release.php
@@ -89,7 +89,7 @@ function isValidConsoleId(int $consoleId): bool
         // 74, // Interton VC 4000
         // 75, // Elektor TV Games Computer
         76, // PC Engine CD
-        // 77, // Atari Jaguar CD
+        77, // Atari Jaguar CD
         78, // Nintendo DSi
         // 79, // TI-83
         // 80, // Uzebox

--- a/app_legacy/Helpers/render/layout.php
+++ b/app_legacy/Helpers/render/layout.php
@@ -62,7 +62,7 @@ function RenderToolbar(): void
                 ["systemName" => "Atari 2600", "listID" => 25],
                 ["systemName" => "Atari 7800", "listID" => 51],
                 ["systemName" => "Atari Jaguar", "listID" => 17],
-                // ["systemName" => "Atari Jaguar CD", "listID"=>77],
+                ["systemName" => "Atari Jaguar CD", "listID"=>77],
                 ["systemName" => "Atari Lynx", "listID" => 13],
             ],
             "NEC" => [

--- a/app_legacy/Helpers/render/layout.php
+++ b/app_legacy/Helpers/render/layout.php
@@ -62,7 +62,7 @@ function RenderToolbar(): void
                 ["systemName" => "Atari 2600", "listID" => 25],
                 ["systemName" => "Atari 7800", "listID" => 51],
                 ["systemName" => "Atari Jaguar", "listID" => 17],
-                ["systemName" => "Atari Jaguar CD", "listID"=>77],
+                ["systemName" => "Atari Jaguar CD", "listID" => 77],
                 ["systemName" => "Atari Lynx", "listID" => 13],
             ],
             "NEC" => [


### PR DESCRIPTION
Atari Jaguar CD validate + adding it to the navbar.

Once merged, this should **NOT** be deployed until Sunday, June 4th at 00:00 GMT.