### PR TITLE
fix: use rendered game titles on beaten game credit dialog

### DIFF
--- a/resources/views/platform/components/modal-content/beaten-game-credit.blade.php
+++ b/resources/views/platform/components/modal-content/beaten-game-credit.blade.php
@@ -12,6 +12,8 @@ $hardcoreIds = explode(",", substr($hardcoreUnlocks, 2)); // skip "h:"
 
 $numProgressionAchievements = count($progressionAchievements);
 $numWinConditionAchievements = count($winConditionAchievements);
+
+$renderedGameTitle = renderGameTitle($gameTitle);
 ?>
 
 <div>
@@ -22,7 +24,7 @@ $numWinConditionAchievements = count($winConditionAchievements);
         </p>
 
         <p>
-            {{ $gameTitle }} has {{ $numProgressionAchievements }} progression
+            {!! $renderedGameTitle !!} has {{ $numProgressionAchievements }} progression
             {{ trans_choice(__('resource.achievement.title'), $numProgressionAchievements) }} and
             {{ $numWinConditionAchievements }} win condition
             {{ trans_choice(__('resource.achievement.title'), $numWinConditionAchievements) }}.


### PR DESCRIPTION
This PR adjusts the rendering of game titles in the beaten game credit dialog so they utilize the `renderGameTitle()` function.

**Before**
![Screenshot 2023-09-17 at 12 28 29 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/00cc1426-df8e-45fb-9e3c-6c3ff99e5928)


**After**
![Screenshot 2023-09-17 at 12 25 55 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/0c0d7285-4463-4991-8104-b5955e0fe7e2)
