### PR TITLE
perf(game): dont compute for hidden leaderboards

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -154,7 +154,7 @@ if ($isFullyFeaturedGame) {
 
     $numArticleComments = getRecentArticleComments(ArticleType::Game, $gameID, $commentData);
 
-    $numLeaderboards = getLeaderboardsForGame($gameID, $lbData, $user);
+    $numLeaderboards = getLeaderboardsForGame($gameID, $lbData, $user, retrieveHidden: false);
 
     if (isset($user)) {
         // Determine if the logged in user is the sole author of the set


### PR DESCRIPTION
Helps particularly on game pages like 1446, which has many legacy hidden leaderboards that are being calculated for, even though the results are never displayed to end users.

**Perf Before**
162ms
158ms
457ms
165ms
158ms
Average: 161ms

**Perf After**
34ms
32ms
17ms
34ms
34ms
Average: 30ms

Note: Several leaderboards on the site are deliberately kept with a -1 DisplayOrder for other practical purposes. We should not purge the -1 leaderboards from the DB.