### PR TITLE
fix(claims): decode game titles in confirm dialogs

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -767,16 +767,25 @@ sanitize_outputs(
             $systemIconUrl = getSystemIconUrl($consoleID);
 
             $gameMetaBindings = [
+                'claimData' => $claimData,
+                'consoleID' => $consoleID,
                 'consoleName' => $consoleName,
                 'developer' => $developer,
+                'forumTopicID' => $forumTopicID,
                 'gameHubs' => $gameHubs,
+                'gameID' => $gameID,
                 'gameTitle' => $gameTitle,
                 'genre' => $genre,
                 'iconUrl' => $systemIconUrl,
                 'imageIcon' => $imageIcon,
                 'isFullyFeaturedGame' => $isFullyFeaturedGame,
+                'isOfficial' => $isOfficial,
+                'isSoleAuthor' => $isSoleAuthor,
+                'numAchievements' => $numAchievements,
+                'permissions' => $permissions,
                 'publisher' => $publisher,
                 'released' => $released,
+                'user' => $user,
             ];
 
             echo Blade::render('
@@ -905,18 +914,7 @@ sanitize_outputs(
                                 :user="$user"
                                 :userPermissions="$permissions"
                             />
-                        ', [
-                            'claimData' => $claimData,
-                            'consoleID' => $consoleID,
-                            'forumTopicID' => $forumTopicID,
-                            'gameID' => $gameID,
-                            'gameTitle' => $gameTitle,
-                            'isOfficial' => $isOfficial,
-                            'isSoleAuthor' => $isSoleAuthor,
-                            'numAchievements' => $numAchievements,
-                            'permissions' => $permissions,
-                            'user' => $user,
-                        ]);
+                        ', $gameMetaBindings);
                     }
 
                     echo "</div>"; // end right column

--- a/resources/views/platform/components/game/devbox-claim-management.blade.php
+++ b/resources/views/platform/components/game/devbox-claim-management.blade.php
@@ -71,7 +71,7 @@ $isRecentPrimaryClaim = $primaryClaimMinutesActive <= 1440;
 
 <script>
 function makeClaim() {
-    const gameTitle = "{{ e($gameTitle) }}";
+    const gameTitle = "{!! html_entity_decode($gameTitle) !!}";
     const hasRevisionFlag = {{ $revisionDialogFlag }};
     const hasTicketFlag = {{ $ticketDialogFlag }};
 
@@ -90,21 +90,21 @@ function makeClaim() {
 }
 
 function dropClaim() {
-    const gameTitle = "{{ e($gameTitle) }}";
+    const gameTitle = "{!! html_entity_decode($gameTitle) !!}";
 
     const message = 'Are you sure you want to drop the claim for ' + gameTitle + '?';
     return confirm(message);
 }
 
 function extendClaim() {
-    const gameTitle = "{{ e($gameTitle) }}";
+    const gameTitle = "{!! html_entity_decode($gameTitle) !!}";
 
     const message = 'Are you sure you want to extend the claim for ' + gameTitle + '?';
     return confirm(message);
 }
 
 function completeClaim() {
-    const gameTitle = "{{ e($gameTitle) }}";
+    const gameTitle = "{!! html_entity_decode($gameTitle) !!}";
     const showEarlyReleaseWarning = {{ $isRecentPrimaryClaim }};
 
     let earlyReleaseMessage = '';


### PR DESCRIPTION
This PR resolves an issue where game names are not being decoded in the `confirm()` dialogs that appear for the claims controls in the devbox component.

![Screenshot 2023-07-01 at 2 48 51 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/c86dcc4c-78a4-49d3-a2a3-41846fbef52e)

**Root Cause**

_gameInfo.php_ is (correctly) sanitizing game names:
```php
sanitize_outputs(
    $gameTitle,
    $consoleName,
    $richPresenceData,
    $user,
);
```

Then, `$gameTitle` is used for non-Blade stuff on the page. My naive guess is the co-mingling of the legacy renderer and the Blade renderer is causing issues like this.