### PR TITLE
fix(achievementinspector): show checkmarks for jr dev collabs

### DIFF
--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -14,7 +14,12 @@ $fullModifyOK = $permissions >= Permissions::Developer;
 $gameID = requestInputSanitized('g', null, 'integer');
 $flag = requestInputSanitized('f', 3, 'integer');
 
-$partialModifyOK = $permissions == Permissions::JuniorDeveloper && (checkIfSoleDeveloper($user, $gameID) || hasSetClaimed($user, $gameID, true, ClaimSetType::NewSet));
+$partialModifyOK = 
+    $permissions == Permissions::JuniorDeveloper 
+    && (
+        checkIfSoleDeveloper($user, $gameID)
+        || hasSetClaimed($user, $gameID, false)
+    );
 
 $achievementList = [];
 $gamesList = [];

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Community\Enums\ClaimSetType;
 use App\Platform\Enums\AchievementFlag;
 use App\Platform\Enums\AchievementType;
 use App\Site\Enums\Permissions;
@@ -14,8 +13,8 @@ $fullModifyOK = $permissions >= Permissions::Developer;
 $gameID = requestInputSanitized('g', null, 'integer');
 $flag = requestInputSanitized('f', 3, 'integer');
 
-$partialModifyOK = 
-    $permissions == Permissions::JuniorDeveloper 
+$partialModifyOK =
+    $permissions == Permissions::JuniorDeveloper
     && (
         checkIfSoleDeveloper($user, $gameID)
         || hasSetClaimed($user, $gameID, false)


### PR DESCRIPTION
Resolves #1887.

**Before**
Jr Dev collab partners could not modify achievement types on the Manage Unofficial Achievements page.

**After**
Jr Dev collab partners can now perform this modification.

![Screenshot 2023-09-26 at 5 58 31 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/6a0e8ab5-9108-470d-8ee6-4eba3c7fa33a)
