### PR TITLE
fix(renderAchievementTitle): remediate blade rendering with special chars

### DIFF
--- a/app/Helpers/render/achievement.php
+++ b/app/Helpers/render/achievement.php
@@ -70,7 +70,7 @@ function renderAchievementTitle(?string $title, bool $tags = true): string
         return '';
     }
     if (!Str::contains($title, '[m]')) {
-        return $title;
+        return htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
     }
 
     $missableTag = '';
@@ -83,7 +83,7 @@ function renderAchievementTitle(?string $title, bool $tags = true): string
     // browser doesn't collapse them in forum <pre> tags.
     $title = preg_replace('/\s+/', ' ', $title);
 
-    return trim("$title$missableTag");
+    return trim(htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . $missableTag);
 }
 
 function renderAchievementCard(int|string|array $achievement, ?string $context = null, ?string $iconUrl = null): string


### PR DESCRIPTION
This PR resolves this issue:

![image](https://github.com/RetroAchievements/RAWeb/assets/3984985/3f077897-6c6b-4363-8771-cd584bdb7a58)

**Root Cause**
When using `renderAchievementTitle()` in a Blade component, the title must be rendered using the `{!! !!}` expression. This syntax tells Blade to output the data as raw HTML without escaping it. When special characters are included in an expression like this, those special characters are interpreted as raw HTML.

We resolve this by using `htmlspecialchars()` to escape just the `$title` string but not the missable tag.

**How to test this PR:**
Change an achievement title to:
* Sam the >!</# Flame