### PR TITLE
perf(user): optimize getAchievementsEarnedBetween()

### DIFF
--- a/app/Helpers/render/user.php
+++ b/app/Helpers/render/user.php
@@ -71,25 +71,6 @@ function renderUserCard(string|array $user): string
     ]);
 }
 
-function getCompletedAndIncompletedSetsCounts(array $userCompletedGamesList): array
-{
-    $completedSetsCount = 0;
-    $incompletedSetsCount = 0;
-
-    foreach ($userCompletedGamesList as $game) {
-        $nextMaxPossible = $game['MaxPossible'];
-        $nextNumAwarded = $game['NumAwarded'];
-
-        if ($nextNumAwarded == $nextMaxPossible) {
-            $completedSetsCount++;
-        } else {
-            $incompletedSetsCount++;
-        }
-    }
-
-    return ['completedSetsCount' => $completedSetsCount, 'incompletedSetsCount' => $incompletedSetsCount];
-}
-
 function RenderCompletedGamesList(
     array $userCompletedGamesList,
     string $username,
@@ -100,28 +81,25 @@ function RenderCompletedGamesList(
     echo "<h3>Completion Progress</h3>";
 
     $checkedAttribute = $isInitiallyHidingCompletedSets ? 'checked' : '';
-    $setsCounts = getCompletedAndIncompletedSetsCounts($userCompletedGamesList);
-    if ($setsCounts['completedSetsCount'] > 0 && $setsCounts['incompletedSetsCount'] > 0) {
-        echo "<div class='flex w-full items-center justify-between mb-2'>";
-        echo <<<HTML
-            <label class="flex items-center gap-x-1">
-                <input 
-                    type="checkbox" 
-                    id="hide-user-completed-sets-checkbox" 
-                    onchange="toggleUserCompletedSetsVisibility()"
-                    $checkedAttribute
-                >
-                    Hide completed games
-                </input>
-            </label>
-        HTML;
 
-        if (config('feature.beat')) {
-            echo "<a href='" . route('user.completion-progress', $username) . "'>See more...</a>";
-        }
+    echo "<div class='flex w-full items-center justify-between mb-2'>";
+    echo <<<HTML
+        <label class="flex items-center gap-x-1">
+            <input 
+                type="checkbox" 
+                id="hide-user-completed-sets-checkbox" 
+                onchange="toggleUserCompletedSetsVisibility()"
+                $checkedAttribute
+            >
+                Hide completed games
+            </input>
+        </label>
+    HTML;
 
-        echo "</div>";
+    if (config('feature.beat')) {
+        echo "<a href='" . route('user.completion-progress', $username) . "'>See more...</a>";
     }
+    echo "</div>";
 
     echo "<div id='usercompletedgamescomponent'>";
 

--- a/database/migrations/platform/2023_10_30_000000_update_player_achievements_table.php
+++ b/database/migrations/platform/2023_10_30_000000_update_player_achievements_table.php
@@ -12,7 +12,7 @@ return new class() extends Migration {
         Schema::table('player_achievements', function (Blueprint $table) {
             $table->index(
                 ['user_id', 'unlocked_at', 'unlocked_hardcore_at', 'achievement_id'],
-                'idx_user_date_achievement'
+                'player_achievements_user_date_achievement'
             );
         });
     }
@@ -20,7 +20,7 @@ return new class() extends Migration {
     public function down(): void
     {
         Schema::table('player_achievements', function (Blueprint $table) {
-            $table->dropIndex('idx_user_date_achievement');
+            $table->dropIndex('player_achievements_user_date_achievement');
         });
     }
 };

--- a/database/migrations/platform/2023_10_30_000000_update_player_achievements_table.php
+++ b/database/migrations/platform/2023_10_30_000000_update_player_achievements_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('player_achievements', function (Blueprint $table) {
+            $table->index(['user_id', 'unlocked_at', 'unlocked_hardcore_at', 'achievement_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_achievements', function (Blueprint $table) {
+            $table->dropIndex(['user_id', 'unlocked_at', 'unlocked_hardcore_at', 'achievement_id']);
+        });
+    }
+};

--- a/database/migrations/platform/2023_10_30_000000_update_player_achievements_table.php
+++ b/database/migrations/platform/2023_10_30_000000_update_player_achievements_table.php
@@ -10,14 +10,17 @@ return new class() extends Migration {
     public function up(): void
     {
         Schema::table('player_achievements', function (Blueprint $table) {
-            $table->index(['user_id', 'unlocked_at', 'unlocked_hardcore_at', 'achievement_id']);
+            $table->index(
+                ['user_id', 'unlocked_at', 'unlocked_hardcore_at', 'achievement_id'],
+                'idx_user_date_achievement'
+            );
         });
     }
 
     public function down(): void
     {
         Schema::table('player_achievements', function (Blueprint $table) {
-            $table->dropIndex(['user_id', 'unlocked_at', 'unlocked_hardcore_at', 'achievement_id']);
+            $table->dropIndex('idx_user_date_achievement');
         });
     }
 };

--- a/database/migrations/platform/2023_10_30_000000_update_player_achievements_table.php
+++ b/database/migrations/platform/2023_10_30_000000_update_player_achievements_table.php
@@ -10,17 +10,27 @@ return new class() extends Migration {
     public function up(): void
     {
         Schema::table('player_achievements', function (Blueprint $table) {
-            $table->index(
-                ['user_id', 'unlocked_at', 'unlocked_hardcore_at', 'achievement_id'],
-                'player_achievements_user_date_achievement'
-            );
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('player_achievements');
+
+            if (!array_key_exists('player_achievements_user_date_achievement', $indexesFound)) {
+                $table->index(
+                    ['user_id', 'unlocked_at', 'unlocked_hardcore_at', 'achievement_id'],
+                    'player_achievements_user_date_achievement'
+                );
+            }
         });
     }
 
     public function down(): void
     {
         Schema::table('player_achievements', function (Blueprint $table) {
-            $table->dropIndex('player_achievements_user_date_achievement');
+            $sm = Schema::getConnection()->getDoctrineSchemaManager();
+            $indexesFound = $sm->listTableIndexes('player_achievements');
+
+            if (array_key_exists('player_achievements_user_date_achievement', $indexesFound)) {
+                $table->dropIndex('player_achievements_user_date_achievement');
+            }
         });
     }
 };


### PR DESCRIPTION
`getAchievementsEarnedBetween()` is responsible for building the chart to show the user's points progress over the last ~2 weeks.

This is currently very slow for users with a lot of progress on the site, even though it is using denormalized data. After running `EXPLAIN` on the query, I identified the main driver behind this slowness is because the query has to scan potentially tens of thousands of rows on the `player_achievements` table due to a missing compound index.

**Benchmark Query**
```sql
SELECT
	COALESCE(pa.unlocked_hardcore_at, pa.unlocked_at) AS Date,
	SUM( IF(pa.unlocked_hardcore_at IS NOT NULL, ach.Points, 0)) AS HardcorePoints,
	SUM(ach.Points) AS SoftcorePoints
FROM
	player_achievements pa
	INNER JOIN Achievements AS ach ON ach.ID = pa.achievement_id
	INNER JOIN GameData AS gd ON gd.ID = ach.GameID
WHERE -- user = MaxMilyin
	pa.user_id = 16446 AND ach.Flags = 3 AND COALESCE(pa.unlocked_hardcore_at, pa.unlocked_at) BETWEEN '2023-10-16 21:52:14' AND '2023-10-30 21:52:14'
GROUP BY
	Date
ORDER BY
	Date ASC
LIMIT 0, 14;
```

**Before**
3.049s
2.748s
2.722s
2.773s
2.765s
Average: 2.81s

**After**
21ms
25ms
26ms
22ms
26ms
Average: 24ms