### PR TITLE
fix(home): remediate zindex issue with carousel buttons [V3]

### DIFF
--- a/resources/views/community/components/news/carousel-scroll-buttons.blade.php
+++ b/resources/views/community/components/news/carousel-scroll-buttons.blade.php
@@ -2,7 +2,7 @@
 
 $buttonClassNames = <<<EOT
     absolute top-1/2 transition transform -translate-y-1/2 lg:active:scale-95
-    z-20 text-link bg-black bg-opacity-80 hover:bg-opacity-100
+    z-10 text-link bg-black bg-opacity-80 hover:bg-opacity-100
     rounded-full w-10 h-10 flex items-center justify-center
 EOT;
 ?>


### PR DESCRIPTION
This PR remediates an issue with the pagination buttons on the home page news carousel. Their current z-index places them on a layer above the navigation menu.

**Before**

![Screenshot 2023-07-03 at 12 42 20 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/9beeabf7-63f8-417e-8f61-6ee9e0365522)

**After**

![Screenshot 2023-07-03 at 12 44 28 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/6828a0fb-491f-406a-8355-4180cefd9695)
