### PR TITLE
fix(active-players): show '12' on hour 0

### DIFF
--- a/resources/views/community/components/active-players/active-players.blade.php
+++ b/resources/views/community/components/active-players/active-players.blade.php
@@ -67,7 +67,9 @@ function activePlayersComponent() {
             hours = hours % 12;
 
             // 12-hour format should treat 0 as 12.
-            hours = hours ?? 12;
+            if (hours === 0) {
+                hours = 12;
+            }
 
             // Pad the minutes with a 0 if necessary.
             const minutesLabel = minutes < 10 ? `0${minutes}` : minutes;


### PR DESCRIPTION
Resolves this issue with the last updated label on the active players widget. "0:37pm" should read "12:37pm".

![Screenshot 2023-11-01 at 12 37 38 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/0a2c1027-63aa-4303-8044-fdc6f3ab006b)

**Root Cause**
Nullish coalescing in JS only checks for null or undefined. I mistakenly believed because 0 is a falsy value the original implementation would work. It doesn't; it requires an explicit check.