### PR TITLE
chore(user): add data-* attrs to game awards for userscripts [V3.2.1]

### DIFF
--- a/app/Helpers/render/site-award.php
+++ b/app/Helpers/render/site-award.php
@@ -186,7 +186,9 @@ function RenderAward(array $award, int $imageSize, string $ownerUsername, bool $
         $award['GameID'] = $award['AwardData'];
         $award['Mastery'] = "<br clear=all>$awarded";
 
-        echo "<div>" . gameAvatar($award, label: false, iconSize: $imageSize, context: $ownerUsername, iconClass: $imgclass) . "</div>";
+        $dataAttrGameId = $award['GameID'];
+        // NOTE: If these data-* attributes are removed, userscripts will begin breaking.
+        echo "<div data-gameid='$dataAttrGameId' data-date='$awardDate'>" . gameAvatar($award, label: false, iconSize: $imageSize, context: $ownerUsername, iconClass: $imgclass) . "</div>";
 
         return;
     }


### PR DESCRIPTION
A few of the popular userscripts for the site depended on "seeing" the mastery dates statically rendered in the user profiles site awards. This no longer occurs because of the dynamic game cards not being initially available in the template.

To retain compatibility with these scripts, `data-gameid` and `data-date` attributes have been added to the wrapper div around each award. The date is presented in the same format it was displayed as in the static cards.

![Screenshot 2023-08-12 at 8 37 16 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/fd44b5b7-8209-46ab-a991-3e899d411679)

NOTE: I have communicated that the preferred solution is https://retroachievements-api-js.vercel.app/v1/users/get-user-awards.html.
