### PR TITLE
feat: improve query performance for game and achievement metrics updates

### DIFF
--- a/app/Platform/Models/Achievement.php
+++ b/app/Platform/Models/Achievement.php
@@ -245,7 +245,7 @@ class Achievement extends BaseModel implements HasComments
      */
     public function playerAchievementsLegacy(): HasMany
     {
-        return $this->hasMany(PlayerAchievementLegacy::class);
+        return $this->hasMany(PlayerAchievementLegacy::class, 'AchievementID');
     }
 
     /**
@@ -262,7 +262,7 @@ class Achievement extends BaseModel implements HasComments
      */
     public function playerAchievements(): HasMany
     {
-        return $this->hasMany(PlayerAchievement::class);
+        return $this->hasMany(PlayerAchievement::class, 'achievement_id');
     }
 
     /**

--- a/app/Site/Models/User.php
+++ b/app/Site/Models/User.php
@@ -78,7 +78,8 @@ class User extends Authenticatable implements CommunityMember, Developer, HasCom
     // TODO drop LastActivityID, LastGameID, UnreadMessageCount -> derived
     // TODO drop PasswordResetToken -> password_resets table
     // TODO move UserWallActive to preferences, allow comments to be visible to/writable for public, friends, private etc
-    // TODO drop Untracked in favor of unranked_at
+    // TODO rename Untracked to unranked or drop in favor of unranked_at (update indexes)
+    // TODO rename ID index to unranked or drop in favor of unranked_at (update indexes)
     // TODO drop ManuallyVerified in favor of forum_verified_at
     // TODO drop SaltedPass in favor of Password
     // TODO drop Permissions in favor of RBAC tables

--- a/app/Site/Models/User.php
+++ b/app/Site/Models/User.php
@@ -79,7 +79,8 @@ class User extends Authenticatable implements CommunityMember, Developer, HasCom
     // TODO drop PasswordResetToken -> password_resets table
     // TODO move UserWallActive to preferences, allow comments to be visible to/writable for public, friends, private etc
     // TODO rename Untracked to unranked or drop in favor of unranked_at (update indexes)
-    // TODO rename ID index to unranked or drop in favor of unranked_at (update indexes)
+    // TODO drop ID index
+    // TODO remove User from PRIMARY, there's already a unique index on username (User)
     // TODO drop ManuallyVerified in favor of forum_verified_at
     // TODO drop SaltedPass in favor of Password
     // TODO drop Permissions in favor of RBAC tables

--- a/database/migrations/platform/2023_10_09_000000_update_player_tables_index.php
+++ b/database/migrations/platform/2023_10_09_000000_update_player_tables_index.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        // add the inverse indexes for user_id so lookups for untracked and deleted are more likely using indexes
+
+        Schema::table('player_achievements', function (Blueprint $table) {
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('player_achievements');
+
+            if (!array_key_exists('player_achievements_achievement_id_user_id_unlocked_hardcore_at', $indexesFound)) {
+                $table->index(
+                    ['achievement_id', 'user_id', 'unlocked_hardcore_at'],
+                    'player_achievements_achievement_id_user_id_unlocked_hardcore_at'
+                );
+            }
+        });
+
+        Schema::table('player_games', function (Blueprint $table) {
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('player_games');
+
+            if (!array_key_exists('player_games_game_id_user_id_index', $indexesFound)) {
+                $table->index(['game_id', 'user_id']);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_achievements', function (Blueprint $table) {
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('player_achievements');
+
+            if (array_key_exists('player_achievements_achievement_id_user_id_unlocked_hardcore_at', $indexesFound)) {
+                $table->dropIndex('player_achievements_achievement_id_user_id_unlocked_hardcore_at');
+            }
+        });
+
+        Schema::table('player_games', function (Blueprint $table) {
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('player_games');
+
+            if (array_key_exists('player_games_game_id_user_id_index', $indexesFound)) {
+                $table->dropIndex(['game_id', 'user_id']);
+            }
+        });
+    }
+};

--- a/database/migrations/platform/2023_10_09_000001_update_achievements_index.php
+++ b/database/migrations/platform/2023_10_09_000001_update_achievements_index.php
@@ -17,7 +17,7 @@ return new class() extends Migration {
 
             if (!array_key_exists('achievements_game_id_published_index', $indexesFound)) {
                 $table->index(
-                    ['game_id', 'Flags'],
+                    ['GameID', 'Flags'],
                     'achievements_game_id_published_index'
                 );
             }

--- a/database/migrations/platform/2023_10_09_000001_update_achievements_index.php
+++ b/database/migrations/platform/2023_10_09_000001_update_achievements_index.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        // add the inverse indexes for user_id so lookups for untracked and deleted are more likely using indexes
+
+        Schema::table('Achievements', function (Blueprint $table) {
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('Achievements');
+
+            if (!array_key_exists('achievements_game_id_published_index', $indexesFound)) {
+                $table->index(
+                    ['game_id', 'Flags'],
+                    'achievements_game_id_published_index'
+                );
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('Achievements', function (Blueprint $table) {
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('Achievements');
+
+            if (array_key_exists('achievements_game_id_published_index', $indexesFound)) {
+                $table->dropIndex('achievements_game_id_published_index');
+            }
+        });
+    }
+};

--- a/database/migrations/platform/2023_10_09_000001_update_achievements_index.php
+++ b/database/migrations/platform/2023_10_09_000001_update_achievements_index.php
@@ -9,8 +9,6 @@ use Illuminate\Support\Facades\Schema;
 return new class() extends Migration {
     public function up(): void
     {
-        // add the inverse indexes for user_id so lookups for untracked and deleted are more likely using indexes
-
         Schema::table('Achievements', function (Blueprint $table) {
             $sm = Schema::getConnection()->getDoctrineSchemaManager();
             $indexesFound = $sm->listTableIndexes('Achievements');

--- a/tests/Feature/Api/V1Test.php
+++ b/tests/Feature/Api/V1Test.php
@@ -14,12 +14,14 @@ use App\Site\Models\StaticData;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Tests\Feature\Api\V1\BootstrapsApiV1;
+use Tests\Feature\Platform\Concerns\TestsPlayerAchievements;
 use Tests\TestCase;
 
 class V1Test extends TestCase
 {
     use RefreshDatabase;
     use BootstrapsApiV1;
+    use TestsPlayerAchievements;
 
     public function testUnauthorizedResponse(): void
     {
@@ -125,8 +127,7 @@ class V1Test extends TestCase
         $game = Game::factory()->create(['ConsoleID' => $system->ID]);
         /** @var Achievement $achievement */
         $achievement = Achievement::factory()->published()->create(['GameID' => $game->ID]);
