### PR TITLE
add admin tool to migrate achievements between games

### DIFF
--- a/public/admin.php
+++ b/public/admin.php
@@ -106,7 +106,7 @@ if ($action === 'migrate-achievement') {
     }
 
     // determine which game(s) the achievements are coming from
-    $oldGames = Achievement::whereIn('ID', $achievementIds)->select(['GameID'])->distinct()->pluck('GameID')->toArray();
+    $oldGames = Achievement::whereIn('ID', $achievementIds)->select(['GameID'])->distinct()->pluck('GameID');
 
     // associate the achievements to the new game
     Achievement::whereIn('ID', $achievementIds)->update(['GameID' => $gameId]);
@@ -115,10 +115,10 @@ if ($action === 'migrate-achievement') {
     addArticleComment('Server', ArticleType::GameModification, $gameId,
         "$user migrated " . Str::plural('achievement', count($achievementIds)) . ' ' .
         implode(',', $achievementIds) . ' from ' .
-        Str::plural('game', count($oldGames)) . ' ' . implode(',', $oldGames) . '.');
+        Str::plural('game', count($oldGames)) . ' ' . $oldGames->implode(',') . '.');
 
     // ensure player_game entries exist for the new game for all affected users
-    foreach (PlayerAchievement::whereIn('achievement_id', $achievementIds)->select(['user_id'])->distinct()->pluck('user_id')->toArray() as $userId) {
+    foreach (PlayerAchievement::whereIn('achievement_id', $achievementIds)->select(['user_id'])->distinct()->pluck('user_id') as $userId) {
         if (!PlayerGame::where('game_id', $gameId)->where('user_id', $userId)->exists()) {
             $playerGame = new PlayerGame(['user_id' => $userId, 'game_id' => $gameId]);
             $playerGame->save();

--- a/public/admin.php
+++ b/public/admin.php
@@ -1,7 +1,13 @@
 <?php
 
+use App\Community\Enums\ArticleType;
 use App\Platform\Jobs\UnlockPlayerAchievementJob;
+use App\Platform\Jobs\UpdateGameMetricsJob;
+use App\Platform\Jobs\UpdatePlayerGameMetricsJob;
 use App\Platform\Models\Achievement;
+use App\Platform\Models\Game;
+use App\Platform\Models\PlayerAchievement;
+use App\Platform\Models\PlayerGame;
 use App\Site\Enums\Permissions;
 use App\Site\Models\StaticData;
 use App\Site\Models\User;
@@ -90,6 +96,43 @@ if ($action === 'manual-unlock') {
     }
 
     return back()->withErrors(__('legacy.error.error'));
+}
+
+if ($action === 'migrate-achievement') {
+    $achievementIds = explode(',', requestInputSanitized('a'));
+    $gameId = requestInputSanitized('g');
+    if (!Game::where('ID', $gameId)->exists()) {
+        return back()->withErrors('Unknown game');
+    }
+
+    // determine which game(s) the achievements are coming from
+    $oldGames = Achievement::whereIn('ID', $achievementIds)->select(['GameID'])->distinct()->pluck('GameID')->toArray();
+
+    // associate the achievements to the new game
+    Achievement::whereIn('ID', $achievementIds)->update(['GameID' => $gameId]);
+
+    // add an audit comment to the new game
+    addArticleComment('Server', ArticleType::GameModification, $gameId,
+        "$user migrated " . Str::plural('achievement', count($achievementIds)) . ' ' .
+        implode(',', $achievementIds) . ' from ' .
+        Str::plural('game', count($oldGames)) . ' ' . implode(',', $oldGames) . '.');
+
+    // ensure player_game entries exist for the new game for all affected users
+    foreach (PlayerAchievement::whereIn('achievement_id', $achievementIds)->select(['user_id'])->distinct()->pluck('user_id')->toArray() as $userId) {
+        if (!PlayerGame::where('game_id', $gameId)->where('user_id', $userId)->exists()) {
+            $playerGame = new PlayerGame(['user_id' => $userId, 'game_id' => $gameId]);
+            $playerGame->save();
+            dispatch(new UpdatePlayerGameMetricsJob($userId, $gameId));
+        }
+    }
+
+    // update the metrics on the new game and the old game(s)
+    dispatch(new UpdateGameMetricsJob($gameId))->onQueue('game-metrics');
+    foreach ($oldGames as $oldGameId) {
+        dispatch(new UpdateGameMetricsJob($oldGameId))->onQueue('game-metrics');
+    }
+
+    return back()->with('success', __('legacy.success.ok'));
 }
 
 if ($action === 'aotw') {
@@ -302,6 +345,39 @@ RenderContentStart('Admin Tools');
                     </td>
                     <td>
                         <input id="award_achievement_hardcore" type="checkbox" name="h" value="1">
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <button class="btn">Submit</button>
+        </form>
+    </article>
+
+    <article>
+        <h4>Migrate Achievements</h4>
+        <form method="post" action="admin.php">
+            <?= csrf_field() ?>
+            <input type="hidden" name="action" value="migrate-achievement">
+            <table class="mb-1">
+                <colgroup>
+                    <col>
+                    <col class="w-full">
+                </colgroup>
+                <tbody>
+                <tr>
+                    <td class="whitespace-nowrap">
+                        <label for="achievement_id">Achievement IDs</label>
+                    </td>
+                    <td>
+                        <input id="achievement_id" name="a">
+                    </td>
+                </tr>
+                <tr>
+                    <td class="whitespace-nowrap">
+                        <label for="game_id">New game to transfer achievements to</label>
+                    </td>
+                    <td>
+                        <input id="game_id" name="g">
                     </td>
                 </tr>
                 </tbody>


### PR DESCRIPTION
Eliminates needs for direct database access to move achievements to a subset, and ensures all appropriate aggregate data gets updated.