### PR TITLE
Add manual unlock buttons to ticket page

### DIFF
--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -47,18 +47,11 @@ function playerHasUnlock(?string $user, int $achievementId): array
 /**
  * @deprecated see UnlockPlayerAchievementAction
  */
-function unlockAchievement(string $username, int $achievementId, bool $isHardcore): array
+function unlockAchievement(User $user, int $achievementId, bool $isHardcore): array
 {
     $retVal = [
         'Success' => false,
     ];
-
-    $user = User::firstWhere('User', $username);
-    if (!$user) {
-        $retVal['Error'] = "Data not found for user $username";
-
-        return $retVal;
-    }
 
     $achievement = Achievement::find($achievementId);
     if (!$achievement) {

--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -278,28 +278,14 @@ function getRecentUnlocksPlayersData(
  */
 function getUnlocksSince(int $id, string $date): array
 {
-    sanitize_sql_inputs($date);
-
-    $query = "
-        SELECT
-            COALESCE(SUM(CASE WHEN HardcoreMode = " . UnlockMode::Softcore . " THEN 1 ELSE 0 END), 0) AS softcoreCount,
-            COALESCE(SUM(CASE WHEN HardcoreMode = " . UnlockMode::Hardcore . " THEN 1 ELSE 0 END), 0) AS hardcoreCount
-        FROM
-            Awarded
-        WHERE
-            AchievementID = $id
-        AND
-            Date > '$date'";
-
-    $dbResult = s_mysql_query($query);
-
-    if ($dbResult !== false) {
-        return mysqli_fetch_assoc($dbResult);
-    }
+    $softcoreCount = PlayerAchievement::where('achievement_id', $id)
+        ->where('unlocked_at', '>', $date)->count();
+    $hardcoreCount = PlayerAchievement::where('achievement_id', $id)
+        ->where('unlocked_hardcore_at', '>', $date)->count();
 
     return [
-        'softcoreCount' => 0,
-        'hardcoreCount' => 0,
+        'softcoreCount' => $softcoreCount,
+        'hardcoreCount' => $hardcoreCount,
     ];
 }
 

--- a/app/Helpers/database/user.php
+++ b/app/Helpers/database/user.php
@@ -72,38 +72,6 @@ function getUserMetadataFromID(int $userID): ?array
     return null;
 }
 
-function getUserUnlockDates(string $user, int $gameID, ?array &$dataOut): int
-{
-    sanitize_sql_inputs($user);
-
-    $query = "SELECT ach.ID, ach.Title, ach.Description, ach.Points, ach.BadgeName, aw.HardcoreMode, aw.Date
-        FROM Achievements ach
-        INNER JOIN Awarded AS aw ON ach.ID = aw.AchievementID
-        WHERE ach.GameID = $gameID AND aw.User = '$user'
-        ORDER BY ach.ID, aw.HardcoreMode DESC";
-
-    $dbResult = s_mysql_query($query);
-
-    $dataOut = [];
-
-    if (!$dbResult) {
-        return 0;
-    }
-
-    $lastID = 0;
-    while ($data = mysqli_fetch_assoc($dbResult)) {
-        $achID = $data['ID'];
-        if ($lastID == $achID) {
-            continue;
-        }
-
-        $dataOut[] = $data;
-        $lastID = $achID;
-    }
-
-    return count($dataOut);
-}
-
 /**
  * @param array<string, mixed>|null $dataOut
  */

--- a/app/Platform/Actions/UpdatePlayerGameMetrics.php
+++ b/app/Platform/Actions/UpdatePlayerGameMetrics.php
@@ -29,6 +29,7 @@ class UpdatePlayerGameMetrics
         $achievementsUnlocked = $user->achievements()->where('GameID', $game->id)
             ->published()
             ->withPivot([
+                'unlocker_id',
                 'unlocked_at',
                 'unlocked_hardcore_at',
             ])
@@ -61,8 +62,8 @@ class UpdatePlayerGameMetrics
             ? $playerGame->created_at
             : $startedAt;
 
-        $lastPlayedAt = $playerAchievements->pluck('unlocked_at')
-            ->merge($playerAchievementsHardcore->pluck('unlocked_hardcore_at'))
+        $lastPlayedAt = $playerAchievements->whereNull('unlocker_id')->pluck('unlocked_at')
+            ->merge($playerAchievementsHardcore->whereNull('unlocker_id')->pluck('unlocked_hardcore_at'))
             ->add($playerGame->last_played_at)
             ->filter()
             ->max();

--- a/lang/en_US/legacy.php
+++ b/lang/en_US/legacy.php
@@ -31,6 +31,7 @@ return [
         'submit' => __("Submitted."),
         'update' => __("Updated."),
 
+        'achievement_unlocked' => __("Achievement unlocked."),
         'achievement_update' => __("Achievement updated."),
         'email_change' => __('Email address changed.'),
         'email_verify' => __("Email verified."),

--- a/public/admin.php
+++ b/public/admin.php
@@ -61,17 +61,16 @@ if ($action === 'manual-unlock') {
         $usersToAward = preg_split('/\W+/', $awardAchievementUser);
         $errors = [];
         foreach ($usersToAward as $nextUser) {
-            $validUser = validateUsername($nextUser);
-            if (!$validUser) {
+            $player = User::firstWhere('User', $nextUser);
+            if (!$player) {
                 continue;
             }
             $ids = separateList($awardAchievementID);
             foreach ($ids as $nextID) {
-                $awardResponse = unlockAchievement($validUser, $nextID, $awardAchHardcore);
+                $awardResponse = unlockAchievement($player, $nextID, $awardAchHardcore);
                 if (array_key_exists('Error', $awardResponse)) {
                     $errors[] = $awardResponse['Error'];
                 }
-                $player = User::firstWhere('User', $validUser);
                 dispatch(
                     new UnlockPlayerAchievementJob(
                         $player->id,

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -267,7 +267,7 @@ switch ($requestType) {
          * Prefer later values, i.e. allow AddEarnedAchievementJSON to overwrite the 'success' key
          * TODO refactor to optimistic update without unlock in place. what are the returned values used for?
          */
-        $response = array_merge($response, unlockAchievement($username, $achIDToAward, $hardcore));
+        $response = array_merge($response, unlockAchievement($user, $achIDToAward, $hardcore));
 
         if (Achievement::where('ID', $achIDToAward)->exists()) {
             dispatch(new UnlockPlayerAchievementJob($user->id, $achIDToAward, $hardcore))

--- a/public/request/user/award-achievement.php
+++ b/public/request/user/award-achievement.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Platform\Actions\UnlockPlayerAchievement;
+use App\Platform\Models\Achievement;
+use App\Site\Enums\Permissions;
+use App\Site\Models\User;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+
+$user = request()->user();
+if ($user === null) {
+    abort(401);
+}
+
+if ($user->Permissions < Permissions::Moderator) {
+    abort(403);
+}
+
+$input = Validator::validate(Arr::wrap(request()->post()), [
+    'user' => 'required|string|exists:UserAccounts,User',
+    'achievement' => 'required|integer|exists:Achievements,ID',
+    'hardcore' => 'required|integer|min:0|max:1'
+]);
+
+$player = User::firstWhere('User', $input['user']);
+
+$achievementId = $input['achievement'];
+$awardHardcore = (bool) $input['hardcore'];
+
+$awardResponse = unlockAchievement($player, $achievementId, $awardHardcore);
+if (array_key_exists('Error', $awardResponse)) {
+   return response()->json(['error' => $awardResponse['Error']]);
+}
+
+$action = app()->make(UnlockPlayerAchievement::class);
+
+$action->execute(
+    $player,
+    Achievement::findOrFail($achievementId),
+    $awardHardcore,
+    unlockedBy: $user,
+);
+
+return response()->json(['message' => __('legacy.success.achievement_unlocked')]);

--- a/public/request/user/award-achievement.php
+++ b/public/request/user/award-achievement.php
@@ -12,14 +12,14 @@ if ($user === null) {
     abort(401);
 }
 
-if ($user->Permissions < Permissions::Moderator) {
+if ($user->getAttribute('Permissions') < Permissions::Moderator) {
     abort(403);
 }
 
 $input = Validator::validate(Arr::wrap(request()->post()), [
     'user' => 'required|string|exists:UserAccounts,User',
     'achievement' => 'required|integer|exists:Achievements,ID',
-    'hardcore' => 'required|integer|min:0|max:1'
+    'hardcore' => 'required|integer|min:0|max:1',
 ]);
 
 $player = User::firstWhere('User', $input['user']);

--- a/public/ticketmanager.php
+++ b/public/ticketmanager.php
@@ -7,7 +7,9 @@ use App\Community\Enums\TicketState;
 use App\Community\Enums\TicketType;
 use App\Platform\Enums\AchievementFlag;
 use App\Platform\Models\Achievement;
+use App\Platform\Models\PlayerAchievement;
 use App\Site\Enums\Permissions;
+use App\Site\Models\User;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Str;
 
@@ -528,6 +530,7 @@ RenderContentStart($pageTitle);
             $reportNotes = str_replace('<br>', "\n", $nextTicket['ReportNotes']);
 
             $reportedAt = $nextTicket['ReportedAt'];
+            $reportedAtTime = strtotime($reportedAt);
             $niceReportedAt = getNiceDate(strtotime($reportedAt));
             $reportedBy = $nextTicket['ReportedBy'];
             $resolvedAt = $nextTicket['ResolvedAt'];
@@ -768,29 +771,78 @@ RenderContentStart($pageTitle);
             }
             echo "<td colspan='7'>";
 
-            $numAchievements = getUserUnlockDates($reportedBy, $gameID, $unlockData);
-            $unlockData[] = ['ID' => 0, 'Title' => 'Ticket Created', 'Date' => $reportedAt, 'HardcoreMode' => 0];
-            usort($unlockData, fn ($a, $b) => strtotime($b["Date"]) - strtotime($a["Date"]));
+            $unlocks = PlayerAchievement::join('UserAccounts', 'UserAccounts.ID', '=', 'player_achievements.user_id')
+                ->join('Achievements', 'Achievements.ID', '=', 'player_achievements.achievement_id')
+                ->where('GameID', '=', $gameID)
+                ->where('UserAccounts.User', '=', $reportedBy)
+                ->orderByRaw('IFNULL(unlocked_hardcore_at, unlocked_at) DESC')
+                ->select(['player_achievements.*', 'Achievements.Title',
+                          'Achievements.Description', 'Achievements.Points', 'Achievements.BadgeName']);
+            $numAchievements = $unlocks->count();
 
-            $unlockDate = null;
-            foreach ($unlockData as $unlockEntry) {
-                if ($unlockEntry['ID'] == $achID) {
-                    $unlockDate = $unlockEntry['Date'];
+            $unlocks = $unlocks->get();
+            $existingUnlock = null;
+            foreach ($unlocks as $unlock) {
+                if ($unlock->achievement_id == $achID) {
+                    $existingUnlock = $unlock;
                     break;
                 }
             }
 
-            if ($unlockDate != null) {
-                echo "$reportedBy earned this achievement at " . getNiceDate(strtotime($unlockDate));
-                if ($unlockDate >= $reportedAt) {
-                    echo " (after the report).";
+            if ($existingUnlock != null) {
+                if ($existingUnlock->unlocked_hardcore_at) {
+                    $unlockDate = $existingUnlock->unlocked_hardcore_at->unix();
                 } else {
-                    echo " (before the report).";
+                    $unlockDate = $existingUnlock->unlocked_at->unix();
                 }
-            } elseif ($numAchievements == 0) {
-                echo "$reportedBy has not earned any achievements for this game.";
+
+                if ($existingUnlock->unlocker_id) {
+                    $unlocker = User::firstWhere('ID', $existingUnlock->unlocker_id);
+                    echo "$reportedBy was manually awarded this achievement at " . getNiceDate($unlockDate) . " by " . $unlocker->User . ".";
+                } else {
+                    echo "$reportedBy earned this achievement at " . getNiceDate($unlockDate);
+
+                    if ($unlockDate >= $reportedAtTime) {
+                        echo " (after the report).";
+                    } else {
+                        echo " (before the report).";
+                    }
+                }
             } else {
-                echo "$reportedBy did not earn this achievement.";
+                if ($numAchievements == 0) {
+                    echo "$reportedBy has not earned any achievements for this game.";
+                } else {
+                    echo "$reportedBy did not earn this achievement.";
+                }
+
+                if ($permissions >= Permissions::Moderator) {
+                    $hasHardcoreUnlock = false;
+                    foreach ($unlocks as $unlock) {
+                        if ($unlock->unlocked_hardcore_at) {
+                            $hasHardcoreUnlock = true;
+                            break;
+                        }
+                    }
+
+                    echo "<script>
+                    function AwardManually(hardcore) {
+                        showStatusMessage('Awarding...');
+
+                        $.post('/request/user/award-achievement.php', {
+                            user: '$reportedBy',
+                            achievement: $achID,
+                            hardcore: hardcore
+                        })
+                            .done(function () {
+                                location.reload();
+                            });
+                    }
+                    </script>";
+                    echo "<button class='btn ml-2' onclick='AwardManually(0)'>Award Softcore</button>";
+                    if ($hasHardcoreUnlock || $numAchievements == 0) {
+                        echo "<button class='btn ml-1' onclick='AwardManually(1)'>Award Hardcore</button>";
+                    }
+                }
             }
             echo "</td></tr>";
 
@@ -802,29 +854,51 @@ RenderContentStart($pageTitle);
                 echo "<div id='unlockhistory' style='display: none'>";
                 echo "<table class='table-highlight'>";
 
-                foreach ($unlockData as $unlockEntry) {
-                    echo "<tr><td>";
-                    if ($unlockEntry['ID'] == 0) {
-                        echo "Ticket Created - ";
-                        echo ($reportType == 1) ? "Triggered at wrong time" : "Doesn't Trigger";
+                $ticketEntryCreated = false;
+                foreach ($unlocks as $unlock) {
+                    if ($unlock->unlocked_hardcore_at) {
+                        $unlockDate = $unlock->unlocked_hardcore_at->unix();
                     } else {
-                        echo achievementAvatar($unlockEntry);
+                        $unlockDate = $unlock->unlocked_at->unix();
                     }
-                    echo "</td><td>";
-                    $unlockDate = getNiceDate(strtotime($unlockEntry['Date']));
-                    if ($unlockEntry['ID'] == $achID) {
+
+                    if (!$ticketEntryCreated && $unlockDate < $reportedAtTime) {
+                        echo "<tr><td class='smalldate whitespace-nowrap'>";
+                        echo $niceReportedAt;
+                        echo "</td><td>Ticket Created - ";
+                        echo ($reportType == 1) ? "Triggered at wrong time" : "Doesn't Trigger";
+                        echo "</td></tr>";
+                        $ticketEntryCreated = true;
+                    }
+
+                    echo "</td><td class='smalldate whitespace-nowrap'>";
+                    $unlockDate = getNiceDate($unlockDate);
+                    if ($unlock->achievement_id == $achID) {
                         echo "<b>$unlockDate</b>";
                     } else {
                         echo $unlockDate;
                     }
-                    echo "</td><td>";
-                    if ($unlockEntry['HardcoreMode'] == 1) {
-                        if ($unlockEntry['ID'] == $achID) {
-                            echo "<b>Hardcore</b>";
-                        } else {
-                            echo "Hardcore";
-                        }
+                    if ($unlock->unlocker_id) {
+                        echo "<br/>&nbsp;(manually awarded)";
                     }
+                    echo "</td><td style='width:99%'>";
+
+                    echo achievementAvatar([
+                        'AchievementID' => $unlock->achievement_id,
+                        'AchievementTitle' => $unlock->Title,
+                        'AchievementDesc' => $unlock->Description,
+                        'Points' => $unlock->Points,
+                        'BadgeName' => $unlock->BadgeName,
+                        'HardcoreMode' => ($unlock->unlocked_hardcore_at != null),
+                    ]);
+                    echo "</td></tr>";
+                }
+
+                if (!$ticketEntryCreated) {
+                    echo "<tr><td class='smalldate whitespace-nowrap'>";
+                    echo ($reportType == 1) ? "Triggered at wrong time" : "Doesn't Trigger";
+                    echo "</td><td>Ticket Created - ";
+                    echo $niceReportedAt;
                     echo "</td></tr>";
                 }
 


### PR DESCRIPTION
Only accessible to moderators.

![image](https://github.com/RetroAchievements/RAWeb/assets/32680403/cf61bcb6-40ca-4d63-bf76-0000e7bd822e)

After being awarded, the ticket page will reflect the fact that it was manually awarded:

![image](https://github.com/RetroAchievements/RAWeb/assets/32680403/5998e2a5-4c8d-4c89-bb60-967508f4159d)

Also note that the "hardcore" text has been removed from the unlock history, and the gold border is displayed instead.