### PR TITLE
fix(game): remediate desktop screenshots scaling [V3.2.1]

### DIFF
--- a/resources/views/platform/components/game/screenshots.blade.php
+++ b/resources/views/platform/components/game/screenshots.blade.php
@@ -18,11 +18,11 @@ function carousel() {
 
 <div class="relative" x-data="carousel()">
     <div x-ref="carousel" class="-mx-5 my-6 sm:mt-0 sm:mb-3 sm:mx-0 flex sm:justify-around sm:w-full sm:gap-x-5 snap-x sm:snap-none sm:overflow-x-hidden snap-mandatory overflow-x-scroll scroll-smooth">
-        <div id="title-screenshot" class="box-content flex w-full sm:w-auto flex-none snap-start sm:items-center">
+        <div id="title-screenshot" class="box-content flex w-full sm:w-auto flex-none sm:flex-auto snap-start sm:items-center">
             <img class="w-full sm:rounded-sm" src="{{ $titleImageSrc }}" alt="Title screenshot">
         </div>
 
-        <div id="ingame-screenshot" class="box-content flex w-full sm:w-auto flex-none snap-start sm:items-center">
+        <div id="ingame-screenshot" class="box-content flex w-full sm:w-auto flex-none sm:flex-auto snap-start sm:items-center">
             <img class="w-full sm:rounded-sm" src="{{ $ingameImageSrc }}" alt="In-game screenshot">
         </div>
     </div>


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1139773947949355070.

**Root Cause**
`flex-none` prohibits downscaling to fit the container correctly on mobile, but this is not desirable on SM and above where the carousel is not used. Added `sm:flex-auto` to "undo" this style on SM+ breakpoints.