### PR TITLE
fix(viewtopic): add 64px offset for deep links [V3]

### DIFF
--- a/app/Helpers/render/comment.php
+++ b/app/Helpers/render/comment.php
@@ -122,7 +122,7 @@ function RenderArticleComment(
         $class .= ' system';
     }
 
-    echo "<tr class='comment$class' id='comment_$commentID'>";
+    echo "<tr class='comment$class' id='comment_" . $commentID . "_highlight'>";
 
     $niceDate = date("j M Y ", $submittedDate);
     $niceDate .= date("H:i", $submittedDate);
@@ -131,6 +131,13 @@ function RenderArticleComment(
     $comment = nl2br($comment);
 
     echo "<td class='align-top py-2'>";
+
+    echo <<<HTML
+        <div class="relative">
+            <div class="absolute h-px w-px left-0" style="top: -74px;" id="comment_$commentID"></div>
+        </div>
+    HTML;
+
     if ($user !== 'Server') {
         echo userAvatar($user, label: false);
     }

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -233,9 +233,19 @@ jQuery(document).ready(function onReady($) {
     return false;
   });
 
-  var $anchor = window.location.hash;
-  if ($anchor.startsWith('#comment_')) {
-    $($anchor).addClass('highlight');
+  // Add highlights to deep-linked comments.
+  const urlHash = window.location.hash;
+  if (urlHash.startsWith('#comment_')) {
+    const highlightTargetEl = document.querySelector(`${urlHash}_highlight`) || document.getElementById(urlHash);
+    if (highlightTargetEl) {
+      highlightTargetEl.classList.add('highlight');
+    }
+  }
+
+  if (urlHash.startsWith('#comment_') && !highlightTargetEl) {
+    $(urlHash).addClass('highlight');
+  } else if (urlHash.startsWith('#comment_') && highlightTargetEl) {
+    $(highlightTargetEl).addClass('highlight');
   }
 });
 

--- a/resources/views/community/components/forum/post-container.blade.php
+++ b/resources/views/community/components/forum/post-container.blade.php
@@ -3,10 +3,13 @@
     'isHighlighted' => false,
 ])
 
-<div
-    id="{{ $commentId }}"
-    class='{{ $isHighlighted ? 'highlight' : '' }} relative w-[calc(100%+16px)] sm:w-full -mx-2 sm:mx-0 lg:flex rounded-lg mt-3 odd:bg-embed bg-embed-highlight px-1 pb-3 pt-2'
-    style="word-break: break-word;"
->
-    {{ $slot }}
+<div class="relative">
+    <div id="{{ $commentId }}" class="absolute left-0 h-px w-px" style="top: -64px;"></div>
+
+    <div
+        class='{{ $isHighlighted ? 'highlight' : '' }} relative w-[calc(100%+16px)] sm:w-full -mx-2 sm:mx-0 lg:flex rounded-lg mt-3 odd:bg-embed bg-embed-highlight px-1 pb-3 pt-2'
+        style="word-break: break-word;"
+    >
+        {{ $slot }}
+    </div>
 </div>


### PR DESCRIPTION
This PR fixes an issue with opening deep links in forum threads where the top of the message is cut off by the navbar. To resolve this, I've set the `id` attributed element to an invisible div that is floating 64px away from the linked post.

The issue can be repro'd by opening (in a new tab) a deep linked forum post that is somewhere halfway through the thread, eg: viewtopic.php?t=20260&c=153328#153328

**Before**
![Screenshot 2023-07-03 at 12 55 30 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/c1446dae-c9a8-4ca7-8ab8-d1da076e5031)

**After**
![Screenshot 2023-07-03 at 12 52 50 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/f79364ca-ce23-4505-81ac-fd352440da77)

