### PR TITLE
Cache ticket count

### DIFF
--- a/app/Helpers/database/ticket.php
+++ b/app/Helpers/database/ticket.php
@@ -386,7 +386,7 @@ function updateTicket(string $user, int $ticketID, int $ticketVal, ?string $reas
 
     addArticleComment("Server", ArticleType::AchievementTicket, $ticketID, $comment, $user);
 
-    expireUserTicketCounts($user);
+    expireUserTicketCounts($ticketData['AchievementAuthor']);
 
     $reporterData = [];
     if (!getAccountDetails($userReporter, $reporterData)) {
@@ -423,7 +423,7 @@ function countRequestTicketsByUser(?User $user = null): int
 
     $cacheKey = CacheKey::buildUserRequestTicketsCacheKey($user->User);
 
-    return Cache::remember($cacheKey, Carbon::now()->addHours(20), function() use($user) {
+    return Cache::remember($cacheKey, Carbon::now()->addHours(20), function () use ($user) {
         return Ticket::where('ReportState', TicketState::Request)
             ->where('ReportedByUserID', $user->ID)
             ->count();
@@ -438,12 +438,12 @@ function countOpenTicketsByDev(string $dev): ?array
 
     $cacheKey = CacheKey::buildUserOpenTicketsCacheKey($dev);
 
-    return Cache::remember($cacheKey, Carbon::now()->addHours(20), function() use ($dev) {
+    return Cache::remember($cacheKey, Carbon::now()->addHours(20), function () use ($dev) {
         $retVal = [
             TicketState::Open => 0,
             TicketState::Request => 0,
         ];
-    
+
         $tickets = Ticket::with('achievement')
             ->whereHas('achievement', function ($query) use ($dev) {
                 $query
@@ -454,12 +454,12 @@ function countOpenTicketsByDev(string $dev): ?array
             ->select('AchievementID', 'ReportState', DB::raw('count(*) as Count'))
             ->groupBy('ReportState')
             ->get();
-    
+
         foreach ($tickets as $ticket) {
             $retVal[$ticket->ReportState] = $ticket->Count;
         }
-    
-        return $retVal;    
+
+        return $retVal;
     });
 }
 

--- a/app/Helpers/database/ticket.php
+++ b/app/Helpers/database/ticket.php
@@ -456,7 +456,7 @@ function countOpenTicketsByDev(string $dev): ?array
             ->get();
 
         foreach ($tickets as $ticket) {
-            $retVal[$ticket->ReportState] = $ticket->Count;
+            $retVal[$ticket->ReportState] = (int) $ticket->Count;
         }
 
         return $retVal;

--- a/app/Support/Cache/CacheKey.php
+++ b/app/Support/Cache/CacheKey.php
@@ -62,6 +62,21 @@ class CacheKey
         return self::buildNormalizedUserCacheKey($username, "recent-games");
     }
 
+    public static function buildUserOpenTicketsCacheKey(string $username): string
+    {
+        return self::buildNormalizedUserCacheKey($username, "open-tickets");
+    }
+
+    public static function buildUserRequestTicketsCacheKey(string $username): string
+    {
+        return self::buildNormalizedUserCacheKey($username, "request-tickets");
+    }
+
+    public static function buildUserExpiringClaimsCacheKey(string $username): string
+    {
+        return self::buildNormalizedUserCacheKey($username, "expiring-claims");
+    }
+
     /**
      * Constructs a normalized cache key.
      *


### PR DESCRIPTION
Eliminates ~20ms from every page load by not constantly looking to see how many tickets or expiring claims a user has. Value is from local testing. I'm not sure exactly how that will translate to the server.

![image](https://github.com/RetroAchievements/RAWeb/assets/32680403/d8fc36b1-6392-485c-8ab4-99675c577c14)

I'm uncertain why the queries are happening twice per page. I assume it has to do with having two copies of the nav bar in the returned page source (one with `<nav class="z-20 flex flex-col w-full justify-center lg:sticky lg:top-0">`, and one with `<nav class="z-10 flex flex-col w-full justify-center lg:sticky lg:top-0 lg:hidden">`). That might be something to look into separately as each copy of the `<nav>` is ~40KB.

Cached ticket counts are expired once a day, or immediately when tickets are updated.
Claim information is only cached for one hour at a time. If a user has no claims, that is cached for three weeks.

Performance results (local testing) on the Download page (which has no queried content outside of the user data in the nav area:

Before:
```

189ms 26.12ms
185ms 26.13ms
187ms 24.34ms
191ms 25.54ms
189ms 26.16ms
191ms 26.51ms
191ms 26.89ms
193ms 25.26ms
190ms 24.94ms
195ms 30.35ms
----- -------
190ms 26.22ms
```

After:
```
186ms 14.97ms <--  still had to query once to cache the data (remember each call fetches the data twice)
174ms 4.41ms
162ms 3.58ms
174ms 3.61ms
164ms 2.62ms
162ms 2.48ms
180ms 3.33ms
167ms 3.52ms
174ms 2.33ms
164ms 3.41ms
----- ------
171ms 4.43ms
```

Over 10 refreshes, the average DB time dropped by 22ms, and the average overall response time dropped by 19ms. I assume this means the cache lookups still take ~3ms.