### PR TITLE
fix(UploadNewAchievement): dont strip `type` value on RAIntegration edits

### DIFF
--- a/app/Helpers/database/achievement.php
+++ b/app/Helpers/database/achievement.php
@@ -194,6 +194,7 @@ function UploadNewAchievement(
         return false;
     }
 
+    // TODO: remove "not-given" when RAIntegration supports `type`
     if ($type !== null && (!AchievementType::isValid($type) && $type !== 'not-given')) {
         $errorOut = "Invalid achievement type";
 
@@ -268,7 +269,7 @@ function UploadNewAchievement(
         $data = mysqli_fetch_assoc($dbResult);
 
         $changingAchSet = ($data['Flags'] != $flag);
-        $changingType = ($data['type'] != $type && $type !== 'not-given');
+        $changingType = ($data['type'] != $type && $type !== 'not-given'); // TODO: remove "not-given" when RAIntegration supports `type`
         $changingPoints = ($data['Points'] != $points);
         $changingTitle = ($data['Title'] !== $rawTitle);
         $changingDescription = ($data['Description'] !== $rawDesc);
@@ -296,6 +297,7 @@ function UploadNewAchievement(
             }
         }
 
+        // TODO: remove when RAIntegration supports `type`
         // `null` is a valid type value, so we use a different fallback value.
         if ($type === 'not-given' && $data['type'] !== null) {
             $typeValue = "'" . $data['type'] . "'";

--- a/app/Helpers/database/achievement.php
+++ b/app/Helpers/database/achievement.php
@@ -296,6 +296,11 @@ function UploadNewAchievement(
             }
         }
 
+        // `null` is valid, so we use a different fallback value.
+        if ($typeValue === 'not-given' && $data['type']) {
+            $typeValue = $data['type'];
+        }
+
         $query = "UPDATE Achievements SET Title='$title', Description='$desc', Progress='$progress', ProgressMax='$progressMax', ProgressFormat='$progressFmt', MemAddr='$mem', Points=$points, Flags=$flag, type=$typeValue, DateModified=NOW(), Updated=NOW(), BadgeName='$badge' WHERE ID=$idInOut";
 
         $db = getMysqliConnection();

--- a/app/Helpers/database/achievement.php
+++ b/app/Helpers/database/achievement.php
@@ -194,7 +194,7 @@ function UploadNewAchievement(
         return false;
     }
 
-    if ($type !== null && !AchievementType::isValid($type)) {
+    if ($type !== null && (!AchievementType::isValid($type) && $type !== 'not-given')) {
         $errorOut = "Invalid achievement type";
 
         return false;
@@ -268,7 +268,7 @@ function UploadNewAchievement(
         $data = mysqli_fetch_assoc($dbResult);
 
         $changingAchSet = ($data['Flags'] != $flag);
-        $changingType = ($data['type'] != $type);
+        $changingType = ($data['type'] != $type && $type !== 'not-given');
         $changingPoints = ($data['Points'] != $points);
         $changingTitle = ($data['Title'] !== $rawTitle);
         $changingDescription = ($data['Description'] !== $rawDesc);
@@ -296,9 +296,9 @@ function UploadNewAchievement(
             }
         }
 
-        // `null` is valid, so we use a different fallback value.
-        if ($typeValue === 'not-given' && $data['type']) {
-            $typeValue = $data['type'];
+        // `null` is a valid type value, so we use a different fallback value.
+        if ($type === 'not-given' && $data['type'] !== null) {
+            $typeValue = "'" . $data['type'] . "'";
         }
 
         $query = "UPDATE Achievements SET Title='$title', Description='$desc', Progress='$progress', ProgressMax='$progressMax', ProgressFormat='$progressFmt', MemAddr='$mem', Points=$points, Flags=$flag, type=$typeValue, DateModified=NOW(), Updated=NOW(), BadgeName='$badge' WHERE ID=$idInOut";

--- a/app/Helpers/database/achievement.php
+++ b/app/Helpers/database/achievement.php
@@ -194,7 +194,6 @@ function UploadNewAchievement(
         return false;
     }
 
-    // TODO: remove "not-given" when RAIntegration supports `type`
     if ($type !== null && (!AchievementType::isValid($type) && $type !== 'not-given')) {
         $errorOut = "Invalid achievement type";
 
@@ -269,7 +268,7 @@ function UploadNewAchievement(
         $data = mysqli_fetch_assoc($dbResult);
 
         $changingAchSet = ($data['Flags'] != $flag);
-        $changingType = ($data['type'] != $type && $type !== 'not-given'); // TODO: remove "not-given" when RAIntegration supports `type`
+        $changingType = ($data['type'] != $type && $type !== 'not-given');
         $changingPoints = ($data['Points'] != $points);
         $changingTitle = ($data['Title'] !== $rawTitle);
         $changingDescription = ($data['Description'] !== $rawDesc);
@@ -297,7 +296,6 @@ function UploadNewAchievement(
             }
         }
 
-        // TODO: remove when RAIntegration supports `type`
         // `null` is a valid type value, so we use a different fallback value.
         if ($type === 'not-given' && $data['type'] !== null) {
             $typeValue = "'" . $data['type'] . "'";

--- a/app/Helpers/database/achievement.php
+++ b/app/Helpers/database/achievement.php
@@ -206,7 +206,7 @@ function UploadNewAchievement(
     sanitize_sql_inputs($title, $desc, $mem, $progress, $progressMax, $progressFmt, $dbAuthor, $type);
 
     $typeValue = "";
-    if ($type === null || trim($type) === '') {
+    if ($type === null || trim($type) === '' || $type === 'not-given') {
         $typeValue = "NULL";
     } else {
         $typeValue = "'$type'";

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -388,7 +388,7 @@ switch ($requestType) {
             progressMax: ' ',
             progressFmt: ' ',
             points: (int) request()->input('z', 0),
-            type: request()->input('x'),
+            type: request()->input('x', 'not-given'),
             mem: request()->input('m'),
             flag: (int) request()->input('f', AchievementFlag::Unofficial),
             idInOut: $achievementID,

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -388,7 +388,7 @@ switch ($requestType) {
             progressMax: ' ',
             progressFmt: ' ',
             points: (int) request()->input('z', 0),
-            type: request()->input('x', 'not-given'), // TODO: remove "not-given" when RAIntegration supports `type`
+            type: request()->input('x', 'not-given'), // `null` is a valid achievement type value, so we use a different fallback value.
             mem: request()->input('m'),
             flag: (int) request()->input('f', AchievementFlag::Unofficial),
             idInOut: $achievementID,

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -388,7 +388,7 @@ switch ($requestType) {
             progressMax: ' ',
             progressFmt: ' ',
             points: (int) request()->input('z', 0),
-            type: request()->input('x', 'not-given'),
+            type: request()->input('x', 'not-given'), // TODO: remove "not-given" when RAIntegration supports `type`
             mem: request()->input('m'),
             flag: (int) request()->input('f', AchievementFlag::Unofficial),
             idInOut: $achievementID,


### PR DESCRIPTION
This PR resolves an issue where achievement edits from RAIntegration are removing an achievement's `type` value.

`null` is a valid `type`, so a different fallback ("not-given") was picked.
These exceptions can be removed if and when RAIntegration natively supports the `type` field.