### PR TITLE
fix(connect): do not record ping requests without a game ID

### DIFF
--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -230,7 +230,7 @@ switch ($requestType) {
      */
 
     case "ping":
-        if ($user === null) {
+        if ($user === null || !$gameID) {
             $response['Success'] = false;
         } else {
             $activityMessage = request()->post('m');


### PR DESCRIPTION
Fixes `App\Platform\Events\PlayerSessionHeartbeat::__construct(): Argument #2 ($game) must be of type App\Platform\Models\Game, null given`.

I don't think saving the last login date for users when no valid date was provided is worth the overhead. There are a lot of writes to the last login date already.