### PR TITLE
fix(game): hide images native scrollbar on SM+

### DIFF
--- a/resources/views/platform/components/game/screenshots.blade.php
+++ b/resources/views/platform/components/game/screenshots.blade.php
@@ -17,7 +17,7 @@ function carousel() {
 </script>
 
 <div class="relative" x-data="carousel()">
-    <div x-ref="carousel" class="-mx-5 my-6 sm:mt-0 sm:mb-3 sm:mx-0 flex sm:justify-around sm:w-full sm:gap-x-5 snap-x sm:snap-none sm:overflow-x-auto snap-mandatory overflow-x-scroll scroll-smooth">
+    <div x-ref="carousel" class="-mx-5 my-6 sm:mt-0 sm:mb-3 sm:mx-0 flex sm:justify-around sm:w-full sm:gap-x-5 snap-x sm:snap-none sm:overflow-x-hidden snap-mandatory overflow-x-scroll scroll-smooth">
         <div id="title-screenshot" class="box-content flex w-full sm:w-auto flex-none snap-start sm:items-center">
             <img class="w-full sm:rounded-sm" src="{{ $titleImageSrc }}" alt="Title screenshot">
         </div>


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1002693810037477377/1139333012446785657.

**Root Cause**
On macOS, this native scrollbar is hidden. However, it is visible on Windows (and I assume Linux).