### PR TITLE
feat: switch to mariadb and convert to utf8mb4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,9 @@ DB_PORT=3306
 DB_DATABASE=retroachievements-web
 DB_USERNAME=retroachievements
 DB_PASSWORD="${DB_USERNAME}"
+# TODO remove after utf8mb4 conversion
+#DB_CHARSET=latin1
+#DB_COLLATION=latin1_general_ci
 
 #LEGACY_MEDIA_PATH=
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/database/*.sql
 /docker/nginx/logs
 /docs/dist
 /node_modules

--- a/app/Site/AppServiceProvider.php
+++ b/app/Site/AppServiceProvider.php
@@ -114,7 +114,7 @@ class AppServiceProvider extends ServiceProvider
                 if (!$db) {
                     throw new Exception('Could not connect to database. Please try again later.');
                 }
-                mysqli_set_charset($db, 'latin1');
+                mysqli_set_charset($db, config('database.connections.mysql.charset'));
                 mysqli_query($db, "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));");
 
                 return $db;

--- a/config/database.php
+++ b/config/database.php
@@ -54,11 +54,8 @@ return [
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
-            // TODO
-            // 'charset' => 'utf8mb4',
-            // 'collation' => 'utf8mb4_general_ci',
-            'charset' => 'latin1',
-            'collation' => 'latin1_general_ci',
+            'charset' => env('DB_CHARSET', 'utf8mb4'),
+            'collation' => env('DB_COLLATION'),
             'prefix' => '',
             'prefix_indexes' => false,
             'strict' => true,

--- a/config/database.php
+++ b/config/database.php
@@ -55,7 +55,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => env('DB_CHARSET', 'utf8mb4'),
-            'collation' => env('DB_COLLATION'),
+            'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
             'prefix' => '',
             'prefix_indexes' => false,
             'strict' => true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         networks:
             - raweb
         depends_on:
-            - mysql
+            - mariadb
             - redis
             - minio
     nginx:
@@ -38,31 +38,36 @@ services:
             - raweb
         depends_on:
             - laravel.test
-    mysql:
+    mariadb:
         build:
             context: ./docker/mysql
             dockerfile: Dockerfile
-        image: 'mysql-pv:8'
+        image: 'mariadb-pv:10'
         environment:
+            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ROOT_HOST: "%"
             MYSQL_DATABASE: '${DB_DATABASE}'
             MYSQL_USER: '${DB_USERNAME}'
-            MYSQL_PASSWORD: '${DB_PASSWORD:-secret}'
-            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD:-secret}'
+            MYSQL_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
         ports:
             - '${FORWARD_DB_PORT:-3306}:3306'
         volumes:
-            - 'mysql-data:/var/lib/mysql'
-            - './database:/docker-entrypoint-initdb.d/'
+            - 'mariadb-data:/var/lib/mysql'
+            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+            - './database:/docker-entrypoint-initdb.d/database'
             - './docker/mysql/mysql.cnf:/etc/mysql/conf.d/mysql.cnf:ro'
         networks:
             - raweb
-        command:
-            - '--default-authentication-plugin=mysql_native_password'
+        healthcheck:
+            test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
+            retries: 3
+            timeout: 5s
     phpmyadmin:
         image: phpmyadmin/phpmyadmin
         environment:
             PMA_ARBITRARY: 1
-            PMA_HOST: mysql
+            PMA_HOST: mariadb
             PMA_USER: '${DB_USERNAME}'
             PMA_PASSWORD: '${DB_PASSWORD}'
             PMA_PORT: 3306
@@ -117,7 +122,7 @@ networks:
     raweb:
         driver: bridge
 volumes:
-    mysql-data:
+    mariadb-data:
         driver: local
     minio-data:
         driver: local

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,3 @@
-FROM mysql:8
+FROM mariadb:10
 
-RUN microdnf install -y epel-release
-RUN microdnf install -y pv
+RUN apt-get update && apt-get install -y pv

--- a/docker/mysql/create-testing-database.sh
+++ b/docker/mysql/create-testing-database.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
-    CREATE DATABASE IF NOT EXISTS testing;
-    GRANT ALL PRIVILEGES ON \`testing%\`.* TO '$MYSQL_USER'@'%';
-EOSQL

--- a/docker/mysql/mysql.cnf
+++ b/docker/mysql/mysql.cnf
@@ -1,3 +1,6 @@
 [mysqld]
 skip-host-cache
 skip-name-resolve
+
+character-set-server  = utf8mb4
+collation-server      = utf8mb4_unicode_ci

--- a/docker/mysql/mysql.cnf
+++ b/docker/mysql/mysql.cnf
@@ -1,3 +1,9 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+
 [mysqld]
 skip-host-cache
 skip-name-resolve


### PR DESCRIPTION
Add the following to your `.env` until the mariadb utf8 dump is ready:
```env
DB_CHARSET=latin1
DB_COLLATION=latin1_general_ci
```

Rebuilding docker containers is not advised yet as it will remove the mysql container from compose.