### PR TITLE
fix(tooltip): conditionally apply pixelated rendering style

### DIFF
--- a/resources/views/components/tooltip-card.blade.php
+++ b/resources/views/components/tooltip-card.blade.php
@@ -1,11 +1,18 @@
 @props([
-    'imgSrc' => ''
+    'imgSrc' => '',
+    'isLowResImage' => false,
 ])
 
 <div class="bg-box-bg text-menu-link rounded border border-embed-highlight leading-normal p-2 w-[400px] overflow-hidden">
     <div class="flex gap-x-2">
         @if($imgSrc)
-            <img src="{{ $imgSrc }}" class="w-32 h-32" width="128" height="128" style="image-rendering: pixelated;">
+            <img
+                src="{{ $imgSrc }}"
+                class="w-32 h-32"
+                width="128"
+                height="128"
+                @if ($isLowResImage) style="image-rendering: pixelated;" @endif
+            >
         @endif
 
         <div class="w-full">


### PR DESCRIPTION
Resolves #1691.

**Root Cause**
In anticipation of using larger images in tooltip cards for game and achievement badges, I applied an `image-rendering: pixelated` style to the card container, which makes those badges look quite a bit nicer when scaled up. However, this has the opposite effect for avatar images.

To resolve this, I've added a new prop, `isLowResImage`, to the `<x-tooltip-card />` component. The style is conditionally applied when this prop is set to `true`.