### PR TITLE
fix(modal-trigger): remove z-50 [V3.2]

### DIFF
--- a/resources/views/components/modal-trigger.blade.php
+++ b/resources/views/components/modal-trigger.blade.php
@@ -3,7 +3,7 @@
 <div
     x-data="{ isModalOpen: false }"
     @keydown.escape.window="isModalOpen = false"
-    class="relative z-50 w-auto h-auto inline"
+    class="relative w-auto h-auto inline"
 >
     <button type="button" class="inline" @click="isModalOpen = true">{{ $buttonLabel }}</button>
 


### PR DESCRIPTION
Resolves this issue:
![image](https://github.com/RetroAchievements/RAWeb/assets/3984985/82d17995-b82e-40a7-9ed1-5a62078ec630)

**Root Cause**
There is an erroneous `z-50` class name attached to the modal trigger component that is unnecessary.