### PR TITLE
split massive game list query into several subqueries

### DIFF
--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -291,7 +291,7 @@ function getGamesListByDev(
 
     $initialQuery = true;
     if ($sortBy === 4 || $sortBy === 14) { // NumLBs
-        $query = "SELECT $foundRows gd.ID, gd.points_total AS MaxPointsAvailable, COUNT(*) AS NumLBs,
+        $query = "SELECT $foundRows gd.ID, gd.points_total AS MaxPointsAvailable, COUNT(*) AS NumLBs
                   FROM LeaderboardDef lb
                   INNER JOIN GameData gd ON gd.ID = lb.GameID
                   INNER JOIN Console c ON c.ID = gd.ConsoleID $listJoin

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Community\Enums\ArticleType;
-use App\Community\Enums\TicketState;
 use App\Platform\Enums\AchievementFlag;
 use App\Platform\Models\Game;
 use App\Site\Enums\Permissions;
@@ -217,11 +216,6 @@ function getGameAlternatives(int $gameID, ?int $sortBy = null): array
     return $results;
 }
 
-function getGamesListWithNumAchievements(int $consoleID, ?array &$dataOut, int $sortBy): int
-{
-    return getGamesListByDev(null, $consoleID, $dataOut, $sortBy);
-}
-
 function getGamesListByDev(
     ?string $dev,
     int $consoleID,
@@ -233,159 +227,279 @@ function getGamesListByDev(
     int $count = 0,
     ?string $listType = null
 ): int {
-    // Specify 0 for $consoleID to fetch games for all consoles, or an ID for just that console
+    $dataOut = [];
+    $numGamesFound = 0;
 
-    $whereConds = [];
-    $moreSelectCond = '';
-    $havingCond = '';
+    $gameIds = [];
+    $gameList = '';
     $bindings = [];
-    $selectTickets = '';
-    $joinTicketsTable = '';
-    $joinUserListsTable = '';
 
-    if ($dev != null) {
-        $bindings['myAchDev'] = $dev;
-        $bindings['myPtsDev'] = $dev;
-        $bindings['myRRDev'] = $dev;
-        $bindings['notMyAchDev'] = $dev;
-        $moreSelectCond = "SUM(CASE WHEN ach.Author = :myAchDev THEN 1 ELSE 0 END) AS MyAchievements,
-                           SUM(CASE WHEN ach.Author = :myPtsDev THEN ach.Points ELSE 0 END) AS MyPoints,
-                           SUM(CASE WHEN ach.Author = :myRRDev THEN ach.TrueRatio ELSE 0 END) AS MyTrueRatio,
-                           SUM(CASE WHEN ach.Author != :notMyAchDev THEN 1 ELSE 0 END) AS NotMyAchievements,
-                           lbdi.MyLBs,";
-        $havingCond = "HAVING MyAchievements > 0 ";
+    if ($sortBy < 10) {
+        $titleSort = ifStatement("gd.Title LIKE '~%'", 1, 0) . ", gd.Title";
     } else {
-        if ($filter == 0) { // only with achievements
-            $havingCond = "HAVING NumAchievements > 0 ";
-        } elseif ($filter == 1) { // only without achievements
-            $havingCond = "HAVING NumAchievements = 0 ";
-        }
+        $titleSort = ifStatement("gd.Title LIKE '~%'", 0, 1) . ", gd.Title DESC";
     }
 
-    if ($ticketsFlag) {
-        $selectTickets = ", ticks.OpenTickets";
-        $joinTicketsTable = "
-        LEFT JOIN (
-            SELECT
-                ach.GameID,
-                count( DISTINCT tick.ID ) AS OpenTickets,
-                SUM(CASE WHEN ach.Author LIKE '$dev' THEN 1 ELSE 0 END) AS MyOpenTickets
-            FROM
-                Ticket AS tick
-            LEFT JOIN
-                Achievements AS ach ON ach.ID = tick.AchievementID
-            WHERE
-                tick.ReportState IN (" . TicketState::Open . "," . TicketState::Request . ")
-            GROUP BY
-                ach.GameID
-        ) as ticks ON ticks.GameID = gd.ID ";
-        $moreSelectCond .= "ticks.MyOpenTickets,";
+    // Specify 0 for $consoleID to fetch games for all consoles, or an ID for just that console
+    $whereClause = '';
+    if ($consoleID !== 0) {
+        $whereClause = "AND gd.ConsoleID = $consoleID";
+    } elseif ($sortBy < 10) {
+        $titleSort .= ", c.Name ";
+    } else {
+        $titleSort .= ", c.Name DESC";
     }
 
-    if ($consoleID != 0) {
-        $whereConds[] = "gd.ConsoleID=$consoleID ";
+    if ($dev === null) {
+        $whereClause .= match ($filter) {
+            0 => ' AND gd.achievements_published > 0', // only with achievements
+            1 => ' AND COALESCE(gd.achievements_published,0) = 0', // only without achievements
+            default => '', // both
+        };
     }
 
+    $listJoin = '';
     if ($listType !== null) {
-        $joinUserListsTable = "JOIN SetRequest sr ON sr.GameID = gd.ID";
-        $whereConds[] = "sr.user_id = " . request()->user()->ID . " AND sr.type = :listType";
+        $listJoin = "INNER JOIN SetRequest sr ON sr.GameID = gd.ID";
+        $whereClause .= " AND sr.user_id = " . request()->user()->ID . " AND sr.type = :listType";
         $bindings['listType'] = $listType;
     }
 
-    $whereCond = '';
-    if (!empty($whereConds)) {
-        $whereCond = 'WHERE ' . join(' AND ', $whereConds);
-    }
-
-    // TODO slow query
-    $query = "SELECT gd.Title, gd.ID, gd.ConsoleID, c.Name AS ConsoleName,
-                COUNT( ach.ID ) AS NumAchievements, MAX(ach.DateModified) AS DateModified, SUM(ach.Points) AS MaxPointsAvailable,
-                lbdi.NumLBs, gd.ImageIcon as GameIcon, gd.TotalTruePoints, gd.ForumTopicID $selectTickets,
-                $moreSelectCond
-                CASE WHEN LENGTH(gd.RichPresencePatch) > 0 THEN 1 ELSE 0 END AS RichPresence,
-                CASE WHEN SUM(ach.Points) > 0 THEN ROUND(gd.TotalTruePoints/SUM(ach.Points), 2) ELSE 0.00 END AS RetroRatio
-                FROM GameData AS gd
-                INNER JOIN Console AS c ON c.ID = gd.ConsoleID
-                LEFT JOIN Achievements AS ach ON gd.ID = ach.GameID AND ach.Flags = " . AchievementFlag::OfficialCore . "
-                LEFT JOIN ( SELECT lbd.GameID, COUNT( DISTINCT lbd.ID ) AS NumLBs,
-                                   SUM(CASE WHEN lbd.Author LIKE '$dev' THEN 1 ELSE 0 END) AS MyLBs
-                            FROM LeaderboardDef AS lbd
-                            GROUP BY lbd.GameID ) AS lbdi ON lbdi.GameID = gd.ID
-                $joinTicketsTable $joinUserListsTable
-                $whereCond
-                GROUP BY gd.ID
-                $havingCond";
-
-    if ($sortBy < 1 || $sortBy > 17) {
-        $sortBy = 1;
-    }
-
     $orderBy = match ($sortBy) {
-        1 => ifStatement("gd.Title LIKE '~%'", 1, 0) . ", gd.Title",
-        11 => ifStatement("gd.Title LIKE '~%'", 0, 1) . ", gd.Title DESC",
-        2 => "NumAchievements DESC, MaxPointsAvailable DESC",
-        12 => "NumAchievements, MaxPointsAvailable",
-        3 => "MaxPointsAvailable DESC, NumAchievements DESC",
-        13 => "MaxPointsAvailable, NumAchievements",
-        4 => "NumLBs DESC, MaxPointsAvailable DESC",
-        14 => "NumLBs, MaxPointsAvailable",
-        5 => $ticketsFlag
-                ? "ticks.OpenTickets DESC "
-                : "",
-        15 => $ticketsFlag
-                ? "ticks.OpenTickets"
-                : "",
-        6 => "DateModified DESC",
-        16 => "DateModified",
-        7 => "RetroRatio DESC, MaxPointsAvailable DESC",
-        17 => "RetroRatio ASC, MaxPointsAvailable ASC",
+        1 => "ORDER BY $titleSort",
+        11 => "ORDER BY $titleSort",
+        2 => "ORDER BY NumAchievements DESC, MaxPointsAvailable DESC, $titleSort",
+        12 => "ORDER BY NumAchievements, MaxPointsAvailable, $titleSort",
+        3 => "ORDER BY MaxPointsAvailable DESC, NumAchievements DESC, $titleSort",
+        13 => "ORDER BY MaxPointsAvailable, NumAchievements, $titleSort",
+        4 => "ORDER BY NumLBs DESC, MaxPointsAvailable DESC, $titleSort",
+        14 => "ORDER BY NumLBs, MaxPointsAvailable, $titleSort",
+        5 => $ticketsFlag ? "ORDER BY OpenTickets DESC, $titleSort" : '',
+        15 => $ticketsFlag ? "ORDER BY OpenTickets, $titleSort" : '',
+        6 => "ORDER BY DateModified DESC, $titleSort",
+        16 => "ORDER BY DateModified, $titleSort",
+        7 => "ORDER BY RetroRatio DESC, MaxPointsAvailable DESC, $titleSort",
+        17 => "ORDER BY RetroRatio ASC, MaxPointsAvailable ASC, $titleSort",
         default => "",
     };
 
-    if (!empty($orderBy)) {
-        if (!Str::contains($orderBy, "Title")) {
-            if ($sortBy < 10) {
-                $orderBy .= ', ' . ifStatement("gd.Title LIKE '~%'", 1, 0) . ", gd.Title";
+    $foundRows = '';
+    if ($count > 0 || $offset > 0) {
+        $orderBy .= " LIMIT $offset, $count";
+        $foundRows = 'SQL_CALC_FOUND_ROWS';
+    }
+
+    $initialQuery = true;
+    if ($sortBy === 4 || $sortBy === 14) { // NumLBs
+        $query = "SELECT $foundRows gd.ID, gd.points_total AS MaxPointsAvailable, COUNT(*) AS NumLBs,
+                  FROM LeaderboardDef lb
+                  INNER JOIN GameData gd ON gd.ID = lb.GameID
+                  INNER JOIN Console c ON c.ID = gd.ConsoleID $listJoin
+                  WHERE 1=1 $whereClause
+                  GROUP BY gd.ID, gd.points_total $orderBy";
+    } elseif ($sortBy === 5 || $sortBy === 15) { // OpenTickets
+        $query = "SELECT $foundRows gd.ID, COUNT(*) AS OpenTickets
+                  FROM Ticket tick
+                  INNER JOIN Achievements ach ON ach.ID=tick.AchievementID
+                  INNER JOIN GameData gd ON gd.ID=ach.GameID
+                  INNER JOIN Console c ON c.ID = gd.ConsoleID $listJoin
+                  WHERE tick.ReportState IN (1,3) $whereClause
+                  GROUP BY gd.ID $orderBy";
+    } elseif ($sortBy === 6 || $sortBy === 16) { // DateModified
+        $query = "SELECT $foundRows gd.ID, MAX(DateModified) AS DateModified
+                  FROM Achievements ach
+                  INNER JOIN GameData gd ON gd.ID=ach.GameID
+                  INNER JOIN Console c ON c.ID = gd.ConsoleID $listJoin
+                  WHERE ach.Flags=" . AchievementFlag::OfficialCore . " $whereClause
+                  GROUP BY gd.ID $orderBy";
+    } else {
+        // other sorts can be handled without an initial query
+        $initialQuery = false;
+    }
+
+    if ($initialQuery) {
+        foreach (legacyDbFetchAll($query, $bindings) as $row) {
+            $gameIds[] = $row['ID'];
+        }
+
+        if (empty($gameIds)) {
+            return 0;
+        }
+        $gameList = implode(',', $gameIds);
+
+        $numGamesFound = count($gameIds);
+        if ($count > 0) {
+            if ($numGamesFound == $count) {
+                $query = "SELECT FOUND_ROWS() AS NumGames";
+                $numGamesFound = legacyDbFetch($query)['NumGames'];
             } else {
-                $orderBy .= ', ' . ifStatement("gd.Title LIKE '~%'", 0, 1) . ", gd.Title DESC";
+                $numGamesFound += $offset;
             }
         }
-        if ($consoleID == 0) {
-            if (Str::contains($orderBy, "Title DESC")) {
-                $orderBy .= ", ConsoleName DESC";
+
+        // already did the complex filters. replace with a simple filter on the matching game list
+        $whereClause = "AND gd.ID IN ($gameList)";
+        $orderBy = '';
+        $foundRows = '';
+        $listJoin = '';
+    }
+
+    $commonFields = 'gd.ID, gd.Title, gd.ImageIcon, gd.TotalTruePoints,
+                     COALESCE(gd.achievements_published,0) AS NumAchievements,
+                     gd.points_total AS MaxPointsAvailable,
+                     CASE WHEN LENGTH(gd.RichPresencePatch) > 0 THEN 1 ELSE 0 END AS RichPresence,
+                     CASE WHEN gd.points_total > 0 THEN ROUND(gd.TotalTruePoints/gd.points_total, 2) ELSE 0.00 END AS RetroRatio,
+                     gd.ForumTopicID, gd.ConsoleID, c.Name as ConsoleName';
+
+    $games = [];
+    if ($dev !== null) {
+        $query = "SELECT $foundRows $commonFields,
+                         COUNT(*) AS MyAchievements,
+                         SUM(ach.Points) AS MyPoints, SUM(ach.TrueRatio) AS MyTrueRatio
+                  FROM Achievements ach
+                  INNER JOIN GameData gd ON gd.ID = ach.GameID
+                  INNER JOIN Console c ON c.ID = gd.ConsoleID $listJoin
+                  WHERE ach.Author=:author AND ach.Flags = " . AchievementFlag::OfficialCore . " $whereClause
+                  GROUP BY ach.GameID $orderBy";
+        foreach (legacyDbFetchAll($query, ['author' => $dev]) as $row) {
+            if (!$initialQuery) {
+                $gameIds[] = $row['ID'];
+            }
+            $games[$row['ID']] = [
+                'ID' => $row['ID'],
+                'Title' => $row['Title'],
+                'GameIcon' => $row['ImageIcon'],
+                'ConsoleID' => $row['ConsoleID'],
+                'ConsoleName' => $row['ConsoleName'],
+                'NumAchievements' => $row['NumAchievements'],
+                'MaxPointsAvailable' => $row['MaxPointsAvailable'],
+                'TotalTruePoints' => $row['TotalTruePoints'],
+                'RetroRatio' => $row['RetroRatio'],
+                'RichPresence' => $row['RichPresence'],
+                'ForumTopicID' => $row['ForumTopicID'],
+                'DateModified' => null,
+                'MyAchievements' => $row['MyAchievements'],
+                'MyPoints' => $row['MyPoints'],
+                'MyTrueRatio' => $row['MyTrueRatio'],
+                'NotMyAchievements' => $row['NumAchievements'] - $row['MyAchievements'],
+                'NumLBs' => null,
+                'MyLBs' => null,
+            ];
+        }
+    } else {
+        $query = "SELECT $foundRows $commonFields
+                  FROM GameData gd
+                  INNER JOIN Console c ON c.ID = gd.ConsoleID $listJoin
+                  WHERE 1=1 $whereClause
+                  GROUP BY gd.ID $orderBy";
+        foreach (legacyDbFetchAll($query, $bindings) as $row) {
+            if (!$initialQuery) {
+                $gameIds[] = $row['ID'];
+            }
+            $games[$row['ID']] = [
+                'ID' => $row['ID'],
+                'Title' => $row['Title'],
+                'GameIcon' => $row['ImageIcon'],
+                'ConsoleID' => $row['ConsoleID'],
+                'ConsoleName' => $row['ConsoleName'],
+                'NumAchievements' => $row['NumAchievements'],
+                'MaxPointsAvailable' => $row['MaxPointsAvailable'],
+                'TotalTruePoints' => $row['TotalTruePoints'],
+                'RetroRatio' => $row['RetroRatio'],
+                'ForumTopicID' => $row['ForumTopicID'],
+                'RichPresence' => $row['RichPresence'],
+                'DateModified' => null,
+                'NumLBs' => null,
+            ];
+        }
+    }
+
+    if (!$initialQuery) {
+        if (empty($gameIds)) {
+            return 0;
+        }
+        $gameList = implode(',', $gameIds);
+
+        $numGamesFound = count($gameIds);
+        if ($count > 0) {
+            if ($numGamesFound == $count) {
+                $query = "SELECT FOUND_ROWS() AS NumGames";
+                $numGamesFound = legacyDbFetch($query)['NumGames'];
             } else {
-                $orderBy .= ", ConsoleName";
+                $numGamesFound += $offset;
             }
         }
-
-        $query .= "ORDER BY $orderBy ";
     }
 
-    if ($count > 0) {
-        $query = substr_replace($query, "SQL_CALC_FOUND_ROWS ", 7, 0);
-        $query .= " LIMIT $offset, $count";
+    // merge leaderboards
+    $query = "SELECT GameID, COUNT(*) AS NumLBs
+              FROM LeaderboardDef
+              WHERE GameID IN ($gameList)
+              GROUP BY GameID";
+    foreach (legacyDBFetchAll($query) as $row) {
+        $games[$row['GameID']]['NumLBs'] = $row['NumLBs'];
     }
 
-    $dataOut = legacyDbFetchAll($query, $bindings)->toArray();
-    foreach ($dataOut as &$row) {
-        settype($row['ID'], 'integer');
-        settype($row['ConsoleID'], 'integer');
-        if ($row['ForumTopicID'] !== null) {
-            settype($row['ForumTopicID'], 'integer');
+    if ($dev !== null) {
+        $query = "SELECT GameID, COUNT(*) AS NumLBs
+                  FROM LeaderboardDef
+                  WHERE GameID IN ($gameList)
+                  AND Author = :author
+                  GROUP BY GameID";
+        foreach (legacyDBFetchAll($query, ['author' => $dev]) as $row) {
+            $games[$row['GameID']]['MyLBs'] = $row['NumLBs'];
         }
     }
 
-    $numGamesFound = count($dataOut);
-    if ($count > 0) {
-        if ($numGamesFound == $count) {
-            $query = "SELECT FOUND_ROWS() AS NumGames";
-            $numGamesFound = legacyDbFetch($query)['NumGames'];
+    // caclulate last updated
+    $query = "SELECT GameID, MAX(DateModified) AS DateModified
+              FROM Achievements
+              WHERE GameID IN ($gameList)
+              GROUP BY GameID";
+    foreach (legacyDbFetchAll($query) as $row) {
+        $games[$row['GameID']]['DateModified'] = $row['DateModified'];
+    }
+
+    // merge ticket counts
+    if ($ticketsFlag) {
+        foreach ($games as &$game) {
+            $game['OpenTickets'] = 0;
+            if ($dev !== null) {
+                $game['MyOpenTickets'] = 0;
+            }
+        }
+        if ($dev === null) {
+            $query = "SELECT ach.GameID, COUNT(*) AS OpenTickets
+                      FROM Ticket tick
+                      INNER JOIN Achievements ach ON ach.ID=tick.AchievementID
+                      WHERE ach.GameID IN ($gameList)
+                      AND tick.ReportState IN (1,3)
+                      GROUP BY ach.GameID";
+            foreach (legacyDbFetchAll($query) as $row) {
+                $games[$row['GameID']]['OpenTickets'] = $row['OpenTickets'];
+            }
         } else {
-            $numGamesFound += $offset;
+            $query = "SELECT ach.GameID, ach.Author, COUNT(*) AS OpenTickets
+                      FROM Ticket tick
+                      INNER JOIN Achievements ach ON ach.ID=tick.AchievementID
+                      WHERE ach.GameID IN ($gameList)
+                      AND tick.ReportState IN (1,3)
+                      GROUP BY ach.GameID, ach.Author";
+            foreach (legacyDbFetchAll($query) as $row) {
+                if ($row['Author'] === $dev) {
+                    $games[$row['GameID']]['MyOpenTickets'] += (int) $row['OpenTickets'];
+                } else {
+                    $games[$row['GameID']]['OpenTickets'] += (int) $row['OpenTickets'];
+                }
+            }
         }
     }
 
-    return (int) $numGamesFound;
+    foreach ($gameIds as $gameId) {
+        $dataOut[] = $games[$gameId];
+    }
+
+    return $numGamesFound;
 }
 
 function getGamesListData(?int $consoleID = null, bool $officialFlag = false): array

--- a/public/gameList.php
+++ b/public/gameList.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Blade;
 $consoleList = System::get(['ID', 'Name'])->keyBy('ID')->map(fn ($system) => $system['Name']);
 $consoleIDInput = requestInputSanitized('c', 0, 'integer');
 $filter = requestInputSanitized('f', 0, 'integer'); // 0 = with achievements, 1 = without achievements, 2 = all
-$sortBy = requestInputSanitized('s', 0, 'integer');
+$sortBy = requestInputSanitized('s', 1, 'integer');
 $dev = requestInputSanitized('d');
 
 if ($dev == null && ($consoleIDInput == 0 || $filter != 0)) {

--- a/tests/Feature/Api/V1/GameListTest.php
+++ b/tests/Feature/Api/V1/GameListTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\V1;
 
+use App\Platform\Actions\UpdateGameMetrics;
 use App\Platform\Models\Achievement;
 use App\Platform\Models\Game;
 use App\Platform\Models\GameHash;
@@ -75,6 +76,13 @@ class GameListTest extends TestCase
         $game4->hashes()->save($hash1);
         $hash2 = new GameHash(['GameID' => $game4->ID, 'MD5' => 'deadbeefdeadbeef']);
         $game4->hashes()->save($hash2);
+
+        // ensure metrics are updated
+        $action = new UpdateGameMetrics();
+        $action->execute($game1);
+        $action->execute($game2);
+        $action->execute($game3);
+        $action->execute($game4);
 
         // all games for system 1
         $this->get($this->apiUrl('GetGameList', ['i' => $system1->ID]))


### PR DESCRIPTION
Provides substantial performance improvements to the All Games page and individual Developer Stats pages.

Provides minor performance improvements to per-console Games lists and Want to Play Games lists when paginated.

Performance for non-paginated lists is basically unchanged.