### PR TITLE
fix(reorderSiteAwards): add btn class to Save All Changes

### DIFF
--- a/public/reorderSiteAwards.php
+++ b/public/reorderSiteAwards.php
@@ -332,7 +332,7 @@ function postAllAwardsDisplayOrder(awards) {
                     </label>
                 </div>
 
-                <button onclick='handleSaveAllClick()' class='text-base'>Save All Changes</button>
+                <button onclick='handleSaveAllClick()' class='btn text-base'>Save All Changes</button>
             </div>
         HTML;
     } else {


### PR DESCRIPTION
This PR adds a missing "btn" classname to the Save All Changes button on the reorder site awards page.

**Before**
![Screenshot 2023-09-30 at 7 29 34 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/a31f19bc-818a-408e-9f8d-01fa066e492f)


**After**
![Screenshot 2023-09-30 at 7 29 26 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/58fc8a8f-669f-4d1a-84e2-487781a7a229)
