### PR TITLE
fix: user created timestamp not cast to Carbon

### DIFF
--- a/app/Api/Middleware/LogApiUsage.php
+++ b/app/Api/Middleware/LogApiUsage.php
@@ -15,7 +15,6 @@ class LogApiUsage
         /** @var User $user */
         $user = $request->user('api-token');
 
-        $user->timestamps = false;
         $user->increment('APIUses');
 
         return $next($request);

--- a/app/Helpers/database/ticket.php
+++ b/app/Helpers/database/ticket.php
@@ -15,22 +15,22 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
-function isAllowedToSubmitTickets(string $user): bool
+function isAllowedToSubmitTickets(string $username): bool
 {
-    if (!isValidUsername($user)) {
+    if (!isValidUsername($username)) {
         return false;
     }
 
-    $cacheKey = CacheKey::buildUserCanTicketCacheKey($user);
+    $cacheKey = CacheKey::buildUserCanTicketCacheKey($username);
 
     $value = Cache::get($cacheKey);
     if ($value !== null) {
         return $value;
     }
 
-    $userModel = request()->user();
-    $value = $userModel->Created->diffInDays() > 1
-        && getRecentlyPlayedGames($user, 0, 1, $userInfo)
+    $user = User::firstWhere('User', $username);
+    $value = $user->Created->diffInDays() > 1
+        && getRecentlyPlayedGames($username, 0, 1, $userInfo)
         && $userInfo[0]['GameID'];
 
     if ($value) {

--- a/app/Helpers/database/ticket.php
+++ b/app/Helpers/database/ticket.php
@@ -28,8 +28,7 @@ function isAllowedToSubmitTickets(string $user): bool
         return $value;
     }
 
-    $value = getUserActivityRange($user, $firstLogin, $lastLogin)
-        && time() - strtotime($firstLogin) > 86400 // 86400 seconds = 1 day
+    $value = $userModel->Created->diffInDays() > 1
         && getRecentlyPlayedGames($user, 0, 1, $userInfo)
         && $userInfo[0]['GameID'];
 

--- a/app/Helpers/database/ticket.php
+++ b/app/Helpers/database/ticket.php
@@ -28,6 +28,7 @@ function isAllowedToSubmitTickets(string $user): bool
         return $value;
     }
 
+    $userModel = request()->user();
     $value = $userModel->Created->diffInDays() > 1
         && getRecentlyPlayedGames($user, 0, 1, $userInfo)
         && $userInfo[0]['GameID'];

--- a/app/Helpers/database/user-activity.php
+++ b/app/Helpers/database/user-activity.php
@@ -90,7 +90,6 @@ function postActivity(string|User $userIn, int $type, ?int $data = null, ?int $d
     // update UserAccount
     $user->LastLogin = Carbon::now();
     $user->LastActivityID = $activity->ID;
-    $user->timestamps = false;
     $user->save();
 
     return true;

--- a/app/Helpers/database/user-auth.php
+++ b/app/Helpers/database/user-auth.php
@@ -78,7 +78,6 @@ function authenticateForConnect(?string $username, ?string $pass = null, ?string
 
     // update appTokenExpiry
     $user->appTokenExpiry = Carbon::now()->clone()->addDays(14);
-    $user->timestamps = false;
     $user->save();
 
     postActivity($user, ActivityType::Login);
@@ -208,7 +207,6 @@ function authenticateFromCookie(
 
     // valid active account. update the last activity timestamp
     $user->LastLogin = Carbon::now();
-    $user->timestamps = false;
     $user->save();
 
     // validate permissions for the current page if required

--- a/app/Support/Cache/CacheKey.php
+++ b/app/Support/Cache/CacheKey.php
@@ -16,11 +16,6 @@ class CacheKey
         return self::buildNormalizedUserCacheKey($username, "last-login");
     }
 
-    public static function buildUserCanTicketCacheKey(string $username): string
-    {
-        return self::buildNormalizedUserCacheKey($username, "can-ticket");
-    }
-
     public static function buildUserCardDataCacheKey(string $username): string
     {
         return self::buildNormalizedUserCacheKey($username, "card-data");

--- a/tests/Unit/CacheKeyTest.php
+++ b/tests/Unit/CacheKeyTest.php
@@ -10,15 +10,6 @@ use Tests\TestCase;
 
 final class CacheKeyTest extends TestCase
 {
-    public function testBuildUserCanTicketCacheKey(): void
-    {
-        $username = "UserName";
-
-        $cacheKey = CacheKey::buildUserCanTicketCacheKey($username);
-
-        $this->assertEquals("user:username:can-ticket", $cacheKey);
-    }
-
     public function testBuildUserCardDataCacheKey(): void
     {
         $username = "UserName";


### PR DESCRIPTION
Do not set timestamps to false on user object - this prevents datetime casting for Created and Updated attributes.

Change ticket `isAllowedToSubmitTickets()` check.