### PR TITLE
fix(dropdown): text font-size

### DIFF
--- a/resources/css/dropdown.css
+++ b/resources/css/dropdown.css
@@ -40,6 +40,7 @@
   padding: 4px 12px;
   border: none;
   border-radius: 0;
+  font-size: 12px;
 }
 
 .dropdown-item:last-child {


### PR DESCRIPTION
A very simple change that lowers the font size of **dropdown elements** by 1 pixel to make it cleaner. (without including the developer's header.)

13px -> 12px

The navbar elements have the same font size as the dropdown menu elements, which makes it unnecessarily big



13px (before):
![image](https://github.com/RetroAchievements/RAWeb/assets/47864347/b63efee4-408b-4c4a-8f89-0f4b1067860e)

12px (after): 
![image](https://github.com/RetroAchievements/RAWeb/assets/47864347/81708e75-abbe-43c7-98dd-e05aab47e962)



