### PR TITLE
fix(active-players): remove native browser tooltips

### DIFF
--- a/public/js/activePlayersBootstrap.js
+++ b/public/js/activePlayersBootstrap.js
@@ -4,10 +4,9 @@ function CreateCardIconDiv(type, id, title, icon, url) {
     initDirective = `x-init="attachTooltipToElement($el, { staticHtmlContent: useCard('game', '${id}') })"`;
   }
 
-  return `<div class=\'inline\' ${initDirective}>`
-    + '<a href=\'' + url + '\'>'
-    + '<img src=\'' + mediaAsset(icon) + '\' width=\'32\' height=\'32\' '
-    + ' alt="' + title + '" title="' + title + '" class=\'badgeimg\' loading=\'lazy\' />'
+  return `<div class="inline" ${initDirective}>`
+    + `<a href="${url}">`
+    + `<img src="${mediaAsset(icon)}" width="32" height="32" alt="${title}" class="badgeimg" loading="lazy" />`
     + '</a>'
     + '</div>';
 }


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1133533776153170022 and https://discord.com/channels/476211979464343552/1026595325038833725/1133879281135657002.

**Root Cause**
The active players widget images are tooltipped, but also pop native browser tooltips using `title` attributes. These take precedence over JS tooltips, thus causing the reported issues.

**Resolution**
The `title` attributes have been removed. They are redundant given the images already have `alt` attributes and JS tooltips.