### PR TITLE
fix: use infobox icons to designate when title attrs are available

### DIFF
--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -297,7 +297,16 @@ RenderContentStart($pageTitle);
                 echo "</select>";
                 echo "</td></tr>";
 
-                echo "<tr><td class='cursor-help' title='A game is considered beaten if ALL Progression achievements are unlocked and ANY Win Condition achievements are unlocked.'>Type:<sup>*</sup></td><td>";
+                $typeHelperContent = "A game is considered beaten if ALL Progression achievements are unlocked and ANY Win Condition achievements are unlocked.";
+                echo "<tr><td>";
+                echo "<label class='cursor-help flex items-center gap-x-1' for='typeinput' title='$typeHelperContent' aria-label='Type, $typeHelperContent'>";
+                echo "Type";
+                echo "<span>";
+                echo Blade::render("<x-pixelarticons-info-box class='w-5 h-5' aria-hidden='true' />");
+                echo ":";
+                echo "</span>";
+                echo "</label>";
+                echo "</td><td>";
                 echo "<select id='typeinput' name='k'>";
                 echo "<option value=''>None</option>";
                 foreach (AchievementType::cases() as $typeOption) {

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1057,7 +1057,14 @@ sanitize_outputs(
                     echo "<input type='hidden' name='genre' value='" . attributeEscape($genre) . "'>";
                     echo "<input type='hidden' name='release' value='" . attributeEscape($released) . "'>";
                     echo "<div class='md:grid grid-cols-[180px_1fr_100px] gap-1 items-center mb-1'>";
-                    echo "<label for='guide_url' class='cursor-help' title='Must be from https://github.com/RetroAchievements/guides'>Guide URL<sup>*</sup></label><input type='url' name='guide_url' id='guide_url' value='" . attributeEscape($guideURL) . "' class='w-full'>";
+
+                    $guideUrlHelperContent = "Must be from https://github.com/RetroAchievements/guides";
+                    echo "<label for='guide_url' class='cursor-help flex items-center gap-x-1' title='$guideUrlHelperContent' aria-label='Guide URL, $guideUrlHelperContent'>";
+                    echo "Guide URL";
+                    echo Blade::render("<x-pixelarticons-info-box class='w-5 h-5' aria-hidden='true' />");
+                    echo "</label>";
+
+                    echo "<input type='url' name='guide_url' id='guide_url' value='" . attributeEscape($guideURL) . "' class='w-full'>";
                     echo "<div class='text-right'><button class='btn'>Submit</button></div>";
                     echo "</div>";
                     echo "</form>";


### PR DESCRIPTION
Replaces the `*` on Guide URL and Type fields with an infobox icon. Also makes a few a11y improvements to those labels.

![Screenshot 2023-08-10 at 8 06 55 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/1e746160-fbef-44bb-929b-47e0a0849a95)
![Screenshot 2023-08-10 at 8 07 17 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/21ba9dca-17d8-4b4a-aec5-222864062476)
