### PR TITLE
fix: remediate multiline game avatar whitespace issue

### DIFF
--- a/resources/views/platform/components/game/multiline-avatar.blade.php
+++ b/resources/views/platform/components/game/multiline-avatar.blade.php
@@ -44,7 +44,7 @@ $showConsoleLine = $consoleId || $consoleName;
     @if($showConsoleLine)
         <div>
             <!-- Provide invisible space to slide the console underneath -->
-            <p class="invisible">{!! $renderedGameTitle !!}</p>
+            <p class="invisible max-w-fit font-medium mb-0.5 text-xs">{!! $renderedGameTitle !!}</p>
 
             <div class="flex items-center gap-x-1">
                 @if($consoleId && $consoleName)


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1139310042869407995.

**Root Cause**
The invisible space doesn't have the same styles applied as the real visible element, resulting in a minor enough style difference to cause the whitespace to appear.