### PR TITLE
don't overwrite session end time unless newer

### DIFF
--- a/app/Helpers/database/user-activity.php
+++ b/app/Helpers/database/user-activity.php
@@ -474,7 +474,9 @@ function getUserGameActivity(string $username, int $gameID): array
             if ($session['StartTime'] <= $when) {
                 if ($session['EndTime'] + $maxSessionGap > $when) {
                     $session['Achievements'][] = $createSessionAchievement($playerAchievement, $when, $hardcore);
-                    $session['EndTime'] = $when;
+                    if ($when > $session['EndTime']) {
+                        $session['EndTime'] = $when;
+                    }
 
                     return;
                 }
@@ -485,7 +487,9 @@ function getUserGameActivity(string $username, int $gameID): array
         if ($possibleSession) {
             if ($when - $possibleSession['EndTime'] < $maxSessionGap) {
                 $possibleSession['Achievements'][] = $createSessionAchievement($playerAchievement, $when, $hardcore);
-                $possibleSession['EndTime'] = $when;
+                if ($when > $possibleSession['EndTime']) {
+                    $possibleSession['EndTime'] = $when;
+                }
 
                 return;
             }


### PR DESCRIPTION
Prevents actual session end time from being overwritten by the last achievement in the session.

Before:
![image](https://github.com/RetroAchievements/RAWeb/assets/32680403/cd236eb8-aa17-4c00-87ee-7d9ffabd19c3)

After:
![image](https://github.com/RetroAchievements/RAWeb/assets/32680403/05677499-c0c8-45a7-990a-884389e769a2)
