### PR TITLE
fix(tooltip): track mouse position properly with static tooltips [V3.3]

### DIFF
--- a/resources/js/alpine/tooltipComponent/tooltipComponent.ts
+++ b/resources/js/alpine/tooltipComponent/tooltipComponent.ts
@@ -104,7 +104,7 @@ export function tooltipComponent(anchorEl: HTMLElement, props: Partial<TooltipPr
   const trackMouseMovement = (event: MouseEvent) => {
     store.trackedMouseX = event.pageX;
     store.trackedMouseY = event.pageY;
-    trackTooltipMouseMovement(anchorEl, event);
+    trackTooltipMouseMovement(anchorEl, event, props?.dynamicType ? 'dynamic' : 'static');
   };
 
   return {

--- a/resources/js/alpine/tooltipComponent/utils/trackTooltipMouseMovement.ts
+++ b/resources/js/alpine/tooltipComponent/utils/trackTooltipMouseMovement.ts
@@ -11,14 +11,22 @@ import { updateTooltipPosition } from './updateTooltipPosition';
  *
  * @param anchorEl The HTML element to anchor the tooltip to.
  * @param event The MouseEvent object containing the current mouse coordinates.
+ * @param tooltipKind "static" if not lazy-loaded, "dynamic" if lazy-loaded.
  */
-export function trackTooltipMouseMovement(anchorEl: HTMLElement, event: MouseEvent) {
+export function trackTooltipMouseMovement(
+  anchorEl: HTMLElement,
+  event: MouseEvent,
+  tooltipKind: 'static' | 'dynamic',
+) {
   const tooltipEl = store.tooltipEl;
 
   store.trackedMouseX = event.pageX;
   store.trackedMouseY = event.pageY;
 
-  if (tooltipEl && anchorEl === store.activeAnchorEl) {
+  if (
+    tooltipEl
+    && (tooltipKind === 'static' || (tooltipKind === 'dynamic' && anchorEl === store.activeAnchorEl))
+  ) {
     updateTooltipPosition(anchorEl, tooltipEl, store.trackedMouseX + 12, store.trackedMouseY + 6);
   }
 }


### PR DESCRIPTION
Remediates an issue where static tooltips (such as those for achievements and tickets) are not following mouse cursor movement and are staying frozen in place.