### PR TITLE
fix(tooltip): add overflow-hidden classname

### DIFF
--- a/resources/js/tooltip/utils/renderTooltip.ts
+++ b/resources/js/tooltip/utils/renderTooltip.ts
@@ -46,6 +46,7 @@ export function renderTooltip(
     'top-0',
     'left-0',
     'rounded',
+    'overflow-hidden',
   );
 
   if (!options?.isBorderless) {


### PR DESCRIPTION
The new Floating UI tooltip implementation has a mild clash with the new user card tooltips due to not accounting for overflow in the card div. Resolved by simply adding `overflow-hidden` to the Floating UI tooltip div.

**Before**
![Screenshot 2023-07-12 at 8 30 32 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/199df085-3e50-44ba-976b-338ba660dc75)

**After**
![Screenshot 2023-07-12 at 8 32 17 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/676644e3-3c9c-46e8-8d40-65f6a6a4ba9e)
