### PR TITLE
perf: remove unnecessary join on UserAccounts

### DIFF
--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -449,8 +449,10 @@ function getAchievementDistribution(
 
     // if a game has more than 100 players, don't filter out the untracked users as the
     // join becomes very expensive. will be addressed when denormalized data is captured
+    $joinStatement = '';
     $requestedByStatement = '';
     if ($numPlayers < 100) {
+        $joinStatement = 'LEFT JOIN UserAccounts AS ua ON ua.User = aw.User';
         $requestedByStatement = 'AND (NOT ua.Untracked';
         if ($requestedBy) {
             $bindings['requestedBy'] = $requestedBy;
@@ -467,7 +469,7 @@ function getAchievementDistribution(
             FROM Awarded AS aw
             LEFT JOIN Achievements AS ach ON ach.ID = aw.AchievementID
             LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
-            LEFT JOIN UserAccounts AS ua ON ua.User = aw.User
+            $joinStatement
             WHERE gd.ID = :gameId
               AND aw.HardcoreMode = :unlockMode
               AND ach.Flags = :achievementFlag


### PR DESCRIPTION
#1712 removes the untracked user filtering for sets with over 100 players but the join on UserAccounts was still there so this removes that as well.

**Benchmarks**
These samples were collected on game ID 1446 with the local MySQL cache disabled. Results are the combine 2 calls for hardcore and softcore

  | Before | After
-- | -- | --
1 | 1105ms | 507ms
2 | 1180ms| 501ms
3 | 1117ms | 505ms
4 | 1135ms | 493ms
5 | 1119ms | 499ms
Average | 1131ms | 501ms

Speedup Factor: ~2.26x
