### PR TITLE
fix: expiring claims in notifications can be non-existent

### DIFF
--- a/app/Site/Components/NotificationIcon.php
+++ b/app/Site/Components/NotificationIcon.php
@@ -58,13 +58,13 @@ class NotificationIcon extends Component
         // Claim expiry notifications
         if ($user->getAttribute('Permissions') >= Permissions::JuniorDeveloper) {
             $expiringClaims = getExpiringClaim($user->User);
-            if ($expiringClaims['Expired'] > 0) {
+            if ($expiringClaims['Expired'] ?? 0) {
                 $notifications->push([
                     'link' => url('/expiringclaims.php?u=' . $user->User),
                     'title' => 'Claim Expired',
                     'class' => 'text-danger',
                 ]);
-            } elseif ($expiringClaims['Expiring'] > 0) {
+            } elseif ($expiringClaims['Expiring'] ?? 0) {
                 $notifications->push([
                     'link' => url('/expiringclaims.php?u=' . $user->User),
                     'title' => 'Claim Expiring Soon',


### PR DESCRIPTION
This currently breaks stage and preview environments:
`"PHP message: PHP Fatal error:  Uncaught ErrorException: Undefined array key "Expired" in /.../app/Site/Components/NotificationIcon.php:61`