### PR TITLE
ignore deleted forum topics when reporting unverified forum posts

### DIFF
--- a/app/Helpers/database/forum.php
+++ b/app/Helpers/database/forum.php
@@ -94,7 +94,7 @@ function getUnauthorisedForumLinks(): ?array
                 LEFT JOIN ForumTopicComment AS ftc ON ftc.ForumTopicID = ft.ID
                 LEFT JOIN Forum AS f ON f.ID = ft.ForumID
                 LEFT JOIN ForumTopicComment AS ftc2 ON ftc2.ForumTopicID = ft.ID
-                WHERE ftc.Authorised = 0
+                WHERE ftc.Authorised = 0 AND ft.deleted_at IS NULL
                 GROUP BY ft.ID, LatestCommentPostedDate
                 ORDER BY LatestCommentPostedDate DESC ";
 

--- a/app/Helpers/database/search.php
+++ b/app/Helpers/database/search.php
@@ -89,10 +89,10 @@ function performSearch(
         FROM ForumTopicComment AS ftc
         LEFT JOIN UserAccounts AS ua ON ua.ID = ftc.AuthorID
         LEFT JOIN ForumTopic AS ft ON ft.ID = ftc.ForumTopicID
-        WHERE ftc.Payload LIKE '%$searchQuery%'
+        WHERE ftc.Payload LIKE '%$searchQuery%' AND ft.deleted_at IS NULL
         AND ft.RequiredPermissions <= '$permissions'
         GROUP BY ID, ftc.ID
-        ORDER BY DateModified DESC";
+        ORDER BY IFNULL(ftc.DateModified, ftc.DateCreated) DESC";
     }
 
     $articleTypes = [];


### PR DESCRIPTION
When a forum topic is deleted, the topic is marked as deleted (soft delete), but the posts remain. This prevents the "deleted" posts from appearing in the list of unverified forum posts and search results.

https://discord.com/channels/476211979464343552/1002689485005406249/1134137157636870164

Side note: should the forum topic comments for the deleted topic also be marked as deleted?