### PR TITLE
feat(achievement): update meta description

### DIFF
--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -88,7 +88,27 @@ $numArticleComments = getRecentArticleComments(ArticleType::Achievement, $achiev
 getCodeNotes($gameID, $codeNotes);
 
 $pageTitle = "$achievementTitleRaw in $gameTitleRaw ($consoleName)";
-RenderOpenGraphMetadata($pageTitle, "achievement", media_asset("/Badge/$badgeName.png"), "$gameTitleRaw ($consoleName) - $achievementDescriptionRaw");
+
+function generateMetaDescription(
+    string $achievementDescription,
+    string $gameTitle,
+    string $consoleName,
+    int $points = 0,
+    int $winnerCount = 0,
+) {
+    $pointsLabel = $points === 1 ? "point" : "points";
+    $localizedWinnerCount = localized_number($winnerCount);
+    $winnerCountLabel = $winnerCount === 1 ? "player" : "players";
+
+    return "$achievementDescription ($points $pointsLabel), won by $localizedWinnerCount $winnerCountLabel - $gameTitle for $consoleName";
+}
+
+RenderOpenGraphMetadata(
+    $pageTitle,
+    "achievement",
+    media_asset("/Badge/$badgeName.png"),
+    generateMetaDescription($achievementDescriptionRaw, $gameTitleRaw, $consoleName, $achPoints, $numWinners)
+);
 RenderContentStart($pageTitle);
 ?>
 <?php if ($permissions >= Permissions::Developer || ($permissions >= Permissions::JuniorDeveloper && $isAuthor)): ?>

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -95,7 +95,7 @@ function generateMetaDescription(
     string $consoleName,
     int $points = 0,
     int $winnerCount = 0,
-) {
+): string {
     $pointsLabel = $points === 1 ? "point" : "points";
     $localizedWinnerCount = localized_number($winnerCount);
     $winnerCountLabel = $winnerCount === 1 ? "player" : "players";


### PR DESCRIPTION
This PR updates the OpenGraph meta description of achievement info pages to add more contextual information about the achievement and move the achievement description to be the primary focal point of the content.

**Before**
```
Mega Man (NES) - Beat the game without losing a life
```

**After**
```
Beat the game without losing a life (50 points), won by 513 players - Mega Man for NES
```