### PR TITLE
feat: use MariaDB uca1400_ai_ci and fix game title tilde sort

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,9 +54,8 @@ DB_PORT=3306
 DB_DATABASE=retroachievements-web
 DB_USERNAME=retroachievements
 DB_PASSWORD="${DB_USERNAME}"
-# TODO remove after utf8mb4 conversion
-#DB_CHARSET=latin1
-#DB_COLLATION=latin1_swedish_ci
+# for MySQL - MariaDB uses uca1400_ai_ci
+#DB_COLLATION=utf8mb4_unicode_ci
 
 #LEGACY_MEDIA_PATH=
 

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -347,7 +347,7 @@ function getGamesListByDev(
             if ($sortBy < 10) {
                 $orderBy .= ", IF(gd.Title LIKE '~%',1,0), gd.Title";
             } else {
-                $orderBy .= ", IF(gd.Title LIKE '~%',1,0), gd.Title";
+                $orderBy .= ", IF(gd.Title LIKE '~%',0,1), gd.Title DESC";
             }
         }
         if ($consoleID == 0) {

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -321,8 +321,8 @@ function getGamesListByDev(
     }
 
     $orderBy = match ($sortBy) {
-        1 => "gd.Title",
-        11 => "gd.Title DESC",
+        1 => "IF(gd.Title LIKE '~%',1,0), gd.Title",
+        11 => "IF(gd.Title LIKE '~%',0,1), gd.Title DESC",
         2 => "NumAchievements DESC, MaxPointsAvailable DESC",
         12 => "NumAchievements, MaxPointsAvailable",
         3 => "MaxPointsAvailable DESC, NumAchievements DESC",
@@ -345,9 +345,9 @@ function getGamesListByDev(
     if (!empty($orderBy)) {
         if (!Str::contains($orderBy, "Title")) {
             if ($sortBy < 10) {
-                $orderBy .= ", Title";
+                $orderBy .= ", IF(gd.Title LIKE '~%',1,0), gd.Title";
             } else {
-                $orderBy .= ", Title DESC";
+                $orderBy .= ", IF(gd.Title LIKE '~%',1,0), gd.Title";
             }
         }
         if ($consoleID == 0) {

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -321,8 +321,8 @@ function getGamesListByDev(
     }
 
     $orderBy = match ($sortBy) {
-        1 => "IF(gd.Title LIKE '~%',1,0), gd.Title",
-        11 => "IF(gd.Title LIKE '~%',0,1), gd.Title DESC",
+        1 => ifStatement("gd.Title LIKE '~%'", 1, 0) . ", gd.Title",
+        11 => ifStatement("gd.Title LIKE '~%'", 0, 1) . ", gd.Title DESC",
         2 => "NumAchievements DESC, MaxPointsAvailable DESC",
         12 => "NumAchievements, MaxPointsAvailable",
         3 => "MaxPointsAvailable DESC, NumAchievements DESC",
@@ -345,9 +345,9 @@ function getGamesListByDev(
     if (!empty($orderBy)) {
         if (!Str::contains($orderBy, "Title")) {
             if ($sortBy < 10) {
-                $orderBy .= ", IF(gd.Title LIKE '~%',1,0), gd.Title";
+                $orderBy .= ifStatement("gd.Title LIKE '~%'", 1, 0) . ", gd.Title";
             } else {
-                $orderBy .= ", IF(gd.Title LIKE '~%',0,1), gd.Title DESC";
+                $orderBy .= ifStatement("gd.Title LIKE '~%'", 0, 1) . ", gd.Title DESC";
             }
         }
         if ($consoleID == 0) {

--- a/app/Helpers/util/database.php
+++ b/app/Helpers/util/database.php
@@ -96,7 +96,7 @@ function timestampAddMinutesStatement(int $minutes): string
 function ifStatement(string $condition, mixed $trueValue, mixed $falseValue): string
 {
     return match (DB::getDriverName()) {
-        'sqlite' => "CASE WHEN $condition THEN $trueValue ELSE $falseValue END",
+        'sqlite' => "IIF($condition, $trueValue, $falseValue)",
         // mysql
         default => "IF($condition, $trueValue, $falseValue)"
     };

--- a/app/Site/AppServiceProvider.php
+++ b/app/Site/AppServiceProvider.php
@@ -115,7 +115,8 @@ class AppServiceProvider extends ServiceProvider
                     throw new Exception('Could not connect to database. Please try again later.');
                 }
                 mysqli_set_charset($db, config('database.connections.mysql.charset'));
-                mysqli_query($db, "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));");
+                $db->query("SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));");
+                $db->query("SET collation_connection = " . config('database.connections.mysql.collation'));
 
                 return $db;
             } catch (Exception $exception) {

--- a/config/database.php
+++ b/config/database.php
@@ -55,7 +55,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => env('DB_CHARSET', 'utf8mb4'),
-            'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'collation' => env('DB_COLLATION', 'uca1400_ai_ci'),
             'prefix' => '',
             'prefix_indexes' => false,
             'strict' => true,


### PR DESCRIPTION
`utf8mb4_unicode_ci` is based on Unicode-4.0.0 which is fairly old. Use `uca1400_ai_ci` collation instead. (see https://jira.mariadb.org/browse/MDEV-27009)

The `utf8mb4_unicode_ci` mariadb container default can stay for now, Laravel will use `uca1400_ai_ci` for migrations. Changing the docker container default to `uca1400_ai_ci` resulted in `SQLSTATE[HY000] [2054] Server sent charset (0) unknown to the client`.
I'll look into that another time, not relevant for the server move.

Already migrated/imported local databases can stay as is - no need to change the collations just yet, but can be done if desired.

Fix tilde sort while at it.

Left is `utf8mb4_unicode_ci` collation without sort fix, right is with `uca1400_ai_ci` with the fix. Note the sorting of `Ł`:

![Screenshot 2023-11-02 at 19 30 00](https://github.com/RetroAchievements/RAWeb/assets/1280590/e02ce421-03a1-4a38-b74d-fb79402f25f5)
