### PR TITLE
fix error viewing unofficial achievements for game with soft-deleted achievements

### DIFF
--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -206,7 +206,7 @@ function getGameMetadata(
         ach.type
     FROM Achievements AS ach
     $metricsJoin
-    WHERE ach.GameID = :gameId AND ach.Flags = :achievementFlag
+    WHERE ach.GameID = :gameId AND ach.Flags = :achievementFlag AND ach.deleted_at IS NULL
     $orderBy";
 
     $achievementDataOut = legacyDbFetchAll($query, array_merge([


### PR DESCRIPTION
Fixes 
> Undefined array key 3 at /home/forge/retroachievements.org/releases/2023-10-21T184740-5.0.1-b4e1dc15/public/gameInfo.php:446)

exception caused by soft-deleting achievements with Flags=0 (https://discord.com/channels/476211979464343552/1026595325038833725/1165025766585671821)

See also: https://discord.com/channels/476211979464343552/1002696640001478769/1165839500572889128