### PR TITLE
fix(tooltip): prevent tooltip flickering on mouseover

### DIFF
--- a/resources/js/tooltip/attachTooltipToElement.ts
+++ b/resources/js/tooltip/attachTooltipToElement.ts
@@ -25,10 +25,16 @@ function attachTooltipListeners(
 ) {
   let showTimeout: number | null = null;
   let lastMouseCoords: { x: number; y: number } | null = null;
+  let isTooltipShowing = false;
 
   const handleMouseOver = () => {
+    if (isTooltipShowing) {
+      return;
+    }
+
     showTimeout = window.setTimeout(() => {
       showFn(lastMouseCoords?.x ?? 0, lastMouseCoords?.y ?? 0);
+      isTooltipShowing = true;
     }, 70);
   };
 
@@ -38,6 +44,7 @@ function attachTooltipListeners(
       showTimeout = null;
     }
 
+    isTooltipShowing = false;
     hideTooltip();
   };
 


### PR DESCRIPTION
This PR resolves a longstanding issue where tooltips flicker when hovering over other elements within a tipped element's context.

**Root Cause**
Event bubbling is causing multiple onmouseover events to fire, even if the tooltip is already opened.

**Before**

https://github.com/RetroAchievements/RAWeb/assets/3984985/82ddbe36-eb0e-4a9a-85c6-0cd29b895532



**After**

https://github.com/RetroAchievements/RAWeb/assets/3984985/cccab760-c715-40da-bd91-d960d0331474

