### PR TITLE
ci: use paratest on pre-push

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -17,7 +17,7 @@ npx eslint --quiet
 printf "\n⏳ npm run test\n"
 npm run test
 
-printf "\n⏳ composer test\n"
-vendor/bin/phpunit
+printf "\n⏳ composer paratest\n"
+vendor/bin/paratest
 
 printf "\n✅ pre-push OK\n\n"


### PR DESCRIPTION
Switches from `phpunit` to `paratest` on pre-push to:
* Match our GH Actions CI pipeline.
* Reduce test execution time by roughly 75%.

I am not sure if there is a major drawback to doing this, so I am opening this a bit naively. However, our test execution time is going to be creeping up more and more, so taking some step to mitigate seems appropriate at this point.