### PR TITLE
fix exception when ping contains invalid UTF-8

### DIFF
--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -234,6 +234,9 @@ switch ($requestType) {
             $response['Success'] = false;
         } else {
             $activityMessage = request()->post('m');
+            if ($activityMessage) {
+                $activityMessage = utf8_sanitize($activityMessage);
+            }
 
             PlayerSessionHeartbeat::dispatch($user, Game::find($gameID), $activityMessage);
 

--- a/tests/Feature/Connect/PingTest.php
+++ b/tests/Feature/Connect/PingTest.php
@@ -73,6 +73,26 @@ class PingTest extends TestCase
         $user1 = User::firstWhere('User', $this->user->User);
         $this->assertEquals($game->ID, $user1->LastGameID);
         $this->assertEquals('Doing good', $user1->RichPresenceMsg);
+
+        // invalid UTF-8 should be sanitized
+        $this->post('dorequest.php', $this->apiParams('ping', ['g' => $game->ID, 'm' => "T\xC3\xA9st t\xC3st"]))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+            ]);
+
+        // player session resumed
+        $playerSession2 = PlayerSession::where([
+            'user_id' => $this->user->id,
+            'game_id' => $game->id,
+        ])->first();
+        $this->assertEquals($playerSession->id, $playerSession2->id);
+        $this->assertEquals(1, $playerSession2->duration);
+        $this->assertEquals('Tést t?st', $playerSession2->rich_presence);
+
+        $user1 = User::firstWhere('User', $this->user->User);
+        $this->assertEquals($game->ID, $user1->LastGameID);
+        $this->assertEquals('Tést t?st', $user1->RichPresenceMsg);
     }
 
     public function testPingInvalidUser(): void


### PR DESCRIPTION
Fixes
```
Unable to JSON encode payload. Error code: 5 at /home/forge/retroachievements.org/releases/2023-11-05T163253-5.1.2-749d077a/vendor/laravel/framework/src/Illuminate/Queue/Queue.php:108)
[stacktrace]
#0 /home/forge/retroachievements.org/releases/2023-11-05T163253-5.1.2-749d077a/vendor/laravel/horizon/src/RedisQueue.php(46): Illuminate\\Queue\\Queue->createPayload()
...
#8 /home/forge/retroachievements.org/releases/2023-11-05T163253-5.1.2-749d077a/public/dorequest.php(238): App\\Platform\\Events\\PlayerSessionHeartbeat::dispatch()
```