### PR TITLE
fix(testBeatenGame): revoke awards when types are completely removed

### DIFF
--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -36,6 +36,8 @@ function testBeatenGame(int $gameId, string $user, bool $postBeaten): array
     // If the game has no beaten-tier achievements assigned, it is not considered beatable.
     // Bail.
     if ($totalProgressions === 0 && $totalWinConditions === 0) {
+        purgeAllPlayerBeatenGameAwardsForGame($user, $gameId);
+
         return [
             'isBeatenSoftcore' => false,
             'isBeatenHardcore' => false,
@@ -91,19 +93,11 @@ function testBeatenGame(int $gameId, string $user, bool $postBeaten): array
     $alreadyHasBeatenAwards = HasBeatenSiteAwards($user, $gameId);
     if ($alreadyHasBeatenAwards && !$isBeaten) {
         if (!$isBeatenSoftcore) {
-            PlayerBadge::where('User', $user)
-                ->where('AwardType', AwardType::GameBeaten)
-                ->where('AwardData', $gameId)
-                ->where('AwardDataExtra', UnlockMode::Softcore)
-                ->delete();
+            purgePlayerBeatenGameAward($user, $gameId, UnlockMode::Softcore);
         }
 
         if (!$isBeatenHardcore) {
-            PlayerBadge::where('User', $user)
-                ->where('AwardType', AwardType::GameBeaten)
-                ->where('AwardData', $gameId)
-                ->where('AwardDataExtra', UnlockMode::Hardcore)
-                ->delete();
+            purgePlayerBeatenGameAward($user, $gameId, UnlockMode::Hardcore);
         }
     }
 
@@ -132,6 +126,23 @@ function testBeatenGame(int $gameId, string $user, bool $postBeaten): array
         'isBeatenHardcore' => $isBeatenHardcore,
         'isBeatable' => true,
     ];
+}
+
+function purgePlayerBeatenGameAward(string $username, int $gameId, int $unlockMode = UnlockMode::Softcore): void
+{
+    PlayerBadge::where('User', $username)
+        ->where('AwardType', AwardType::GameBeaten)
+        ->where('AwardData', $gameId)
+        ->where('AwardDataExtra', $unlockMode)
+        ->delete();
+}
+
+function purgeAllPlayerBeatenGameAwardsForGame(string $username, int $gameId): void
+{
+    PlayerBadge::where('User', $username)
+        ->where('AwardType', AwardType::GameBeaten)
+        ->where('AwardData', $gameId)
+        ->delete();
 }
 
 /**

--- a/tests/Feature/Platform/BeatenGameTest.php
+++ b/tests/Feature/Platform/BeatenGameTest.php
@@ -425,6 +425,38 @@ class BeatenGameTest extends TestCase
         );
     }
 
+    public function testBeatenAwardRevocation3(): void
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var System $system */
+        $system = System::factory()->create();
+        /** @var Game $game */
+        $game = Game::factory()->create(['ConsoleID' => $system->ID]);
+
+        Achievement::factory()->published()->count(6)->create(['GameID' => $game->ID]);
+        /** @var Achievement $progressionAchievement */
+        $progressionAchievement = Achievement::factory()->published()->progression()->create(['GameID' => $game->ID]);
+
+        // The user unlocks the one progression achievement. They should be given beaten game credit.
+        $this->addHardcoreUnlock($user, $progressionAchievement);
+        testBeatenGame($game->ID, $user->User, true);
+        $this->assertEquals(PlayerBadge::where('User', $user->User)->count(), 1);
+
+        // Now, pretend a dev removes the progression type from the achievement.
+        $progressionAchievement->type = null;
+        $progressionAchievement->save();
+        $progressionAchievement->refresh();
+
+        // Next, pretend the player does a score recalc, which triggers testBeatenGame().
+        testBeatenGame($game->ID, $user->User, true);
+
+        // The beaten game award should be revoked.
+        $this->assertEquals(PlayerBadge::where('User', $user->User)->count(), 0);
+    }
+
     public function testRetroactiveAward(): void
     {
         Carbon::setTestNow(Carbon::now());

--- a/tests/Feature/Platform/BeatenGameTest.php
+++ b/tests/Feature/Platform/BeatenGameTest.php
@@ -124,7 +124,7 @@ class BeatenGameTest extends TestCase
 
     public function testAllProgressionAchievementsUnlockedAndNoWinConditionExists(): void
     {
-                // Arrange
+        // Arrange
         /** @var User $user */
         $user = User::factory()->create();
         /** @var System $system */


### PR DESCRIPTION
Resolves an issue found in #1780 in [this comment](https://github.com/RetroAchievements/RAWeb/pull/1780#pullrequestreview-1585778201):

>Not necessarily related to this specific page but through more testing I also noticed if I have a beat award for a game with a single progression achievement if I change that single achievement type to none (no longer any progression) and recalculate my score I still retain the beat award in the database which I would expect is no longer valid and gets removed. This will likely be more apparent when we have the user profile update.

**Root Cause**
`testBeatenGame()` bails when a set has no progression or win condition achievements. Because of the premature return, the code for revocation wasn't being hit.

Now, when the function falls into this premature return block, the system naively attempts to delete all beaten game awards associated with both the user and the game.