### PR TITLE
chore: disable web-based leaderboard editing

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -984,13 +984,7 @@ sanitize_outputs(
                 }
 
                 // Display leaderboard management options depending on the current number of leaderboards
-                if ($numLeaderboards == 0) {
-                    echo "<form action='/request/leaderboard/create.php' method='post'>";
-                    echo csrf_field();
-                    echo "<input type='hidden' name='game' value='$gameID'>";
-                    echo "<button class='btn'>Create First Leaderboard</button>";
-                    echo "</form>";
-                } else {
+                if ($numLeaderboards != 0) {
                     echo "<div><a class='btn btn-link' href='/leaderboardList.php?g=$gameID'>Manage Leaderboards</a></div>";
                 }
 

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -113,7 +113,7 @@ if ($permissions >= Permissions::JuniorDeveloper) {
 
 $listCount = 0;
 
-$bgColorClassNames = ["!bg-box-bg", "!bg-embed"];
+$bgColorClassNames = ["!bg-embed", "!bg-box-bg"];
 $currentBgColorIndex = 1;
 
 foreach ($lbData as $nextLB) {

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -82,37 +82,6 @@ if (isset($gameData['ID'])) {
     echo "</div>";
 }
 
-if ($permissions >= Permissions::JuniorDeveloper) {
-    $numGames = getGamesList(0, $gamesList);
-
-    echo "<div class='devbox'>";
-    echo "<span onclick=\"$('#devboxcontent').toggle(); return false;\">Dev ▼</span>";
-    echo "<div id='devboxcontent' style='display: none'>";
-
-    echo "<ul>";
-    echo "<li>";
-    echo "<form method='post' action='/request/leaderboard/create.php'>";
-    echo csrf_field();
-    echo "<input type='hidden' name='game' value='$gameID' />";
-    echo "<button class='btn'>Create Leaderboard</button>";
-    echo "</form>";
-    echo "<form method='post' action='/request/leaderboard/create.php'>";
-    echo csrf_field();
-    echo "<input type='hidden' name='game' value='$gameID'>";
-    echo "Duplicate leaderboard ID: ";
-    echo "<input style='width: 10%;' min='1' name='leaderboard'> ";
-    echo "Amount: ";
-    echo "<input style='width: 10%;' type='number' min='1' max='25' value='1' name='amount'>";
-    echo "&nbsp;&nbsp;";
-    echo "<button class='btn'>Duplicate</button>";
-    echo "</form>";
-    echo "</li>";
-    echo "</ul>";
-
-    echo "</div>";
-    echo "</div>";
-}
-
 echo "<table><tbody>";
 
 $sort1 = ($sortBy == 1) ? 11 : 1;

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -293,13 +293,4 @@ echo "</tbody></table>";
 echo "</div>";
 ?>
 </article>
-<?php
-if (!empty($codeNotes) && $permissions >= Permissions::JuniorDeveloper) {
-    view()->share('sidebar', true);
-    echo "<aside>";
-    echo "<h3>Code Notes</h3>";
-    RenderCodeNotes($codeNotes);
-    echo "</aside>";
-}
-?>
 <?php RenderContentEnd(); ?>

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -57,6 +57,8 @@ RenderContentStart($pageTitle);
                 + '::VAL:' + $.trim($('#LB_' + lbID + '_Mem4').val()),
             lowerIsBetter: $('#LB_' + lbID + '_LowerIsBetter').is(':checked') ? '1' : '0',
             order:  $.trim($('#LB_' + lbID + '_DisplayOrder').val())
+        }).then(() => {
+            window.location.reload();
         });
     }
     </script>
