### PR TITLE
fix(userInfo): dont render Progression Status if only event games

### DIFF
--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -480,9 +480,13 @@ RenderContentStart($userPage);
         echo "</div>"; // devbox
     }
 
-    // The component isn't as useful if we don't have data for the
-    // Completion Progress component.
-    if (config('feature.beat') && $user && count($userCompletedGamesList) > 0) {
+    $canShowProgressionStatusComponent =
+        config('feature.beat')
+        && !empty($userCompletedGamesList)
+        // Needs at least one non-event game.
+        && count(array_filter($userCompletedGamesList, fn ($game) => $game['ConsoleID'] != 101)) > 0;
+
+    if ($canShowProgressionStatusComponent) {
         echo "<div class='mt-2 mb-8'>";
         echo Blade::render('
             <x-user-progression-status


### PR DESCRIPTION
Fixes an edge case on user profiles where the Progression Status can component will render if the user has only games for the "Events" console.

This notably happens on WilHiteWarrior's user profile.

**Before**
![Screenshot 2023-09-17 at 12 23 07 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/950108ce-a30a-4eff-b2ba-ff818050ac5c)

**After**
![Screenshot 2023-09-17 at 12 21 12 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/9341acb6-1ada-44a1-943c-d8119475f4ed)