-        /** @var PlayerAchievementLegacy $unlock */
-        $unlock = PlayerAchievementLegacy::factory()->create(['AchievementID' => $achievement->ID, 'User' => $this->user->User]);
+        $this->addSoftcoreUnlock($this->user, $achievement);
 
         $staticData = StaticData::factory()->create([
             'Event_AOTW_AchievementID' => $achievement->ID,
@@ -154,7 +155,7 @@ class V1Test extends TestCase
                     [
                         'User' => $this->user->User,
                         'RAPoints' => $this->user->RAPoints,
-                        'HardcoreMode' => $unlock->HardcoreMode,
+                        'HardcoreMode' => 0,
                     ],
                 ],
                 'UnlocksCount' => 1,
@@ -256,8 +257,7 @@ class V1Test extends TestCase
         $game = Game::factory()->create(['ConsoleID' => $system->ID]);
         /** @var Achievement $achievement */
         $achievement = Achievement::factory()->published()->create(['GameID' => $game->ID]);
-        /** @var PlayerAchievementLegacy $unlock */
-        $unlock = PlayerAchievementLegacy::factory()->create(['AchievementID' => $achievement->ID, 'User' => $this->user->User]);
+        $this->addSoftcoreUnlock($this->user, $achievement);
 
         $this->get($this->apiUrl('GetAchievementUnlocks', ['a' => $achievement->ID]))
             ->assertSuccessful()
@@ -276,7 +276,7 @@ class V1Test extends TestCase
                     [
                         'User' => $this->user->User,
                         'RAPoints' => $this->user->RAPoints,
-                        'HardcoreMode' => $unlock->HardcoreMode,
+                        'HardcoreMode' => 0,
                     ],
                 ],
                 'UnlocksCount' => 1,


