### PR TITLE
ignore negative offset

### DIFF
--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -28,6 +28,9 @@ if ($permissions < $topicData['RequiredPermissions']) {
 // Fetch other params
 $count = 15;
 $offset = requestInputSanitized('o', 0, 'integer');
+if ($offset < 0) {
+    $offset = 0;
+}
 
 // Fetch 'goto comment' param if available
 $gotoCommentID = requestInputSanitized('c', null, 'integer');


### PR DESCRIPTION
It's been almost a year, and the error supposedly fixed by #1276 still pops up every now and then. I have to assume users have bad data in their bookmarks or links in forum posts. While the bad urls should no longer be getting generated, this will also address any that are still floating around.