### PR TITLE
fix(game): remediate metadata anchor tag issue

### DIFF
--- a/resources/views/platform/components/game/primary-meta-row-item.blade.php
+++ b/resources/views/platform/components/game/primary-meta-row-item.blade.php
@@ -29,12 +29,17 @@ if ($gameHubs) {
 
                 $key = array_search($value, $metadataValues);
                 if ($key !== false) {
-                    unset($unmergedKeys[$key]);
+                    unset($unmergedKeys[array_search($key, $unmergedKeys)]);
                 }
 
-                // If the value is already in metadataValues, we replace it with a linkified version.
-                // Otherwise, we add a new entry to the end of the array.
-                $metadataValues[$key ?? array_push($metadataValues, '') - 1] = "<a href='/game/{$hub['gameIDAlt']}'>$value</a>";
+                $escapedLink = "<a href='/game/" . htmlspecialchars($hub['gameIDAlt']) . "'>" . htmlspecialchars($value) . "</a>";
+
+                // Check if key is valid.
+                if (is_int($key)) {
+                    $metadataValues[$key] = $escapedLink;
+                } else {
+                    $metadataValues[] = $escapedLink;
+                }
             }
         }
     }

--- a/resources/views/platform/components/game/primary-meta-row-item.blade.php
+++ b/resources/views/platform/components/game/primary-meta-row-item.blade.php
@@ -27,9 +27,15 @@ if ($gameHubs) {
                     ? str_replace("Hacks - ", "Hack - ", substr($title, 1, -1)) // For "Hack", normalize the title.
                     : substr($title, strlen($hubPrefix), -1); // Otherwise, just remove the prefix.
 
+                // Does the value exist in the metadataValues array?
                 $key = array_search($value, $metadataValues);
                 if ($key !== false) {
-                    unset($unmergedKeys[array_search($key, $unmergedKeys)]);
+                    // If the value does indeed exist, we don't need to keep track of it anymore in the
+                    // unmergedKeys array. Find its index in unmergedKeys, then remove it from the array.
+                    $index = array_search($key, $unmergedKeys);
+                    if ($index !== false) {
+                        unset($unmergedKeys[$index]);
+                    }
                 }
 
                 $escapedLink = "<a href='/game/" . htmlspecialchars($hub['gameIDAlt']) . "'>" . htmlspecialchars($value) . "</a>";


### PR DESCRIPTION
This PR resolves an issue with hyperlink rendering on game page metadata rows.

**Root Cause**
There is a logic error when handling the keys in the `$metadataValues` array.

When using the `array_search` function to find the key of a value in an array, it returns `false` if it cannot find the value. PHP will automatically cast this `false` value to 0 when it's used as an array key. Therefore, if `$value` is not found in `$metadataValues`, `$key` will be set to `false`, and then used as 0 when setting a value in `$metadataValues`. This would cause the first value in the array to always be replaced with the new value, which leads to the current prod issue.

**Before**
![Screenshot 2023-06-07 at 4 40 05 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/ba05001e-dd98-4339-a5c5-93eeaa49668f)

**After**
![Screenshot 2023-06-07 at 4 39 51 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/bd0e59b8-a99e-4d54-929c-c3e6d37d7925)

Current (prod): https://retroachievements.org/game/12635
Expected (v3 preview): https://preview.retroachievements.org/game/12635