### PR TITLE
feat(individualdevstats): migrate game tables to blade and add beaten stats

### DIFF
--- a/app/Community/AppServiceProvider.php
+++ b/app/Community/AppServiceProvider.php
@@ -14,6 +14,7 @@ use App\Community\Commands\SyncRatings;
 use App\Community\Commands\SyncTickets;
 use App\Community\Commands\SyncUserRelations;
 use App\Community\Commands\SyncVotes;
+use App\Community\Components\DeveloperGameStatsTable;
 use App\Community\Components\GlobalStatistics;
 use App\Community\Components\MessageIcon;
 use App\Community\Components\UserCard;
@@ -104,6 +105,7 @@ class AppServiceProvider extends ServiceProvider
         TriggerTicketComment::disableSearchSyncing();
         UserComment::disableSearchSyncing();
 
+        Blade::component('developer-game-stats-table', DeveloperGameStatsTable::class);
         Blade::component('global-statistics', GlobalStatistics::class);
         Blade::component('user-card', UserCard::class);
         Blade::component('user-progression-status', UserProgressionStatus::class);

--- a/app/Community/Components/DeveloperGameStatsTable.php
+++ b/app/Community/Components/DeveloperGameStatsTable.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Community\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class DeveloperGameStatsTable extends Component
+{
+    private array $easiestGame = [];
+    private array $hardestGame = [];
+    private array $targetGameIds = [];
+    private int $numGamesWithLeaderboards = 0;
+    private int $numGamesWithRichPresence = 0;
+    private int $numTotalLeaderboards = 0;
+    private string $statsKind = 'any'; // 'any' | 'majority' | 'sole'
+    private string $targetDeveloperUsername = '';
+
+    public function __construct(
+        array $easiestGame,
+        array $hardestGame,
+        array $targetGameIds,
+        int $numGamesWithLeaderboards,
+        int $numGamesWithRichPresence,
+        int $numTotalLeaderboards,
+        string $statsKind,
+        string $targetDeveloperUsername,
+    ) {
+        $this->easiestGame = $easiestGame;
+        $this->hardestGame = $hardestGame;
+        $this->numGamesWithLeaderboards = $numGamesWithLeaderboards;
+        $this->numGamesWithRichPresence = $numGamesWithRichPresence;
+        $this->numTotalLeaderboards = $numTotalLeaderboards;
+        $this->statsKind = $statsKind;
+        $this->targetDeveloperUsername = $targetDeveloperUsername;
+        $this->targetGameIds = $targetGameIds;
+    }
+
+    public function render(): View
+    {
+        $builtStats = $this->buildStats($this->targetDeveloperUsername, $this->targetGameIds);
+
+        return view('community.components.developer.game-stats-table', array_merge(
+            $builtStats, [
+                'easiestGame' => $this->easiestGame,
+                'hardestGame' => $this->hardestGame,
+                'numGamesWithLeaderboards' => $this->numGamesWithLeaderboards,
+                'numGamesWithRichPresence' => $this->numGamesWithRichPresence,
+                'numTotalLeaderboards' => $this->numTotalLeaderboards,
+                'statsKind' => $this->statsKind,
+                'targetDeveloperUsername' => $this->targetDeveloperUsername,
+                'targetGameIds' => $this->targetGameIds,
+            ],
+        ));
+    }
+
+    private function buildStats(string $targetDeveloperUsername, array $targetGameIds): array
+    {
+        $ownAwards = [];
+        $mostBeatenSoftcoreGame = $mostBeatenHardcoreGame = $mostCompletedGame = $mostMasteredGame = [];
+        $userMostBeatenSoftcore = $userMostBeatenHardcore = $userMostCompleted = $userMostMastered = [];
+        $beatenSoftcoreAwards = $beatenHardcoreAwards = $completedAwards = $masteredAwards = 0;
+
+        $mostAwardedGames = getMostAwardedGames($targetGameIds);
+        foreach ($mostAwardedGames as $game) {
+            $mostBeatenSoftcoreGame = $this->findMost($game, 'BeatenSoftcore', $mostBeatenSoftcoreGame);
+            $mostBeatenHardcoreGame = $this->findMost($game, 'BeatenHardcore', $mostBeatenHardcoreGame);
+            $mostCompletedGame = $this->findMost($game, 'Completed', $mostCompletedGame);
+            $mostMasteredGame = $this->findMost($game, 'Mastered', $mostMasteredGame);
+        }
+
+        $mostAwardedUsers = getMostAwardedUsers($targetGameIds);
+        foreach ($mostAwardedUsers as $userInfo) {
+            $userMostBeatenSoftcore = $this->findMost($userInfo, 'BeatenSoftcore', $userMostBeatenSoftcore);
+            $userMostBeatenHardcore = $this->findMost($userInfo, 'BeatenHardcore', $userMostBeatenHardcore);
+            $userMostCompleted = $this->findMost($userInfo, 'Completed', $userMostCompleted);
+            $userMostMastered = $this->findMost($userInfo, 'Mastered', $userMostMastered);
+
+            if (strcmp($targetDeveloperUsername, $userInfo['User']) == 0) {
+                $ownAwards = $userInfo;
+            }
+
+            $beatenSoftcoreAwards += $userInfo['BeatenSoftcore'];
+            $beatenHardcoreAwards += $userInfo['BeatenHardcore'];
+            $completedAwards += $userInfo['Completed'];
+            $masteredAwards += $userInfo['Mastered'];
+        }
+
+        return compact(
+            'mostBeatenSoftcoreGame',
+            'mostBeatenHardcoreGame',
+            'mostCompletedGame',
+            'mostMasteredGame',
+            'ownAwards',
+            'beatenSoftcoreAwards',
+            'beatenHardcoreAwards',
+            'completedAwards',
+            'masteredAwards',
+            'userMostBeatenSoftcore',
+            'userMostBeatenHardcore',
+            'userMostCompleted',
+            'userMostMastered',
+        );
+    }
+
+    private function findMost(array $record, string $key, array $currentMost): array
+    {
+        if (empty($currentMost) && (int) $record[$key] > 0) {
+            return $record;
+        }
+
+        return isset($currentMost[$key]) && ($currentMost[$key] < (int) $record[$key]) ? $record : $currentMost;
+    }
+}

