### PR TITLE
fix: remediate js error on comment deep links

### DIFF
--- a/public/js/all.js
+++ b/public/js/all.js
@@ -239,12 +239,6 @@ jQuery(document).ready(function onReady($) {
       highlightTargetEl.classList.add('highlight');
     }
   }
-
-  if (urlHash.startsWith('#comment_') && !highlightTargetEl) {
-    $(urlHash).addClass('highlight');
-  } else if (urlHash.startsWith('#comment_') && highlightTargetEl) {
-    $(highlightTargetEl).addClass('highlight');
-  }
 });
 
 $(function () {


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1127755709442961438.

**Root Cause**
In https://github.com/RetroAchievements/RAWeb/pull/1641, code was added to increase the offset to these links to account for the site's sticky navbar. However, I forgot to delete some code from the previous implementation, which is now blowing up and causing the error exhibited at the Discord URL above.