### PR TITLE
refactor(game): migrate mature content gate to blade

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -109,66 +109,25 @@ if ($v != 1) {
 }
 ?>
 <?php if ($gate): ?>
-    <?php RenderContentStart($pageTitle) ?>
-    <script>
-        function disableMatureContentWarningPreference() {
-            const isLoggedIn = <?= isset($userDetails) ?>;
-            if (!isLoggedIn) {
-                throw new Error('Tried to modify settings for an unauthenticated user.');
-            }
-
-            const newPreferencesValue = <?= ($userDetails['websitePrefs'] ?? 0) | (1 << $matureContentPref) ?>;
-            const gameId = <?= $gameID ?>;
-
-            fetch('/request/user/update-preferences.php', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-                },
-                body: `preferences=${newPreferencesValue}`,
-                credentials: 'same-origin'
-            }).then(() => {
-                window.location = `/game/<?= $gameID ?>`;
-            })
-        }
-    </script>
     <article>
-        <div class='navpath'>
-            <?= renderGameBreadcrumb($gameData, addLinkToLastCrumb: false) ?>
-        </div>
-        <h1 class="text-h3"><?= renderGameTitle($pageTitle) ?></h1>
-        <h4>WARNING: THIS PAGE MAY CONTAIN CONTENT NOT APPROPRIATE FOR ALL AGES.</h4>
-        <br/>
-        <div id="confirmation">
-            Are you sure that you want to view this page?
-            <br/>
-            <br/>
-
-            <div class="flex flex-col sm:flex-row gap-4 sm:gap-2">
-                <form id='escapeform' action='/gameList.php'>
-                    <input type='hidden' name='c' value='<?= $consoleID ?>'/>
-                    <button class='btn leading-normal'>No. Get me out of here.</button>
-                </form>
-
-                <form id='consentform' action='/game/<?= $gameID ?>'>
-                    <input type='hidden' name='v' value='1'/>
-                    <button class='btn leading-normal'>Yes. I'm an adult.</button>
-                </form>
-
-                <?php if ($userWebsitePrefs): ?>
-                    <button
-                        type="button"
-                        class='btn break-words whitespace-normal leading-normal'
-                        onclick='disableMatureContentWarningPreference()'
-                    >
-                        Yes. And never ask me again for pages with mature content.
-                    </button>
-                <?php endif; ?>
-            </div>
-        </div>
+    <?php
+        echo Blade::render('
+            <x-game.mature-content-gate
+                :gameId="$gameId"
+                :gameTitle="$gameTitle"
+                :consoleId="$consoleId"
+                :consoleName="$consoleName"
+                :userWebsitePrefs="$userWebsitePrefs"
+            />
+        ', [
+            'gameId' => $gameID,
+            'gameTitle' => $gameTitle,
+            'consoleId' => $consoleID,
+            'consoleName' => $consoleName,
+            'userWebsitePrefs' => $userDetails['websitePrefs'] ?? 0,
+        ]);
+    ?>
     </article>
-    <?php RenderContentEnd(); ?>
     <?php return ?>
 <?php endif ?>
 <?php

--- a/resources/views/platform/components/game/mature-content-gate.blade.php
+++ b/resources/views/platform/components/game/mature-content-gate.blade.php
@@ -1,0 +1,72 @@
+@props([
+    'gameId' => 0,
+    'gameTitle' => 'Unknown game',
+    'consoleId' => 0,
+    'consoleName' => 'Unknown console',
+    'userWebsitePrefs' => 0,
+])
+
+<?php
+use App\Site\Enums\UserPreference;
+
+$matureContentPref = UserPreference::Site_SuppressMatureContentWarning;
+?>
+
+<script>
+function matureContentNoticeComponent() {
+    return {
+        async disableMatureContentWarningPreference() {
+            const existingUserPrefs = {{ $userWebsitePrefs }} ?? 0;
+            const matureContentPref = {{ $matureContentPref }} ?? 0;
+
+            const newPreferencesValue = {{ ($userWebsitePrefs ?? 0) | (1 << $matureContentPref) }};
+            const gameId = {{ $gameId }};
+
+            await fetcher('/request/user/update-preferences.php', {
+                method: 'POST',
+                body: `preferences=${newPreferencesValue}`
+            });
+
+            window.location = '{{ route('game.show', $gameId) }}';
+        }
+    };
+}
+</script>
+
+<div class="navpath">
+    {!!
+        renderGameBreadcrumb([
+            'GameID' => $gameId,
+            'GameTitle' => $gameTitle,
+            'ConsoleID' => $consoleId,
+            'ConsoleName' => $consoleName
+        ], addLinkToLastCrumb: false)
+    !!}
+</div>
+
+<x-game.heading
+    :gameId="$gameId"
+    :gameTitle="$gameTitle"
+    :consoleId="$consoleId"
+    :consoleName="$consoleName"
+/>
+
+<p class="text-h4 uppercase mb-6">Warning: This page may contain content not appropriate for all ages.</p>
+
+<div id="confirmation" x-data="matureContentNoticeComponent()">
+    <p class="mb-4">Are you sure you want to view this page?</p>
+
+    <div class="flex flex-col sm:flex-row gap-4 sm:gap-2">
+        <a href="{{ url('gameList.php?c=' . $consoleId) }}" class="btn leading-normal max-w-fit">No. Get me out of here.</a>
+        <a rel="nofollow" href="{{ route('game.show', [$gameId, 'v' => 1]) }}" class="btn leading-normal max-w-fit">Yes. I'm an adult.</a>
+
+        @if ($userWebsitePrefs)
+            <button
+                class="btn break-words whitespace-normal leading-normal"
+                @click="disableMatureContentWarningPreference()"
+            >
+                Yes. And never ask me again for pages with mature content.
+            </button>
+        @endif
+    </div>
+</div>

--- a/resources/views/platform/components/game/mature-content-gate.blade.php
+++ b/resources/views/platform/components/game/mature-content-gate.blade.php
@@ -10,24 +10,19 @@
 use App\Site\Enums\UserPreference;
 
 $matureContentPref = UserPreference::Site_SuppressMatureContentWarning;
+$newPreferencesValue = ($userWebsitePrefs ?? 0) | (1 << $matureContentPref);
 ?>
 
 <script>
 function matureContentNoticeComponent() {
     return {
         async disableMatureContentWarningPreference() {
-            const existingUserPrefs = {{ $userWebsitePrefs }} ?? 0;
-            const matureContentPref = {{ $matureContentPref }} ?? 0;
-
-            const newPreferencesValue = {{ ($userWebsitePrefs ?? 0) | (1 << $matureContentPref) }};
-            const gameId = {{ $gameId }};
-
             await fetcher('/request/user/update-preferences.php', {
                 method: 'POST',
-                body: `preferences=${newPreferencesValue}`
+                body: "preferences={{ $newPreferencesValue }}"
             });
 
-            window.location = '{{ route('game.show', $gameId) }}';
+            window.location.reload();
         }
     };
 }


### PR DESCRIPTION
Refactors the mature content warning to a Blade component as part of the continued refactoring of the game page.

To test: visit any game in the mature content hub, such as ID 2772.

Preserves all existing functionality, with only two subtle differences:
* `fetcher` is used instead of native `fetch`.
* The `<x-game.heading>` component is used, which renders the console name and icon as a subheading.

![Screenshot 2023-09-17 at 6 58 54 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/949af54f-4797-48b4-9678-19570a70249d)
