### PR TITLE
fix exception accessing manage hashes page for non-existant game

### DIFF
--- a/public/managehashes.php
+++ b/public/managehashes.php
@@ -16,6 +16,10 @@ if (empty($gameID)) {
 $gamesList = [];
 $gameData = getGameData($gameID);
 
+if (!$gameData) {
+    abort(404);
+}
+
 $hashes = getHashListByGameID($gameID);
 $numLinks = count($hashes);
 


### PR DESCRIPTION
Fixes "ErrorException(code: 0): Trying to access array offset on value of type null at /home/forge/retroachievements.org/releases/2023-11-04T091534-5.1.0-27696186/public/managehashes.php:22"