### PR TITLE
fix(UserCard): remediate typo

### DIFF
--- a/app/Community/Components/UserCard.php
+++ b/app/Community/Components/UserCard.php
@@ -106,7 +106,7 @@ class UserCard extends Component
         $siteRank = 0;
         $totalRankedUsersCount = 0;
         $rankType = RankType::Hardcore;
-        $rankLabel = 'Site Rank:';
+        $rankLabel = 'Site Rank';
         $rankPctLabel = '';
         $rankMinPoints = Rank::MIN_POINTS;
 


### PR DESCRIPTION
The site rank row in the user card renders as "Site Rank:: #N", with two colons. This is due to a refactor that occurred in the most recent release to transition those cards over to using more reusable components.