### PR TITLE
fix(devbox): remediate early claim notice appearing after 24 hours [V3.3]

### DIFF
--- a/resources/views/platform/components/game/devbox-claim-management.blade.php
+++ b/resources/views/platform/components/game/devbox-claim-management.blade.php
@@ -64,16 +64,16 @@ $claimBlockedByMissingForumTopic = !$isRevision && $userPermissions == Permissio
 // User has an open claim or is claiming own set or is making a collaboration claim and missing forum topic is not blocking
 $canClaim = ($userHasClaimSlot || $isSoleAuthor || $isCollaboration) && !$hasGameClaimed && !$claimBlockedByMissingForumTopic;
 
-$revisionDialogFlag = ($isRevision && !$isSoleAuthor) ? 'true' : 'false';
-$ticketDialogFlag = $hasOpenTickets ? 'true' : 'false';
-$isRecentPrimaryClaim = $primaryClaimMinutesActive <= 1440 ? 'true' : 'false';
+$revisionDialogFlag = ($isRevision && !$isSoleAuthor) ? true : false;
+$ticketDialogFlag = $hasOpenTickets ? true : false;
+$isRecentPrimaryClaim = $primaryClaimMinutesActive <= 1440 ? true : false;
 ?>
 
 <script>
 function makeClaim() {
     const gameTitle = "{!! html_entity_decode($gameTitle) !!}";
     const hasRevisionFlag = {{ $revisionDialogFlag }};
-    const hasTicketFlag = {{ $ticketDialogFlag }};
+    const hasTicketFlag = {{ $ticketDialogFlag ? 1 : 0 }};
 
     let revisionMessage = '';
     if (hasRevisionFlag) {
@@ -105,7 +105,7 @@ function extendClaim() {
 
 function completeClaim() {
     const gameTitle = "{!! html_entity_decode($gameTitle) !!}";
-    const showEarlyReleaseWarning = {{ $isRecentPrimaryClaim }};
+    const showEarlyReleaseWarning = {{ $isRecentPrimaryClaim ? 1 : 0 }};
 
     let earlyReleaseMessage = '';
     if (showEarlyReleaseWarning) {


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/962817919698501702/1145153656702914580.

The "Within 24 hours of Claim" notice is appearing even after multiple days. This is due to a type coercion bug.