### PR TITLE
perf: use lazy loading on multiline game avatar images

### DIFF
--- a/resources/views/platform/components/game/multiline-avatar.blade.php
+++ b/resources/views/platform/components/game/multiline-avatar.blade.php
@@ -34,6 +34,8 @@ $showConsoleLine = $consoleId || $consoleName;
             width="36" 
             height="36" 
             class="w-9 h-9"
+            loading="lazy"
+            decoding="async"
         >
 
         <p class="{{ $showConsoleLine ? "absolute pl-4 top-0 left-7" : "" }} max-w-fit font-medium mb-0.5 text-xs">


### PR DESCRIPTION
The `<img>` tag in these components is missing `loading="lazy"` and `decoding="async"` attributes, causing all the images to load before they're in the browser viewport.