### PR TITLE
feat(game): allow devs to reassign game topic OPs on their claims

### DIFF
--- a/app_legacy/Helpers/database/forum.php
+++ b/app_legacy/Helpers/database/forum.php
@@ -216,7 +216,7 @@ function updateTopicOriginalPoster(string $newOriginalPoster, int $existingTopic
         ]);
     }
 
-    // Did the write operation work? 
+    // Did the write operation work?
     // We need to double-check because the writes themselves just returns `null`.
     $readTopicQuery = "SELECT Author FROM ForumTopic WHERE ID = :forumTopicId";
     $readTopicPostQuery = "SELECT Author FROM ForumTopicComment WHERE ForumTopicID = :forumTopicId ORDER BY DateCreated ASC LIMIT 1";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -749,6 +749,11 @@ sanitize_outputs(
         }
     });
 
+    // Popup for updating the forum topic original poster
+    function updateForumTopicOwner(gameTitle) {
+        return confirm(`Are you sure you want to become the new original poster for ${gameTitle}?`);
+    }
+    
     // Popup for making a claim
     function makeClaim(gameTitle, revisionFlag = false, ticketFlag = false) {
         var revisionMessage = '';
@@ -956,7 +961,7 @@ sanitize_outputs(
                     }
 
                     if ($permissions >= Permissions::Developer && $hasGameClaimed && $forumTopicMetadata['Author'] !== $user) {
-                        echo "<form action='/request/game/update-forum-topic-op.php' method='post'>";
+                        echo "<form action='/request/game/update-forum-topic-op.php' method='post' onsubmit='return updateForumTopicOwner(\"$escapedGameTitle\")'>";
                         echo csrf_field();
                         echo "<input type='hidden' name='game' value='$gameID'>";
                         echo "<input type='hidden' name='existing_forum_topic' value='$forumTopicID'>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -55,6 +55,8 @@ $forumTopicID = $gameData['ForumTopicID'];
 $richPresenceData = $gameData['RichPresencePatch'];
 $guideURL = $gameData['GuideURL'];
 
+getTopicDetails($forumTopicID, $forumTopicMetadata);
+
 // Entries that aren't actual game only have alternatives exposed, e.g. hubs.
 $isFullyFeaturedGame = $consoleName !== 'Hubs';
 $isEventGame = $consoleName == 'Events';
@@ -950,6 +952,15 @@ sanitize_outputs(
                         echo csrf_field();
                         echo "<input type='hidden' name='game' value='$gameID'>";
                         echo "<button>Recalculate True Ratios</button>";
+                        echo "</form>";
+                    }
+
+                    if ($permissions >= Permissions::Developer && $hasGameClaimed && $forumTopicMetadata['Author'] !== $user) {
+                        echo "<form action='/request/game/update-forum-topic-op.php' method='post'>";
+                        echo csrf_field();
+                        echo "<input type='hidden' name='game' value='$gameID'>";
+                        echo "<input type='hidden' name='existing_forum_topic' value='$forumTopicID'>";
+                        echo "<button>Become Forum Topic OP</button>";
                         echo "</form>";
                     }
 

--- a/public/request/game/update-forum-topic-op.php
+++ b/public/request/game/update-forum-topic-op.php
@@ -32,6 +32,7 @@ if ($claimListLength > 0 && $claimData[0]['ClaimType'] == ClaimType::Primary) {
 
 if ($hasGameClaimed && updateTopicOriginalPoster($user, $forumTopicID)) {
     addArticleComment("Server", ArticleType::GameModification, $gameID, "$user set themselves as the game's forum topic original poster.");
+
     return back()->with('success', __('legacy.success.ok'));
 }
 

--- a/public/request/game/update-forum-topic-op.php
+++ b/public/request/game/update-forum-topic-op.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+use LegacyApp\Community\Enums\ClaimType;
+use LegacyApp\Site\Enums\Permissions;
+
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+    return back()->withErrors(__('legacy.error.permissions'));
+}
+
+$input = Validator::validate(Arr::wrap(request()->post()), [
+    'game' => 'required|integer|exists:mysql_legacy.GameData,ID',
+    'existing_forum_topic' => 'required|integer|exists:mysql_legacy.ForumTopic,ID',
+]);
+
+// The user must have a claim on this game to become the OP of the game's forum topic.
+$hasGameClaimed = false;
+$claimData = getClaimData((int) $input['game'], true);
+$claimListLength = count($claimData);
+if ($claimListLength > 0 && $claimData[0]['ClaimType'] == ClaimType::Primary) {
+    foreach ($claimData as $claim) {
+        if (isset($claim['User']) && $claim['User'] === $user) {
+            $hasGameClaimed = true;
+        }
+    }
+}
+
+if ($hasGameClaimed && updateTopicOriginalPoster($user, (int) $input['existing_forum_topic'])) {
+    return back()->with('success', __('legacy.success.ok'));
+}
+
+return back()->withErrors(__('legacy.error.error'));


### PR DESCRIPTION
This PR gives achievement developers the ability to reassign the game's forum topic original poster to themselves if they have an active claim on a given game.

**Why?**
Currently when something like this needs to happen, it goes to #admin-site-cleanup who then performs a thread transfer. However, this seems like more of a workaround, and now it is possible that a game's discussion is split between two forum threads instead of isolated into one.

**How?**
A new button has been added to the devbox. The button appears if the user has the Developer role and has an active claim on the game. When pressed, a confirmation dialog appears that if accepted, reassigns the game's forum topic OP to the active user.


https://github.com/RetroAchievements/RAWeb/assets/3984985/df9226cc-34bf-4c8a-9025-35a6f3861233

