### PR TITLE
fix(home): use smalldate on recent awards

### DIFF
--- a/resources/views/community/components/global-statistics/recent-game-progress.blade.php
+++ b/resources/views/community/components/global-statistics/recent-game-progress.blade.php
@@ -23,7 +23,7 @@ $gameUrl = route('game.show', $game->ID);
 <div>
     <div class="text-2xs flex lg:justify-between items-center gap-x-2 w-full mb-0.5 flex-nowrap">
         <p>{{ $headingLabel }}</p>
-        <p>({{ $timestamp }})</p>
+        <p class="smalldate !min-w-0">{{ $timestamp }}</p>
     </div>
 
     <div class="text-xs bg-embed p-4 rounded border border-embed-highlight">


### PR DESCRIPTION
![Screenshot 2023-09-06 at 6 41 35 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/97bfddd2-09bb-4eff-aeae-f60e39ae0895)

Side note: It seems `.smalldate` has a forced min-width. We may want to get rid of that at some point, it is combative with flex layouts :-(