### PR TITLE
fix exception viewing dev stats for developer with no sole/majority credits

### DIFF
--- a/app/Helpers/database/user.php
+++ b/app/Helpers/database/user.php
@@ -394,6 +394,10 @@ function GetUserFields(string $username, array $fields): ?array
 function getMostAwardedUsers(array $gameIDs): array
 {
     $retVal = [];
+    if (empty($gameIDs)) {
+        return $retVal;
+    }
+
     $query = "SELECT ua.User,
               SUM(IF(AwardDataExtra LIKE '0', 1, 0)) AS Completed,
               SUM(IF(AwardDataExtra LIKE '1', 1, 0)) AS Mastered
@@ -421,6 +425,10 @@ function getMostAwardedUsers(array $gameIDs): array
 function getMostAwardedGames(array $gameIDs): array
 {
     $retVal = [];
+    if (empty($gameIDs)) {
+        return $retVal;
+    }
+
     $query = "SELECT gd.Title, sa.AwardData AS ID, c.Name AS ConsoleName, gd.ImageIcon as GameIcon,
               SUM(IF(AwardDataExtra LIKE '0' AND Untracked = 0, 1, 0)) AS Completed,
               SUM(IF(AwardDataExtra LIKE '1' AND Untracked = 0, 1, 0)) AS Mastered


### PR DESCRIPTION
fixes
```
(mysqli_sql_exception(code: 1064): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')
              GROUP BY sa.AwardData, gd.Title
              ORDER BY Title'
```
```
[stacktrace]
#0 /home/forge/retroachievements.org/releases/2023-08-14T082503-3.2.2-83eca4ee/app/Helpers/util/database.php(107): mysqli_query()
#1 /home/forge/retroachievements.org/releases/2023-08-14T082503-3.2.2-83eca4ee/app/Helpers/database/user.php(436): s_mysql_query()
#2 /home/forge/retroachievements.org/releases/2023-08-14T082503-3.2.2-83eca4ee/public/individualdevstats.php(202): getMostAwardedGames()
```