### PR TITLE
don't filter out untracked users if set has more than 100 players

### DIFF
--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -6,6 +6,8 @@ use App\Platform\Enums\AchievementFlag;
 use App\Platform\Enums\UnlockMode;
 use App\Platform\Models\Game;
 use App\Site\Enums\Permissions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 function getGameData(int $gameID): ?array
@@ -83,22 +85,89 @@ function getGameMetadata(
     $metricsJoin = '';
     $metricsBindings = [];
     if ($metrics) {
+        $cacheKey = "game:$gameID:playercount";
+        $gameMetrics = Cache::get($cacheKey);
+        if ($gameMetrics === null) {
+            $parentGameId = getParentGameIdFromGameTitle($gameDataOut['Title'], $gameDataOut['ConsoleID']);
+
+            $bindings = [
+                'gameId' => $gameID,
+                'achievementFlag' => $flag,
+            ];
+
+            $gameIdStatement = 'ach.GameID = :gameId';
+            if ($parentGameId !== null) {
+                $bindings['parentGameId'] = $parentGameId;
+                $gameIdStatement = 'ach.GameID IN (:gameId, :parentGameId)';
+            }
+
+            $query = "SELECT aw.HardcoreMode, COUNT(DISTINCT aw.User) as Users
+                        FROM Awarded AS aw
+                        LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
+                        LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
+                        WHERE $gameIdStatement AND ach.Flags = :achievementFlag
+                        AND NOT ua.Untracked
+                    GROUP BY aw.HardcoreMode";
+
+            $gameMetaData = legacyDbFetchAll($query, $bindings);
+
+            $numDistinctPlayersCasual = 0;
+            $numDistinctPlayersHardcore = 0;
+            foreach ($gameMetaData as $data) {
+                if ($data['HardcoreMode'] == UnlockMode::Hardcore) {
+                    $numDistinctPlayersHardcore = $data['Users'];
+                } else {
+                    $numDistinctPlayersCasual = $data['Users'];
+                }
+            }
+
+            $gameMetrics = [
+                'ParentGameID' => $parentGameId,
+                'NumDistinctPlayersCasual' => $numDistinctPlayersCasual,
+                'NumDistinctPlayersHardcore' => $numDistinctPlayersHardcore,
+            ];
+
+            // if a game has more than 100 players, only update the player count once an hour
+            if ($numDistinctPlayersCasual > 100) {
+                Cache::put($cacheKey, $gameMetrics, Carbon::now()->addHours(1));
+            }
+        }
+
+        $gameDataOut['ParentGameID'] = $gameMetrics['ParentGameID'];
+        $gameDataOut['NumDistinctPlayersCasual'] = $gameMetrics['NumDistinctPlayersCasual'];
+        $gameDataOut['NumDistinctPlayersHardcore'] = $gameMetrics['NumDistinctPlayersHardcore'];
+
         $metricsBindings = [
             'metricsGameId' => $gameID,
             'metricsAchievementFlag' => $flag,
         ];
         $metricsColumns = 'IFNULL(tracked_aw.NumAwarded, 0) AS NumAwarded,
                            IFNULL(tracked_aw.NumAwardedHardcore, 0) AS NumAwardedHardcore,';
-        $metricsJoin = "LEFT JOIN (
-            SELECT ach.ID AS AchievementID,
-                (COUNT(aw.AchievementID) - SUM(IFNULL(aw.HardcoreMode, 0))) AS NumAwarded,
-                (SUM(IFNULL(aw.HardcoreMode, 0))) AS NumAwardedHardcore
-            FROM Achievements AS ach
-            INNER JOIN Awarded AS aw ON aw.AchievementID = ach.ID
-            INNER JOIN UserAccounts AS ua ON ua.User = aw.User
-            WHERE ach.GameID = :metricsGameId AND ach.Flags = :metricsAchievementFlag AND NOT ua.Untracked
-            GROUP BY ach.ID
-        ) AS tracked_aw ON tracked_aw.AchievementID = ach.ID";
+
+        // if a game has more than 100 players, don't filter out the untracked users as the
+        // join becomes very expensive. will be addressed when denormalized data is captured
+        if ($gameMetrics['NumDistinctPlayersCasual'] > 100) {
+            $metricsJoin = "LEFT JOIN (
+                SELECT ach.ID AS AchievementID,
+                    (COUNT(aw.AchievementID) - SUM(IFNULL(aw.HardcoreMode, 0))) AS NumAwarded,
+                    (SUM(IFNULL(aw.HardcoreMode, 0))) AS NumAwardedHardcore
+                FROM Achievements AS ach
+                LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID
+                WHERE ach.GameID = :metricsGameId AND ach.Flags = :metricsAchievementFlag
+                GROUP BY ach.ID
+            ) AS tracked_aw ON tracked_aw.AchievementID = ach.ID";
+        } else {
+            $metricsJoin = "LEFT JOIN (
+                SELECT ach.ID AS AchievementID,
+                    (COUNT(aw.AchievementID) - SUM(IFNULL(aw.HardcoreMode, 0))) AS NumAwarded,
+                    (SUM(IFNULL(aw.HardcoreMode, 0))) AS NumAwardedHardcore
+                FROM Achievements AS ach
+                LEFT JOIN Awarded AS aw ON aw.AchievementID = ach.ID
+                LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
+                WHERE ach.GameID = :metricsGameId AND ach.Flags = :metricsAchievementFlag AND NOT ua.Untracked
+                GROUP BY ach.ID
+            ) AS tracked_aw ON tracked_aw.AchievementID = ach.ID";
+        }
     }
 
     $query = "
@@ -165,51 +234,6 @@ function getGameMetadata(
                 }
             }
         }
