### PR TITLE
feat: allow activating aggregate queries with a cookie

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -22,6 +22,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Site\Middleware\RedirectsMissingPages::class,
         \App\Site\Middleware\RobotsMiddleware::class,
+        \App\Site\Middleware\FeatureFlagMiddleware::class,
     ];
 
     /**

--- a/app/Platform/Actions/UpdateGameMetrics.php
+++ b/app/Platform/Actions/UpdateGameMetrics.php
@@ -100,8 +100,8 @@ class UpdateGameMetrics
                     $query->whereNot('achievement_set_version_hash', '=', $game->achievement_set_version_hash)
                         ->orWhereNull('achievement_set_version_hash');
                 })
-                ->orderByDesc('last_played_at')
-                ->chunk(500, function (Collection $chunk) {
+                ->orderBy('id')
+                ->chunkById(1000, function (Collection $chunk) {
                     // map and dispatch this chunk as a batch of jobs
                     Bus::batch(
                         $chunk->map(

--- a/app/Site/Middleware/EncryptCookies.php
+++ b/app/Site/Middleware/EncryptCookies.php
@@ -18,5 +18,6 @@ class EncryptCookies extends Middleware
         'prefers_hidden_user_completed_sets',
         'prefers_seeing_saved_hidden_rows_when_reordering',
         'progression_status_widths_preference',
+        'feature_aggregate_queries',
     ];
 }

--- a/app/Site/Middleware/FeatureFlagMiddleware.php
+++ b/app/Site/Middleware/FeatureFlagMiddleware.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Request;
 
 class FeatureFlagMiddleware
 {
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): mixed
     {
         // Check for the presence of the 'aggregate_queries' cookie.
         $cookieValue = $request->cookie('feature_aggregate_queries');

--- a/app/Site/Middleware/FeatureFlagMiddleware.php
+++ b/app/Site/Middleware/FeatureFlagMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Site\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class FeatureFlagMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        // Check for the presence of the 'aggregate_queries' cookie.
+        $cookieValue = $request->cookie('feature_aggregate_queries');
+
+        // Override the feature flag configuration if the cookie is set to 'true'
+        if ($cookieValue === 'true') {
+            config(['feature.aggregate_queries' => true]);
+        } elseif ($cookieValue === 'false') {
+            config(['feature.aggregate_queries' => false]);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Site/Middleware/FeatureFlagMiddleware.php
+++ b/app/Site/Middleware/FeatureFlagMiddleware.php
@@ -11,10 +11,9 @@ class FeatureFlagMiddleware
 {
     public function handle(Request $request, Closure $next): mixed
     {
-        // Check for the presence of the 'aggregate_queries' cookie.
         $cookieValue = $request->cookie('feature_aggregate_queries');
 
-        // Override the feature flag configuration if the cookie is set to 'true'
+        // Override the feature flag configuration if the cookie is set to 'true'.
         if ($cookieValue === 'true') {
             config(['feature.aggregate_queries' => true]);
         } elseif ($cookieValue === 'false') {

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -13,6 +13,7 @@ import {
   autoExpandTextInput,
   copyToClipboard,
   fetcher,
+  getCookie,
   getStringByteCount,
   handleLeaderboardTabClick,
   initializeTextareaCounter,
@@ -36,6 +37,7 @@ lazyLoadModuleOnIdFound({
 window.autoExpandTextInput = autoExpandTextInput;
 window.copyToClipboard = copyToClipboard;
 window.fetcher = fetcher;
+window.getCookie = getCookie;
 window.getStringByteCount = getStringByteCount;
 window.handleLeaderboardTabClick = handleLeaderboardTabClick;
 window.initializeTextareaCounter = initializeTextareaCounter;

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -13,7 +13,7 @@ import type { handleLeaderboardTabClick as HandleLeaderboardTabClick } from '@/u
 import type { initializeTextareaCounter as InitializeTextareaCounter } from '@/utils/initializeTextareaCounter';
 import type { injectShortcode as InjectShortcode } from '@/utils/injectShortcode';
 import type { loadPostPreview as LoadPostPreview } from '@/utils/loadPostPreview';
-import type { setCookie as SetCookie } from '@/utils/cookie';
+import type { getCookie as GetCookie, setCookie as SetCookie } from '@/utils/cookie';
 import type { toggleUserCompletedSetsVisibility as ToggleUserCompletedSetsVisibility } from '@/utils/toggleUserCompletedSetsVisibility';
 
 declare global {
@@ -24,6 +24,7 @@ declare global {
   var cfg: Record<string, unknown> | undefined;
   var copyToClipboard: (text: string) => void;
   var fetcher: typeof Fetcher;
+  var getCookie: typeof GetCookie;
   var getStringByteCount: typeof GetStringByteCount;
   var handleLeaderboardTabClick: typeof HandleLeaderboardTabClick;
   var hideEarnedCheckboxComponent: typeof HideEarnedCheckboxComponent;

--- a/resources/views/components/feature-flags.blade.php
+++ b/resources/views/components/feature-flags.blade.php
@@ -1,3 +1,7 @@
+<?php
+$aggregateQueriesSource = \Request::cookie('feature_aggregate_queries') !== null ? 'cookie' : 'env';
+?>
+
 <script>
 function handleToggleCookie() {
     const currentValue = getCookie('feature_aggregate_queries');
@@ -29,8 +33,8 @@ function handleToggleCookie() {
     </button>
 
     @hasfeature("aggregate_queries")
-        Enabled
+        Enabled (Source: {{ $aggregateQueriesSource }})
     @else
-        Disabled
+        Disabled (Source: {{ $aggregateQueriesSource }})
     @endhasfeature
 </div>

--- a/resources/views/components/feature-flags.blade.php
+++ b/resources/views/components/feature-flags.blade.php
@@ -6,3 +6,12 @@
         Disabled
     @endhasfeature
 </div>
+
+<div class="flex justify-between">
+    <p>Aggregate Queries</p>
+    @hasfeature("aggregate_queries")
+        Enabled
+    @else
+        Disabled
+    @endhasfeature
+</div>

--- a/resources/views/components/feature-flags.blade.php
+++ b/resources/views/components/feature-flags.blade.php
@@ -1,3 +1,17 @@
+<script>
+function handleToggleCookie() {
+    const currentValue = getCookie('feature_aggregate_queries');
+
+    let newValue = true;
+    if (currentValue === 'true') {
+        newValue = false;
+    }
+
+    setCookie('feature_aggregate_queries', `${newValue}`);
+    showStatusSuccess(`feature_aggregate_queries cookie set to ${newValue}.`);
+}
+</script>
+
 <div class="flex justify-between">
     <p>Beaten Games Player-facing UX</p>
     @hasfeature("beat")
@@ -9,6 +23,11 @@
 
 <div class="flex justify-between">
     <p>Aggregate Queries</p>
+
+    <button class="btn" onClick="handleToggleCookie()">
+        Toggle cookie
+    </button>
+
     @hasfeature("aggregate_queries")
         Enabled
     @else


### PR DESCRIPTION
This PR adds a middleware which allows a user to force-enable aggregate queries at the request level by having a cookie `feature_aggregate_queries` set to `true`.

It also adds a label for the feature flag to the `<x-feature-flags />` component, which is visible on the admin panel.

![Screenshot 2023-10-13 at 8 41 56 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/634c2873-a5a2-4cc9-9db4-6a1af1445242)
