### PR TITLE
feat: allow for user id or username command parameters

### DIFF
--- a/app/Platform/Commands/UnlockPlayerAchievement.php
+++ b/app/Platform/Commands/UnlockPlayerAchievement.php
@@ -13,7 +13,7 @@ use Illuminate\Console\Command;
 class UnlockPlayerAchievement extends Command
 {
     protected $signature = 'ra:platform:player:unlock-achievement
-                            {username}
+                            {userId : User ID or username. Usernames containing only numbers are not applicable and must be referenced by user ID}
                             {achievementIds : Comma-separated list of achievement IDs}
                             {--hardcore}';
     protected $description = 'Unlock achievement(s) for user';
@@ -29,12 +29,14 @@ class UnlockPlayerAchievement extends Command
      */
     public function handle(): void
     {
-        $username = $this->argument('username');
+        $userId = $this->argument('userId');
         $achievementIds = collect(explode(',', $this->argument('achievementIds')))
             ->map(fn ($id) => (int) $id);
         $hardcore = (bool) $this->option('hardcore');
 
-        $user = User::where('User', $this->argument('username'))->firstOrFail();
+        $user = is_numeric($userId)
+            ? User::findOrFail($userId)
+            : User::where('User', $this->argument('username'))->firstOrFail();
 
         $achievements = Achievement::whereIn('id', $achievementIds)->get();
 

--- a/app/Platform/Commands/UnlockPlayerAchievement.php
+++ b/app/Platform/Commands/UnlockPlayerAchievement.php
@@ -55,7 +55,6 @@ class UnlockPlayerAchievement extends Command
         }
 
         $progressBar->finish();
-
-        $this->info('Done');
+        $this->line(PHP_EOL);
     }
 }

--- a/app/Platform/Commands/UnlockPlayerAchievement.php
+++ b/app/Platform/Commands/UnlockPlayerAchievement.php
@@ -40,7 +40,7 @@ class UnlockPlayerAchievement extends Command
 
         $achievements = Achievement::whereIn('id', $achievementIds)->get();
 
-        $this->info('Unlocking ' . $achievements->count() . ' [' . ($hardcore ? 'hardcore' : 'softcore') . '] ' . __res('achievement', $achievements->count()) . ' for user [' . $user->username . '] [' . $user->id . ']');
+        $this->info('Unlocking ' . $achievements->count() . ' [' . ($hardcore ? 'hardcore' : 'softcore') . '] ' . __res('achievement', $achievements->count()) . ' for user [' . $user->id . ':' . $user->username . ']');
 
         $progressBar = $this->output->createProgressBar($achievements->count());
         $progressBar->start();

--- a/app/Platform/Commands/UnlockPlayerAchievement.php
+++ b/app/Platform/Commands/UnlockPlayerAchievement.php
@@ -40,7 +40,7 @@ class UnlockPlayerAchievement extends Command
 
         $achievements = Achievement::whereIn('id', $achievementIds)->get();
 
-        $this->info('Unlocking ' . $achievements->count() . ' [' . ($hardcore ? 'hardcore' : 'softcore') . '] ' . __res('achievement', $achievements->count()) . ' for user [' . $username . '] [' . $user->id . ']');
+        $this->info('Unlocking ' . $achievements->count() . ' [' . ($hardcore ? 'hardcore' : 'softcore') . '] ' . __res('achievement', $achievements->count()) . ' for user [' . $user->username . '] [' . $user->id . ']');
 
         $progressBar = $this->output->createProgressBar($achievements->count());
         $progressBar->start();
@@ -55,5 +55,7 @@ class UnlockPlayerAchievement extends Command
         }
 
         $progressBar->finish();
+
+        $this->info('Done');
     }
 }

--- a/app/Platform/Commands/UnlockPlayerAchievement.php
+++ b/app/Platform/Commands/UnlockPlayerAchievement.php
@@ -36,7 +36,7 @@ class UnlockPlayerAchievement extends Command
 
         $user = is_numeric($userId)
             ? User::findOrFail($userId)
