### PR TITLE
fix(user): dont hide profile completion progress widget row

### DIFF
--- a/app/Helpers/render/user.php
+++ b/app/Helpers/render/user.php
@@ -71,25 +71,6 @@ function renderUserCard(string|array $user): string
     ]);
 }
 
-function getCompletedAndIncompletedSetsCounts(array $userCompletedGamesList): array
-{
-    $completedSetsCount = 0;
-    $incompletedSetsCount = 0;
-
-    foreach ($userCompletedGamesList as $game) {
-        $nextMaxPossible = $game['MaxPossible'];
-        $nextNumAwarded = $game['NumAwarded'];
-
-        if ($nextNumAwarded == $nextMaxPossible) {
-            $completedSetsCount++;
-        } else {
-            $incompletedSetsCount++;
-        }
-    }
-
-    return ['completedSetsCount' => $completedSetsCount, 'incompletedSetsCount' => $incompletedSetsCount];
-}
-
 function RenderCompletedGamesList(
     array $userCompletedGamesList,
     string $username,
@@ -100,28 +81,25 @@ function RenderCompletedGamesList(
     echo "<h3>Completion Progress</h3>";
 
     $checkedAttribute = $isInitiallyHidingCompletedSets ? 'checked' : '';
-    $setsCounts = getCompletedAndIncompletedSetsCounts($userCompletedGamesList);
-    if ($setsCounts['completedSetsCount'] > 0 && $setsCounts['incompletedSetsCount'] > 0) {
-        echo "<div class='flex w-full items-center justify-between mb-2'>";
-        echo <<<HTML
-            <label class="flex items-center gap-x-1">
-                <input 
-                    type="checkbox" 
-                    id="hide-user-completed-sets-checkbox" 
-                    onchange="toggleUserCompletedSetsVisibility()"
-                    $checkedAttribute
-                >
-                    Hide completed games
-                </input>
-            </label>
-        HTML;
 
-        if (config('feature.beat')) {
-            echo "<a href='" . route('user.completion-progress', $username) . "'>See more...</a>";
-        }
+    echo "<div class='flex w-full items-center justify-between mb-2'>";
+    echo <<<HTML
+        <label class="flex items-center gap-x-1">
+            <input 
+                type="checkbox" 
+                id="hide-user-completed-sets-checkbox" 
+                onchange="toggleUserCompletedSetsVisibility()"
+                $checkedAttribute
+            >
+                Hide completed games
+            </input>
+        </label>
+    HTML;
 
-        echo "</div>";
+    if (config('feature.beat')) {
+        echo "<a href='" . route('user.completion-progress', $username) . "'>See more...</a>";
     }
+    echo "</div>";
 
     echo "<div id='usercompletedgamescomponent'>";
 


### PR DESCRIPTION
Resolves an issue on user profiles where the "see more..." link to take the user to the unfiltered Completion Progress page may never appear.

@luchaos, this is another issue that is exhibited on your profile 😅

**Before**
![Screenshot 2023-10-30 at 5 08 51 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/7385f1b7-47ee-401a-a178-043359fe9cfd)

**After**
![Screenshot 2023-10-30 at 5 08 40 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/3442c508-2da0-4ee0-a47b-47b08dd8c9da)

**Root Cause**
The conditional for determining whether or not to render the filter checkbox was driving the entire div that also contained the "see more" link. I've removed the conditional and its helper function entirely- IMO, they're overkill.