### PR TITLE
perf(navbar): don't eagerly load console icons

### DIFF
--- a/resources/views/components/menu/main.blade.php
+++ b/resources/views/components/menu/main.blade.php
@@ -103,7 +103,7 @@ $menuSystemsList = [
                         $iconName = Str::kebab($cleanSystemShortName);
                         ?>
                         <x-dropdown-item :link="url('gameList.php?c=' . $listId)">
-                            <img src="{{ asset('assets/images/system/' . $iconName . '.png') }}" width="16" height="16" alt='{{ $systemName }}'>
+                            <img src="{{ asset('assets/images/system/' . $iconName . '.png') }}" loading="lazy" width="16" height="16" alt='{{ $systemName }}'>
                             <span>{{ $systemName }}</span>
                         </x-dropdown-item>
                     @endforeach


### PR DESCRIPTION
Currently, the site is eagerly loading all console icons from the navbar, even if the user never opens the "Games" pane in the navbar.

On mobile with 4G conditions, this eager loading results in a ~1s longer overall page load time across the entire site due to hitting the browser's maximum connections limit. Render-blocking resources downstream are being delayed because of the max connections occupancy. The waterfall can be seen here: https://www.webpagetest.org/video/compare.php?tests=231030_BiDc3Y_EH4-r:3-c:0-e:filmstrip

After this PR, the icons will only load when the user opens the menu (or sees them elsewhere on the page).

![Screenshot 2023-10-30 at 6 48 15 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/affae1a0-f1bf-460d-a4be-6dabdf0532cc)