### PR TITLE
feat: re-enable followed users ranking, move it to Followers page

### DIFF
--- a/app/Helpers/render/ranking.php
+++ b/app/Helpers/render/ranking.php
@@ -475,8 +475,8 @@ function getGlobalRankingData(
             SUM(ach.Points) AS Points,
             SUM(ach.TrueRatio) AS RetroPoints
             FROM player_achievements AS aw
-            LEFT JOIN Achievements AS ach ON ach.ID = aw.achievement_id
-            LEFT JOIN UserAccounts AS ua ON ua.ID = aw.user_id
+            INNER JOIN Achievements AS ach ON ach.ID = aw.achievement_id
+            INNER JOIN UserAccounts AS ua ON ua.ID = aw.user_id
             WHERE TRUE $whereDateAchievement $typeCond
             $friendCondAchievement
             $singleUserAchievementCond

--- a/public/friends.php
+++ b/public/friends.php
@@ -152,4 +152,13 @@ RenderContentStart("Following");
     RenderUserList('Blocked', $blockedUsersList, UserRelationship::Blocked, $followingList);
     ?>
 </article>
+<?php
+if (!empty($followingList)) {
+    view()->share('sidebar', true);
+
+    echo "<aside>";
+    echo RenderPointsRankingComponent($user, true);
+    echo "</aside>";
+}
+?>
 <?php RenderContentEnd(); ?>

--- a/public/friends.php
+++ b/public/friends.php
@@ -157,7 +157,7 @@ if (!empty($followingList)) {
     view()->share('sidebar', true);
 
     echo "<aside>";
-    echo RenderPointsRankingComponent($user, true);
+    RenderPointsRankingComponent($user, true);
     echo "</aside>";
 }
 ?>

--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -649,8 +649,8 @@ RenderContentStart($userPage);
     echo "</div>";
 
     if ($user !== null && $user === $userPage) {
-        // FIXME: https://discord.com/channels/476211979464343552/1026595325038833725/1162746245996093450
-        // RenderPointsRankingComponent($user, true);
+        $friendCount = getFriendCount($user);
+        echo Blade::render('<x-user.followed-leaderboard-cta :friendCount="$friendCount" />', ['friendCount' => $friendCount]);
     }
     ?>
 </aside>

--- a/resources/views/community/components/user/followed-leaderboard-cta.blade.php
+++ b/resources/views/community/components/user/followed-leaderboard-cta.blade.php
@@ -1,0 +1,21 @@
+@props([
+    'friendCount' => 0,
+])
+
+<div class="component">
+    <h3>Followed Users Ranking</h3>
+
+    @if ($friendCount === 0)
+        <p>
+            You don't appear to be following anyone yet. Why not
+            <a href="{{ url('userList.php') }}">browse the user pages</a>
+            to find someone to follow?
+        </p>
+    @else
+        <p>You're following {{ localized_number($friendCount) }} other players.</p>
+        <p>
+            <a href="{{ url('friends.php') }}">Visit your Following page</a> to see how you
+            compare in daily, weekly, and monthly points.
+        </p>
+    @endif
+</div>

--- a/resources/views/community/components/user/followed-leaderboard-cta.blade.php
+++ b/resources/views/community/components/user/followed-leaderboard-cta.blade.php
@@ -12,7 +12,7 @@
             to find someone to follow?
         </p>
     @else
-        <p>You're following {{ localized_number($friendCount) }} other players.</p>
+        <p>You're following {{ localized_number($friendCount) }} other {{ mb_strtolower(__res('player', $friendCount)) }}.</p>
         <p>
             <a href="{{ url('friends.php') }}">Visit your Following page</a> to see how you
             compare in daily, weekly, and monthly points.


### PR DESCRIPTION
This PR:
* Makes some minor adjustments to the ranking query, swapping `LEFT JOIN` to `INNER JOIN` for a very minor performance improvement.
* Moves the followed users ranking component to _friends.php_.
* Adds a link to user profiles where the component used to be so users know where to find it now.

When following 800 users, the query always runs at less than 300ms for me. At more reasonable following counts, it's around 100ms. With it being off the user profile, it should have much less of an impact on the site.

![Screenshot 2023-11-04 at 9 25 02 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/9d4b917e-807a-480a-9f9a-5957d24dc10e)

![Screenshot 2023-11-04 at 9 25 10 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/3bd429ae-5055-4a9d-bcae-e820278b5b89)
