### PR TITLE
remove unused field from query

### DIFF
--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -687,7 +687,6 @@ function getUsersCompletedGamesAndMax(string $user): array
     if (config('feature.aggregate_queries')) {
         $query = "SELECT gd.ID AS GameID, c.Name AS ConsoleName, c.ID AS ConsoleID, 
                          gd.ImageIcon, gd.Title, gd.achievements_published as MaxPossible,
-                IF(pg.achievements_unlocked_hardcore > 0, 1, 0), 
                 pg.achievements_unlocked AS NumAwarded, pg.achievements_unlocked_hardcore AS NumAwardedHC, " .
                 floatDivisionStatement('pg.achievements_unlocked', 'gd.achievements_published') . " AS PctWon, " .
                 floatDivisionStatement('pg.achievements_unlocked_hardcore', 'gd.achievements_published') . " AS PctWonHC
@@ -707,7 +706,7 @@ function getUsersCompletedGamesAndMax(string $user): array
 
         // TODO slow query. optimize with denormalized data.
         $query = "SELECT gd.ID AS GameID, c.Name AS ConsoleName, c.ID AS ConsoleID, gd.ImageIcon, gd.Title, inner1.MaxPossible,
-                MAX(aw.HardcoreMode), SUM(aw.HardcoreMode = 0) AS NumAwarded, SUM(aw.HardcoreMode = 1) AS NumAwardedHC, " .
+                SUM(aw.HardcoreMode = 0) AS NumAwarded, SUM(aw.HardcoreMode = 1) AS NumAwardedHC, " .
                 floatDivisionStatement('SUM(aw.HardcoreMode = 0)', 'inner1.MaxPossible') . " AS PctWon, " .
                 floatDivisionStatement('SUM(aw.HardcoreMode = 1)', 'inner1.MaxPossible') . " AS PctWonHC
             FROM Awarded AS aw


### PR DESCRIPTION
With the feature enabled, returns a field that can't reasonably be referenced from the code:
```
array:13 [▼ // app/Platform/Controllers/PlayerCompletionProgressController.php:131
  "ConsoleID" => 27
  "ConsoleName" => "Arcade"
  "FirstWonDate" => "2021-02-15 16:51:35"
  "GameID" => 11944
  "IF(pg.achievements_unlocked_hardcore > 0, 1, 0)" => 1  <----
  "ImageIcon" => "/Images/035728.png"
  "MaxPossible" => 22
  "MostRecentWonDate" => null
  "NumAwarded" => 13
  "NumAwardedHC" => 13
  "PctWon" => "0.5909"
  "PctWonHC" => "0.5909"
  "Title" => "Donkey Kong Junior"
]
```

Without the feature enabled, the field doesn't appear to be returned at all.
```
array:12 [▼ // app/Platform/Controllers/PlayerCompletionProgressController.php:131
  "ConsoleName" => "Arcade"
  "ConsoleID" => 27
  "FirstWonDate" => "2021-02-15 16:51:35"
  "GameID" => 11944
  "ImageIcon" => "/Images/035728.png"
  "MaxPossible" => 22
  "MostRecentWonDate" => ""
  "NumAwarded" => 13
  "NumAwardedHC" => 13
  "PctWon" => 0.59090909090909
  "PctWonHC" => 0.59090909090909
  "Title" => "Donkey Kong Junior"
]
```