### PR TITLE
chore: startsession legacy rich presence & last game save

### DIFF
--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -320,18 +320,6 @@ switch ($requestType) {
             return DoRequestError("Unknown game");
         }
 
-        if ($user->LastGameID != $gameID) {
-            expireRecentlyPlayedGames($user->User);
-            $user->LastGameID = $gameID;
-        }
-
-        // legacy rich presence support (deprecated - see ResumePlayerSession)
-        $user->RichPresenceMsg = "Playing {$game->Title}";
-        $user->RichPresenceMsgDate = Carbon::now();
-
-        $user->LastLogin = Carbon::now();
-        $user->save();
-
         PlayerSessionHeartbeat::dispatch($user, $game);
 
         $response['Success'] = true;


### PR DESCRIPTION
missed one in https://github.com/RetroAchievements/RAWeb/pull/1948, only checked `postactivity` and `ping` previously.