### PR TITLE
refactor(game): migrate recent game players to blade and improve mobile ux

### DIFF
--- a/app/Helpers/render/game.php
+++ b/app/Helpers/render/game.php
@@ -293,46 +293,6 @@ function RenderLinkToGameForum(string $gameTitle, int $gameID, ?int $forumTopicI
     }
 }
 
-function RenderRecentGamePlayers(array $recentPlayerData, string $gameTitle): void
-{
-    echo "<div class='component overflow-x-auto sm:overflow-x-hidden'>Recent Players:";
-    echo "<table class='table-highlight'><tbody>";
-    echo "<tr><th></th><th>User</th><th>When</th><th class='w-full'>Activity</th>";
-    foreach ($recentPlayerData as $recentPlayer) {
-        echo "<tr>";
-        $userName = $recentPlayer['User'];
-        $date = $recentPlayer['Date'];
-        $activity = $recentPlayer['Activity'];
-        sanitize_outputs(
-            $userName,
-            $activity
-        );
-
-        // Check if $activity contains a message about an "Unknown macro", and
-        // if so, strip the RP and replace it with an outdated emulator warning.
-        if (mb_strpos($activity, 'Unknown macro') !== false) {
-            $activity = <<<HTML
-                <div class="cursor-help" title="$activity">
-                    <span>⚠️</span>
-                    <span>Playing $gameTitle</span>
-                </div>
-            HTML;
-        }
-
-        echo "<td>";
-        echo userAvatar($userName, label: false);
-        echo "</td>";
-        echo "<td>";
-        echo userAvatar($userName, icon: false);
-        echo "</td>";
-        echo "<td class='whitespace-nowrap'>$date</td>";
-        echo "<td>$activity</td>";
-        echo "</tr>";
-    }
-    echo "</tbody></table>";
-    echo "</div>";
-}
-
 function RenderGameProgress(int $numAchievements, int $numEarnedCasual, int $numEarnedHardcore, ?string $fullWidthUntil = null): void
 {
     $pctComplete = 0;

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1453,7 +1453,14 @@ sanitize_outputs(
         if ($isFullyFeaturedGame) {
             $recentPlayerData = getGameRecentPlayers($gameID, 10);
             if (!empty($recentPlayerData)) {
-                RenderRecentGamePlayers($recentPlayerData, $gameTitle);
+                echo "<div class='mt-6 mb-8'>";
+                echo Blade::render('
+                    <x-game.recent-game-players :recentPlayerData="$recentPlayerData" :gameTitle="$gameTitle" />
+                ', [
+                    'recentPlayerData' => $recentPlayerData,
+                    'gameTitle' => $gameTitle,
+                ]);
+                echo "</div>";
             }
 
             RenderCommentsComponent($user, $numArticleComments, $commentData, $gameID, ArticleType::Game, $permissions);

--- a/resources/views/platform/components/game/recent-game-players.blade.php
+++ b/resources/views/platform/components/game/recent-game-players.blade.php
@@ -1,0 +1,73 @@
+@props([
+    'recentPlayerData' => [],
+    'gameTitle' => '',
+])
+
+<?php
+use Illuminate\Support\Carbon;
+
+$processedRecentPlayers = [];
+
+foreach ($recentPlayerData as $recentPlayer) {
+    $date = Carbon::parse($recentPlayer['Date'])->format('d M Y, g:ia');
+    $isBroken = mb_strpos($recentPlayer['Activity'], 'Unknown macro') !== false;
+
+    $processedRecentPlayers[] = [
+        'User' => $recentPlayer['User'],
+        'Date' => $date,
+        'IsBroken' => $isBroken,
+        'Activity' => $recentPlayer['Activity'],
+    ];
+}
+?>
+
+<h2 class="text-h4">Recent Players</h2>
+
+<div class="sm:hidden flex flex-col gap-y-2">
+    @foreach ($processedRecentPlayers as $recentPlayer)
+        <div class="flex flex-col gap-y-0.5 px-2 py-1.5 odd:bg-embed">
+            <div class="w-full flex items-center justify-between">
+                {!! userAvatar($recentPlayer['User'], iconClass: 'rounded-sm', iconSize: 20) !!}
+                <p class="smalldate">{{ $recentPlayer['Date'] }}</p>
+            </div>
+
+            @if ($recentPlayer['IsBroken'])
+                <div class="cursor-help text-xs" title="{{ $recentPlayer['Activity'] }}">
+                    <span>⚠️</span>
+                    <span>Playing {{ $gameTitle }}</span>
+                </div>
+            @else
+                <p class="text-xs">{{ $recentPlayer['Activity'] }}</p>
+            @endif
+        </div>
+    @endforeach
+</div>
+
+<table class="hidden sm:table table-highlight">
+    <thead>
+        <tr>
+            <th>Player</th>
+            <th>When</th>
+            <th class="w-full">Activity</th>
+        </tr>
+    </thead>
+
+    <tbody>
+        @foreach ($processedRecentPlayers as $recentPlayer)
+            <tr>
+                <td class="py-2.5">{!! userAvatar($recentPlayer['User'], iconClass: 'rounded-sm mr-1', iconSize: 28) !!}</td>
+                <td class="whitespace-nowrap smalldate">{{ $recentPlayer['Date'] }}</td>
+                <td>
+                    @if ($recentPlayer['IsBroken'])
+                        <div class="cursor-help text-xs" title="{{ $recentPlayer['Activity'] }}">
+                            <span>⚠️</span>
+                            <span>Playing {{ $gameTitle }}</span>
+                        </div>
+                    @else
+                        {{ $recentPlayer['Activity'] }}
+                    @endif
+                </td>
+            </tr>
+        @endforeach
+    </tbody>
+</table>

--- a/resources/views/platform/components/game/recent-game-players.blade.php
+++ b/resources/views/platform/components/game/recent-game-players.blade.php
@@ -59,7 +59,7 @@ foreach ($recentPlayerData as $recentPlayer) {
                 <td class="whitespace-nowrap smalldate">{{ $recentPlayer['Date'] }}</td>
                 <td>
                     @if ($recentPlayer['IsBroken'])
-                        <div class="cursor-help text-xs" title="{{ $recentPlayer['Activity'] }}">
+                        <div class="cursor-help" title="{{ $recentPlayer['Activity'] }}">
                             <span>⚠️</span>
                             <span>Playing {{ $gameTitle }}</span>
                         </div>

--- a/tests/Feature/Platform/Components/RecentGamePlayersTest.php
+++ b/tests/Feature/Platform/Components/RecentGamePlayersTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Platform\Components;
+
+use App\Site\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RecentGamePlayersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testItRendersRichPresenceMessages(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $mockDate = Carbon::now();
+        $recentPlayerData = [
+            [
+                'User' => $user->User,
+                'Date' => $mockDate,
+                'Activity' => 'Playing Sonic the Hedgehog',
+            ]
+        ];
+
+        $view = $this->blade('
+            <x-game.recent-game-players
+                :recentPlayerData="$recentPlayerData"
+                gameTitle="Sonic the Hedgehog"
+            />
+        ', [
+            'recentPlayerData' => $recentPlayerData,
+        ]);
+
+        $view->assertSee($user->User);
+        $view->assertSeeText('Playing Sonic the Hedgehog');
+        $view->assertSeeText($mockDate->format('d M Y, g:ia'));
+    }
+
+    public function testItRendersBrokenRichPresenceMessages(): void
+    {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $recentPlayerData = [
+            [
+                'User' => $user->User,
+                'Date' => Carbon::now(),
+                'Activity' => 'Unknown macro this should not appear',
+            ]
+        ];
+
+        $view = $this->blade('
+            <x-game.recent-game-players
+                :recentPlayerData="$recentPlayerData"
+                gameTitle="Sonic the Hedgehog"
+            />
+        ', [
+            'recentPlayerData' => $recentPlayerData,
+        ]);
+
+        $view->assertDontSeeText("this should not appear");
+        $view->assertSeeTextInOrder(["⚠️", "Playing Sonic the Hedgehog"]);
+    }
+}

