### PR TITLE
populate as much of Recent Players list as possible from aggregate data

### DIFF
--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -5,6 +5,7 @@ use App\Platform\Enums\AchievementType;
 use App\Platform\Enums\UnlockMode;
 use App\Platform\Models\Achievement;
 use App\Platform\Models\PlayerAchievement;
+use App\Platform\Models\PlayerSession;
 use App\Site\Enums\Permissions;
 use App\Site\Models\User;
 use App\Support\Cache\CacheKey;
@@ -698,26 +699,55 @@ function getTotalUniquePlayers(
     return (int) (legacyDbFetch($query, $bindings)['players_count'] ?? 0);
 }
 
-function getGameRecentPlayers(int $gameID, int $maximum_results = 0): array
+function getGameRecentPlayers(int $gameID, int $maximum_results = 10): array
 {
     $retval = [];
+    $filter = '';
+
+    if (config('feature.aggregate_queries')) {
+        $sessions = PlayerSession::where('game_id', $gameID)
+            ->join('UserAccounts', 'UserAccounts.ID', '=', 'user_id')
+            ->where('UserAccounts.Permissions', '>=', Permissions::Unregistered)
+            ->whereNotNull('rich_presence')
+            ->orderBy('rich_presence_updated_at', 'DESC')
+            ->groupBy('user_id')
+            ->select(['user_id', 'User', 'rich_presence', DB::raw('MAX(rich_presence_updated_at) AS rich_presence_updated_at')]);
+
+        if ($maximum_results) {
+            $sessions = $sessions->limit($maximum_results);
+        }
+
+        foreach ($sessions->get() as $session) {
+            $retval[] = [
+                'UserID' => $session->user_id,
+                'User' => $session->User,
+                'Date' => $session->rich_presence_updated_at->__toString(),
+                'Activity' => $session->rich_presence,
+            ];
+        }
+
+        if ($maximum_results) {
+            $maximum_results -= count($retval);
+            if ($maximum_results == 0) {
+                return $retval;
+            }
+        }
+
+        $filter = 'AND ua.ID NOT IN (' . implode(',', array_column($retval, 'UserID')) . ')';
+    }
 
     $query = "SELECT ua.ID as UserID, ua.User, ua.RichPresenceMsgDate AS Date, ua.RichPresenceMsg AS Activity
               FROM UserAccounts AS ua
               WHERE ua.LastGameID = $gameID AND ua.Permissions >= " . Permissions::Unregistered . "
-              AND ua.RichPresenceMsgDate > TIMESTAMPADD(MONTH, -6, NOW())
+              AND ua.RichPresenceMsgDate > TIMESTAMPADD(MONTH, -6, NOW()) $filter
               ORDER BY ua.RichPresenceMsgDate DESC";
 
     if ($maximum_results > 0) {
         $query .= " LIMIT $maximum_results";
     }
 
-    $dbResult = s_mysql_query($query);
-
-    if ($dbResult !== false) {
-        while ($data = mysqli_fetch_assoc($dbResult)) {
-            $retval[] = $data;
-        }
+    foreach (legacyDbFetchAll($query) as $data) {
+        $retval[] = $data;
     }
 
     return $retval;


### PR DESCRIPTION
Fetching rich presence data from UserAccounts takes 2-5 times longer than fetching it from player_sessions. This attempts to fill as much of the Recent Players list as possible from player_sessions. If 10 rows can be generated, then the UserAccounts table doesn't have to even be looked at.

For games with less than 10 players since the v5 release, the result will be slower because two queries will be executed, but they will be taking less traffic, so that's an acceptable tradeoff.