### PR TITLE
fix(forum): resolve parser outputting broken docs links

### DIFF
--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -165,7 +165,7 @@ final class Shortcode
         $html = $this->autoEmbedYouTube($html);
         $html = $this->autoEmbedTwitch($html);
         $html = $this->autolinkRetroachievementsUrls($html);
-        
+
         return $this->autolinkUrls($html);
     }
 
@@ -284,6 +284,7 @@ final class Shortcode
             function ($matches) {
                 $subdomain = isset($matches[1]) ? $matches[1] : '';
                 $path = isset($matches[2]) ? '/' . $matches[2] : '';
+
                 return '<a href="https://' . $subdomain . 'retroachievements.org' . $path . '">https://' . $subdomain . 'retroachievements.org' . $path . '</a>';
             },
             $text

--- a/tests/Unit/ShortcodeTest.php
+++ b/tests/Unit/ShortcodeTest.php
@@ -40,6 +40,16 @@ final class ShortcodeTest extends TestCase
             '<a href="https://retroachievements.org/">https://retroachievements.org/</a>.',
             Shortcode::render('http://retroachievements.org/.')
         );
+
+        $this->assertSame(
+            '<a href="https://docs.retroachievements.org/Working-with-the-Right-ROM">https://docs.retroachievements.org/Working-with-the-Right-ROM</a>',
+            Shortcode::render('docs.retroachievements.org/Working-with-the-Right-ROM')
+        );
+
+        $this->assertSame(
+            '<a href="https://media.retroachievements.org/12345.png">https://media.retroachievements.org/12345.png</a>',
+            Shortcode::render('media.retroachievements.org/12345.png')
+        );
     }
 
     public function testUnclosedCodeTag(): void


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/1655.

**Before**
When making a post with the text content:

```
docs.retroachievements.org/Working-with-the-Right-ROM
```

The displayed content would be:

```
docs.https://retroachievements.org/Working-with-the-Right-ROM
```

**After**
The displayed content is now:

```
https://docs.retroachievements.org/Working-with-the-Right-ROM
```