### PR TITLE
fix(carousel): add minimum height

### DIFF
--- a/resources/views/community/components/news/carousel-item.blade.php
+++ b/resources/views/community/components/news/carousel-item.blade.php
@@ -1,5 +1,5 @@
 <div
-    class="relative box-content flex w-full flex-none snap-start"
+    class="relative box-content flex w-full flex-none snap-start min-h-[270px]"
     role="group"
     aria-label="{{ "News item " . ($index + 1) }}"
     {{ $index === 0 ? 'id=first-news-item' : '' }}


### PR DESCRIPTION
This resolves an issue with the news carousel where on slow connections if the image does not fill the container, the carousel height appears as too small for a few frames.