--- a/tests/Feature/Platform/Components/RecentGamePlayersTest.php
+++ b/tests/Feature/Platform/Components/RecentGamePlayersTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\Feature\Platform\Components;
 
 use App\Site\Models\User;
-use Illuminate\Support\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 class RecentGamePlayersTest extends TestCase
@@ -23,7 +23,7 @@ class RecentGamePlayersTest extends TestCase
                 'User' => $user->User,
                 'Date' => $mockDate,
                 'Activity' => 'Playing Sonic the Hedgehog',
-            ]
+            ],
         ];
 
         $view = $this->blade('
@@ -49,7 +49,7 @@ class RecentGamePlayersTest extends TestCase
                 'User' => $user->User,
                 'Date' => Carbon::now(),
                 'Activity' => 'Unknown macro this should not appear',
-            ]
+            ],
         ];
 
         $view = $this->blade('


### PR DESCRIPTION
This PR migrates the game page's "Recent Players" section to Blade and improves the mobile UX for the component.

**Mobile Before**
![Screenshot 2023-09-25 at 5 09 42 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/af43758a-93c2-43c3-a967-59d32064fad4)

**Mobile After**
![Screenshot 2023-09-25 at 5 09 14 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/3050bef8-5fef-413f-8005-5b3750c30564)

**Desktop Before**
![Screenshot 2023-09-25 at 5 09 50 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/58a30fa2-ff77-4661-9fa7-5fe918f2a290)

**Desktop After**
![Screenshot 2023-09-25 at 5 08 53 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/ec373490-3f6e-4725-83b6-a5a5d159c54c)

---

UX Notes:
* "Recent Players" is now an H2 tag similar to the "Achievements" heading higher up on the page. I wasn't sure if this was perhaps too loud. If we think it's too loud, let's reduce the size but give the tag a `role` attribute with a "heading" value and an `aria-level` of "2".