### PR TITLE
feat(inspector): allow Jr Devs to mark progression in bulk

### DIFF
--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -175,9 +175,6 @@ function toggleAllCodeRows() {
                     to see the new order on this page.
                 </p>
             HTML;
-        }
-
-        if ($partialModifyOK || $fullModifyOK) {
             echo <<<HTML
                 <p align="justify">
                     You can mark multiple achievements as '$progressionLabel' or '$winConditionLabel'. To do this, check the desired
@@ -330,12 +327,11 @@ function toggleAllCodeRows() {
                 }
                 echo "<a class='btn w-full flex justify-center py-2' href='/achievementinspector.php?g=$gameID&f=5'>Unofficial Achievement Inspector</a>";
             }
-
-            if ($fullModifyOK || $partialModifyOK) {
-                echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::Progression . "\")'>Set Selected to $progressionLabel</a>";
-                echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::WinCondition . "\")'>Set Selected to $winConditionLabel</a>";
-                echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", null)'>Set Selected to No Type</a>";
-            }
+                
+            echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::Progression . "\")'>Set Selected to $progressionLabel</a>";
+            echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::WinCondition . "\")'>Set Selected to $winConditionLabel</a>";
+            echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", null)'>Set Selected to No Type</a>";
+            
         }
 
         if ($fullModifyOK) {

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -239,7 +239,11 @@ function toggleAllCodeRows() {
 
             echo "<tr class='$bgColorClassNames[$currentBgColorIndex]'>";
             if ($partialModifyOK || $fullModifyOK) {
-                echo "<td><span style='white-space: nowrap'><input type='checkbox' name='achievement" . $achID . "' value='" . $achID . "'> <label for='achievement'>$achID</label></span></td>";
+                if ($achievementData[$achID]['Author'] === $user) {
+                    echo "<td><span style='white-space: nowrap'><input type='checkbox' name='achievement" . $achID . "' value='" . $achID . "'> <label for='achievement'>$achID</label></span></td>";
+                } else {
+                    echo "<td>$achID</td>";
+                }
             } else {
                 echo "<td>$achID</td>";
             }

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -177,7 +177,7 @@ function toggleAllCodeRows() {
             HTML;
         }
 
-        if ($fullModifyOK) {
+        if ($partialModifyOK || $fullModifyOK) {
             echo <<<HTML
                 <p align="justify">
                     You can mark multiple achievements as '$progressionLabel' or '$winConditionLabel'. To do this, check the desired
@@ -188,7 +188,9 @@ function toggleAllCodeRows() {
                     if any $winConditionLabel achievements are unlocked.
                 </p>
             HTML;
+        }
 
+        if ($fullModifyOK) {
             echo "<p>You can " . ($flag === AchievementFlag::Unofficial ? "promote" : "demote") . " multiple achievements at the same time from this page by checking " .
                 "the desired checkboxes in the far left column and clicking the '" . ($flag === AchievementFlag::Unofficial ? "Promote" : "Demote") . " Selected' " .
                 "link. You can check or uncheck all checkboxes by clicking the 'All' or 'None' links in the first row of the table.</p>";
@@ -236,7 +238,7 @@ function toggleAllCodeRows() {
             sanitize_outputs($achTitle, $achDesc);
 
             echo "<tr class='$bgColorClassNames[$currentBgColorIndex]'>";
-            if ($fullModifyOK) {
+            if ($partialModifyOK || $fullModifyOK) {
                 echo "<td><span style='white-space: nowrap'><input type='checkbox' name='achievement" . $achID . "' value='" . $achID . "'> <label for='achievement'>$achID</label></span></td>";
             } else {
                 echo "<td>$achID</td>";
@@ -325,7 +327,7 @@ function toggleAllCodeRows() {
                 echo "<a class='btn w-full flex justify-center py-2' href='/achievementinspector.php?g=$gameID&f=5'>Unofficial Achievement Inspector</a>";
             }
 
-            if ($fullModifyOK) {
+            if ($fullModifyOK || $partialModifyOK) {
                 echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::Progression . "\")'>Set Selected to $progressionLabel</a>";
                 echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::WinCondition . "\")'>Set Selected to $winConditionLabel</a>";
                 echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", null)'>Set Selected to No Type</a>";

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -239,7 +239,7 @@ function toggleAllCodeRows() {
 
             echo "<tr class='$bgColorClassNames[$currentBgColorIndex]'>";
             if ($partialModifyOK || $fullModifyOK) {
-                if ($achievementData[$achID]['Author'] === $user) {
+                if ($achievementData[$achID]['Author'] === $user || $permissions >= Permissions::Developer) {
                     echo "<td><span style='white-space: nowrap'><input type='checkbox' name='achievement" . $achID . "' value='" . $achID . "'> <label for='achievement'>$achID</label></span></td>";
                 } else {
                     echo "<td>$achID</td>";

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -174,8 +174,6 @@ function toggleAllCodeRows() {
                     changes you make on this page will instantly take effect on the website, but you will need to press 'Refresh List'
                     to see the new order on this page.
                 </p>
-            HTML;
-            echo <<<HTML
                 <p align="justify">
                     You can mark multiple achievements as '$progressionLabel' or '$winConditionLabel'. To do this, check the desired
                     checkboxes in the far-left column and click either the 'Set Selected as $progressionLabel' or 'Set Selected as $winConditionLabel'

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -325,11 +325,11 @@ function toggleAllCodeRows() {
                 }
                 echo "<a class='btn w-full flex justify-center py-2' href='/achievementinspector.php?g=$gameID&f=5'>Unofficial Achievement Inspector</a>";
             }
-                
+
             echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::Progression . "\")'>Set Selected to $progressionLabel</a>";
             echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", \"" . AchievementType::WinCondition . "\")'>Set Selected to $winConditionLabel</a>";
             echo "<a class='btn w-full flex justify-center py-2' onclick='updateAchievementsProperty(\"type\", null)'>Set Selected to No Type</a>";
-            
+
         }
 
         if ($fullModifyOK) {

--- a/public/request/achievement/update-type.php
+++ b/public/request/achievement/update-type.php
@@ -2,12 +2,13 @@
 
 use App\Community\Enums\ArticleType;
 use App\Platform\Enums\AchievementType;
+use App\Platform\Models\Achievement;
 use App\Site\Enums\Permissions;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
-if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Developer)) {
+if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::JuniorDeveloper)) {
     abort(401);
 }
 
@@ -18,6 +19,12 @@ $input = Validator::validate(Arr::wrap(request()->post()), [
 
 $achievementIds = $input['achievements'];
 $value = $input['type'];
+
+// Check for authorship on achievements if a Jr. is editing the type
+$isSoleDeveloper = Achievement::find($achievementIds)->pluck('Author')->unique()->toArray() === [$user];
+if ($permissions === Permissions::JuniorDeveloper && !$isSoleDeveloper) {
+    abort(403);
+}
 
 if (updateAchievementType($achievementIds, $value)) {
     $commentText = '';


### PR DESCRIPTION
Manually marking progression sucks so now Jrs can do it in bulk on sets where they are the sole developer