### PR TITLE
feat(navbar): put softcore points on top for softcore players

### DIFF
--- a/resources/views/components/menu/account.blade.php
+++ b/resources/views/components/menu/account.blade.php
@@ -27,15 +27,21 @@ $user = request()->user();
 @endguest
 @auth
     <div class="nav-link flex-col justify-center items-end text-2xs" style="line-height: 1.1em">
+        @if($user->RASoftcorePoints && $user->RASoftcorePoints > $user->points_total)
+            <div class='softcore cursor-help' title="Points earned in softcore mode">{{ localized_number($user->RASoftcorePoints) }}</div>
+        @endif
+
         @if($user->points_total)
             <div class="text-color cursor-help" title="Points earned in hardcore mode">{{ localized_number($user->points_total) }}</div>
         @endif
+
         @if($user->points_weighted_total)
             <x-points-weighted-container>
                 <span class='trueratio'>{{ localized_number($user->points_weighted_total) }}</span>
             </x-points-weighted-container>
         @endif
-        @if($user->RASoftcorePoints)
+
+        @if($user->RASoftcorePoints && $user->RASoftcorePoints < $user->points_total)
             <div class='softcore cursor-help' title="Points earned in softcore mode">{{ localized_number($user->RASoftcorePoints) }}</div>
         @endif
     </div>

--- a/resources/views/components/menu/account.blade.php
+++ b/resources/views/components/menu/account.blade.php
@@ -41,7 +41,7 @@ $user = request()->user();
             </x-points-weighted-container>
         @endif
 
-        @if($user->RASoftcorePoints && $user->RASoftcorePoints < $user->points_total)
+        @if($user->RASoftcorePoints && $user->RASoftcorePoints <= $user->points_total)
             <div class='softcore cursor-help' title="Points earned in softcore mode">{{ localized_number($user->RASoftcorePoints) }}</div>
         @endif
     </div>


### PR DESCRIPTION
![Screenshot 2023-09-07 at 8 03 21 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/0dfe2df5-7177-4d17-85e6-80ca3a170f2e)

If the user has more softcore points than hardcore points, use softcore points as the first points indicator in the navbar.