### PR TITLE
split massive dev stats query into several subqueries

### DIFF
--- a/app/Helpers/database/user.php
+++ b/app/Helpers/database/user.php
@@ -191,7 +191,6 @@ function GetDeveloperStatsFull(int $count, int $sortBy, int $devFilter = 7): arr
     $stateCond = "ua.ContribCount > 0 AND ua.ContribYield > 0 " . $stateCond;
 
     $devs = [];
-
     $data = [];
     $buildData = function ($query) use (&$devs, &$data) {
         $populateDevs = empty($devs);
@@ -221,7 +220,7 @@ function GetDeveloperStatsFull(int $count, int $sortBy, int $devFilter = 7): arr
             $devs[] = $row['ID'];
         }
         if (empty($devs)) {
-            return [];
+            return;
         }
         $devList = implode(',', $devs);
 

--- a/app/Helpers/database/user.php
+++ b/app/Helpers/database/user.php
@@ -226,7 +226,7 @@ function GetDeveloperStatsFull(int $count, int $sortBy, int $devFilter = 7): arr
 
         // user data (this must be a LEFT JOIN to pick up users with 0 published achievements)
         $query = "SELECT ua.ID, ua.User, ua.Permissions, ua.ContribCount, ua.ContribYield,
-                         ua.LastLogin, COUNT(*) AS NumAchievements
+                         ua.LastLogin, SUM(!ISNULL(ach.ID)) AS NumAchievements
                   FROM UserAccounts ua
                   LEFT JOIN Achievements ach ON ach.Author=ua.User AND ach.Flags = 3
                   WHERE ua.ID IN ($devList)

--- a/app/Helpers/database/user.php
+++ b/app/Helpers/database/user.php
@@ -246,7 +246,7 @@ function GetDeveloperStatsFull(int $count, int $sortBy, int $devFilter = 7): arr
                   ORDER BY OpenTickets DESC";
         $buildDevList($query);
     } elseif ($sortBy == 4) { // TicketsResolvedForOthers DESC
-        $query = "SELECT ua.ID, SUM(!ISNULL(tick.ID)) as total
+        $query = "SELECT ua.ID, SUM(!ISNULL(ach.ID)) as total
                   FROM UserAccounts as ua
                   LEFT JOIN Ticket tick ON tick.ResolvedByUserID = ua.ID AND tick.ReportState = 2 AND tick.ResolvedByUserID != tick.ReportedByUserID
                   LEFT JOIN Achievements as ach ON ach.ID = tick.AchievementID AND ach.flags = 3 AND ach.Author != ua.User

--- a/app/Helpers/database/user.php
+++ b/app/Helpers/database/user.php
@@ -243,7 +243,7 @@ function GetDeveloperStatsFull(int $count, int $sortBy, int $devFilter = 7): arr
                   LEFT JOIN Ticket tick ON tick.AchievementID=ach.ID AND tick.ReportState IN (1,3)
                   WHERE $stateCond
                   GROUP BY ua.ID
-                  ORDER BY OpenTickets DESC";
+                  ORDER BY OpenTickets DESC, ua.User";
         $buildDevList($query);
     } elseif ($sortBy == 4) { // TicketsResolvedForOthers DESC
         $query = "SELECT ua.ID, SUM(!ISNULL(ach.ID)) as total
@@ -252,7 +252,7 @@ function GetDeveloperStatsFull(int $count, int $sortBy, int $devFilter = 7): arr
                   LEFT JOIN Achievements as ach ON ach.ID = tick.AchievementID AND ach.flags = 3 AND ach.Author != ua.User
                   WHERE $stateCond
                   GROUP BY ua.ID
-                  ORDER BY total DESC";
+                  ORDER BY total DESC, ua.User";
         $buildDevList($query);
     } elseif ($sortBy == 7) { // ActiveClaims DESC
         $query = "SELECT ua.ID, SUM(!ISNULL(sc.ID)) AS ActiveClaims
@@ -260,15 +260,15 @@ function GetDeveloperStatsFull(int $count, int $sortBy, int $devFilter = 7): arr
                   LEFT JOIN SetClaim sc ON sc.User=ua.User AND sc.Status IN (" . ClaimStatus::Active . ',' . ClaimStatus::InReview . ")
                   WHERE $stateCond
                   GROUP BY ua.ID
-                  ORDER BY ActiveClaims DESC";
+                  ORDER BY ActiveClaims DESC, ua.User";
         $buildDevList($query);
     } else {
         $order = match ($sortBy) {
-            1 => "ua.ContribYield DESC",
-            2 => "ua.ContribCount DESC",
-            5 => "ua.LastLogin DESC",
+            1 => "ua.ContribYield DESC, ua.User",
+            2 => "ua.ContribCount DESC, ua.User",
+            5 => "ua.LastLogin DESC, ua.User",
             6 => "ua.User ASC",
-            default => "NumAchievements DESC",
+            default => "NumAchievements DESC, ua.User",
         };
 
         // ASSERT: ContribYield cannot be > 0 unless NumAchievements > 0, so use


### PR DESCRIPTION
Improves load time of "Community > Developer Stats" page from ~21seconds to ~900ms.