@@ -111,7 +113,13 @@ if ($permissions >= Permissions::JuniorDeveloper) {
 
 $listCount = 0;
 
+$bgColorClassNames = ["!bg-box-bg", "!bg-embed"];
+$currentBgColorIndex = 1;
+
 foreach ($lbData as $nextLB) {
+    // Alternate the background color of the achievement rows.
+    $currentBgColorIndex = $currentBgColorIndex === 1 ? 0 : 1;
+
     $lbID = $nextLB['ID'];
     $lbTitle = attributeEscape($nextLB['Title']);
     $lbDesc = attributeEscape($nextLB['Description']);
@@ -129,7 +137,7 @@ foreach ($lbData as $nextLB) {
 
     $niceFormat = ($lbLowerIsBetter ? "Smallest " : "Largest ") . (($lbFormat == "SCORE") ? "Score" : "Time");
 
-    echo "<tr>";
+    echo "<tr class='$bgColorClassNames[$currentBgColorIndex]'>";
 
     if ($permissions >= Permissions::JuniorDeveloper) {
         // Allow leaderboard edits for devs and jr. devs if they are the author
@@ -186,7 +194,7 @@ foreach ($lbData as $nextLB) {
 
         echo "</tr>";
 
-        echo "<tr>";
+        echo "<tr class='$bgColorClassNames[$currentBgColorIndex]'>";
 
         echo "<td>";
         // echo "Memory:";
@@ -211,37 +219,10 @@ foreach ($lbData as $nextLB) {
         }
 
         echo "<table class='table-highlight mb-3'><tbody>";
-        echo "<tr>";
-        echo "<td style='width:10%;'>Start:</td>";
-        echo "<td>";
-        echo "<p>$memStart</p>";
         echo "<input type='hidden' id='LB_" . $lbID . "_Mem1' value='$memStart' readonly />";
-        echo "</td>";
-        echo "</tr>";
-
-        echo "<tr>";
-        echo "<td style='width:10%;'>Cancel:</td>";
-        echo "<td>";
-        echo "<p>$memCancel</p>";
         echo "<input type='hidden' id='LB_" . $lbID . "_Mem2' value='$memCancel' readonly />";
-        echo "</td>";
-        echo "</tr>";
-
-        echo "<tr>";
-        echo "<td style='width:10%;'>Submit:</td>";
-        echo "<td>";
-        echo "<p>$memSubmit</p>";
         echo "<input type='hidden' id='LB_" . $lbID . "_Mem3' value='$memSubmit' readonly />";
-        echo "</td>";
-        echo "</tr>";
-
-        echo "<tr>";
-        echo "<td style='width:10%;'>Value:</td>";
-        echo "<td>";
-        echo "<p>$memValue</p>";
         echo "<input type='hidden' id='LB_" . $lbID . "_Mem4' value='$memValue' readonly />";
-        echo "</td>";
-        echo "</tr>";
 
         echo "</tbody></table>";
 

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -245,28 +245,32 @@ foreach ($lbData as $nextLB) {
         echo "<tr>";
         echo "<td style='width:10%;'>Start:</td>";
         echo "<td>";
-        echo "<input type='text' id='LB_" . $lbID . "_Mem1' value='$memStart' style='width: 100%;' " . ($editAllowed ? "" : "readonly") . "/>";
+        echo "<p>$memStart</p>";
+        echo "<input type='hidden' id='LB_" . $lbID . "_Mem1' value='$memStart' readonly />";
         echo "</td>";
         echo "</tr>";
 
         echo "<tr>";
         echo "<td style='width:10%;'>Cancel:</td>";
         echo "<td>";
-        echo "<input type='text' id='LB_" . $lbID . "_Mem2' value='$memCancel' style='width: 100%;' " . ($editAllowed ? "" : "readonly") . "/>";
+        echo "<p>$memCancel</p>";
+        echo "<input type='hidden' id='LB_" . $lbID . "_Mem2' value='$memCancel' readonly />";
         echo "</td>";
         echo "</tr>";
 
         echo "<tr>";
         echo "<td style='width:10%;'>Submit:</td>";
         echo "<td>";
-        echo "<input type='text' id='LB_" . $lbID . "_Mem3' value='$memSubmit' style='width: 100%;' " . ($editAllowed ? "" : "readonly") . "/>";
+        echo "<p>$memSubmit</p>";
+        echo "<input type='hidden' id='LB_" . $lbID . "_Mem3' value='$memSubmit' readonly />";
         echo "</td>";
         echo "</tr>";
 
         echo "<tr>";
         echo "<td style='width:10%;'>Value:</td>";
         echo "<td>";
-        echo "<input type='text' id='LB_" . $lbID . "_Mem4' value='$memValue' style='width: 100%;' " . ($editAllowed ? "" : "readonly") . "/>";
+        echo "<p>$memValue</p>";
+        echo "<input type='hidden' id='LB_" . $lbID . "_Mem4' value='$memValue' readonly />";
         echo "</td>";
         echo "</tr>";
 


### PR DESCRIPTION
Sets the start, cancel, submit, and value fields in leaderboardList.php to read-only. Now that RAIntegration supports editing leaderboards, and given that we have no validation of input on the web, it doesn't make sense for these fields to be editable in the web UI anymore.

<img width="847" alt="Screenshot 2023-09-14 at 5 45 14 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/6b2433d1-3da0-40d4-a279-c5872f903aed">
