### PR TITLE
fix(ticket): add audit log on achievement demotion

### DIFF
--- a/app_legacy/Helpers/database/ticket.php
+++ b/app_legacy/Helpers/database/ticket.php
@@ -351,6 +351,7 @@ function updateTicket(string $user, int $ticketID, int $ticketVal, ?string $reas
         case TicketState::Closed:
             if ($reason == TicketState::REASON_DEMOTED) {
                 updateAchievementFlags($achID, AchievementType::Unofficial);
+                addArticleComment("Server", ArticleType::Achievement, $achID, "$user demoted this achievement to Unofficial.", $user);
             }
             $comment = "Ticket closed by $user. Reason: \"$reason\".";
             postActivity($user, ActivityType::ClosedTicket, $achID);

--- a/public/request/achievement/update-flag.php
+++ b/public/request/achievement/update-flag.php
@@ -32,7 +32,7 @@ if (updateAchievementFlags($achievementIds, $value)) {
     if ($value == AchievementType::Unofficial) {
         $commentText = 'demoted this achievement to Unofficial';
     }
-    addArticleComment("Server", ArticleType::Achievement, $achievementIds, "\"$user\" $commentText.", $user);
+    addArticleComment("Server", ArticleType::Achievement, $achievementIds, "$user $commentText.", $user);
     expireGameTopAchievers($achievement['GameID']);
 
     return response()->json(['message' => __('legacy.success.ok')]);


### PR DESCRIPTION
This PR resolves an issue where if an achievement is demoted as a ticket resolution action, an audit log is not added indicating who demoted the achievement.

ref: https://discord.com/channels/476211979464343552/1026595325038833725/1116877958733365369

https://github.com/RetroAchievements/RAWeb/assets/3984985/d211fe77-1803-464c-b904-2faf35d0da24