--- a/public/individualdevstats.php
+++ b/public/individualdevstats.php
@@ -2,6 +2,7 @@
 
 use App\Community\Enums\TicketState;
 use App\Site\Models\User;
+use Illuminate\Support\Facades\Blade;
 
 authenticateFromCookie($user, $permissions, $userDetails);
 
@@ -127,200 +128,6 @@ foreach ($gamesList as $game) {
             }
         }
     }
-}
-
-// Initialize any dev game award variables
-$anyDevMostCompletedGame = [];
-$anyDevMostMasteredGame = [];
-
-// Get user award data for any developed games
-$anyDevCompletedMasteredGames = getMostAwardedGames($anyDevGameIDs);
-foreach ($anyDevCompletedMasteredGames as $game) {
-    if (empty($anyDevMostCompletedGame)) {
-        if ($game['Completed'] > 0) {
-            $anyDevMostCompletedGame = $game;
-        }
-    } else {
-        if ($anyDevMostCompletedGame['Completed'] < $game['Completed']) {
-            $anyDevMostCompletedGame = $game;
-        }
-    }
-
-    if (empty($anyDevMostMasteredGame)) {
-        if ($game['Mastered'] > 0) {
-            $anyDevMostMasteredGame = $game;
-        }
-    } else {
-        if ($anyDevMostMasteredGame['Mastered'] < $game['Mastered']) {
-            $anyDevMostMasteredGame = $game;
-        }
-    }
-}
-
-// Initialize any dev user award variables
-$anyDevOwnAwards = [];
-$anyDevCompletedAwards = 0;
-$anyDevMasteredAwards = 0;
-$anyDevUserMostCompleted = [];
-$anyDevUserMostMastered = [];
-
-// Get user award data for any developed games
-$anyDevAwardInfo = getMostAwardedUsers($anyDevGameIDs);
-foreach ($anyDevAwardInfo as $userInfo) {
-    if (empty($anyDevUserMostCompleted)) {
-        if ($userInfo['Completed'] > 0) {
-            $anyDevUserMostCompleted = $userInfo;
-        }
-    } else {
-        if ($anyDevUserMostCompleted['Completed'] < $userInfo['Completed']) {
-            $anyDevUserMostCompleted = $userInfo;
-        }
-    }
-
-    if (empty($anyDevUserMostMastered)) {
-        if ($userInfo['Mastered'] > 0) {
-            $anyDevUserMostMastered = $userInfo;
-        }
-    } else {
-        if ($anyDevUserMostMastered['Mastered'] < $userInfo['Mastered']) {
-            $anyDevUserMostMastered = $userInfo;
-        }
-    }
-
-    if (strcmp($dev, $userInfo['User']) == 0) {
-        $anyDevOwnAwards = $userInfo;
-    }
-    $anyDevCompletedAwards += $userInfo['Completed'];
-    $anyDevMasteredAwards += $userInfo['Mastered'];
-}
-
-// Initialize majority dev game award variables
-$majorityDevMostCompletedGame = [];
-$majorityDevMostMasteredGame = [];
-
-// Get user award data for majority developed games
-$majorityDevCompletedMasteredGames = getMostAwardedGames($majorityDevGameIDs);
-foreach ($majorityDevCompletedMasteredGames as $game) {
-    if (empty($majorityDevMostCompletedGame)) {
-        if ($game['Completed'] > 0) {
-            $majorityDevMostCompletedGame = $game;
-        }
-    } else {
-        if ($majorityDevMostCompletedGame['Completed'] < $game['Completed']) {
-            $majorityDevMostCompletedGame = $game;
-        }
-    }
-
-    if (empty($majorityDevMostMasteredGame)) {
-        if ($game['Mastered'] > 0) {
-            $majorityDevMostMasteredGame = $game;
-        }
-    } else {
-        if ($majorityDevMostMasteredGame['Mastered'] < $game['Mastered']) {
-            $majorityDevMostMasteredGame = $game;
-        }
-    }
-}
-
-// Initialize majority dev user award variables
-$majorityDevOwnAwards = [];
-$majorityDevCompletedAwards = 0;
-$majorityDevMasteredAwards = 0;
-$majorityDevUserMostCompleted = [];
-$majorityDevUserMostMastered = [];
-
-// Get user award data for majority developed games
-$majorityDevAwardInfo = getMostAwardedUsers($majorityDevGameIDs);
-foreach ($majorityDevAwardInfo as $userInfo) {
-    if (empty($majorityDevUserMostCompleted)) {
-        if ($userInfo['Completed'] > 0) {
-            $majorityDevUserMostCompleted = $userInfo;
-        }
-    } else {
-        if ($majorityDevUserMostCompleted['Completed'] < $userInfo['Completed']) {
-            $majorityDevUserMostCompleted = $userInfo;
-        }
-    }
-
-    if (empty($majorityDevUserMostMastered)) {
-        if ($userInfo['Mastered'] > 0) {
-            $majorityDevUserMostMastered = $userInfo;
-        }
-    } else {
-        if ($majorityDevUserMostMastered['Mastered'] < $userInfo['Mastered']) {
-            $majorityDevUserMostMastered = $userInfo;
-        }
-    }
-
-    if (strcmp($dev, $userInfo['User']) == 0) {
-        $majorityDevOwnAwards = $userInfo;
-    }
-    $majorityDevCompletedAwards += $userInfo['Completed'];
-    $majorityDevMasteredAwards += $userInfo['Mastered'];
-}
-
-// Initialize sole dev game award variables
-$onlyDevMostCompletedGame = [];
-$onlyDevMostMasteredGame = [];
-
-// Get user award data for solely developed games
-$onlyDevCompletedMasteredGames = getMostAwardedGames($onlyDevGameIDs);
-foreach ($onlyDevCompletedMasteredGames as $game) {
-    if (empty($onlyDevMostCompletedGame)) {
-        if ($game['Completed'] > 0) {
-            $onlyDevMostCompletedGame = $game;
-        }
-    } else {
-        if ($onlyDevMostCompletedGame['Completed'] < $game['Completed']) {
-            $onlyDevMostCompletedGame = $game;
-        }
-    }
-
-    if (empty($onlyDevMostMasteredGame)) {
-        if ($game['Mastered'] > 0) {
-            $onlyDevMostMasteredGame = $game;
-        }
-    } else {
-        if ($onlyDevMostMasteredGame['Mastered'] < $game['Mastered']) {
-            $onlyDevMostMasteredGame = $game;
-        }
-    }
-}
-
-// Initialize sole dev user award variables
-$onlyDevOwnAwards = [];
-$onlyDevCompletedAwards = 0;
-$onlyDevMasteredAwards = 0;
-$onlyDevUserMostCompleted = [];
-$onlyDevUserMostMastered = [];
-
-// Get user award data for solely developed games
-$onlyDevAwardInfo = getMostAwardedUsers($onlyDevGameIDs);
-foreach ($onlyDevAwardInfo as $userInfo) {
-    if (empty($onlyDevUserMostCompleted)) {
-        if ($userInfo['Completed'] > 0) {
-            $onlyDevUserMostCompleted = $userInfo;
-        }
-    } else {
-        if ($onlyDevUserMostCompleted['Completed'] < $userInfo['Completed']) {
-            $onlyDevUserMostCompleted = $userInfo;
-        }
-    }
-    if (empty($onlyDevUserMostMastered)) {
-        if ($userInfo['Mastered'] > 0) {
-            $onlyDevUserMostMastered = $userInfo;
-        }
-    } else {
-        if ($onlyDevUserMostMastered['Mastered'] < $userInfo['Mastered']) {
-            $onlyDevUserMostMastered = $userInfo;
-        }
-    }
-
-    if (strcmp($dev, $userInfo['User']) == 0) {
-        $onlyDevOwnAwards = $userInfo;
-    }
-    $onlyDevCompletedAwards += $userInfo['Completed'];
-    $onlyDevMasteredAwards += $userInfo['Mastered'];
 }
 
 // Initialize user achievement variables
