### PR TITLE
prevent exception comparing to non-existant user

### DIFF
--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -311,6 +311,9 @@ function getUserAchievementUnlocksForGame(string $username, int $gameID, int $fl
 {
     if (config('feature.aggregate_queries')) {
         $user = User::firstWhere('User', $username);
+        if (!$user) {
+            return [];
+        }
         $achievementIds = Achievement::where('GameID', $gameID)
             ->where('Flags', $flag)
             ->pluck('ID');

--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,7 @@
             "@php -r \"copy('storage/app/releases.dist.php', 'storage/app/releases.php');\"",
             "@php -r \"file_exists('storage/app/settings.json') || copy('storage/app/settings.dist.json', 'storage/app/settings.json');\""
         ],
-        "stan": "vendor/bin/phpstan analyse --memory-limit 512M --ansi",
+        "stan": "vendor/bin/phpstan analyse --memory-limit 768M --ansi",
         "stan-clear": "vendor/bin/phpstan clear-result-cache",
         "start": "php artisan serve --port=64000",
         "test": "php artisan test"

--- a/public/gamecompare.php
+++ b/public/gamecompare.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Site\Enums\Permissions;
+use App\Site\Models\User;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Unregistered)) {
     abort(401);
@@ -8,6 +9,10 @@ if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Unre
 
 $gameID = requestInputSanitized('ID', null, 'integer');
 $user2 = requestInputSanitized('f');
+
+if (!User::where('User', '=', $user2)->exists()) {
+    abort(404);
+}
 
 $totalFriends = getAllFriendsProgress($user, $gameID, $friendScores);
 


### PR DESCRIPTION
Fixes exception:
> Attempt to read property \"id\" on null at /home/forge/retroachievements.org/releases/2023-10-23T221621-5.0.1-2265ac73/app/Helpers/database/player-game.php:317

returns 404 instead