### PR TITLE
perf: add priority hints to the LCP

### DIFF
--- a/resources/views/layouts/components/brand-top.blade.php
+++ b/resources/views/layouts/components/brand-top.blade.php
@@ -31,7 +31,9 @@
                 </div>
             @endif--}}
             <div class="p-4 text-center">
-                <a href="{{ route('home') }}"><img style="max-width:550px;width:100%" src="{{ asset('assets/images/ra-logo-sm.webp') }}" alt="RetroAchievements logo"></a>
+                <a href="{{ route('home') }}">
+                    <img class="max-w-[550px] w-full" fetchpriority="high" src="{{ asset('assets/images/ra-logo-sm.webp') }}" alt="RetroAchievements logo">
+                </a>
             </div>
             <x-user.top-card/>
         </div>

--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -4,6 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ (!empty($pageTitle) ? $pageTitle . ' · ' : '') . config('app.name') }}</title>
     <link rel="icon" type="image/png" href="{{ asset(app()->environment('local', 'stage') ? 'assets/images/favicon-gray.webp' : 'assets/images/favicon.webp') }}">
+    <link rel="preload" as="image" importance="high" href="{{ asset('assets/images/ra-logo-sm.webp') }}">
     <link rel="image_src" href="{{ asset('assets/images/ra-logo-sm.webp') }}">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="copyright" content="Copyright 2014-{{ date('Y') }}">


### PR DESCRIPTION
The LCP on nearly every page of the site is the logo in the navbar. Currently it has no preloading, priority, or importance hinting. These hints move the image further up the waterfall to coerce the browser to fetch the image earlier, resulting in better LCP scores.