### PR TITLE
fix: change '- points' label to 'No achievements'

### DIFF
--- a/resources/views/platform/components/game/similar-game-table-row.blade.php
+++ b/resources/views/platform/components/game/similar-game-table-row.blade.php
@@ -23,17 +23,18 @@
             <div class="flex flex-col items-end">
                 <p class="text-2xs whitespace-nowrap {{ $totalPoints === 0 ? 'text-text-muted' : '' }}">
                     <span @if ($totalPoints > 0) class="font-semibold" @endif>
-                        {{ $totalPoints > 0 ? localized_number($totalPoints) : '-' }}
+                        @if ($totalPoints > 0)
+                            {{ localized_number($totalPoints) }} points
+                        @else
+                            No achievements
+                        @endif
                     </span>
-                    points
                 </p>
 
                 <x-points-weighted-container>
                     <p class="text-2xs whitespace-nowrap {{ $totalRetroPoints === 0 ? 'text-text-muted' : '' }}">
                         @if ($totalRetroPoints > 0)
                             ({{ localized_number($totalRetroPoints) }})
-                        @else
-                            -
                         @endif
                     </p>
                 </x-points-weighted-container>

--- a/resources/views/platform/components/game/similar-game-table-row.blade.php
+++ b/resources/views/platform/components/game/similar-game-table-row.blade.php
@@ -26,7 +26,7 @@
                         @if ($totalPoints > 0)
                             {{ localized_number($totalPoints) }} points
                         @else
-                            No achievements
+                            no achievements
                         @endif
                     </span>
                 </p>


### PR DESCRIPTION
Changes "- points" on similar games rows on game pages to instead show "no achievements".

![Screenshot 2023-08-24 at 5 27 40 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/1a38d267-3dc9-4e22-bd78-f93bcd2bed91)
