### PR TITLE
fix(search): ignore pipes in game names

### DIFF
--- a/app_legacy/Helpers/database/search.php
+++ b/app_legacy/Helpers/database/search.php
@@ -52,7 +52,7 @@ function performSearch(
         LEFT JOIN Console AS c ON gd.ConsoleID = c.ID
         WHERE gd.Title LIKE '%$searchQuery%'
         GROUP BY gd.ID, gd.Title
-        ORDER BY SecondarySort, gd.Title";
+        ORDER BY SecondarySort, REPLACE(gd.Title, '|', ''), gd.Title";
     }
 
     if (in_array(SearchType::Achievement, $searchType)) {


### PR DESCRIPTION
This PR remediates an undesirable behavior where pipes in game names causes those results to be placed too far down the list, often resulting in a dropoff altogether. This can notably be seen in the original release of Pac-Man for the arcade, which currently does not appear as a result in the search component unless searching for its Japanese name.

**Before**
![Untitled](https://github.com/RetroAchievements/RAWeb/assets/3984985/b175d51c-0a0e-4578-870d-d1aabf207b01)

**After**
<img width="377" alt="Screenshot 2023-06-06 at 8 57 37 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/2acb8ea5-568e-4a78-9614-5da7177d3849">
