### PR TITLE
feat(home): delay autoscrolling on the news' first slide

### DIFF
--- a/resources/js/alpine/newsCarouselComponent/newsCarouselComponent.test.ts
+++ b/resources/js/alpine/newsCarouselComponent/newsCarouselComponent.test.ts
@@ -119,7 +119,7 @@ describe('Component: newsCarouselComponent', () => {
     render();
 
     // ACT
-    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(8000);
     await vi.advanceTimersToNextTimerAsync();
 
     // ASSERT

--- a/resources/js/alpine/newsCarouselComponent/newsCarouselComponent.test.ts
+++ b/resources/js/alpine/newsCarouselComponent/newsCarouselComponent.test.ts
@@ -119,7 +119,8 @@ describe('Component: newsCarouselComponent', () => {
     render();
 
     // ACT
-    await vi.advanceTimersByTimeAsync(8000);
+    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersToNextTimerAsync();
 
     // ASSERT
     expect(screen.getByTestId('active-index-label')).toHaveTextContent('1');

--- a/resources/js/alpine/newsCarouselComponent/newsCarouselComponent.ts
+++ b/resources/js/alpine/newsCarouselComponent/newsCarouselComponent.ts
@@ -220,7 +220,9 @@ const newsCarouselStore = {
 
   /** Initialize the carousel. */
   init() {
-    this.startAutoScroll();
+    setTimeout(() => {
+      this.startAutoScroll();
+    }, AUTO_SCROLL_DELAY * 2);
 
     // Listen for window resize events. If we don't, we'll lose our tracking
     // position and nasty bugs can emerge on mobile devices.

--- a/resources/js/alpine/newsCarouselComponent/newsCarouselComponent.ts
+++ b/resources/js/alpine/newsCarouselComponent/newsCarouselComponent.ts
@@ -222,7 +222,7 @@ const newsCarouselStore = {
   init() {
     setTimeout(() => {
       this.startAutoScroll();
-    }, AUTO_SCROLL_DELAY * 2);
+    }, AUTO_SCROLL_DELAY); // Give the first item more emphasis.
 
     // Listen for window resize events. If we don't, we'll lose our tracking
     // position and nasty bugs can emerge on mobile devices.


### PR DESCRIPTION
A trivial UX improvement to the home page news carousel. Show the first slide for significantly longer (~20 seconds) before beginning autoscrolling to slide 2.

Whatever is on the first slide is likely the most important item for incoming users to see, so it should receive more prominence in the component.