### PR TITLE
fix(navbar): hide System column if no tools available

### DIFF
--- a/resources/views/components/menu/management.blade.php
+++ b/resources/views/components/menu/management.blade.php
@@ -14,7 +14,7 @@ $tools = $settings['tools'] ?? null;
         <span class="ml-1 hidden sm:inline-block">{{ __('Manage') }}</span>
     </x-slot>
     <div class="md:flex">
-        @if($tools && count($tools) > 0)
+        @if($tools && !empty($tools))
             <div class="dropdown-column">
                 <x-dropdown-header>{{ __('System') }}</x-dropdown-header>
                 @foreach ($tools as $tool)

--- a/resources/views/components/menu/management.blade.php
+++ b/resources/views/components/menu/management.blade.php
@@ -14,7 +14,7 @@ $tools = $settings['tools'] ?? null;
         <span class="ml-1 hidden sm:inline-block">{{ __('Manage') }}</span>
     </x-slot>
     <div class="md:flex">
-        @if($tools)
+        @if($tools && count($tools) > 0)
             <div class="dropdown-column">
                 <x-dropdown-header>{{ __('System') }}</x-dropdown-header>
                 @foreach ($tools as $tool)


### PR DESCRIPTION
Resolves this issue, where the System column can appear even if no tools are available:
![Screenshot 2023-09-07 at 8 54 26 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/a930154a-d54c-461d-a3c4-9042c01e13c9)
