### PR TITLE
fix(achievement-list-item): show unofficial authors

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1428,17 +1428,19 @@ sanitize_outputs(
                 echo Blade::render('
                     <x-game.achievements-list.root
                         :achievements="$achievements"
-                        :totalPlayerCount="$totalPlayerCount"
-                        :progressionTypeValue="$progressionTypeValue"
-                        :winConditionTypeValue="$winConditionTypeValue"
                         :isCreditDialogEnabled="$isCreditDialogEnabled"
+                        :progressionTypeValue="$progressionTypeValue"
+                        :showAuthorNames="$showAuthorNames"
+                        :totalPlayerCount="$totalPlayerCount"
+                        :winConditionTypeValue="$winConditionTypeValue"
                     />
                 ', [
                     'achievements' => $achievementData,
-                    'totalPlayerCount' => $numDistinctPlayers,
-                    'progressionTypeValue' => AchievementType::Progression,
-                    'winConditionTypeValue' => AchievementType::WinCondition,
                     'isCreditDialogEnabled' => $user && $flagParam != $unofficialFlag,
+                    'progressionTypeValue' => AchievementType::Progression,
+                    'showAuthorNames' => !$isOfficial && isset($user) && $permissions >= Permissions::JuniorDeveloper,
+                    'totalPlayerCount' => $numDistinctPlayers,
+                    'winConditionTypeValue' => AchievementType::WinCondition,
                 ]);
             }
         }

--- a/resources/views/platform/components/game/achievements-list/achievements-list-item.blade.php
+++ b/resources/views/platform/components/game/achievements-list/achievements-list-item.blade.php
@@ -8,6 +8,7 @@
     'isUnlocked' => false,
     'isUnlockedHardcore' => false,
     'isCreditDialogEnabled' => true,
+    'showAuthorName' => false,
     'totalPlayerCount' => 0,
 ])
 
@@ -85,7 +86,18 @@ if (isset($achievement['DateEarnedHardcore'])) {
                 @endhasfeature
             </div>
 
-            <p class="leading-4">{{ $achievement['Description'] }}</p>
+            <p class="leading-4">
+                {{ $achievement['Description'] }}
+
+                @if ($showAuthorName)
+                    <span class="flex gap-x-1 text-[0.6rem] mt-2">
+                        Author:
+                        <a href="{{ route('user.show', $achievement['Author']) }}">
+                            {{ $achievement['Author'] }}
+                        </a>
+                    </span>
+                @endif
+            </p>
 
             @if ($isUnlocked || $isUnlockedHardcore)
                 <p class="hidden md:block mt-1.5 text-[0.6rem] text-neutral-400/70">

--- a/resources/views/platform/components/game/achievements-list/root.blade.php
+++ b/resources/views/platform/components/game/achievements-list/root.blade.php
@@ -4,6 +4,7 @@
     'progressionTypeValue' => 'progression', // `AchievementType`
     'winConditionTypeValue' => 'win_condition', // `AchievementType`
     'isCreditDialogEnabled' => true,
+    'showAuthorNames' => false,
 ])
 
 <?php
@@ -27,22 +28,24 @@ $beatenGameCreditDialogContext = buildBeatenGameCreditDialogContext($unlockedAch
         @foreach ($unlockedAchievements as $achievement)
             <x-game.achievements-list.achievements-list-item
                 :achievement="$achievement"
-                :totalPlayerCount="$totalPlayerCount"
-                :progressionTypeValue="$progressionTypeValue"
-                :winConditionTypeValue="$winConditionTypeValue"
                 :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
                 :isCreditDialogEnabled="$isCreditDialogEnabled"
+                :progressionTypeValue="$progressionTypeValue"
+                :showAuthorName="$showAuthorNames"
+                :totalPlayerCount="$totalPlayerCount"
+                :winConditionTypeValue="$winConditionTypeValue"
             />
         @endforeach
 
         @foreach ($lockedAchievements as $achievement)
             <x-game.achievements-list.achievements-list-item
                 :achievement="$achievement"
-                :totalPlayerCount="$totalPlayerCount"
-                :progressionTypeValue="$progressionTypeValue"
-                :winConditionTypeValue="$winConditionTypeValue"
                 :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
                 :isCreditDialogEnabled="$isCreditDialogEnabled"
+                :progressionTypeValue="$progressionTypeValue"
+                :showAuthorName="$showAuthorNames"
+                :totalPlayerCount="$totalPlayerCount"
+                :winConditionTypeValue="$winConditionTypeValue"
             />
         @endforeach
     </ul>

--- a/tests/Feature/Platform/Components/AchievementsListTest.php
+++ b/tests/Feature/Platform/Components/AchievementsListTest.php
@@ -104,4 +104,19 @@ class AchievementsListTest extends TestCase
 
         $view->assertSeeTextInOrder(['Progression', 'Win Condition']);
     }
+
+    public function testItRendersAuthorNameIfInstructed(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        /** @var Achievement $achievement */
+        $achievement = Achievement::factory()->create(['Author' => $user->User]);
+
+        $view = $this->blade('<x-game.achievements-list.root :achievements="$achievements" :showAuthorNames="$showAuthorNames" />', [
+            'achievements' => compact('achievement'),
+            'showAuthorNames' => true,
+        ]);
+
+        $view->assertSeeTextInOrder(['Author', $user->User]);
+    }
 }


### PR DESCRIPTION
Restores the ability to see author names while viewing Unofficial.

<img width="860" alt="Screenshot 2023-09-08 at 8 50 22 AM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/e8e54d97-f6a3-45ed-9f85-f756f498a0ac">
