### PR TITLE
fix(user): only count games with at least 1 earned achievement as "Unfinished"

### DIFF
--- a/app/Platform/Controllers/PlayerCompletionProgressController.php
+++ b/app/Platform/Controllers/PlayerCompletionProgressController.php
@@ -14,12 +14,10 @@ use Illuminate\Support\Facades\Auth;
 
 class PlayerCompletionProgressController extends Controller
 {
-    protected PlayerProgressionService $playerProgressionService;
     private int $pageSize = 100;
 
-    public function __construct(PlayerProgressionService $playerProgressionService)
+    public function __construct(protected PlayerProgressionService $playerProgressionService)
     {
-        $this->playerProgressionService = $playerProgressionService;
     }
 
     public function __invoke(Request $request): View
@@ -43,7 +41,7 @@ class PlayerCompletionProgressController extends Controller
 
         $me = Auth::user() ?? null;
         // TODO: Remove when denormalized data is ready.
-        if (!config('feature.aggregate_queries') && !$me) {
+        if (!$me) {
             abort(401);
         }
 

--- a/app/Platform/Services/PlayerProgressionService.php
+++ b/app/Platform/Services/PlayerProgressionService.php
@@ -89,7 +89,13 @@ class PlayerProgressionService
         // [B] Iterate once while appending the entities with constant time O(1).
         $filteredAndJoined = [];
         foreach ($gamesList as &$game) {
-            if ($game['ConsoleID'] != 101 && isValidConsoleId($game['ConsoleID'])) {
+            $canUseGame = (
+                isValidConsoleId($game['ConsoleID'])
+                && $game['ConsoleID'] != 101
+                && $game['NumAwarded'] != 0
+            );
+
+            if ($canUseGame) {
                 if (isset($awardsLookup[$game['GameID']])) {
                     $game['HighestAwardKind'] = $awardsLookup[$game['GameID']];
                     $game['HighestAwardDate'] = $awardsDateLookup[$game['GameID']];


### PR DESCRIPTION
This PR fixes a bug on user profiles and the user completion progress page where, now that aggregate queries are enabled, games with no achievements unlocked are appearing/counting in these areas as "Unfinished".

We should only count a game as Unfinished if the user has earned at least one achievement for the game. Simply booting a game should not qualify.

@luchaos , this issue is highly visible on your profile for these areas of the UI.

**Before**
![Screenshot 2023-10-30 at 4 49 41 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/779f612a-d0e5-43a4-8190-677db667320e)

![Screenshot 2023-10-30 at 4 49 30 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/2476c0d6-405d-423d-8b70-683da662322e)

![Screenshot 2023-10-30 at 4 49 36 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/fdad1f6c-2592-49d1-8da4-559b0d9b26e3)


**After**
![Screenshot 2023-10-30 at 4 48 43 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/1f8d792f-da4c-470a-bd29-1560c9d0c9d4)

![Screenshot 2023-10-30 at 4 49 14 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/741cd2e9-07fc-49f4-828b-08329f3ab840)
