### PR TITLE
fix(setRequestList): remediate user request list sort order issue

### DIFF
--- a/app/Helpers/database/set-request.php
+++ b/app/Helpers/database/set-request.php
@@ -36,7 +36,12 @@ function getUserRequestList(?string $user = null): array
         GROUP BY
             sr.GameID
         ORDER BY
-            GameTitle ASC";
+            CASE
+                WHEN gd.Title LIKE '~%' THEN
+                    SUBSTRING(gd.Title, LOCATE(' ', gd.Title) + 1)
+                ELSE
+                    gd.Title
+            END ASC";
 
     $dbResult = s_mysql_query($query);
 

--- a/app/Helpers/database/set-request.php
+++ b/app/Helpers/database/set-request.php
@@ -35,13 +35,7 @@ function getUserRequestList(?string $user = null): array
             sr.user = '$user' AND sr.type='" . UserGameListType::AchievementSetRequest . "'
         GROUP BY
             sr.GameID
-        ORDER BY
-            CASE
-                WHEN gd.Title LIKE '~%' THEN
-                    SUBSTRING(gd.Title, LOCATE(' ', gd.Title) + 1)
-                ELSE
-                    gd.Title
-            END ASC";
+        ORDER BY " . ifStatement("gd.Title LIKE '~%'", 1, 0) . ", gd.Title";
 
     $dbResult = s_mysql_query($query);
 


### PR DESCRIPTION
Remediates an issue where tilde characters in game titles are not being ignored in the sort order.

In the images below, look at the position of the unlicensed title, "Tiles of Fate".

**Before**
![Screenshot 2023-11-04 at 9 56 40 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/48b3c7a5-9dc5-46be-8c94-a41c9e640641)


**After**
![Screenshot 2023-11-04 at 9 56 33 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/a28f59bc-2e65-41dd-82bd-fd5616035739)
