### PR TITLE
fix(forum): remediate deep links anchors

### DIFF
--- a/resources/views/community/components/forum/post-container.blade.php
+++ b/resources/views/community/components/forum/post-container.blade.php
@@ -5,7 +5,7 @@
 ])
 
 <div class="relative {{ $isPreview ? "my-2" : "" }}">
-    <div {{ $commentId ? 'id="$commentId"' : ''}} class="absolute left-0 h-px w-px" style="top: -64px;"></div>
+    <div {{ $commentId ? "id=" . $commentId : "" }} class="absolute left-0 h-px w-px" style="top: -64px;"></div>
 
     <div
         class='{{ $isHighlighted ? 'highlight' : '' }} {{ $isPreview ? 'py-2' : 'pb-3 pt-2' }} relative w-[calc(100%+16px)] sm:w-full -mx-2 sm:mx-0 lg:flex rounded-lg mt-3 odd:bg-embed bg-embed-highlight px-1'


### PR DESCRIPTION
Noticed this issue while testing #1786. It appears the IDs for posts are not being interpolated correctly, resulting in the page not auto-scrolling to the linked forum post.