### PR TITLE
prevent exception when receiving invalid f parameter

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -28,7 +28,11 @@ $matureContentPref = UserPreference::Site_SuppressMatureContentWarning;
 $officialFlag = AchievementType::OfficialCore;
 $unofficialFlag = AchievementType::Unofficial;
 $flags = requestInputSanitized('f', $officialFlag, 'integer');
-$isOfficial = $flags !== $unofficialFlag;
+$isOfficial = false;
+if ($flags !== $unofficialFlag) {
+    $isOfficial = true;
+    $flags = $officialFlag;
+}
 
 $defaultSort = 1;
 if (isset($user)) {


### PR DESCRIPTION
fixes:
```
Undefined array key 1 at /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/public/gameInfo.php:385)
[stacktrace]
#0 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(270): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/public/gameInfo.php(385): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->Illuminate\\Foundation\\Bootstrap\\{closure}()
#2 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/public/gameInfo.php(468): calculateBuckets()
```
when visiting `/game/X?f=N` where N is something other than 3 or 5.