### PR TITLE
fix(game): resolve screenshot height issue [V3.2]

### DIFF
--- a/resources/views/platform/components/game/screenshots.blade.php
+++ b/resources/views/platform/components/game/screenshots.blade.php
@@ -16,23 +16,35 @@ function carousel() {
 }
 </script>
 
-<div class="relative" x-data="carousel()">
-    <div x-ref="carousel" class="-mx-5 my-6 sm:mt-0 sm:mb-3 sm:mx-0 flex sm:justify-around sm:w-full sm:gap-x-5 snap-x sm:snap-none sm:overflow-x-hidden snap-mandatory overflow-x-scroll scroll-smooth">
-        <div id="title-screenshot" class="box-content flex w-full sm:w-auto flex-none sm:flex-auto snap-start sm:items-center">
-            <img class="w-full sm:rounded-sm" src="{{ $titleImageSrc }}" alt="Title screenshot">
+<!-- XS Only -->
+<div class="relative sm:hidden" x-data="carousel()">
+    <div x-ref="carousel" class="-mx-5 my-6 flex snap-x snap-mandatory overflow-x-scroll scroll-smooth">
+        <div id="title-screenshot" class="box-content flex w-full flex-none snap-start">
+            <img class="w-full" src="{{ $titleImageSrc }}" alt="Title screenshot">
         </div>
 
-        <div id="ingame-screenshot" class="box-content flex w-full sm:w-auto flex-none sm:flex-auto snap-start sm:items-center">
-            <img class="w-full sm:rounded-sm" src="{{ $ingameImageSrc }}" alt="In-game screenshot">
+        <div id="ingame-screenshot" class="box-content flex w-full flex-none snap-start">
+            <img class="w-full" src="{{ $ingameImageSrc }}" alt="In-game screenshot">
         </div>
     </div>
 
-    <div class="absolute right-1/2 translate-x-1/2 bottom-2 sm:hidden" @click.prevent="">
+    <div class="absolute right-1/2 translate-x-1/2 bottom-2" @click.prevent="">
         <a href="#title-screenshot" @click.prevent="scrollTo('title-screenshot')" class="inline-block w-4 h-4 rounded-full outline-none bg-neutral-100 border-2 border-neutral-800 cursor-pointer">
             <span class="sr-only">Title screenshot</span>
         </a>
         <a href="#ingame-screenshot" @click.prevent="scrollTo('ingame-screenshot')" class="inline-block w-4 h-4 rounded-full outline-none bg-neutral-100 border-2 border-neutral-800 cursor-pointer">
             <span class="sr-only">Ingame screenshot</span>
         </a>
+    </div>
+</div>
+
+<!-- SM+ -->
+<div class="hidden sm:flex mb-3 mx-0 justify-around w-full gap-y-1 gap-x-5">
+    <div class="flex justify-center items-center">
+        <img class="w-full rounded-sm" src="{{ $titleImageSrc }}" alt="Title screenshot">
+    </div>
+
+    <div class="flex justify-center items-center">
+        <img class="w-full rounded-sm" src="{{ $ingameImageSrc }}" alt="In-game screenshot">
     </div>
 </div>


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1140208098909372457.

The carousel styles are only visible now at the XS breakpoint. SM+ sees exactly the content that was present in release 3.1.

**Before**
![Screenshot 2023-08-13 at 9 19 27 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/e55f2280-6d43-4e4c-9130-e39dcb458db8)


**After**
![Screenshot 2023-08-13 at 9 18 12 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/02f3b0ae-9942-4834-b292-a43faa104ae0)