-            : User::where('User', $this->argument('username'))->firstOrFail();
+            : User::where('User', $userId)->firstOrFail();
 
         $achievements = Achievement::whereIn('id', $achievementIds)->get();
 

--- a/app/Platform/Commands/UnlockPlayerAchievement.php
+++ b/app/Platform/Commands/UnlockPlayerAchievement.php
@@ -13,7 +13,7 @@ use Illuminate\Console\Command;
 class UnlockPlayerAchievement extends Command
 {
     protected $signature = 'ra:platform:player:unlock-achievement
-                            {userId : User ID or username. Usernames containing only numbers are not applicable and must be referenced by user ID}
+                            {userId : User ID or username. Usernames containing only numbers are ambiguous and must be referenced by user ID}
                             {achievementIds : Comma-separated list of achievement IDs}
                             {--hardcore}';
     protected $description = 'Unlock achievement(s) for user';

--- a/app/Platform/Commands/UpdatePlayerGameMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerGameMetrics.php
@@ -13,7 +13,7 @@ use Illuminate\Console\Command;
 class UpdatePlayerGameMetrics extends Command
 {
     protected $signature = 'ra:platform:player:update-game-metrics
-                            {userId : User ID or username. Usernames containing only numbers are not applicable and must be referenced by user ID}
+                            {userId : User ID or username. Usernames containing only numbers are ambiguous and must be referenced by user ID}
                             {gameIds? : Comma-separated list of game IDs. Leave empty to update all games in player library}
                             {--outdated}';
     protected $description = 'Update player game(s) metrics';

--- a/app/Platform/Commands/UpdatePlayerGameMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerGameMetrics.php
@@ -13,7 +13,7 @@ use Illuminate\Console\Command;
 class UpdatePlayerGameMetrics extends Command
 {
     protected $signature = 'ra:platform:player:update-game-metrics
-                            {username}
+                            {userId : User ID or username. Usernames containing only numbers are not applicable and must be referenced by user ID}
                             {gameIds? : Comma-separated list of game IDs. Leave empty to update all games in player library}
                             {--outdated}';
     protected $description = 'Update player game(s) metrics';
@@ -27,13 +27,16 @@ class UpdatePlayerGameMetrics extends Command
 
     public function handle(): void
     {
+        $userId = $this->argument('userId');
         $outdated = $this->option('outdated');
 
         $gameIds = collect(explode(',', $this->argument('gameIds') ?? ''))
             ->filter()
             ->map(fn ($id) => (int) $id);
 
-        $user = User::where('User', $this->argument('username'))->firstOrFail();
+        $user = is_numeric($userId)
+            ? User::findOrFail($userId)
+            : User::where('User', $this->argument('username'))->firstOrFail();
 
         $query = $user->playerGames()
             ->with(['user', 'game']);

--- a/app/Platform/Commands/UpdatePlayerGameMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerGameMetrics.php
@@ -36,7 +36,7 @@ class UpdatePlayerGameMetrics extends Command
 
         $user = is_numeric($userId)
             ? User::findOrFail($userId)
-            : User::where('User', $this->argument('username'))->firstOrFail();
+            : User::where('User', $userId)->firstOrFail();
 
         $query = $user->playerGames()
             ->with(['user', 'game']);

--- a/app/Platform/Commands/UpdatePlayerGameMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerGameMetrics.php
@@ -51,7 +51,7 @@ class UpdatePlayerGameMetrics extends Command
         }
         $playerGames = $query->get();
 
-        $this->info('Updating ' . $playerGames->count() . ' ' . __res('game', $playerGames->count()) . ' for user [' . $user->username . '] [' . $user->id . ']');
+        $this->info('Updating ' . $playerGames->count() . ' ' . __res('game', $playerGames->count()) . ' for user [' . $user->id . ':' . $user->username . ']');
 
         $progressBar = $this->output->createProgressBar($playerGames->count());
         $progressBar->start();

--- a/app/Platform/Commands/UpdatePlayerGameMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerGameMetrics.php
@@ -70,7 +70,6 @@ class UpdatePlayerGameMetrics extends Command
         }
 
         $progressBar->finish();
-
-        $this->info('Done');
+        $this->line(PHP_EOL);
     }
 }

