### PR TITLE
fix(demo): remediate xl breakpoint left container width

### DIFF
--- a/resources/views/layouts/components/main.blade.php
+++ b/resources/views/layouts/components/main.blade.php
@@ -2,7 +2,7 @@
     <main class="{{ $class ?? 'mb-5' }}" data-scroll-target>
         @if(trim($sidebar ?? false))
             <div class="lg:grid grid-flow-col gap-4">
-                <article class="mb-3 lg:col-span-2 {{ $fluid ? '' : 'lg:max-w-[668px]'}} {{ $sidebarPosition === 'right' ? 'order-1' : 'order-2'}}">
+                <article class="mb-3 lg:col-span-2 {{ $fluid ? '' : 'lg:max-w-[668px] xl:max-w-[1180px]' }} {{ $sidebarPosition === 'right' ? 'order-1' : 'order-2'}}">
                     {{ $slot }}
                 </article>
                 <aside class="lg:col-span-1 {{ $sidebarPosition === 'right' ? 'order-2' : 'order-1'}}">


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1132259447494951042.

The only problem here is the original solution just accounted from the `lg` breakpoint and not the `xl` breakpoint. Now both screen widths are accounted for, the container is correctly sized, and there is no layout shift.