### PR TITLE
fix(devbox): remediate js error from blade interpolation

### DIFF
--- a/resources/views/platform/components/game/devbox-claim-management.blade.php
+++ b/resources/views/platform/components/game/devbox-claim-management.blade.php
@@ -66,7 +66,7 @@ $canClaim = ($userHasClaimSlot || $isSoleAuthor || $isCollaboration) && !$hasGam
 
 $revisionDialogFlag = ($isRevision && !$isSoleAuthor) ? 'true' : 'false';
 $ticketDialogFlag = $hasOpenTickets ? 'true' : 'false';
-$isRecentPrimaryClaim = $primaryClaimMinutesActive <= 1440;
+$isRecentPrimaryClaim = $primaryClaimMinutesActive <= 1440 ? 'true' : 'false';
 ?>
 
 <script>


### PR DESCRIPTION
This PR resolves a JS error that can occur due to an interpolation problem in the devbox. This is because the raw PHP boolean value is not being interpolated correctly into the component's inline <script> tag.

![Screenshot 2023-08-14 at 7 21 33 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/45a4b0c5-8c3a-4d1f-a3fd-be6aa0344bcd)
