### PR TITLE
fix(tooltip): remediate render cycle race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "name": "raweb",
             "dependencies": {
                 "@alpinejs/focus": "^3.12.3",
-                "@floating-ui/dom": "^1.2.3",
+                "@floating-ui/dom": "^1.5.1",
                 "alpinejs": "^3.12.2",
                 "js-cookie": "^3.0.5",
                 "ua-parser-js": "^1.0.35"
@@ -309,17 +309,26 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
-            "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+            "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+            "dependencies": {
+                "@floating-ui/utils": "^0.1.1"
+            }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.4.tgz",
-            "integrity": "sha512-21hhDEPOiWkGp0Ys4Wi6Neriah7HweToKra626CIK712B5m9qkdz54OP9gVldUg+URnBTpv/j/bi/skmGdstXQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
+            "integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
             "dependencies": {
-                "@floating-ui/core": "^1.3.1"
+                "@floating-ui/core": "^1.4.1",
+                "@floating-ui/utils": "^0.1.1"
             }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
+            "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.10",
@@ -6395,17 +6404,26 @@
             "dev": true
         },
         "@floating-ui/core": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
-            "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+            "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+            "requires": {
+                "@floating-ui/utils": "^0.1.1"
+            }
         },
         "@floating-ui/dom": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.4.tgz",
-            "integrity": "sha512-21hhDEPOiWkGp0Ys4Wi6Neriah7HweToKra626CIK712B5m9qkdz54OP9gVldUg+URnBTpv/j/bi/skmGdstXQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
+            "integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
             "requires": {
-                "@floating-ui/core": "^1.3.1"
+                "@floating-ui/core": "^1.4.1",
+                "@floating-ui/utils": "^0.1.1"
             }
+        },
+        "@floating-ui/utils": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
+            "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
         },
         "@humanwhocodes/config-array": {
             "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@alpinejs/focus": "^3.12.3",
-        "@floating-ui/dom": "^1.2.3",
+        "@floating-ui/dom": "^1.5.1",
         "alpinejs": "^3.12.2",
         "js-cookie": "^3.0.5",
         "ua-parser-js": "^1.0.35"

--- a/resources/js/alpine/tooltipComponent/tooltipComponent.ts
+++ b/resources/js/alpine/tooltipComponent/tooltipComponent.ts
@@ -84,6 +84,7 @@ export function tooltipComponent(anchorEl: HTMLElement, props: Partial<TooltipPr
             event.pageY + 6,
           );
         }
+
         isTooltipShowing = true;
       }
     }, 70);

--- a/resources/js/alpine/tooltipComponent/utils/loadDynamicTooltip.test.ts
+++ b/resources/js/alpine/tooltipComponent/utils/loadDynamicTooltip.test.ts
@@ -91,7 +91,9 @@ describe('Util: loadDynamicTooltip', () => {
     // ASSERT
     expect(renderTooltipSpy).toHaveBeenCalledWith(
       anchorEl,
-      store.dynamicContentCache.mockType_mockId
+      store.dynamicContentCache.mockType_mockId,
+      undefined,
+      undefined,
     );
   });
 

