### PR TITLE
fix: hide comments when deleting them

### DIFF
--- a/public/js/all.js
+++ b/public/js/all.js
@@ -225,7 +225,9 @@ function removeComment(artTypeID, artID, commentID) {
     comment: commentID
   })
     .done(function () {
-      $(`[id^="comment_${commentID}"]`).hide();
+      document.querySelectorAll(`[id^="comment_${commentID}"]`).forEach(function (el) {
+        el.style.display = 'none';
+      });
     });
   return true;
 }

--- a/public/js/all.js
+++ b/public/js/all.js
@@ -225,7 +225,7 @@ function removeComment(artTypeID, artID, commentID) {
     comment: commentID
   })
     .done(function () {
-      $('#comment_' + commentID).hide();
+      $(`[id^="comment_${commentID}"]`).hide();
     });
   return true;
 }


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/1678, a regression introduced by https://github.com/RetroAchievements/RAWeb/pull/1641.

Additionally, I've migrated the query call from jQuery to vanilla JS.

**Root Cause**
Deleted comments to be hidden are no longer being queried correctly in the DOM.