### PR TITLE
perf(beaten-leaderboard): if more than 50 pages, don't page with a select control

### DIFF
--- a/resources/views/platform/components/beaten-games-leaderboard/pagination-controls.blade.php
+++ b/resources/views/platform/components/beaten-games-leaderboard/pagination-controls.blade.php
@@ -31,6 +31,15 @@ $isHighlightedRankOnCurrentPage = $paginator->currentPage() === $userPageNumber;
 function handlePageChanged(event) {
     window.updateUrlParameter('page[number]', event.target.value);
 }
+
+function goToPage(pageNumber) {
+    const page = parseInt(pageNumber, 10);
+    if (page !== NaN && page > 0 && page <= {{ $paginator->lastPage() }}) {
+        window.location.href = `{{ $baseUrl }}?page[number]=${page}`;
+    } else {
+        alert('Please enter a valid page number.');
+    }
+}
 </script>
 
 <div class="flex flex-col sm:flex-row gap-y-4 items-center justify-between md:gap-x-4">
@@ -56,15 +65,34 @@ function handlePageChanged(event) {
             @endif
         </div>
 
-        <div x-init="{}" class="text-xs flex items-center gap-x-2">
+        <div x-init="{}" class="text-xs items-center gap-x-2 @if ($paginator->lastPage() > 50) hidden sm:flex @endif">
             Viewing Page
-            <select @change="handlePageChanged">
-                @for ($i = 1; $i <= $paginator->lastPage(); $i++)
-                    <option value="{{ $i }}" @if ($i == $paginator->currentPage()) selected @endif>
-                        {{ $i }}
-                    </option>
-                @endfor
-            </select>
+
+            @if ($paginator->lastPage() > 50)
+                <form onsubmit="goToPage(document.getElementById('page-number-input').value); return false;">
+                    <label for="page-number-input" class="sr-only">page number</label>
+                    <input
+                        type="number"
+                        value="{{ $paginator->currentPage() }}"
+                        id="page-number-input"
+                        name="page[number]"
+                        min="1"
+                        max="{{ $paginator->lastPage() }}"
+                        class="text-xs"
+                    >
+
+                    <button type="submit" class="btn transition-transform lg:active:scale-95 sm:hidden w-full">Go</button>
+                </form>
+            @else
+                <select @change="handlePageChanged">
+                    @for ($i = 1; $i <= $paginator->lastPage(); $i++)
+                        <option value="{{ $i }}" @if ($i == $paginator->currentPage()) selected @endif>
+                            {{ $i }}
+                        </option>
+                    @endfor
+                </select>
+            @endif
+
             of {{ localized_number($paginator->lastPage()) }}
         </div>
 


### PR DESCRIPTION
A minor optimization to the beaten games leaderboard UI. The document is a little slower than it should be to load if there are hundreds of pages because the document size is inflated by all the options in the select control.

Now, if there are more than 50 pages on a leaderboard, an input field will be displayed on SM+ and individual pagination will be hidden completely on XS.

The individual page can be selected by submitting the form (pressing the Enter key).

**Before**
![Screenshot 2023-11-05 at 6 50 36 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/76198763-b259-4829-9ba0-7b6f1dd4aad6)

**After**
![Screenshot 2023-11-05 at 6 46 54 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/203ad6e0-2f65-4215-b04d-98aeef089ed5)