--- a/resources/js/alpine/tooltipComponent/utils/loadDynamicTooltip.ts
+++ b/resources/js/alpine/tooltipComponent/utils/loadDynamicTooltip.ts
@@ -38,7 +38,7 @@ export async function loadDynamicTooltip(
   // If we already have cached HTML content for this tooltip available,
   // don't refetch the content. Display the cached content instead.
   if (store.dynamicContentCache[cacheKey]) {
-    displayDynamicTooltip(anchorEl, store.dynamicContentCache[cacheKey], givenY);
+    displayDynamicTooltip(anchorEl, store.dynamicContentCache[cacheKey]);
     return;
   }
 
@@ -103,18 +103,16 @@ async function fetchDynamicTooltipContent(type: string, id: string, context?: un
  *
  * @param anchorEl The HTML element to anchor the tooltip to.
  * @param htmlContent The HTML content to be displayed in the tooltip.
- * @param givenY Optional Y-coordinate to adjust the tooltip's starting position.
  */
-function displayDynamicTooltip(anchorEl: HTMLElement, htmlContent: string, givenY?: number) {
-  const setX = store.trackedMouseX;
-  let setY = store.trackedMouseY;
-
-  // We'll do a slight subtraction to avoid a jump of the tooltip position.
-  // This is a visual anomaly that can occur on the first frame a tooltip is rendered.
-  if (givenY) {
-    setY = givenY - 10;
-  }
-
+function displayDynamicTooltip(anchorEl: HTMLElement, htmlContent: string) {
   renderTooltip(anchorEl, htmlContent);
-  pinTooltipToCursorPosition(anchorEl, store.tooltipEl, setX, setY);
+
+  if (store.trackedMouseX && store.trackedMouseY) {
+    pinTooltipToCursorPosition(
+      anchorEl,
+      store.tooltipEl,
+      store.trackedMouseX,
+      store.trackedMouseY - 10,
+    );
+  }
 }

--- a/resources/js/alpine/tooltipComponent/utils/loadDynamicTooltip.ts
+++ b/resources/js/alpine/tooltipComponent/utils/loadDynamicTooltip.ts
@@ -105,14 +105,10 @@ async function fetchDynamicTooltipContent(type: string, id: string, context?: un
  * @param htmlContent The HTML content to be displayed in the tooltip.
  */
 function displayDynamicTooltip(anchorEl: HTMLElement, htmlContent: string) {
-  renderTooltip(anchorEl, htmlContent);
-
-  if (store.trackedMouseX && store.trackedMouseY) {
-    pinTooltipToCursorPosition(
-      anchorEl,
-      store.tooltipEl,
-      store.trackedMouseX,
-      store.trackedMouseY - 10,
-    );
-  }
+  renderTooltip(
+    anchorEl,
+    htmlContent,
+    store.trackedMouseX ? store.trackedMouseX + 10 : undefined,
+    store.trackedMouseY ? store.trackedMouseY + 8 : undefined,
+  );
 }

--- a/resources/js/alpine/tooltipComponent/utils/pinTooltipToCursorPosition.ts
+++ b/resources/js/alpine/tooltipComponent/utils/pinTooltipToCursorPosition.ts
@@ -17,7 +17,7 @@ export function pinTooltipToCursorPosition(
   anchorEl: HTMLElement,
   tooltipEl: HTMLElement | null,
   trackedMouseX: number | null,
-  trackedMouseY: number | null
+  trackedMouseY: number | null,
 ) {
   if (trackedMouseX && trackedMouseY && tooltipEl) {
     updateTooltipPosition(anchorEl, tooltipEl, trackedMouseX + 12, trackedMouseY + 16);

--- a/resources/js/alpine/tooltipComponent/utils/trackTooltipMouseMovement.ts
+++ b/resources/js/alpine/tooltipComponent/utils/trackTooltipMouseMovement.ts
@@ -18,7 +18,7 @@ export function trackTooltipMouseMovement(anchorEl: HTMLElement, event: MouseEve
   store.trackedMouseX = event.pageX;
   store.trackedMouseY = event.pageY;
 
-  if (tooltipEl) {
+  if (tooltipEl && anchorEl === store.activeAnchorEl) {
     updateTooltipPosition(anchorEl, tooltipEl, store.trackedMouseX + 12, store.trackedMouseY + 6);
   }
 }


### PR DESCRIPTION
This PR resolves a race condition in the tooltip rendering functionality which is currently causing a flicker when rapidly alternating between dynamic tooltips. It is also causing a positioning miscalculation, which sometimes causes tooltips to render in the wrong place.

**Current Prod Behavior (which this PR fixes)**

https://github.com/RetroAchievements/RAWeb/assets/3984985/6a17aa67-09df-4141-91c2-1d5940bdbf85

