### PR TITLE
feat: add primary key to SiteAwards table

### DIFF
--- a/app/Platform/Models/PlayerBadge.php
+++ b/app/Platform/Models/PlayerBadge.php
@@ -18,10 +18,6 @@ class PlayerBadge extends BaseModel
     // TODO Note: will be renamed and split into Community/UserBadge and Platform/PlayerBadge
     protected $table = 'SiteAwards';
 
-    // TODO introduce a primary key - or do the split as mentioned above
-    protected $primaryKey;
-    public $incrementing = false;
-
     public const CREATED_AT = 'AwardDate';
     public const UPDATED_AT = null;
 

--- a/database/migrations/2012_10_03_133633_create_base_tables.php
+++ b/database/migrations/2012_10_03_133633_create_base_tables.php
@@ -579,6 +579,11 @@ return new class() extends Migration {
 
         if (!Schema::hasTable('SiteAwards')) {
             Schema::create('SiteAwards', function (Blueprint $table) {
+                if (DB::connection()->getDriverName() === 'sqlite') {
+                    // SQLite does not allow changing a primary key after a table has been created so it has to be done here
+                    $table->bigIncrements('id')->first();
+                }
+
                 $table->dateTimeTz('AwardDate');
                 $table->string('User', 32)->index();
                 $table->unsignedInteger('AwardType')->index();

--- a/database/migrations/platform/2023_09_29_000000_update_site_awards_table.php
+++ b/database/migrations/platform/2023_09_29_000000_update_site_awards_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('SiteAwards', function (Blueprint $table) {
+            if (DB::connection()->getDriverName() !== 'sqlite') {
+                $table->bigIncrements('id')->first();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('SiteAwards', function (Blueprint $table) {
+            $table->dropColumn('id');
+        });
+    }
+};


### PR DESCRIPTION
`SiteAwards` has been the only table in the V3 schema changes that did not receive a primary key. This should prevent running into bugs with Eloquent again due to its handling of missing primary keys.