### PR TITLE
prevent inserting truncated UTF-8 into motto field

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -64,7 +64,9 @@ class Handler extends ExceptionHandler
             if (str_ends_with($context['url'], 'dorequest.php')) {
                 unset($params['u']);
                 unset($params['t']);
-                if ($params['r'] == 'login') {
+
+                $method = $params['r'] ?? '';
+                if ($method === 'login') {
                     unset($params['p']);
                 }
             } elseif (str_contains($context['url'], '/API/')) {

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -64,6 +64,9 @@ class Handler extends ExceptionHandler
             if (str_ends_with($context['url'], 'dorequest.php')) {
                 unset($params['u']);
                 unset($params['t']);
+                if ($params['r'] == 'login') {
+                    unset($params['p']);
+                }
             } elseif (str_contains($context['url'], '/API/')) {
                 unset($params['z']);
                 unset($params['y']);

--- a/public/request/user/update-motto.php
+++ b/public/request/user/update-motto.php
@@ -12,7 +12,7 @@ $input = Validator::validate(Arr::wrap(request()->post()), [
     'motto' => 'nullable|string|max:50',
 ]);
 
-$newMotto = $input['motto'];
+$newMotto = mb_strcut($input['motto'], 0, 50, "UTF-8");
 
 sanitize_sql_inputs($user, $cookie, $newMotto);
 


### PR DESCRIPTION
Reccurrance of:
```
Error encoding model [App\\Site\\Models\\User] with ID  to JSON: Malformed UTF-8 characters, possibly incorrectly encoded 
at /home/forge/retroachievements.org/releases/2023-08-14T082503-3.2.2-83eca4ee/vendor/laravel/framework/src/Illuminate/Database/Eloquent/JsonEncodingException.php:18)
```

Which was originally reported [here](https://discord.com/channels/310192285306454017/1135568221995536554/1135568221995536554).

This sanitizes the motto going into the database so the error shouldn't occur again in the future.