### PR TITLE
prevent exception requesting non-existant achievement

### DIFF
--- a/public/API/API_GetAchievementUnlocks.php
+++ b/public/API/API_GetAchievementUnlocks.php
@@ -41,6 +41,14 @@ if (empty($achievementID)) {
 }
 
 $achievementData = GetAchievementData($achievementID);
+if ($achievementData === null) {
+    return response()->json([
+        'Achievement' => [],
+        'UnlocksCount' => 0,
+        'TotalPlayers' => 0,
+        'Unlocks' => [],
+    ], 404);
+}
 
 $achievement = [
     'ID' => $achievementData['AchievementID'] ?? null,

--- a/tests/Feature/Api/V1Test.php
+++ b/tests/Feature/Api/V1Test.php
@@ -281,6 +281,15 @@ class V1Test extends TestCase
                 ],
                 'UnlocksCount' => 1,
             ]);
+
+        $this->get($this->apiUrl('GetAchievementUnlocks', ['a' => 999999999]))
+            ->assertStatus(404)
+            ->assertExactJson([
+                'Achievement' => [],
+                'TotalPlayers' => 0,
+                'Unlocks' => [],
+                'UnlocksCount' => 0,
+            ]);
     }
 
     public function testGetConsoleIds(): void


### PR DESCRIPTION
fixes
```
Trying to access array offset on value of type null at /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/public/API/API_GetAchievementUnlocks.php:66)
[stacktrace]
#0 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(270): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/public/API/API_GetAchievementUnlocks.php(66): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->Illuminate\\Foundation\\Bootstrap\\{closure}()
```