### PR TITLE
fix(home): use a single table column for showing claim devs

### DIFF
--- a/resources/views/community/components/claims/finished-claim-table-row.blade.php
+++ b/resources/views/community/components/claims/finished-claim-table-row.blade.php
@@ -22,8 +22,7 @@ $finishedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['DoneTime'])->
         />
     </td>
 
-    <td class="pr-0">{!! userAvatar($claim['User'], label: false) !!}</td>
-    <td>{!! userAvatar($claim['User'], icon: false) !!}</td>
+    <td class="pr-0">{!! userAvatar($claim['User']) !!}</td>
     <td>{{ $claimSetTypeCopy }}</td>
     <td class="smalldate">{{ $finishedTimeAgo }}</td>
 </tr>

--- a/resources/views/community/components/claims/finished-claims.blade.php
+++ b/resources/views/community/components/claims/finished-claims.blade.php
@@ -119,7 +119,7 @@ $allFinishedClaimsHref = '/claimlist.php?s=' . ClaimSorting::FinishedDateDescend
                 <thead>
                     <tr class="do-not-highlight">
                         <th>Game</th>
-                        <th colspan="2">Dev</th>
+                        <th>Dev</th>
                         <th>Type</th>
                         <th>Finished</th>
                     </tr>

--- a/resources/views/community/components/claims/new-claim-table-row.blade.php
+++ b/resources/views/community/components/claims/new-claim-table-row.blade.php
@@ -6,7 +6,7 @@ $startedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['Created'])->di
 ?>
 
 <tr>
-    <td class="py-1.5">
+    <td class="py-1.5" width="55%">
         <x-game.multiline-avatar
             :gameId="$claim['GameID']"
             :gameTitle="$claim['GameTitle']"
@@ -16,7 +16,6 @@ $startedTimeAgo = Carbon::createFromFormat("Y-m-d H:i:s", $claim['Created'])->di
         />
     </td>
 
-    <td class="pr-0">{!! userAvatar($claim['User'], label: false) !!}</td>
-    <td>{!! userAvatar($claim['User'], icon: false) !!}</td>
+    <td class="pr-0">{!! userAvatar($claim['User']) !!}</td>
     <td class="smalldate">{{ $startedTimeAgo }}</td>
 </tr>

--- a/resources/views/community/components/claims/new-claims.blade.php
+++ b/resources/views/community/components/claims/new-claims.blade.php
@@ -22,7 +22,7 @@ $claimData = getFilteredClaims(
                 <thead>
                     <tr class="do-not-highlight">
                         <th>Game</th>
-                        <th colspan="2">Dev</th>
+                        <th>Dev</th>
                         <th class="whitespace-nowrap">Started</th>
                     </tr>
                 </thead>


### PR DESCRIPTION
This PR resolves a potential issue that can arise on the home page as a result of user avatars being rendered in two different table columns.

This is a stopgap solution- these components ideally shouldn't be using table layouts.

**Before**
![Screenshot 2023-07-29 at 12 40 28 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/6e36b855-1a9b-4505-8606-e6be5bb31f5e)

**After**
![Screenshot 2023-07-29 at 12 40 19 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/6bba6301-9f45-402c-8689-168811924808)