--- a/app/Platform/Commands/UpdatePlayerGameMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerGameMetrics.php
@@ -51,6 +51,8 @@ class UpdatePlayerGameMetrics extends Command
         }
         $playerGames = $query->get();
 
+        $this->info('Updating ' . $playerGames->count() . ' ' . __res('game', $playerGames->count()) . ' for user [' . $user->username . '] [' . $user->id . ']');
+
         $progressBar = $this->output->createProgressBar($playerGames->count());
         $progressBar->start();
 
@@ -68,5 +70,7 @@ class UpdatePlayerGameMetrics extends Command
         }
 
         $progressBar->finish();
+
+        $this->info('Done');
     }
 }

--- a/app/Platform/Commands/UpdatePlayerMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerMetrics.php
@@ -28,7 +28,7 @@ class UpdatePlayerMetrics extends Command
             ? User::findOrFail($userId)
             : User::where('User', $userId)->firstOrFail();
 
-        $this->info('Updating metrics for player [' . $user->username . '] [' . $user->id . ']');
+        $this->info('Updating metrics for player [' . $user->id . ':' . $user->username . ']');
 
         $this->updatePlayerMetrics->execute($user);
     }

--- a/app/Platform/Commands/UpdatePlayerMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerMetrics.php
@@ -26,7 +26,5 @@ class UpdatePlayerMetrics extends Command
         $this->info('Updating metrics for player ' . $user->username . ' [' . $user->id . ']');
 
         $this->updatePlayerMetrics->execute($user);
-
-        $this->info('Done');
     }
 }

--- a/app/Platform/Commands/UpdatePlayerMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerMetrics.php
@@ -10,7 +10,8 @@ use Illuminate\Console\Command;
 
 class UpdatePlayerMetrics extends Command
 {
-    protected $signature = 'ra:platform:player:update-metrics {username}';
+    protected $signature = 'ra:platform:player:update-metrics
+                            {userId : User ID or username. Usernames containing only numbers are ambiguous and must be referenced by user ID}';
     protected $description = 'Update player metrics';
 
     public function __construct(
@@ -21,9 +22,13 @@ class UpdatePlayerMetrics extends Command
 
     public function handle(): void
     {
-        $user = User::where('User', $this->argument('username'))->firstOrFail();
+        $userId = $this->argument('userId');
 
-        $this->info('Updating metrics for player ' . $user->username . ' [' . $user->id . ']');
+        $user = is_numeric($userId)
+            ? User::findOrFail($userId)
+            : User::where('User', $userId)->firstOrFail();
+
+        $this->info('Updating metrics for player [' . $user->username . '] [' . $user->id . ']');
 
         $this->updatePlayerMetrics->execute($user);
     }

--- a/app/Platform/Commands/UpdatePlayerMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerMetrics.php
@@ -23,7 +23,10 @@ class UpdatePlayerMetrics extends Command
     {
         $user = User::where('User', $this->argument('username'))->firstOrFail();
 
-        $this->info('Update metrics for player ' . $user->username . ' [' . $user->id . ']');
+        $this->info('Updating metrics for player ' . $user->username . ' [' . $user->id . ']');
+
         $this->updatePlayerMetrics->execute($user);
+
+        $this->info('Done');
     }
 }


### PR DESCRIPTION
Makes it easier to run on the server when focusing on individual `player_games` updates where the `user_id` is more prevalent than usernames.

As mentioned in the command parameter descriptions:
> User ID or username. Usernames containing only numbers are ambiguous and must be referenced by user ID