### PR TITLE
feat(achievementInspector): allow mass removing achievement types

### DIFF
--- a/app/Helpers/database/achievement.php
+++ b/app/Helpers/database/achievement.php
@@ -536,7 +536,7 @@ function updateAchievementFlag(int|string|array $achID, int $newFlag): bool
     return true;
 }
 
-function updateAchievementType(int|string|array $achID, string $newType): bool
+function updateAchievementType(int|string|array $achID, ?string $newType): bool
 {
     $achievementIds = is_array($achID) ? $achID : [$achID];
 

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -320,9 +320,9 @@ function toggleAllCodeRows() {
             }
 
             if ($fullModifyOK) {
-                echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", null)'>Remove Types from Selected</a>";
                 echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::Progression . "\")'>Set Selected to Progression</a>";
                 echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::WinCondition . "\")'>Set Selected to Win Condition</a>";
+                echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", null)'>Set Selected to No Type</a>";
             }
         }
 

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -89,7 +89,7 @@ function getConfirmMessage(property, newValue, selectedCount) {
 
 /**
  * @param {'flag' | 'type'} property
- * @param {3 | 5 | 'Progression' | 'Win Condition'} newValue
+ * @param {3 | 5 | 'Progression' | 'Win Condition' | null} newValue
  */
 function updateAchievementsProperty(property, newValue) {
     // Creates an array of checked achievement IDs and sends it to the updateAchievements function

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -320,6 +320,7 @@ function toggleAllCodeRows() {
             }
 
             if ($fullModifyOK) {
+                echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", null)'>Remove Types from Selected</a>";
                 echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::Progression . "\")'>Set Selected to Progression</a>";
                 echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::WinCondition . "\")'>Set Selected to Win Condition</a>";
             }

--- a/public/request/achievement/update-type.php
+++ b/public/request/achievement/update-type.php
@@ -13,7 +13,7 @@ if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Deve
 
 $input = Validator::validate(Arr::wrap(request()->post()), [
     'achievements' => 'required',
-    'type' => ['required', 'string', Rule::in(AchievementType::cases())],
+    'type' => ['nullable', 'string', Rule::in(AchievementType::cases())],
 ]);
 
 $achievementIds = $input['achievements'];
@@ -26,6 +26,9 @@ if (updateAchievementType($achievementIds, $value)) {
     }
     if ($value === AchievementType::WinCondition) {
         $commentText = "set this achievement's type to Win Condition";
+    }
+    if (!$value) {
+        $commentText = "removed this achievement's type";
     }
     addArticleComment("Server", ArticleType::Achievement, $achievementIds, "$user $commentText.", $user);
 

--- a/tests/Feature/Platform/BeatenGameTest.php
+++ b/tests/Feature/Platform/BeatenGameTest.php
@@ -270,6 +270,8 @@ class BeatenGameTest extends TestCase
     public function testHardcoreAwardAssignment(): void
     {
         // Arrange
+        Carbon::setTestNow(Carbon::now());
+
         /** @var User $user */
         $user = User::factory()->create();
         /** @var System $system */
@@ -333,6 +335,8 @@ class BeatenGameTest extends TestCase
 
     public function testBeatenAwardRevocation2(): void
     {
+        Carbon::setTestNow(Carbon::now());
+
         /** @var User $user */
         $user = User::factory()->create();
         /** @var System $system */
@@ -393,6 +397,8 @@ class BeatenGameTest extends TestCase
 
     public function testRetroactiveAward(): void
     {
+        Carbon::setTestNow(Carbon::now());
+
         /** @var User $user */
         $user = User::factory()->create();
         /** @var System $system */
@@ -426,35 +432,39 @@ class BeatenGameTest extends TestCase
         );
     }
 
-public function testRetroactiveAward2(): void
-{
-    /** @var User $user */
-    $user = User::factory()->create();
-    /** @var System $system */
-    $system = System::factory()->create();
-    /** @var Game $game */
-    $game = Game::factory()->create(['ConsoleID' => $system->ID]);
+    public function testRetroactiveAward2(): void
+    {
+        Carbon::setTestNow(Carbon::now());
 
-    Achievement::factory()->published()->count(6)->create(['GameID' => $game->ID]);
-    $winConditionAchievements = Achievement::factory()->published()->winCondition()->count(2)->create(['GameID' => $game->ID]);
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var System $system */
+        $system = System::factory()->create();
+        /** @var Game $game */
+        $game = Game::factory()->create(['ConsoleID' => $system->ID]);
 
-    $this->addHardcoreUnlock($user, $winConditionAchievements->get(0), Carbon::now()->subHours(12));
-    $this->addHardcoreUnlock($user, $winConditionAchievements->get(1), Carbon::now()->subHours(6));
+        Achievement::factory()->published()->count(6)->create(['GameID' => $game->ID]);
+        $winConditionAchievements = Achievement::factory()->published()->winCondition()->count(2)->create(['GameID' => $game->ID]);
 
-    testBeatenGame($game->ID, $user->User, true);
+        $this->addHardcoreUnlock($user, $winConditionAchievements->get(0), Carbon::now()->subHours(12));
+        $this->addHardcoreUnlock($user, $winConditionAchievements->get(1), Carbon::now()->subHours(6));
 
-    $this->assertEquals(PlayerBadge::where('User', $user->User)->count(), 1);
-    $this->assertNotNull(PlayerBadge::where('User', $user->User)
-        ->where('AwardType', AwardType::GameBeaten)
-        ->where('AwardData', $game->ID)
-        ->where('AwardDataExtra', UnlockMode::Hardcore)
-        ->where('AwardDate', Carbon::now()->subHours(12))
-        ->first()
-    );
-}
+        testBeatenGame($game->ID, $user->User, true);
+
+        $this->assertEquals(PlayerBadge::where('User', $user->User)->count(), 1);
+        $this->assertNotNull(PlayerBadge::where('User', $user->User)
+            ->where('AwardType', AwardType::GameBeaten)
+            ->where('AwardData', $game->ID)
+            ->where('AwardDataExtra', UnlockMode::Hardcore)
+            ->where('AwardDate', Carbon::now()->subHours(12))
+            ->first()
+        );
+    }
 
     public function testRetroactiveAward3(): void
     {
+        Carbon::setTestNow(Carbon::now());
+
         /** @var User $user */
         $user = User::factory()->create();
         /** @var System $system */


### PR DESCRIPTION
This PR adds another button to the toolbox for mass removal of types from the achievements in the list.

@Tsearo How do you feel about the button position and label?

![Screenshot 2023-08-12 at 12 54 58 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/a8e8197a-6ff4-4007-9178-b035028c4eda)
