### PR TITLE
Fix username/role cutoff in user cards

### DIFF
--- a/app_legacy/Helpers/render/user.php
+++ b/app_legacy/Helpers/render/user.php
@@ -94,7 +94,7 @@ function renderUserCard(string|array $user): string
     $lastLogin = $data['LastLogin'] ? getNiceDate(strtotime($data['LastLogin'])) : null;
     $memberSince = $data['Created'] ? getNiceDate(strtotime($data['Created']), true) : null;
 
-    $tooltip = "<div class='tooltip-body flex items-start gap-2 p-2' style='width: 400px'>";
+    $tooltip = "<div class='tooltip-body flex items-start gap-2 p-2' style='min-width: 400px'>";
 
     $tooltip .= "<img width='128' height='128' src='" . media_asset('/UserPic/' . $username . '.png') . "'>";
 
@@ -102,7 +102,7 @@ function renderUserCard(string|array $user): string
 
     $tooltip .= "<div class='flex justify-between mb-2'>";
     $tooltip .= "<div class='usercardusername'>$username</div>";
-    $tooltip .= "<div class='usercardaccounttype'>$userAccountType</div>";
+    $tooltip .= "<div class='usercardaccounttype ml-3'>$userAccountType</div>";
     $tooltip .= "</div>";
 
     // Add the user motto if it's set


### PR DESCRIPTION
* Set 400px as the minimum width instead of fixed width
* Add a margin between the username and user role

Higher fixed width would work too but since roles are variable-length it seems saner to just give it a variable width, in practice it can't be longer than ~500px due to the username length cap and current role lengths.

Before
![image](https://github.com/RetroAchievements/RAWeb/assets/7488362/5b422d2d-08cd-44d5-a4d7-63e22e2cbc2f)
After
![image](https://github.com/RetroAchievements/RAWeb/assets/7488362/97ec40fe-3de0-4caf-be54-42ca3aef6281)

Tested only in the inspector, not a local environment because WSL v1 doesn't support Docker, Sail couldn't run and I gave up when populating the database failed probably because of some missing init step.