### PR TITLE
feat(search): allow opening new tabs via right clicking

### DIFF
--- a/public/js/all.js
+++ b/public/js/all.js
@@ -156,6 +156,7 @@ jQuery(document).ready(function onReady($) {
   $('.msgPayload').hide();
 
   var $searchBoxInput = $('.searchboxinput');
+  // eslint-disable-next-line no-underscore-dangle -- required by autocomplete's API
   $searchBoxInput.autocomplete({
     source: function (request, response) {
       $.post('/request/search.php', request)
@@ -163,17 +164,22 @@ jQuery(document).ready(function onReady($) {
           response(data);
         });
     },
-    minLength: 2
-  });
-  $searchBoxInput.autocomplete({
-    select: function (event, ui) {
-      return false;
-    },
-  });
-  $searchBoxInput.on('autocompleteselect', function (event, ui) {
-    window.location = ui.item.mylink;
-    return false;
-  });
+    minLength: 2,
+    select: function (event) {
+      // This is required by jQuery UI Autocomplete. Unfortunately we can't
+      // just rely on the browser's native behavior for dealing with anchor tags.
+      event.preventDefault();
+      window.location = event.srcElement.href;
+    }
+  }).data('autocomplete')._renderItem = function (ul, item) {
+    const li = $('<li>');
+    const a = $('<a>', {
+      text: item.label,
+      href: item.mylink,
+    });
+
+    return li.append(a).appendTo(ul);
+  };
 
   var $seachBoxCompareUser = $('.searchboxgamecompareuser');
   $seachBoxCompareUser.autocomplete({


### PR DESCRIPTION
This PR converts search results in the site's searchbox to be actual hyperlinks. With this change, the user is able to right click on them and open results in a new tab.

ref: https://discord.com/channels/310192285306454017/1113094098010771526

https://github.com/RetroAchievements/RAWeb/assets/3984985/3828092c-cd29-41b2-817f-1f2bd4041e07

