### PR TITLE
fix(resetPassword): allow resetting even with short username

### DIFF
--- a/public/request/auth/reset-password.php
+++ b/public/request/auth/reset-password.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 
 $input = Validator::validate(Arr::wrap(request()->post()), [
-    'username' => 'required|string|exists:UserAccounts,User|alpha_num|min:4|max:20',
+    'username' => 'required|string|exists:UserAccounts,User|alpha_num|max:20',
     'token' => 'required',
     'password' => 'required|confirmed|min:8|different:username',
 ]);


### PR DESCRIPTION
There is currently a bug on the reset password page affecting users with usernames less than 4 characters long. These users are unable to reset their passwords.

This PR removes the min length validation from the password reset endpoint, allowing these users to reset their passwords and regain access to their account.