-    }
-
-    if ($metrics) {
-        $parentGameId = getParentGameIdFromGameTitle($gameDataOut['Title'], $gameDataOut['ConsoleID']);
-
-        $bindings = [
-            'gameId' => $gameID,
-            'achievementFlag' => $flag,
-        ];
-
-        $requestedByStatement = '';
-        if ($user) {
-            $bindings['username'] = $user;
-            $requestedByStatement = 'OR ua.User = :username';
-        }
-
-        $gameIdStatement = 'ach.GameID = :gameId';
-        if ($parentGameId !== null) {
-            $bindings['parentGameId'] = $parentGameId;
-            $gameIdStatement = 'ach.GameID IN (:gameId, :parentGameId)';
-        }
-
-        $query = "SELECT aw.HardcoreMode, COUNT(DISTINCT aw.User) as Users
-                  FROM Awarded AS aw
-                  LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
-                  LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
-                  WHERE $gameIdStatement AND ach.Flags = :achievementFlag
-                  AND (NOT ua.Untracked $requestedByStatement)
-                GROUP BY aw.HardcoreMode";
-
-        $gameMetaData = legacyDbFetchAll($query, $bindings);
-
-        $numDistinctPlayersCasual = 0;
-        $numDistinctPlayersHardcore = 0;
-        foreach ($gameMetaData as $data) {
-            if ($data['HardcoreMode'] == UnlockMode::Hardcore) {
-                $numDistinctPlayersHardcore = $data['Users'];
-            } else {
-                $numDistinctPlayersCasual = $data['Users'];
-            }
-        }
-
-        $gameDataOut['ParentGameID'] = $parentGameId;
-        $gameDataOut['NumDistinctPlayersCasual'] = $numDistinctPlayersCasual;
-        $gameDataOut['NumDistinctPlayersHardcore'] = $numDistinctPlayersHardcore;
     }
 
     $gameDataOut['NumAchievements'] = $numAchievements;

--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -429,7 +429,8 @@ function getAchievementDistribution(
     int $gameID,
     int $hardcore,
     ?string $requestedBy = null,
-    int $flag = AchievementFlag::OfficialCore
+    int $flag = AchievementFlag::OfficialCore,
+    int $numPlayers = 0,
 ): array {
     /** @var Game $game */
     $game = Game::withCount(['achievements' => fn ($query) => $query->type($flag)])
@@ -446,10 +447,16 @@ function getAchievementDistribution(
         'achievementFlag' => $flag,
     ];
 
+    // if a game has more than 100 players, don't filter out the untracked users as the
+    // join becomes very expensive. will be addressed when denormalized data is captured
     $requestedByStatement = '';
-    if ($requestedBy) {
-        $bindings['requestedBy'] = $requestedBy;
-        $requestedByStatement = 'OR ua.User = :requestedBy';
+    if ($numPlayers < 100) {
+        $requestedByStatement = 'AND (NOT ua.Untracked';
+        if ($requestedBy) {
+            $bindings['requestedBy'] = $requestedBy;
+            $requestedByStatement .= ' OR ua.User = :requestedBy';
+        }
+        $requestedByStatement .= ')';
     }
 
     // Returns an array of the number of players who have achieved each total, up to the max.
@@ -464,7 +471,7 @@ function getAchievementDistribution(
             WHERE gd.ID = :gameId
               AND aw.HardcoreMode = :unlockMode
               AND ach.Flags = :achievementFlag
-              AND (NOT ua.Untracked $requestedByStatement)
+              $requestedByStatement
             GROUP BY aw.User
             ORDER BY AwardedCount DESC
         ) AS InnerTable

--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -430,7 +430,7 @@ function getAchievementDistribution(
     int $hardcore,
     ?string $requestedBy = null,
     int $flag = AchievementFlag::OfficialCore,
-    int $numPlayers = 0,
+    int $numPlayers = 0
 ): array {
     /** @var Game $game */
     $game = Game::withCount(['achievements' => fn ($query) => $query->type($flag)])

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -189,8 +189,8 @@ if ($isFullyFeaturedGame) {
     $numDistinctPlayersCasual = $gameData['NumDistinctPlayersCasual'];
     $numDistinctPlayersHardcore = $gameData['NumDistinctPlayersHardcore'];
 
-    $achDist = getAchievementDistribution($gameID, UnlockMode::Softcore, $user, $flagParam);
-    $achDistHardcore = getAchievementDistribution($gameID, UnlockMode::Hardcore, $user, $flagParam);
+    $achDist = getAchievementDistribution($gameID, UnlockMode::Softcore, $user, $flagParam, $numDistinctPlayersCasual);
+    $achDistHardcore = getAchievementDistribution($gameID, UnlockMode::Hardcore, $user, $flagParam, $numDistinctPlayersCasual);
 
     $numArticleComments = getRecentArticleComments(ArticleType::Game, $gameID, $commentData);
 


### PR DESCRIPTION
Filtering out the untracked users for metrics calculations appears to have an exponential impact to the query performance. Game pages make four metrics calculations:

1) number of players for the game
2) number of players who have earned each achievement in hardcore or softcore
3) number of achievements earned per player in hardcore (distribution graph)
4) number of achievements earned per player in softcore (distribution graph)

As a result, loading game pages for popular games is slow. The plan was to generate denormalized data in the database to address this, but we need a more immediate solution for now.

This PR modifies the game page logic for games where there are more than 100 players. The number of players for the game is calculated in the same way (excluding untracked users). If that value is more than 100, it is cached for an hour (player count will only update once an hour). If the player count is more than 100, the untracked users are no longer filtered from queries 2, 3, or 4. This results in approximately 75% speedup loading pages for our most popular games with the tradeoff that the numbers aren't quite accurate.