@@ -683,7 +490,7 @@ RenderContentStart("$dev's Developer Stats");
     <?php endif ?>
 
     <?php
-    echo "<h2>$dev's Developer Stats</h2>";
+    echo "<h1>$dev's Developer Stats</h1>";
 
     // Only show stats if the user has a contribute count
     if ($userContribCount > 0) {
@@ -698,342 +505,81 @@ RenderContentStart("$dev's Developer Stats");
         /*
          * Games
          */
-        echo "<H1>Games</H1>";
+        echo "<h2>Games</h2>";
 
-        /*
-         * Any Development
-         */
-        echo "<table class='table-highlight'><tbody>";
-        echo "<tr class='do-not-highlight'><td colspan='2' align='center' style=\"font-size:24px; padding-top:10px; padding-bottom:10px\">Any Development</td></tr>";
-        echo "<tr></tr><tr class='do-not-highlight'><td colspan='2' align='center'>Stats below are for games that $dev has published at least one achievement for.</td></tr>";
+        // Any development
+        echo Blade::render('
+            <x-developer-game-stats-table
+                :easiestGame="$easiestGame"
+                :hardestGame="$hardestGame"
+                :numGamesWithLeaderboards="$numGamesWithLeaderboards"
+                :numGamesWithRichPresence="$numGamesWithRichPresence"
+                :numTotalLeaderboards="$numTotalLeaderboards"
+                :statsKind="$statsKind"
+                :targetDeveloperUsername="$targetDeveloperUsername"
+                :targetGameIds="$targetGameIds"
+            />
+        ', [
+            'easiestGame' => $anyDevEasiestGame,
+            'hardestGame' => $anyDevHardestGame,
+            'numGamesWithLeaderboards' => $anyDevLeaderboardCount,
+            'numGamesWithRichPresence' => $anyDevRichPresenceCount,
+            'numTotalLeaderboards' => $anyDevLeaderboardTotal,
+            'statsKind' => 'any',
+            'targetDeveloperUsername' => $dev,
+            'targetGameIds' => $anyDevGameIDs,
+        ]);
 