### PR DESCRIPTION
Add indexes for player_achievements, player_games, and Achievements tables to improve game metrics queries.

Migrations have been applied to stage environment.

Refactor `getTotalUniquePlayers` to use `player_achievements`.

Verified that the query optimizer actually uses those indexes using the following queries:
```sql
-- players

EXPLAIN
SELECT
  COUNT(DISTINCT pa.user_id)
FROM
  player_achievements pa
  LEFT JOIN Achievements a ON a.ID = pa.achievement_id
  LEFT JOIN UserAccounts u ON u.ID = pa.user_id
WHERE
  a.GameID = 228 -- 1, 228, 337
  AND a.Flags = 3
  AND u.Untracked = 0;

EXPLAIN
SELECT
  COUNT(DISTINCT pa.user_id)
FROM
  player_achievements pa
  LEFT JOIN Achievements a ON a.ID = pa.achievement_id
  LEFT JOIN UserAccounts u ON u.ID = pa.user_id
WHERE
  a.GameID = 228 -- 1, 228, 337
  AND a.Flags = 3
  AND u.Untracked = 0
  AND pa.unlocked_hardcore_at IS NOT NULL;

EXPLAIN
SELECT
  COUNT(DISTINCT aw.User)
FROM
  Awarded aw
  LEFT JOIN Achievements ach ON ach.ID = aw.AchievementID
  LEFT JOIN UserAccounts ua ON ua.User = aw.User
WHERE
  ach.GameID = 228 -- 1, 228, 337
  AND ach.Flags = 3
  AND ua.Untracked = 0;

-- player games

EXPLAIN
SELECT
  COUNT(*)
FROM
  player_games pg
LEFT JOIN UserAccounts u ON pg.user_id = u.ID
WHERE
  pg.game_id = 1 -- 1, 228, 337
  AND pg.game_id IS NOT NULL
  AND u.Untracked = 0;

-- player achievements

EXPLAIN
SELECT
  COUNT(*)
FROM
  player_achievements pa
LEFT JOIN UserAccounts u ON pa.user_id = u.ID
WHERE
  pa.achievement_id = 342 -- 342, 341, 2253, 4874, 347, 2251, 2298, 2299, 2261, 4933 
  AND pa.achievement_id IS NOT NULL
  AND u.Untracked = 0;

-- player achievements hardcore

EXPLAIN
SELECT
  COUNT(*)
FROM
  player_achievements pa
LEFT JOIN UserAccounts u ON pa.user_id = u.ID
WHERE
  pa.achievement_id = 342 -- 342, 341, 2253, 4874, 347, 2251, 2298, 2299, 2261, 4933
  AND pa.achievement_id IS NOT NULL
  AND u.Untracked = 0
  AND pa.unlocked_hardcore_at IS NOT NULL;

-- awarded

EXPLAIN
SELECT
  COUNT(*)
FROM
  Awarded aw
LEFT JOIN UserAccounts u ON aw.User = u.User
WHERE
  aw.AchievementID = 342 -- 342, 341, 2253, 4874, 347, 2251, 2298, 2299, 2261, 4933
  AND aw.AchievementID IS NOT NULL
  AND u.Untracked = 0;
```