### PR TITLE
fix client error retrieving softcore unlocks with aggregate queries on

### DIFF
--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -322,11 +322,18 @@ function getUserAchievementUnlocksForGame(string $username, int $gameID, int $fl
                 'unlocked_hardcore_at',
             ])
             ->mapWithKeys(function (PlayerAchievement $unlock, int $key) {
-                return [$unlock->achievement_id => [
-                    // TODO move this transformation to where it's needed (web api) and use models everywhere else
-                    'DateEarned' => $unlock->unlocked_at?->format('Y-m-d H:i:s'),
-                    'DateEarnedHardcore' => $unlock->unlocked_hardcore_at?->format('Y-m-d H:i:s'),
-                ]];
+                $result = [];
+
+                // TODO move this transformation to where it's needed (web api) and use models everywhere else
+                if ($unlock->unlocked_at) {
+                    $result['DateEarned'] = $unlock->unlocked_at->format('Y-m-d H:i:s');
+                }
+
+                if ($unlock->unlocked_hardcore_at) {
+                    $result['DateEarnedHardcore'] = $unlock->unlocked_hardcore_at->format('Y-m-d H:i:s');
+                }
+
+                return [$unlock->achievement_id => $result];
             });
 
         return $playerAchievements->toArray();

--- a/tests/Feature/Connect/AwardAchievementTest.php
+++ b/tests/Feature/Connect/AwardAchievementTest.php
@@ -125,7 +125,7 @@ class AwardAchievementTest extends TestCase
 
         // make sure the unlock cache was updated
         $unlocks = getUserAchievementUnlocksForGame($this->user->User, $game->ID);
-        $this->assertEquals([$achievement1->ID, $achievement5->ID, $achievement6->ID, $achievement3->ID], array_keys($unlocks));
+        $this->assertEqualsCanonicalizing([$achievement1->ID, $achievement5->ID, $achievement6->ID, $achievement3->ID], array_keys($unlocks));
         $this->assertEquals($now, $unlocks[$achievement3->ID]['DateEarnedHardcore']);
         $this->assertEquals($now, $unlocks[$achievement3->ID]['DateEarned']);
 
@@ -296,7 +296,7 @@ class AwardAchievementTest extends TestCase
 
         // make sure the unlock cache was updated
         $unlocks = getUserAchievementUnlocksForGame($this->user->User, $game->ID);
-        $this->assertEquals([$achievement1->ID, $achievement5->ID, $achievement6->ID, $achievement3->ID], array_keys($unlocks));
+        $this->assertEqualsCanonicalizing([$achievement1->ID, $achievement5->ID, $achievement6->ID, $achievement3->ID], array_keys($unlocks));
         $this->assertEquals($now, $unlocks[$achievement3->ID]['DateEarned']);
         $this->assertArrayNotHasKey('DateEarnedHardcore', $unlocks[$achievement3->ID]);
 
@@ -366,7 +366,7 @@ class AwardAchievementTest extends TestCase
 
         // make sure the unlock cache was updated
         $unlocks = getUserAchievementUnlocksForGame($this->user->User, $game->ID);
-        $this->assertEquals([$achievement1->ID, $achievement5->ID, $achievement6->ID, $achievement3->ID], array_keys($unlocks));
+        $this->assertEqualsCanonicalizing([$achievement1->ID, $achievement5->ID, $achievement6->ID, $achievement3->ID], array_keys($unlocks));
         $this->assertEquals($now, $unlocks[$achievement3->ID]['DateEarned']);
         $this->assertEquals($newNow, $unlocks[$achievement3->ID]['DateEarnedHardcore']);
 

--- a/tests/Feature/Connect/BootstrapsConnect.php
+++ b/tests/Feature/Connect/BootstrapsConnect.php
@@ -15,6 +15,8 @@ trait BootstrapsConnect
     {
         parent::setUp();
 
+        // config(['feature.aggregate_queries' => true]);
+
         /** @var User $user */
         $user = User::factory()->create(['appToken' => Str::random(16)]);
         $this->user = $user;


### PR DESCRIPTION
```
'DateEarnedHardcore' => $unlock->unlocked_hardcore_at?->format('Y-m-d H:i:s'),
```
would return a null entry for `DateEarnedHardcore`, whereas the non-aggregate code does not populate the key. This caused the filtering code for the `unlocks` and `startsession` requests to not produce the desired results.

https://github.com/RetroAchievements/RAWeb/blob/c0fa53753c0c1a16ce9418c17af8c72f23af1233/public/dorequest.php#L392-L394

https://github.com/RetroAchievements/RAWeb/blob/c0fa53753c0c1a16ce9418c17af8c72f23af1233/public/dorequest.php#L325-L335

In fact, the `strtotime` call would change the value from `null` to `false` resulting in unparseable timestamps for the client.
```
{"Success":true,"HardcoreUnlocks":[{"ID":361917,"When":false},{"ID":361918,"When":false},{"ID":361919,"When":false},
{"ID":361921,"When":false},{"ID":361922,"When":false},{"ID":361924,"When":false},{"ID":361925,"When":false},
{"ID":361928,"When":false},{"ID":361931,"When":false}],"ServerNow":1697396485}
```