### PR TITLE
Resolves #1670 By adding ConsoleId to the ClaimKey check

### DIFF
--- a/database/seeders/AchievementSetClaimSeeder.php
+++ b/database/seeders/AchievementSetClaimSeeder.php
@@ -13,8 +13,8 @@ class AchievementSetClaimSeeder extends Seeder
 {
     public function run(): void
     {
-        //
-        if(AchievementSetClaim::count() > 0) {
+
+        if (AchievementSetClaim::count() > 0) {
             return;
         }
         Game::take(5)->get()->each(function (Game $game) {

--- a/database/seeders/AchievementSetClaimSeeder.php
+++ b/database/seeders/AchievementSetClaimSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Community\Enums\ClaimStatus;
+use App\Community\Models\AchievementSetClaim;
+use App\Platform\Models\Game;
+use Illuminate\Database\Seeder;
+
+class AchievementSetClaimSeeder extends Seeder
+{
+    public function run(): void
+    {
+        //
+        if(AchievementSetClaim::count() > 0) {
+            return;
+        }
+        Game::take(5)->get()->each(function (Game $game) {
+            AchievementSetClaim::factory()->count(5)->create([
+                'GameID' => $game->ID,
+                'Status' => ClaimStatus::Complete,
+            ]);
+        });
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,6 +23,7 @@ class DatabaseSeeder extends Seeder
             $this->call(UsersTableSeeder::class);
             $this->call(GamesTableSeeder::class);
             $this->call(NewsTableSeeder::class);
+            $this->call(AchievementSetClaimSeeder::class);
         }
     }
 }

--- a/resources/views/community/components/claims/finished-claims.blade.php
+++ b/resources/views/community/components/claims/finished-claims.blade.php
@@ -9,8 +9,8 @@ use App\Community\Enums\ClaimSorting;
  * Creates a unique key based on the given game title and user.
  * This key can then be used for convenient comparison of potential duplicates.
  */
-$createClaimKey = function (string $gameTitle, string $user): string {
-    return $gameTitle . '_' . $user;
+$createClaimKey = function (string $gameTitle, string $user, int $consoleId): string {
+    return $gameTitle . '_' . $user . '_' . $consoleId;
 };
 
 /**
@@ -53,7 +53,7 @@ $updateClaimData = function (array &$claimData, array $existingClaim, array $new
 ): void {
     foreach ($claimsBatch as $batchedClaim) {
         if (isValidConsoleId($batchedClaim['ConsoleID'])) {
-            $claimKey = $createClaimKey($batchedClaim['GameTitle'], $batchedClaim['User']);
+            $claimKey = $createClaimKey($batchedClaim['GameTitle'], $batchedClaim['User'], $batchedClaim['ConsoleID']);
 
             if (!isset($uniqueClaims[$claimKey])) {
                 $uniqueClaims[$claimKey] = $batchedClaim;

--- a/resources/views/community/components/claims/finished-claims.blade.php
+++ b/resources/views/community/components/claims/finished-claims.blade.php
@@ -6,7 +6,7 @@ use App\Community\Enums\ClaimFilters;
 use App\Community\Enums\ClaimSorting;
 
 /**
- * Creates a unique key based on the given game title and user.
+ * Creates a unique key based on the given game title, user, and console id.
  * This key can then be used for convenient comparison of potential duplicates.
  */
 $createClaimKey = function (string $gameTitle, string $user, int $consoleId): string {


### PR DESCRIPTION
This resolves #1670 by adding the ConsoleId on the edge case if a game shares a name with one on another console then it does not get flagged. I know the others were using the name of user and game, but figured ConsoleId would be a bit more unquie, smaller in size and maybe stop any other possible edge cases.

Also added a Seeder to populate some claims. Set `Status => ClaimStatus::Complete` so it has some data to display on the front page.