### PR TITLE
chore: do not sanitize integers

### DIFF
--- a/app/Helpers/database/code-note.php
+++ b/app/Helpers/database/code-note.php
@@ -8,8 +8,6 @@ function getCodeNotesData(int $gameID): array
 {
     $codeNotesOut = [];
 
-    sanitize_sql_inputs($gameID);
-
     $query = "SELECT ua.User, cn.Address, cn.Note
               FROM CodeNotes AS cn
               LEFT JOIN UserAccounts AS ua ON ua.ID = cn.AuthorID
@@ -32,8 +30,6 @@ function getCodeNotesData(int $gameID): array
 
 function getCodeNotes(int $gameID, ?array &$codeNotesOut): bool
 {
-    sanitize_sql_inputs($gameID);
-
     $query = "SELECT ua.User, cn.Address, cn.Note
               FROM CodeNotes AS cn
               LEFT JOIN UserAccounts AS ua ON ua.ID = cn.AuthorID

--- a/app/Helpers/database/forum.php
+++ b/app/Helpers/database/forum.php
@@ -136,8 +136,6 @@ function getTopicDetails(int $topicID, ?array &$topicDataOut = []): bool
 
 function getTopicComments(int $topicID, int $offset, int $count, ?int &$maxCountOut): ?array
 {
-    sanitize_sql_inputs($topicID);
-
     $query = "    SELECT COUNT(*) FROM ForumTopicComment AS ftc
                 WHERE ftc.ForumTopicID = $topicID ";
 
@@ -349,7 +347,7 @@ function submitTopicComment(
 
 function notifyUsersAboutForumActivity(int $topicID, string $topicTitle, string $author, int $commentID): void
 {
-    sanitize_sql_inputs($topicID, $author, $commentID);
+    sanitize_sql_inputs($author);
 
     // $author has made a post in the topic $topicID
     // Find all people involved in this forum topic, and if they are not the author and prefer to
@@ -382,8 +380,6 @@ function getTopicCommentCommentOffset(int $forumTopicID, int $commentID, int $co
     if ($commentID == -1) {
         $commentID = 99_999_999;
     }
-
-    sanitize_sql_inputs($forumTopicID, $commentID);
 
     $query = "SELECT COUNT(ID) AS CommentOffset
               FROM ForumTopicComment

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -69,24 +69,24 @@ function getGameMetadata(
         5 => "ORDER BY ach.Title, ach.ID ASC ",
         15 => "ORDER BY ach.Title DESC, ach.ID DESC ",
 
-        6 => "ORDER BY 
-            CASE 
-                WHEN ach.type = 'progression' THEN 0 
-                WHEN ach.type = 'win_condition' THEN 1 
-                WHEN ach.type IS NULL THEN 2 
-                ELSE 3 
-            END, 
-            ach.DisplayOrder, 
+        6 => "ORDER BY
+            CASE
+                WHEN ach.type = 'progression' THEN 0
+                WHEN ach.type = 'win_condition' THEN 1
+                WHEN ach.type IS NULL THEN 2
+                ELSE 3
+            END,
+            ach.DisplayOrder,
             ach.ID ASC ",
 
-        16 => "ORDER BY 
-            CASE 
-                WHEN ach.type = 'progression' THEN 0 
-                WHEN ach.type = 'win_condition' THEN 1 
-                WHEN ach.type IS NULL THEN 2 
-                ELSE 3 
-            END DESC, 
-            ach.DisplayOrder DESC, 
+        16 => "ORDER BY
+            CASE
+                WHEN ach.type = 'progression' THEN 0
+                WHEN ach.type = 'win_condition' THEN 1
+                WHEN ach.type IS NULL THEN 2
+                ELSE 3
+            END DESC,
+            ach.DisplayOrder DESC,
             ach.ID DESC ",
 
         // 1
@@ -576,7 +576,7 @@ function modifyGameData(
         return true;
     }
 
-    sanitize_sql_inputs($gameID, $developer, $publisher, $genre, $released, $guideURL);
+    sanitize_sql_inputs($developer, $publisher, $genre, $released, $guideURL);
 
     $query = "UPDATE GameData AS gd
               SET gd.Developer = '$developer', gd.Publisher = '$publisher', gd.Genre = '$genre', gd.Released = '$released', gd.GuideURL = '$guideURL'
@@ -681,8 +681,6 @@ function modifyGameAlternatives(string $user, int $gameID, int|string|null $toAd
 
 function modifyGameForumTopic(string $user, int $gameID, int $newForumTopic): bool
 {
-    sanitize_sql_inputs($gameID, $newForumTopic);
-
     if ($gameID == 0 || $newForumTopic == 0) {
         return false;
     }
@@ -740,7 +738,7 @@ function getGameListSearch(int $offset, int $count, int $method, ?int $consoleID
 
 function createNewGame(string $title, int $consoleID): ?array
 {
-    sanitize_sql_inputs($title, $consoleID);
+    sanitize_sql_inputs($title);
     // $title = str_replace( "--", "-", $title );    // subtle non-comment breaker
 
     $query = "INSERT INTO GameData (Title, ConsoleID, ForumTopicID, Flags, ImageIcon, ImageTitle, ImageIngame, ImageBoxArt, Publisher, Developer, Genre, Released, IsFinal, RichPresencePatch, TotalTruePoints)
@@ -872,7 +870,7 @@ function modifyGameRichPresence(string $user, int $gameID, string $dataIn): bool
         return true;
     }
 
-    sanitize_sql_inputs($gameID, $dataIn);
+    sanitize_sql_inputs($dataIn);
     $query = "UPDATE GameData SET RichPresencePatch='$dataIn' WHERE ID=$gameID";
 
     $db = getMysqliConnection();

--- a/app/Helpers/database/message.php
+++ b/app/Helpers/database/message.php
@@ -86,7 +86,7 @@ function GetSentMessageCount(string $user): int
 
 function GetMessage(string $user, int $id): ?array
 {
-    sanitize_sql_inputs($user, $id);
+    sanitize_sql_inputs($user);
 
     $query = "SELECT * FROM Messages AS msg
               WHERE msg.ID='$id' AND msg.UserTo='$user'";
@@ -107,7 +107,7 @@ function GetMessage(string $user, int $id): ?array
 
 function GetAllMessages(string $user, int $offset, int $count, bool $unreadOnly): array
 {
-    sanitize_sql_inputs($user, $offset, $count);
+    sanitize_sql_inputs($user);
 
     $retval = [];
 
@@ -136,7 +136,7 @@ function GetAllMessages(string $user, int $offset, int $count, bool $unreadOnly)
 
 function GetSentMessages(string $user, int $offset, int $count): array
 {
-    sanitize_sql_inputs($user, $offset, $count);
+    sanitize_sql_inputs($user);
 
     $retval = [];
 

--- a/app/Helpers/database/set-claim.php
+++ b/app/Helpers/database/set-claim.php
@@ -145,8 +145,6 @@ function dropClaim(string $user, int $gameID): bool
  */
 function extendClaim(string $user, int $gameID): bool
 {
-    sanitize_sql_inputs($gameID);
-
     if (hasSetClaimed($user, $gameID, true)) {
         $query = "
             UPDATE
@@ -442,7 +440,7 @@ function getActiveClaimCount(?string $user = null, bool $countCollaboration = tr
  */
 function updateClaim(int $claimID, int $claimType, int $setType, int $status, int $special, string $claimDate, string $finishedDate): bool
 {
-    sanitize_sql_inputs($claimID, $claimType, $setType, $status, $special, $claimDate, $finishedDate);
+    sanitize_sql_inputs($claimDate, $finishedDate);
 
     $query = "
         UPDATE

--- a/app/Helpers/database/set-request.php
+++ b/app/Helpers/database/set-request.php
@@ -112,7 +112,6 @@ function getUserRequestsInformation(string $user, array $list, int $gameID = -1)
  */
 function getSetRequestCount(int $gameID): int
 {
-    sanitize_sql_inputs($gameID);
     if ($gameID < 1) {
         return 0;
     }
@@ -136,8 +135,6 @@ function getSetRequestCount(int $gameID): int
  */
 function getSetRequestorsList(int $gameID, bool $getEmailInfo = false): array
 {
-    sanitize_sql_inputs($gameID);
-
     $retVal = [];
 
     if ($gameID < 1) {
@@ -187,8 +184,6 @@ function getSetRequestorsList(int $gameID, bool $getEmailInfo = false): array
  */
 function getMostRequestedSetsList(array|int|null $console, int $offset, int $count, int $requestStatus = RequestStatus::Any): array
 {
-    sanitize_sql_inputs($offset, $count);
-
     $retVal = [];
 
     $query = "

--- a/app/Helpers/database/user-activity.php
+++ b/app/Helpers/database/user-activity.php
@@ -416,8 +416,6 @@ function getArticleComments(
     ?array &$dataOut,
     bool $recent = false
 ): int {
-    sanitize_sql_inputs($articleTypeID, $articleID, $offset, $count);
-
     $dataOut = [];
     $numArticleComments = 0;
     $order = $recent ? ' DESC' : '';
@@ -500,8 +498,6 @@ function getLatestRichPresenceUpdates(): array
 
 function getLatestNewAchievements(int $numToFetch, ?array &$dataOut): int
 {
-    sanitize_sql_inputs($numToFetch);
-
     $numFound = 0;
 
     $query = "SELECT ach.ID, ach.GameID, ach.Title, ach.Description, ach.Points, gd.Title AS GameTitle, gd.ImageIcon as GameIcon, ach.DateCreated, UNIX_TIMESTAMP(ach.DateCreated) AS timestamp, ach.BadgeName, c.Name AS ConsoleName
@@ -527,8 +523,6 @@ function getLatestNewAchievements(int $numToFetch, ?array &$dataOut): int
 
 function GetMostPopularTitles(int $daysRange = 7, int $offset = 0, int $count = 10): array
 {
-    sanitize_sql_inputs($daysRange, $offset, $count);
-
     $data = [];
 
     $query = "SELECT COUNT(*) as PlayedCount, gd.ID, gd.Title, gd.ImageIcon, c.Name as ConsoleName

--- a/app/Helpers/database/user.php
+++ b/app/Helpers/database/user.php
@@ -62,8 +62,6 @@ function getUserIDFromUser(?string $user): int
 
 function getUserMetadataFromID(int $userID): ?array
 {
-    sanitize_sql_inputs($userID);
-
     $query = "SELECT * FROM UserAccounts WHERE ID ='$userID'";
     $dbResult = s_mysql_query($query);
 
@@ -76,7 +74,7 @@ function getUserMetadataFromID(int $userID): ?array
 
 function getUserUnlockDates(string $user, int $gameID, ?array &$dataOut): int
 {
-    sanitize_sql_inputs($user, $gameID);
+    sanitize_sql_inputs($user);
 
     $query = "SELECT ach.ID, ach.Title, ach.Description, ach.Points, ach.BadgeName, aw.HardcoreMode, aw.Date
         FROM Achievements ach
@@ -111,7 +109,7 @@ function getUserUnlockDates(string $user, int $gameID, ?array &$dataOut): int
  */
 function getUserUnlocksDetailed(string $user, int $gameID, ?array &$dataOut): int
 {
-    sanitize_sql_inputs($user, $gameID);
+    sanitize_sql_inputs($user);
 
     $query = "SELECT ach.Title, ach.ID, ach.Points, aw.HardcoreMode
         FROM Achievements AS ach


### PR DESCRIPTION
With typed parameters there is no need for additional sanitizing of integers. `sabitize_sql_inputs()` changes the type of integers to strings which lead to unexpected side-effects. (See https://github.com/RetroAchievements/RAWeb/commit/3b4b6e36419ecbf322960a79b34b78a00fe14877)