### PR TITLE
fix(seeders): `composer mfs` cannot run down migration

### DIFF
--- a/database/seeders/GamesTableSeeder.php
+++ b/database/seeders/GamesTableSeeder.php
@@ -37,6 +37,7 @@ class GamesTableSeeder extends Seeder
             ]))->hashes()->save(new GameHash([
                 'system_id' => $game->ConsoleID,
                 'hash' => Str::random(16),
+                'MD5' => Str::random(16),
             ]));
         });
 


### PR DESCRIPTION
The `MD5` column of game hashes has to be populated by seeders to allow the down migration of `2018_10_02_000004_create_game_meta_tables` to revert the composite primary key.

`composer mfs` is a shorthand for `php artisan migrate:refresh --seed` which runs the down migrations instead of dropping all tables.

`php artisan migrate:fresh --seed` drops all tables and does not run into this issue.

> **Warning**
> Do NOT run these commands if you do not want to lose any data in your local database.


```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '' for key 'GameHashLibrary.PRIMARY' (SQL: alter table `GameHashLibrary` add primary key (`MD5`))
```