### PR TITLE
fix(game): remediate issue where more than 100% progress is shown [V3.2.1]

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1444,6 +1444,23 @@ sanitize_outputs(
                                     ($wonBy + $wonByHardcore) * 100.0 / $numDistinctPlayersCasual
                                 );
                             }
+
+                            // TODO: Remove when denormalized data is ready.
+                            // Because we're currently including Untracked players when the player count
+                            // for the game is >100, it's possible for the unlock rate to be greater than
+                            // 100%.
+                            // @see https://github.com/RetroAchievements/RAWeb/pull/1712
+                            if ($pctAwardedCasual > 100) {
+                                $pctAwardedCasual = 100;
+                            }
+                            if ($wonBy > $numDistinctPlayersCasual) {
+                                $wonBy = $numDistinctPlayersCasual;
+                            }
+                            if ($wonByHardcore > $numDistinctPlayersCasual) {
+                                $wonByHardcore = $numDistinctPlayersCasual;
+                            }
+                            // TODO: Untracked players filtering workaround ends here
+
                             echo "<div class='achievementdata'>";
                             echo "<div class='mb-1 lg:mt-1'>";
                             echo achievementAvatar(

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1453,6 +1453,12 @@ sanitize_outputs(
                             if ($pctAwardedCasual > 100) {
                                 $pctAwardedCasual = 100;
                             }
+                            if ($wonBy > $numDistinctPlayersCasual) {
+                                $wonBy = $numDistinctPlayersCasual;
+                            }
+                            if ($wonByHardcore > $numDistinctPlayersCasual) {
+                                $wonByHardcore = $numDistinctPlayersCasual;
+                            }
                             // TODO: Untracked players filtering workaround ends here
 
                             echo "<div class='achievementdata'>";

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1453,12 +1453,6 @@ sanitize_outputs(
                             if ($pctAwardedCasual > 100) {
                                 $pctAwardedCasual = 100;
                             }
-                            if ($wonBy > $numDistinctPlayersCasual) {
-                                $wonBy = $numDistinctPlayersCasual;
-                            }
-                            if ($wonByHardcore > $numDistinctPlayersCasual) {
-                                $wonByHardcore = $numDistinctPlayersCasual;
-                            }
                             // TODO: Untracked players filtering workaround ends here
 
                             echo "<div class='achievementdata'>";


### PR DESCRIPTION
Mitigates https://discord.com/channels/476211979464343552/1026595325038833725/1139734338041299065, which was introduced by the optimizations in #1712.

Now if unlock rate % is greater than 100% because Untracked players are being included, the UI will just fall back to showing 100%.