### PR TITLE
use aggregate_queries feature for high scores on game page

### DIFF
--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -751,7 +751,7 @@ function getGameTopAchievers(int $gameID): array
         $query = "SELECT ua.User, pg.achievements_unlocked_hardcore AS NumAchievements,
                          pg.points_hardcore AS TotalScore, pg.last_unlock_hardcore_at AS LastAward
                     FROM player_games pg
-                    LEFT JOIN UserAccounts ua ON ua.ID = pg.user_id
+                    INNER JOIN UserAccounts ua ON ua.ID = pg.user_id
                     WHERE ua.Untracked = 0
                     AND pg.game_id = $gameID
                     AND pg.achievements_unlocked_hardcore > 0

--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -752,7 +752,7 @@ function getGameTopAchievers(int $gameID): array
                          pg.points_hardcore AS TotalScore, pg.last_unlock_hardcore_at AS LastAward
                     FROM player_games pg
                     LEFT JOIN UserAccounts ua ON ua.ID = pg.user_id
-                    WHERE NOT ua.Untracked
+                    WHERE ua.Untracked = 0
                     AND pg.game_id = $gameID
                     AND pg.achievements_unlocked_hardcore > 0
                     ORDER BY TotalScore DESC, NumAchievements DESC, LastAward";


### PR DESCRIPTION
Takes ~250ms to build the high scores list for Super Mario World vs 2.5s with the feature disabled.

250ms is still a reasonably large amount of time, so I recommend we continue to cache the result (line 733 above).