### PR TITLE
fix spurious unit test

### DIFF
--- a/tests/Feature/Platform/BeatenGameTest.php
+++ b/tests/Feature/Platform/BeatenGameTest.php
@@ -199,7 +199,7 @@ class BeatenGameTest extends TestCase
 
     public function testSoftcoreAwardAssignment(): void
     {
-        Carbon::setTestNow();
+        Carbon::setTestNow(Carbon::now());
 
         /** @var User $user */
         $user = User::factory()->create();


### PR DESCRIPTION
Fixes https://github.com/RetroAchievements/RAWeb/actions/runs/6825993731/job/18564962167

Calling `Carbon::setTestNow` without a timestamp actually disables the time mocking functionality, so if the time changes between lines 216 and 220, the test fails.