### PR TITLE
feat(game): remove 'Your Progress' heading

### DIFF
--- a/resources/views/platform/components/game/current-progress/root.blade.php
+++ b/resources/views/platform/components/game/current-progress/root.blade.php
@@ -35,9 +35,9 @@ $canShowGlow = $hasUnlockedAnyAchievements && $hasAnyProgressionAward;
             </div>
         @endif
 
-        <div class="lg:rounded bg-embed border border-embed-highlight p-5 relative">
+        <div class="lg:rounded bg-embed border border-embed-highlight px-5 pt-3.5 pb-5 relative">
             <div class="mb-2">
-                <p class="text-lg">Your Progress</p>
+                <p class="sr-only">Your Progress</p>
 
                 @if (!$hasUnlockedAnyAchievements)
                     <p class="leading-4 mt-2">You haven't unlocked any achievements for this game.</p>


### PR DESCRIPTION
Sets the "Your Progress" label to screen readers only on the current-progress component.

**Before**
![Screenshot 2023-10-29 at 8 35 42 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/854ef5e7-ba2b-4fc4-bd79-9ab9408fa29f)

![Screenshot 2023-10-29 at 8 35 36 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/743678a2-d05c-4076-96ae-96d529f5f77d)

**After**
![Screenshot 2023-10-29 at 8 35 19 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/df16b114-a95a-48c9-9800-abe922cd8bc1)

![Screenshot 2023-10-29 at 8 35 27 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/00a9507a-4eff-4abd-912c-542d040f8259)

