### PR TITLE
avoid querying Activity table for recent logins

### DIFF
--- a/app/Support/Cache/CacheKey.php
+++ b/app/Support/Cache/CacheKey.php
@@ -11,6 +11,11 @@ class CacheKey
         return self::buildNormalizedCacheKey("game", $gameId, "card-data");
     }
 
+    public static function buildUserLastLoginCacheKey(string $username): string
+    {
+        return self::buildNormalizedUserCacheKey($username, "last-login");
+    }
+
     public static function buildUserCompletedGamesCacheKey(string $username): string
     {
         return self::buildNormalizedUserCacheKey($username, "completed-games");


### PR DESCRIPTION
should minimize login failures

```
[object] (Illuminate\\Database\\QueryException(code: HY000): SQLSTATE[HY000]: General error:
 3024 Query execution was interrupted, maximum statement execution time exceeded (SQL:
 SELECT * FROM Activity AS act
              WHERE act.ID =
                ( SELECT MAX(Activity.ID) FROM Activity WHERE Activity.user = :user AND Activity.activityType = 2 ) )
 at /home/forge/retroachievements.org/releases/2023-09-25T165924-4.1.0-97eec26c/vendor/laravel/framework/src/Illuminate/Database/Connection.php:760
```