### PR TITLE
feat(home): update welcome and faq/docs journey

### DIFF
--- a/resources/views/content/getting-started.blade.php
+++ b/resources/views/content/getting-started.blade.php
@@ -1,0 +1,15 @@
+<x-section>
+    <div class="bg-embed p-4 border-text rounded">
+        <h2>{{ __('Getting Started') }}</h2>
+
+        <p class="mb-2">
+            We're excited to have you here! We know you might have some questions about
+            hardcore mode, RetroPoints (white points), or which emulators to use. Don't worry,
+            we've got you covered! Check out our
+            <a href="https://docs.retroachievements.org/FAQ/" target="_blank" rel="noreferrer">
+                comprehensive FAQ
+            </a>
+            to get started. Happy gaming!
+        </p>
+    </div>
+</x-section>

--- a/resources/views/content/welcome.blade.php
+++ b/resources/views/content/welcome.blade.php
@@ -1,15 +1,17 @@
 <x-section>
-    <x-section-header>
-        <x-slot name="title"><h2>{{ __('Welcome!') }}</h2></x-slot>
-    </x-section-header>
-    <p class="mb-2">
-        Were you the greatest in your day at Mega Drive or SNES games? Wanna prove it? Use our
-        <a href="{{ route('download.index') }}">modified emulators</a> and you will obtain achievements and badges as
-        you play! Your progress will be tracked so you can compete with your friends to complete all your favourite
-        classics to 100%: we provide <a href="{{ route('download.index') }}">the emulators</a>,
-        all you need are the <a href="{{ route('game.index') }}">games</a>!
-    </p>
-    <p>
-        <a href="{{ route('game.show', 1) }}">Which of these do you think you can get?</a>
-    </p>
+    <div class="bg-embed p-4 border-text rounded">
+        <h2>{{ __('Welcome!') }}</h2>
+
+        <p class="mb-2">
+            Were you the greatest in your day at Mega Drive, SNES, or PlayStation 2 games? Wanna prove it? Use our
+            <a href="{{ route('download.index') }}">supported emulators</a> and you will obtain achievements and badges as
+            you play! Your progress will be tracked so you can compete with your friends to complete all your favorite
+            classics to 100%: we provide <a href="{{ route('download.index') }}">the emulators</a>,
+            all you need are the <a href="{{ route('game.index') }}">games</a>!
+        </p>
+
+        <p>
+            <a href="{{ route('game.show', 1) }}">Which of these achievements do you think you can get?</a>
+        </p>
+    </div>
 </x-section>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,6 +1,8 @@
 <x-app-layout>
     @guest
         @include('content.welcome')
+    @elseif(Carbon\Carbon::now()->diffInMonths(Auth::user()->Created) < 1)
+        @include('content.getting-started')
     @endguest
 
     <x-news.carousel-2 />


### PR DESCRIPTION
This PR makes slight modifications to the "Welcome!" text that appears if a user is not logged in. Additionally, a new component is shown if the user is logged in but their account is less than 1 month old. This new component guides the user towards the user docs FAQ page.

**Before**
![Screenshot 2023-07-08 at 4 31 29 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/9064e8ed-8a1f-43b1-bd2b-6315def99978)

**After**
![Screenshot 2023-07-08 at 4 28 11 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/64972df3-8cdb-4db4-ab8e-f39fb7e16347)

![Screenshot 2023-07-08 at 4 27 53 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/7d61386a-8ecd-45c1-9f47-5478b0f28afd)