-        // Any Development - Games developed for
-        echo "<tr><td width='50%'>Games Developed For:</td><td>" . count($anyDevGameIDs) . "</td></tr>";
+        // Majority development
+        echo Blade::render('
+            <x-developer-game-stats-table
+                :easiestGame="$easiestGame"
+                :hardestGame="$hardestGame"
+                :numGamesWithLeaderboards="$numGamesWithLeaderboards"
+                :numGamesWithRichPresence="$numGamesWithRichPresence"
+                :numTotalLeaderboards="$numTotalLeaderboards"
+                :statsKind="$statsKind"
+                :targetDeveloperUsername="$targetDeveloperUsername"
+                :targetGameIds="$targetGameIds"
+            />
+        ', [
+            'easiestGame' => $majorityDevEasiestGame,
+            'hardestGame' => $majorityDevHardestGame,
+            'numGamesWithLeaderboards' => $majorityDevLeaderboardCount,
+            'numGamesWithRichPresence' => $majorityDevRichPresenceCount,
+            'numTotalLeaderboards' => $majorityDevLeaderboardTotal,
+            'statsKind' => 'majority',
+            'targetDeveloperUsername' => $dev,
+            'targetGameIds' => $majorityDevGameIDs,
+        ]);
 
-        // Any Development - Games with Rich Presence
-        echo "<tr><td>Games with Rich Presence:</td><td>";
-        if (!empty($anyDevGameIDs)) {
-            echo $anyDevRichPresenceCount . " - " . number_format($anyDevRichPresenceCount / count($anyDevGameIDs) * 100, 2, '.', '') . "%";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Any Development - Games with Leaderboards and Leaderboard count
-        echo "<tr><td>Games with Leaderboards:</td><td>";
-        if (!empty($anyDevGameIDs)) {
-            echo $anyDevLeaderboardCount . " - " . number_format($anyDevLeaderboardCount / count($anyDevGameIDs) * 100, 2, '.', '') . "%</br>" . $anyDevLeaderboardTotal . " Unique Leaderboards";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Any Development - Easiest game by retro ratio
-        echo "<tr><td>Easiest Game by Retro Ratio:</td><td>";
-        if (!empty($anyDevEasiestGame)) {
-            echo number_format($anyDevEasiestGame['TotalTruePoints'] / $anyDevEasiestGame['MaxPointsAvailable'], 2, '.', '') . " - ";
-            echo gameAvatar($anyDevEasiestGame);
-            echo "</br>" . $anyDevEasiestGame['MyAchievements'] . " of " . $anyDevEasiestGame['NumAchievements'] . " Achievements Created";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Any Development - Hardest game by retro ratio
-        echo "<tr><td>Hardest Game by Retro Ratio</td><td>";
-        if (!empty($anyDevHardestGame)) {
-            echo number_format($anyDevHardestGame['TotalTruePoints'] / $anyDevHardestGame['MaxPointsAvailable'], 2, '.', '') . " - ";
-            echo gameAvatar($anyDevHardestGame);
-            echo "</br>" . $anyDevHardestGame['MyAchievements'] . " of " . $anyDevHardestGame['NumAchievements'] . " Achievements Created</br>";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Any Development - Complete/Mastered games
-        echo "<tr><td>Completed/Mastered Awards:</td><td>";
-        if (!empty($anyDevGameIDs)) {
-            echo $anyDevCompletedAwards . " <b>(" . $anyDevMasteredAwards . ")</br>";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Any Development - Own Complete/Mastered games
-        echo "<tr><td>Own Completed/Mastered Awards:</td><td>";
-        if (!empty($anyDevOwnAwards)) {
-            echo $anyDevOwnAwards['Completed'] . " <b>(" . $anyDevOwnAwards['Mastered'] . ")</br>";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Any Development - Most completed game
-        echo "<tr><td>Most Completed Game:</td><td>";
-        if (!empty($anyDevMostCompletedGame)) {
-            echo $anyDevMostCompletedGame['Completed'] . " - ";
-            echo gameAvatar($anyDevMostCompletedGame);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Any Development - Most mastered game
-        echo "<tr><td>Most Mastered Game:</td><td>";
-        if (!empty($anyDevMostMasteredGame)) {
-            echo $anyDevMostMasteredGame['Mastered'] . " - ";
-            echo gameAvatar($anyDevMostMasteredGame);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Any Development - User with most completed awards
-        echo "<tr><td>User with Most Completed Awards:</td><td>";
-        if (!empty($anyDevUserMostCompleted)) {
-            echo $anyDevUserMostCompleted['Completed'] . " - ";
-            echo userAvatar($anyDevUserMostCompleted['User']);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Any Development - User with most mastered awards
-        echo "<tr><td>User with Most Mastered Awards:</td><td>";
-        if (!empty($anyDevUserMostMastered)) {
-            echo $anyDevUserMostMastered['Mastered'] . " - ";
-            echo userAvatar($anyDevUserMostMastered['User']);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-        echo "</table></tbody>";
-        echo "</br>";
-
-        /*
-         * Majority Developer
-         */
-        echo "<table class='table-highlight'><tbody>";
-        echo "<tr class='do-not-highlight'><td colspan='2' align='center' style=\"font-size:24px; padding-top:10px; padding-bottom:10px\">Majority Developer</td></tr>";
-        echo "<tr></tr><tr class='do-not-highlight'><td colspan='2' align='center'>Stats below are for games that $dev has published at least half the achievements for.</td></tr>";
-
-        // Majority Developer - Games developed for
-        echo "<tr><td width='50%'>Games Developed For:</td><td>" . count($majorityDevGameIDs) . "</td></tr>";
-
-        // Majority Developer - Games with Rich Presence
-        echo "<tr><td>Games with Rich Presence:</td><td>";
-        if (!empty($majorityDevGameIDs)) {
-            echo $majorityDevRichPresenceCount . " - " . number_format($majorityDevRichPresenceCount / count($majorityDevGameIDs) * 100, 2, '.', '') . "%";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Majority Developer - Games with Leaderboards and Leaderboard count
-        echo "<tr><td>Games with Leaderboards:</td><td>";
-        if (!empty($majorityDevGameIDs)) {
-            echo $majorityDevLeaderboardCount . " - " . number_format($majorityDevLeaderboardCount / count($majorityDevGameIDs) * 100, 2, '.', '') . "%</br>" . $majorityDevLeaderboardTotal . " Unique Leaderboards";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Majority Developer - Easiest game by retro ratio
-        echo "<tr><td>Easiest Game by Retro Ratio:</td><td>";
-        if (!empty($majorityDevEasiestGame)) {
-            echo number_format($majorityDevEasiestGame['TotalTruePoints'] / $majorityDevEasiestGame['MaxPointsAvailable'], 2, '.', '') . " - ";
-            echo gameAvatar($majorityDevEasiestGame);
-            echo "</br>" . $majorityDevEasiestGame['MyAchievements'] . " of " . $majorityDevEasiestGame['NumAchievements'] . " Achievements Created";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Majority Developer - Hardest game by retro ratio
-        echo "<tr><td>Hardest Game by Retro Ratio:</td><td>";
-        if (!empty($majorityDevHardestGame)) {
-            echo number_format($majorityDevHardestGame['TotalTruePoints'] / $majorityDevHardestGame['MaxPointsAvailable'], 2, '.', '') . " - ";
-            echo gameAvatar($majorityDevHardestGame);
-            echo "</br>" . $majorityDevHardestGame['MyAchievements'] . " of " . $majorityDevHardestGame['NumAchievements'] . " Achievements Created";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Majority Developer - Complete/Mastered games
-        echo "<tr><td>Completed/Mastered Awards:</td><td>";
-        if (!empty($majorityDevGameIDs)) {
-            echo $majorityDevCompletedAwards . " <b>(" . $majorityDevMasteredAwards . ")</br>";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Majority Developer - Own Complete/Mastered games
-        echo "<tr><td>Own Completed/Mastered Awards:</td><td>";
-        if (!empty($majorityDevOwnAwards)) {
-            echo $majorityDevOwnAwards['Completed'] . " <b>(" . $majorityDevOwnAwards['Mastered'] . ")</br>";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Majority Developer - Most completed game
-        echo "<tr><td>Most Completed Game:</td><td>";
-        if (!empty($majorityDevMostCompletedGame)) {
-            echo $majorityDevMostCompletedGame['Completed'] . " - ";
-            echo gameAvatar($majorityDevMostCompletedGame);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Majority Developer - Most mastered game
-        echo "<tr><td>Most Mastered Game:</td><td>";
-        if (!empty($majorityDevMostMasteredGame)) {
-            echo $majorityDevMostMasteredGame['Mastered'] . " - ";
-            echo gameAvatar($majorityDevMostMasteredGame);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Majority Developer - User with most completed awards
-        echo "<tr><td>User with Most Completed Awards:</td><td>";
-        if (!empty($majorityDevUserMostCompleted)) {
-            echo $majorityDevUserMostCompleted['Completed'] . " - ";
-            echo userAvatar($majorityDevUserMostCompleted['User']);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Majority Developer - User with most mastered awards
-        echo "<tr><td>User with Most Mastered Awards:</td><td>";
-        if (!empty($majorityDevUserMostMastered)) {
-            echo $majorityDevUserMostMastered['Mastered'] . " - ";
-            echo userAvatar($majorityDevUserMostMastered['User']);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-        echo "</table></tbody>";
-        echo "</br>";
-
-        /*
-         * Sole Developer
-         */
-        echo "<table class='table-highlight'><tbody>";
-        echo "<tr class='do-not-highlight'><td colspan='2' align='center' style=\"font-size:24px; padding-top:10px; padding-bottom:10px\">Sole Developer</td></tr>";
-        echo "<tr></tr><tr class='do-not-highlight'><td colspan='2' align='center'>Stats below are for games that $dev has published all the achievements for.</td></tr>";
-
-        // Sole Developer - Games developed for
-        echo "<tr><td width='50%'>Games Developed For:</td><td>" . count($onlyDevGameIDs) . "</td></tr>";
-
-        // Sole Developer - Games with Rich Presence
-        echo "<tr><td>Games with Rich Presence:</td><td>";
-        if (!empty($onlyDevGameIDs)) {
-            echo $onlyDevRichPresenceCount . " - " . number_format($onlyDevRichPresenceCount / count($onlyDevGameIDs) * 100, 2, '.', '') . "%";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Sole Developer - Games with Leaderboards and Leaderboard count
-        echo "<tr><td>Games with Leaderboards:</td><td>";
-        if (!empty($onlyDevGameIDs)) {
-            echo $onlyDevLeaderboardCount . " - " . number_format($onlyDevLeaderboardCount / count($onlyDevGameIDs) * 100, 2, '.', '') . "%</br>" . $onlyDevLeaderboardTotal . " Unique Leaderboards";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Sole Developer - Easiest game by retro ratio
-        echo "<tr><td>Easiest Game by Retro Ratio:</td><td>";
-        if (!empty($onlyDevEasiestGame)) {
-            echo number_format($onlyDevEasiestGame['TotalTruePoints'] / $onlyDevEasiestGame['MaxPointsAvailable'], 2, '.', '') . " - ";
-            echo gameAvatar($onlyDevEasiestGame);
-            echo "</br>" . $onlyDevEasiestGame['MyAchievements'] . " of " . $onlyDevEasiestGame['NumAchievements'] . " Achievements Created";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Sole Developer - Hardest game by retro ratio
-        echo "<tr><td>Hardest Game by Retro Ratio:</td><td>";
-        if (!empty($onlyDevHardestGame)) {
-            echo number_format($onlyDevHardestGame['TotalTruePoints'] / $onlyDevHardestGame['MaxPointsAvailable'], 2, '.', '') . " - ";
-            echo gameAvatar($onlyDevHardestGame);
-            echo "</br>" . $onlyDevHardestGame['MyAchievements'] . " of " . $onlyDevHardestGame['NumAchievements'] . " Achievements Created";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Sole Developer - Complete/Mastered games
-        echo "<tr><td>Completed/Mastered Awards:</td><td>";
-        if (!empty($onlyDevGameIDs)) {
-            echo $onlyDevCompletedAwards . " <b>(" . $onlyDevMasteredAwards . ")</br>";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Sole Developer - Own Complete/Mastered games
-        echo "<tr><td>Own Completed/Mastered Awards:</td><td>";
-        if (!empty($onlyDevOwnAwards)) {
-            echo $onlyDevOwnAwards['Completed'] . " <b>(" . $onlyDevOwnAwards['Mastered'] . ")</br>";
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Sole Developer - Most completed game
-        echo "<tr><td>Most Completed Game:</td><td>";
-        if (!empty($onlyDevMostCompletedGame)) {
-            echo $onlyDevMostCompletedGame['Completed'] . " - ";
-            echo gameAvatar($onlyDevMostCompletedGame);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Sole Developer - Most mastered game
-        echo "<tr><td>Most Mastered Game:</td><td>";
-        if (!empty($onlyDevMostMasteredGame)) {
-            echo $onlyDevMostMasteredGame['Mastered'] . " - ";
-            echo gameAvatar($onlyDevMostMasteredGame);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Sole Developer - User with most completed awards
-        echo "<tr><td>User with Most Completed Awards:</td><td>";
-        if (!empty($onlyDevUserMostCompleted)) {
-            echo $onlyDevUserMostCompleted['Completed'] . " - ";
-            echo userAvatar($onlyDevUserMostCompleted['User']);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-
-        // Sole Developer - User with most mastered awards
-        echo "<tr><td>User with Most Mastered Awards:</td><td>";
-        if (!empty($onlyDevUserMostMastered)) {
-            echo $onlyDevUserMostMastered['Mastered'] . " - ";
-            echo userAvatar($onlyDevUserMostMastered['User']);
-        } else {
-            echo "N/A";
-        }
-        echo "</td></tr>";
-        echo "</table></tbody>";
-        echo "</br></br>";
+        // Sole development
+        echo Blade::render('
+            <x-developer-game-stats-table
+                :easiestGame="$easiestGame"
+                :hardestGame="$hardestGame"
+                :numGamesWithLeaderboards="$numGamesWithLeaderboards"
+                :numGamesWithRichPresence="$numGamesWithRichPresence"
+                :numTotalLeaderboards="$numTotalLeaderboards"
+                :statsKind="$statsKind"
+                :targetDeveloperUsername="$targetDeveloperUsername"
+                :targetGameIds="$targetGameIds"
+            />
+        ', [
+            'easiestGame' => $onlyDevEasiestGame,
+            'hardestGame' => $onlyDevHardestGame,
+            'numGamesWithLeaderboards' => $onlyDevLeaderboardCount,
+            'numGamesWithRichPresence' => $onlyDevRichPresenceCount,
+            'numTotalLeaderboards' => $onlyDevLeaderboardTotal,
+            'statsKind' => 'sole',
+            'targetDeveloperUsername' => $dev,
+            'targetGameIds' => $onlyDevGameIDs,
+        ]);
 
         /*
          * Achievements
          */
-        echo "<H1>Achievements</H1>";
+        echo "<h2>Achievements</h2>";
         echo "<table class='table-highlight'><tbody>";
 
         // Any Development - Achievements created
@@ -1196,7 +742,7 @@ RenderContentStart("$dev's Developer Stats");
         /*
          * Code Notes
          */
-        echo "<H1>Code Notes</H1>";
+        echo "<h2>Code Notes</h2>";
         echo "<table><tbody>";
 
         // Code notes created
@@ -1227,7 +773,7 @@ RenderContentStart("$dev's Developer Stats");
         /*
          * Tickets
          */
-        echo "<H1>Tickets</H1>";
+        echo "<h2>Tickets</h2>";
         echo "<table class='table-highlight'><tbody>";
 
         // Total tickets created

--- a/resources/views/community/components/developer/game-stats-table-row.blade.php
+++ b/resources/views/community/components/developer/game-stats-table-row.blade.php
@@ -1,0 +1,8 @@
+@props([
+    'headingLabel' => '',
+])
+
+<tr>
+    <td width="50%">{{ $headingLabel }}</td>
+    <td>{{ $slot }}</td>
+</tr>

--- a/resources/views/community/components/developer/game-stats-table.blade.php
+++ b/resources/views/community/components/developer/game-stats-table.blade.php
@@ -1,0 +1,240 @@
+@props([
+    'beatenHardcoreAwards',
+    'beatenSoftcoreAwards',
+    'completedAwards',
+    'easiestGame',
+    'hardestGame',
+    'masteredAwards',
+    'mostBeatenHardcoreGame',
+    'mostBeatenSoftcoreGame',
+    'mostCompletedGame',
+    'mostMasteredGame',
+    'numGamesWithLeaderboards',
+    'numGamesWithRichPresence',
+    'numTotalLeaderboards',
+    'ownAwards',
+    'statsKind',
+    'targetDeveloperUsername',
+    'targetGameIds',
+    'userMostBeatenHardcore',
+    'userMostBeatenSoftcore',
+    'userMostCompleted',
+    'userMostMastered',
+])
+
+<table class="table-highlight">
+    <thead>
+        <tr class="do-not-highlight">
+            <td colspan="2" align="center" class="text-h3 {{ $statsKind === 'any' ? 'pt-2' : 'pt-8' }}" role="heading" aria-level="2">
+                @if ($statsKind === 'any')
+                    Any Development
+                @elseif ($statsKind === 'majority')
+                    Majority Developer
+                @elseif ($statsKind === 'sole')
+                    Sole Developer
+                @endif
+            </td>
+        </tr>
+        <tr></tr>
+        <tr class="do-not-highlight">
+            <td colspan="2" align="center" class="pb-4">
+                @if ($statsKind === 'any')
+                    Stats below are for games that {{ $targetDeveloperUsername }} has published at least one achievement for.
+                @elseif ($statsKind === 'majority')
+                    Stats below are for games that {{ $targetDeveloperUsername }} has published at least half the achievements for.
+                @elseif ($statsKind === 'sole')
+                    Stats below are for games that {{ $targetDeveloperUsername }} has published all the achievements for.
+                @endif
+            </td>
+        </tr>
+    </thead>
+
+    <tbody>
+        <x-developer.game-stats-table-row headingLabel="Games Developed For:">
+            {{ count($targetGameIds) }}
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Games with Rich Presence:">
+            @if (empty($targetGameIds))
+                N/A
+            @else
+                {{ $numGamesWithRichPresence }}
+                &ndash;
+                {{ number_format($numGamesWithRichPresence / count($targetGameIds) * 100, 2, '.', '') }}%
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Games with Leaderboards:">
+            @if (empty($targetGameIds))
+                N/A
+            @else
+                <div class="flex flex-col">
+                    <span>
+                        {{ $numGamesWithLeaderboards }}
+                        &ndash;
+                        {{ number_format($numGamesWithLeaderboards / count($targetGameIds) * 100, 2, '.', '') }}%
+                    </span>
+                    <span>
+                        {{ $numTotalLeaderboards }} Unique Leaderboards
+                    </span>
+                </div>
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Easiest Game by Retro Ratio:">
+            @if (empty($easiestGame))
+                N/A
+            @else
+                <div class="flex flex-col">
+                    <div>
+                        {{ number_format($easiestGame['TotalTruePoints'] / $easiestGame['MaxPointsAvailable'], 2, '.', '') }}
+                        &ndash;
+                        {!! gameAvatar($easiestGame) !!}
+                    </div>
+                    <div>
+                        {{ $easiestGame['MyAchievements'] }}
+                        of
+                        {{ $easiestGame['NumAchievements'] }}
+                        Achievements Created
+                    </div>
+                </div>
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Hardest Game by Retro Ratio:">
+            @if (empty($hardestGame))
+                N/A
+            @else
+                <div class="flex flex-col">
+                    <div>
+                        {{ number_format($hardestGame['TotalTruePoints'] / $hardestGame['MaxPointsAvailable'], 2, '.', '') }}
+                        &ndash;
+                        {!! gameAvatar($hardestGame) !!}
+                    </div>
+                    <div>
+                        {{ $hardestGame['MyAchievements'] }}
+                        of
+                        {{ $hardestGame['NumAchievements'] }}
+                        Achievements Created
+                    </div>
+                </div>
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Beaten Softcore/Hardcore Awards:">
+            @if ($beatenSoftcoreAwards === 0 && $beatenHardcoreAwards === 0)
+                N/A
+            @else
+                {{ localized_number($beatenSoftcoreAwards) }}
+                <strong>({{ localized_number($beatenHardcoreAwards) }})</strong>
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Completed/Mastered Awards:">
+            @if ($completedAwards === 0 && $masteredAwards === 0)
+                N/A
+            @else
+                {{ localized_number($completedAwards) }}
+                <strong>({{ localized_number($masteredAwards) }})</strong>
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Own Beaten Softcore/Hardcore Awards:">
+            @if ($ownAwards['BeatenSoftcore'] === 0 && $ownAwards['BeatenHardcore'] === 0)
+                N/A
+            @else
+                {{ $ownAwards['BeatenSoftcore'] }}
+                <strong>({{ $ownAwards['BeatenHardcore'] }})</strong>
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Own Completed/Mastered Awards:">
+            @if ($ownAwards['Completed'] === 0 && $ownAwards['Mastered'] === 0)
+                N/A
+            @else
+                {{ $ownAwards['Completed'] }}
+                <strong>({{ $ownAwards['Mastered'] }})</strong>
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Most Beaten Softcore Game:">
+            @if (($mostBeatenSoftcoreGame['BeatenSoftcore'] ?? 0) === 0)
+                N/A
+            @else
+                {{ localized_number($mostBeatenSoftcoreGame['BeatenSoftcore'] ?? 0) }}
+                &ndash;
+                {!! gameAvatar($mostBeatenSoftcoreGame) !!}
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Most Beaten Hardcore Game:">
+            @if (($mostBeatenHardcoreGame['BeatenHardcore'] ?? 0) === 0)
+                N/A
+            @else
+                {{ localized_number($mostBeatenHardcoreGame['BeatenHardcore'] ?? 0) }}
+                &ndash;
+                {!! gameAvatar($mostBeatenHardcoreGame) !!}
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Most Completed Game:">
+            @if (($mostCompletedGame['Completed'] ?? 0) === 0)
+                N/A
+            @else
+                {{ localized_number($mostCompletedGame['Completed'] ?? 0) }}
+                &ndash;
+                {!! gameAvatar($mostCompletedGame) !!}
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="Most Mastered Game:">
+            @if (($mostMasteredGame['Mastered'] ?? 0) === 0)
+                N/A
+            @else
+                {{ localized_number($mostMasteredGame['Mastered'] ?? 0) }}
+                &ndash;
+                {!! gameAvatar($mostMasteredGame) !!}
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="User with Most Beaten Softcore Awards:">
+            @if (empty($userMostBeatenSoftcore))
+                N/A
+            @else
+                {{ localized_number($userMostBeatenSoftcore['BeatenSoftcore']) }}
+                &ndash;
+                {!! userAvatar($userMostBeatenSoftcore['User']) !!}
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="User with Most Beaten Hardcore Awards:">
+            @if (empty($userMostBeatenHardcore))
+                N/A
+            @else
+                {{ localized_number($userMostBeatenHardcore['BeatenHardcore']) }}
+                &ndash;
+                {!! userAvatar($userMostBeatenHardcore['User']) !!}
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="User with Most Completed Awards:">
+            @if (empty($userMostCompleted))
+                N/A
+            @else
+                {{ localized_number($userMostCompleted['Completed']) }}
+                &ndash;
+                {!! userAvatar($userMostCompleted['User']) !!}
+            @endif
+        </x-developer.game-stats-table-row>
+
+        <x-developer.game-stats-table-row headingLabel="User with Most Mastered Awards:">
+            @if (empty($userMostMastered))
+                N/A
+            @else
+                {{ localized_number($userMostMastered['Mastered']) }}
+                &ndash;
+                {!! userAvatar($userMostMastered['User']) !!}
+            @endif
+        </x-developer.game-stats-table-row>
+    </tbody>
+</table>

--- a/resources/views/community/components/developer/game-stats-table.blade.php
+++ b/resources/views/community/components/developer/game-stats-table.blade.php
@@ -140,7 +140,7 @@
         </x-developer.game-stats-table-row>
 
         <x-developer.game-stats-table-row headingLabel="Own Beaten Softcore/Hardcore Awards:">
-            @if ($ownAwards['BeatenSoftcore'] === 0 && $ownAwards['BeatenHardcore'] === 0)
+            @if (($ownAwards['BeatenSoftcore'] ?? 0) === 0 && ($ownAwards['BeatenHardcore'] ?? 0) === 0)
                 N/A
             @else
                 {{ $ownAwards['BeatenSoftcore'] }}
@@ -149,7 +149,7 @@
         </x-developer.game-stats-table-row>
 
         <x-developer.game-stats-table-row headingLabel="Own Completed/Mastered Awards:">
-            @if ($ownAwards['Completed'] === 0 && $ownAwards['Mastered'] === 0)
+            @if (($ownAwards['Completed'] ?? 0) === 0 && ($ownAwards['Mastered'] ?? 0) === 0)
                 N/A
             @else
                 {{ $ownAwards['Completed'] }}


### PR DESCRIPTION
This PR migrates the three "Games" tables on individualdevstats.php to Blade and adds beaten game awards stats to the tables themselves. A significant amount of duplicated code on individualdevstats.php has been deleted.

**NOTE:** I opted not to put these new stats behind a feature flag because, currently, the feature flag is only guarding against player-facing UI/UX. I don't think there's any harm in eagerly exposing these new stats to devs.

![Screenshot 2023-09-27 at 8 30 36 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/b00d7768-1537-438a-9a74-0d6f282f1b86)
