### PR TITLE
fix(game): disable beaten credit dialog unless authenticated

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1433,7 +1433,7 @@ sanitize_outputs(
                     'totalPlayerCount' => $numDistinctPlayersCasual,
                     'progressionTypeValue' => AchievementType::Progression,
                     'winConditionTypeValue' => AchievementType::WinCondition,
-                    'isCreditDialogEnabled' => $flagParam != $unofficialFlag,
+                    'isCreditDialogEnabled' => $user && $flagParam != $unofficialFlag,
                 ]);
             }
         }


### PR DESCRIPTION
This dialog is user context specific. There should be no reason for it to be enabled/accessible if the user is not authenticated.