### PR TITLE
perf: eliminate lodash

### DIFF
--- a/public/js/activePlayersBootstrap.js
+++ b/public/js/activePlayersBootstrap.js
@@ -64,15 +64,15 @@ var ActivePlayersViewModel = function () {
   }, this);
 
   this.filteredPlayers = ko.pureComputed(function () {
-    return _.filter(this.players(), (player) => {
+    return this.players().filter((player) => {
       var lowercaseFilterTextTerms = this.playerFilterText().toLowerCase().split('|');
       var matchFound = false;
       lowercaseFilterTextTerms.forEach((lowercaseFilterText) => {
-        matchFound = lowercaseFilterText !== ''
+        matchFound = matchFound || (lowercaseFilterText !== ''
           && (player.username().toLowerCase().includes(lowercaseFilterText)
             || player.gameTitle().toLowerCase().includes(lowercaseFilterText)
             || player.consoleName().toLowerCase().includes(lowercaseFilterText)
-            || player.richPresenceDisplay().toLowerCase().includes(lowercaseFilterText));
+            || player.richPresenceDisplay().toLowerCase().includes(lowercaseFilterText)));
       });
       return this.playerFilterText() === '' || matchFound;
     });

--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -44,7 +44,6 @@
     {{-- TODO replace with ESM imports, Alpine, tailwind --}}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js" integrity="sha256-qXBd/EfAdjOA2FGrGAG+b3YBn2tn5A6bhz+LSgYD96k=" crossorigin="anonymous"></script>
 
     @if(app()->environment('local'))
         <script src="/js/all.js?v={{ random_int(0, mt_getrandmax()) }}"></script>


### PR DESCRIPTION
There is only one lodash call in the entire app: `_.filter()` in the Active Players widget.

The lodash dependency is roughly 27KB unminified, and the entire app pays this tax due to this one call. On mobile 3G connections, this adds roughly 500ms of load time to an end user's first page view.

This PR migrates the `_.filter()` call to native JS `Array.prototype.filter()` and removes the lodash dependency.