### PR TITLE
fix(site-awards): filter out beaten games from awards displays [V3.2.1]

### DIFF
--- a/app/Helpers/database/site-award.php
+++ b/app/Helpers/database/site-award.php
@@ -84,7 +84,7 @@ function getUsersSiteAwards(string $user, bool $showHidden = false): array
                   FROM SiteAwards AS saw
                   LEFT JOIN GameData AS gd ON ( gd.ID = saw.AwardData AND saw.AwardType = " . AwardType::Mastery . " )
                   LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-                  WHERE saw.AwardType = " . AwardType::Mastery . " AND saw.User = :username
+                  WHERE (saw.AwardType = " . AwardType::Mastery . " OR saw.AwardType = " . AwardType::GameBeaten . ") AND saw.User = :username
                   GROUP BY saw.AwardType, saw.AwardData, saw.AwardDataExtra
     UNION
     SELECT " . unixTimestampStatement('MAX(saw.AwardDate)', 'AwardedAt') . ", saw.AwardType, MAX( saw.AwardData ), saw.AwardDataExtra, saw.DisplayOrder, NULL, NULL, NULL, NULL

--- a/app/Helpers/render/site-award.php
+++ b/app/Helpers/render/site-award.php
@@ -24,9 +24,14 @@ function SeparateAwards(array $userAwards): array
 
     $eventAwards = array_values(array_filter($eventAwards, fn ($award) => !in_array($award, $devEventAwards)));
 
-    $siteAwards = array_values(array_filter($userAwards, fn ($award) => ($award['AwardType'] != AwardType::Mastery && AwardType::isActive((int) $award['AwardType']))
-        || in_array($award, $devEventAwards)
-    ));
+    $filterSiteAwards = function ($userAward) use ($devEventAwards) {
+        $isNotMasteryOrGameBeaten = $userAward['AwardType'] != AwardType::Mastery && $userAward['AwardType'] != AwardType::GameBeaten;
+        $isActiveAwardType = AwardType::isActive((int) $userAward['AwardType']);
+        $isDevEventAward = in_array($userAward, $devEventAwards);
+    
+        return ($isNotMasteryOrGameBeaten && $isActiveAwardType) || $isDevEventAward;    
+    };
+    $siteAwards = array_values(array_filter($userAwards, $filterSiteAwards));
 
     return [$gameAwards, $eventAwards, $siteAwards];
 }

--- a/app/Helpers/render/site-award.php
+++ b/app/Helpers/render/site-award.php
@@ -28,8 +28,8 @@ function SeparateAwards(array $userAwards): array
         $isNotMasteryOrGameBeaten = $userAward['AwardType'] != AwardType::Mastery && $userAward['AwardType'] != AwardType::GameBeaten;
         $isActiveAwardType = AwardType::isActive((int) $userAward['AwardType']);
         $isDevEventAward = in_array($userAward, $devEventAwards);
-    
-        return ($isNotMasteryOrGameBeaten && $isActiveAwardType) || $isDevEventAward;    
+
+        return ($isNotMasteryOrGameBeaten && $isActiveAwardType) || $isDevEventAward;
     };
     $siteAwards = array_values(array_filter($userAwards, $filterSiteAwards));
 


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1139786829290291241.

* Ensures beaten games are being fetched properly by the all-purpose `getUsersSiteAwards()` function.
* Ensures they're filtered out in the `SeparateAwards()` function so they don't increase the count of Site Awards on user profiles.