### PR TITLE
fix cache key generation

### DIFF
--- a/app/Helpers/database/user-activity.php
+++ b/app/Helpers/database/user-activity.php
@@ -121,7 +121,7 @@ function postActivity(string|User $userIn, int $type, ?int $data = null, ?int $d
              */
             $lastPlayedTimestamp = null;
             $activityID = null;
-            $recentlyPlayedGamesCacheKey = CacheKey::buildUserRecentGamesCacheKey($user);
+            $recentlyPlayedGamesCacheKey = CacheKey::buildUserRecentGamesCacheKey($user->User);
             $recentlyPlayedGames = Cache::get($recentlyPlayedGamesCacheKey);
             if (!empty($recentlyPlayedGames)) {
                 foreach ($recentlyPlayedGames as $recentlyPlayedGame) {


### PR DESCRIPTION
Fixes
```
"exception":"[object] (Illuminate\\Database\\Eloquent\\JsonEncodingException(code: 0): Error encoding model [App\\Site\\Models\\User] with ID  to JSON: Malformed UTF-8 characters, possibly incorrectly encoded at /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/vendor/laravel/framework/src/Illuminate/Database/Eloquent/JsonEncodingException.php:18)
[stacktrace]
#0 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1649): Illuminate\\Database\\Eloquent\\JsonEncodingException::forModel()
#1 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(2354): Illuminate\\Database\\Eloquent\\Model->toJson()
#2 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/app/Support/Cache/CacheKey.php(47): Illuminate\\Database\\Eloquent\\Model->__toString()
#3 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/app/Helpers/database/user-activity.php(124): App\\Support\\Cache\\CacheKey::buildUserRecentGamesCacheKey()
#4 /srv/web/releases/2023-07-23T133407-3.1.1-29c6335f/public/dorequest.php(258): postActivity()
```

A merge conflict between #1659 and #1673 resulted in passing a User model to the `CacheKey::buildUserRecentGamesCacheKey` function, which expects a `string`. PHP was apparently calling the model's `__toString` function to implicitly do the conversion, resulting in a cache key like:
```
user:{"user":"jamiras","permissions":4,"achievements_unlocked":null,"achievements_unlocked_hardcore":null,"completion_percentage_average":null,"completion_percentage_average_hardcore":null,"rapoints":92540,"rasoftcorepoints":1105,"lastlogin":"2023-07-31t14:06:57.000000z","motto":"","contribcount":104852,"contribyield":704834,"truerapoints":246761,"untracked":0,"created":"2017-06-18t12:49:00.000000z","avatarurl":"http:\/\/media.retroachievements.org\/userpic\/jamiras.png"}:recent-games
```
If the user's motto included invalid UTF-8 (truncated mid multi-byte), an exception would be thrown.

This fixes the merge conflict so a sane cache key is created. As it's just attempting to read the key, we aren't polluting the cache with these invalid monstrosities. However, it guarantees to always be a cache miss, which causes additional load on the server. I plan to hotfix this as soon as it's approved.

I've also updated the database to fix invalid UTF-8 in user mottos:
```
> UPDATE UserAccounts SET Motto=SUBSTRING(Motto, 1, CHAR_LENGTH(Motto)-1) WHERE ASCII(RIGHT(Motto,1)) > 191;
> UPDATE UserAccounts SET Motto=SUBSTRING(Motto, 1, CHAR_LENGTH(Motto)-2) WHERE ASCII(LEFT(RIGHT(Motto,2),1)) > 223;
```