### PR TITLE
perf: defer loading of google charts

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -297,10 +297,14 @@ sanitize_outputs(
 <?php endif ?>
 <?php RenderContentStart($pageTitle); ?>
 <?php if ($isFullyFeaturedGame): ?>
-    <script src="https://www.gstatic.com/charts/loader.js"></script>
+    <script defer src="https://www.gstatic.com/charts/loader.js"></script>
     <script>
-    google.load('visualization', '1.0', { 'packages': ['corechart'] });
-    google.setOnLoadCallback(drawCharts);
+    document.addEventListener('DOMContentLoaded', function() {
+        if (typeof google !== 'undefined') {
+            google.load('visualization', '1.0', { 'packages': ['corechart'] });
+            google.setOnLoadCallback(drawCharts);
+        }
+    });
 
     function drawCharts() {
         var dataTotalScore = new google.visualization.DataTable();
@@ -1561,7 +1565,7 @@ sanitize_outputs(
             if ($numAchievements > 0) {
                 echo "<div id='achdistribution' class='component' >";
                 echo "<h2 class='text-h3'>Achievement Distribution</h2>";
-                echo "<div id='chart_distribution'></div>";
+                echo "<div id='chart_distribution' class='min-h-[260px]'></div>";
                 echo "</div>";
 
                 RenderTopAchieversComponent($user, $gameTopAchievers['HighScores'], $gameTopAchievers['Masters']);

--- a/public/history.php
+++ b/public/history.php
@@ -34,13 +34,14 @@ $userScoreData = getAwardedList($userPage);
 
 RenderContentStart("$userPage's Legacy");
 ?>
-<script src="https://www.gstatic.com/charts/loader.js"></script>
+<script defer src="https://www.gstatic.com/charts/loader.js"></script>
 <script>
-  google.load('visualization', '1.0', { 'packages': ['corechart'] });
-  google.setOnLoadCallback(drawCharts);
+  document.addEventListener('DOMContentLoaded', function() {
+    google.load('visualization', '1.0', { 'packages': ['corechart'] });
+    google.setOnLoadCallback(drawCharts);
+  });
 
   function drawCharts() {
-
     var dataTotalScore = new google.visualization.DataTable();
 
     // Declare columns
@@ -251,10 +252,10 @@ RenderContentStart("$userPage's Legacy");
 
         echo "</div>";
 
-        echo "<div id='chart_scoreprogress'></div>";
+        echo "<div id='chart_scoreprogress' class='min-h-[250px]'></div>";
 
         echo "<h3>Best Days</h3>";
-        echo "<div id='chart_bestdays'></div>";
+        echo "<div id='chart_bestdays' class='min-h-[250px]'></div>";
 
         echo "<table class='table-highlight'><tbody>";
 

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -544,10 +544,12 @@ $totalTicketPlusMinus = ($totalTicketPlusMinus > 0) ? '+' . $totalTicketPlusMinu
 
 RenderContentStart("$dev's Developer Stats");
 ?>
-<script src="https://www.gstatic.com/charts/loader.js"></script>
+<script defer src="https://www.gstatic.com/charts/loader.js"></script>
 <script>
-    google.charts.load('current', { 'packages': ['corechart'] });
-    google.charts.setOnLoadCallback(drawChart);
+    document.addEventListener('DOMContentLoaded', function() {
+        google.charts.load('current', { 'packages': ['corechart'] });
+        google.charts.setOnLoadCallback(drawChart);
+    });
 
     function drawChart() {
         <?php if ($userContribCount > 0) { ?>
@@ -689,9 +691,9 @@ RenderContentStart("$dev's Developer Stats");
             /*
              * Pie Charts
              */
-            echo "<div style='width: 100%; overflow: hidden; text-align: center'>";
-            echo "<div style='display: inline-block' id='gameChart'></div>";
-            echo "<div style='display: inline-block' id='achievementChart'></div>";
+            echo "<div class='w-full overflow-hidden text-center'>";
+            echo "<div class='inline-block min-h-[325px]' id='gameChart'></div>";
+            echo "<div class='inline-block min-h-[325px]' id='achievementChart'></div>";
             echo "</div>";
 
             /*

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -126,10 +126,14 @@ RenderOpenGraphMetadata(
 );
 RenderContentStart($userPage);
 ?>
-<script src="https://www.gstatic.com/charts/loader.js"></script>
+<script defer src="https://www.gstatic.com/charts/loader.js"></script>
 <script>
-  google.load('visualization', '1.0', { 'packages': ['corechart'] });
-  google.setOnLoadCallback(drawCharts);
+  document.addEventListener('DOMContentLoaded', function() {
+    if (typeof google !== 'undefined') {
+        google.load('visualization', '1.0', { 'packages': ['corechart'] });
+        google.setOnLoadCallback(drawCharts);
+    }
+  });
 
   function drawCharts() {
       var dataRecentProgress = new google.visualization.DataTable();
@@ -628,7 +632,7 @@ RenderContentStart($userPage);
 
         echo "<div id='achdistribution' class='component'>";
         echo "<h3>Recent Progress</h3>";
-        echo "<div id='chart_recentprogress' class='mb-5'></div>";
+        echo "<div id='chart_recentprogress' class='mb-5 min-h-[200px]'></div>";
         echo "<div class='text-right'><a class='btn btn-link' href='/history.php?u=$userPage'>more...</a></div>";
         echo "</div>";
 

--- a/resources/views/community/components/user/online-count-chart.blade.php
+++ b/resources/views/community/components/user/online-count-chart.blade.php
@@ -19,10 +19,12 @@ if (file_exists("../storage/logs/playersonline.log")) {
 
 $numPlayers = User::where('LastLogin', '>', Carbon::now()->subMinutes(10))->count();
 ?>
-<script src="https://www.gstatic.com/charts/loader.js"></script>
+<script defer src="https://www.gstatic.com/charts/loader.js"></script>
 <script>
-    google.load('visualization', '1.0', { 'packages': ['corechart'] });
-    google.setOnLoadCallback(drawCharts);
+    document.addEventListener('DOMContentLoaded', function() {
+        google.load('visualization', '1.0', { 'packages': ['corechart'] });
+        google.setOnLoadCallback(drawCharts);
+    });
 
     function drawCharts() {
         var dataTotalScore = new google.visualization.DataTable();


### PR DESCRIPTION
This PR adjusts how Google Charts renders on all relevant pages.

Right now, on game pages and user profiles, once the browser receives its first byte but before the page fully paints to the screen, 50% of that time is spent parsing JS. A huge chunk of that JS is Google Charts.

After this PR, Google Charts will no longer be render-blocking. It will load asynchronously in the background, and while loading the chart component will just render empty space.