### PR TITLE
fix: hide zero-value RetroPoints display if Points value is zero

### DIFF
--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -193,7 +193,7 @@ RenderContentStart($pageTitle);
         echo "<div class='flex justify-between'>";
         echo "<div>";
         echo "<a href='/achievement/$achievementID'><strong>$renderedTitle</strong></a>";
-        if ($achPoints !== 0 && $achTruePoints !== 0) {
+        if ($achPoints !== 0) {
             echo " ($achPoints)<span class='TrueRatio'> ($achTruePoints)</span>";
         }
         echo "<br>";

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -189,9 +189,14 @@ RenderContentStart($pageTitle);
         echo "<div id='achievemententry'>";
 
         $renderedTitle = renderAchievementTitle($achievementTitle);
+
         echo "<div class='flex justify-between'>";
         echo "<div>";
-        echo "<a href='/achievement/$achievementID'><strong>$renderedTitle</strong></a> ($achPoints)<span class='TrueRatio'> ($achTruePoints)</span><br>";
+        echo "<a href='/achievement/$achievementID'><strong>$renderedTitle</strong></a>";
+        if ($achPoints !== 0 && $achTruePoints !== 0) {
+            echo " ($achPoints)<span class='TrueRatio'> ($achTruePoints)</span>";
+        }
+        echo "<br>";
         echo "$desc";
         echo "</div>";
         if ($achievedLocal) {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1360,7 +1360,9 @@ sanitize_outputs(
                                 icon: false,
                                 tooltip: false,
                             );
-                            echo " <span class='TrueRatio'>($achTrueRatio)</span>";
+                            if ($achPoints !== 0) {
+                                echo " <span class='TrueRatio'>($achTrueRatio)</span>";
+                            }
                             echo "</div>";
                             echo "<div class='mb-2'>$achDesc</div>";
                             if ($flags != $officialFlag && isset($user) && $permissions >= Permissions::JuniorDeveloper) {


### PR DESCRIPTION
This PR fixes an issue on game pages and achievement info pages where if points is equal to zero, a retropoints value of zero is always shown when it should actually be hidden.

Currently:
On game pages, the zero points value is currently hidden but retro points is always shown.
On achievement info pages, both zero-point values are shown.

After this PR:
On game pages, if an achievement is worth zero points, a retro points value of zero does not appear.
On achievement info pages, if both the achievement and its retro points are zero, neither will be displayed.

**BEFORE**
![Screenshot 2023-06-09 at 6 34 43 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/aa764028-058c-4830-8a85-12791c384f1d)

![Screenshot 2023-06-09 at 6 34 55 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/5d4748d4-1950-494b-832c-1e98996d1ce7)

**AFTER**
![Screenshot 2023-06-09 at 6 32 10 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/dea79073-5c61-4a55-8290-d7d6ed6810aa)

![Screenshot 2023-06-09 at 6 32 20 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/90795687-f757-4fd5-9cd7-d8c15aa776b7)
