### PR TITLE
fix(code-notes): remediate js error on save

### DIFF
--- a/public/codenotes.php
+++ b/public/codenotes.php
@@ -178,14 +178,10 @@ function saveCodeNote(rowIndex, isDeleting = false) {
             rowEl.querySelector('td[data-current-author]').dataset.currentAuthor = currentUsername;
 
             const authorAvatarSpan = authorAvatarCellEl.querySelector('span.inline.whitespace-nowrap');
-            const tooltipOnMouseOverAttr = authorAvatarSpan.getAttribute('onmouseover');
-            const updatedOnMouseOverAttr = tooltipOnMouseOverAttr.replace(
-                /loadCard\(this, 'user', '([^']*)', ''\)/,
-                `loadCard(this, 'user', '${currentUsername}', '')`
-            );
-            authorAvatarSpan.setAttribute('onmouseover', updatedOnMouseOverAttr);
+            const newXInitValue = `attachTooltipToElement($el, { dynamicType: 'user', dynamicId: '${currentUsername}', dynamicContext: '' })`;
+            authorAvatarSpan.setAttribute('x-init', newXInitValue);
+            attachTooltipToElement(authorAvatarSpan, { dynamicType: 'user', dynamicId: currentUsername, dynamicContext: '' });
         }
-
 
         // Now it's safe to bail.
         setRowEditingEnabled(rowEl, false);


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1137756621519454238.

**Root Cause**
The JS in this file is assuming the old wz_tooltip implementation is still in place, and is not correctly compensating for the new Alpine.js-driven implementation.