### PR TITLE
perf(avatar): force async decoding

### DIFF
--- a/app/Helpers/render/avatar.php
+++ b/app/Helpers/render/avatar.php
@@ -20,7 +20,7 @@ function avatar(
     }
 
     if ($iconUrl) {
-        $iconLabel = "<img loading='lazy' width='$iconSize' height='$iconSize' src='$iconUrl' alt='$escapedName' class='$iconClass'>";
+        $iconLabel = "<img loading='lazy' decoding='async' width='$iconSize' height='$iconSize' src='$iconUrl' alt='$escapedName' class='$iconClass'>";
 
         $label = $iconLabel . ' ' . $label;
     }


### PR DESCRIPTION
Should improve perceived performance of large user profile pages in some browsers.

Even though image loading is set to lazy, on profile pages that have a lot of badges, all the badges start rendering+decoding synchronously because they appear above the fold. This deadlocks the UI thread.

More info:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding
https://css-tricks.com/newsletter/249-decoding-async-tree-rings-and-flexbox-gap/