### PR TITLE
feat: migrate inspector toolbox to blade, hide type additions to subsets

### DIFF
--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -46,6 +46,12 @@ if ($gameIDSpecified) {
 $progressionLabel = __('achievement-type.' . AchievementType::Progression);
 $winConditionLabel = __('achievement-type.' . AchievementType::WinCondition);
 
+$canHaveTypes = (
+    mb_strpos($gameTitle, "[Subset") === false
+    && mb_strpos($gameTitle, "~Test Kit~") === false
+    && $gameData['ConsoleID'] !== 101
+);
+
 RenderContentStart("Manage Achievements");
 ?>
 <script>
@@ -93,16 +99,26 @@ if ($gameIDSpecified) {
                 changes you make on this page will instantly take effect on the website, but you will need to press 'Refresh List'
                 to see the new order on this page.
             </p>
-
-            <p align="justify">
-                You can mark multiple achievements as '$progressionLabel' or '$winConditionLabel'. To do this, check the desired
-                checkboxes in the far-left column and click either the 'Set Selected to $progressionLabel' or 'Set Selected to $winConditionLabel'
-                button, depending on your needs. A game is considered 'beaten' when all $progressionLabel achievements and at least
-                one $winConditionLabel achievement are unlocked. If there are no $winConditionLabel achievements, the game is beaten
-                if all $progressionLabel achievements are unlocked. If there are no $progressionLabel achievements, the game is beaten
-                if any $winConditionLabel achievements are unlocked.
-            </p>
         HTML;
+
+        if ($canHaveTypes) {
+            echo <<<HTML
+                <p align="justify">
+                    You can mark multiple achievements as '$progressionLabel' or '$winConditionLabel'. To do this, check the desired
+                    checkboxes in the far-left column and click either the 'Set Selected to $progressionLabel' or 'Set Selected to $winConditionLabel'
+                    button, depending on your needs. A game is considered 'beaten' when all $progressionLabel achievements and at least
+                    one $winConditionLabel achievement are unlocked. If there are no $winConditionLabel achievements, the game is beaten
+                    if all $progressionLabel achievements are unlocked. If there are no $progressionLabel achievements, the game is beaten
+                    if any $winConditionLabel achievements are unlocked.
+                </p>
+            HTML;
+        } else {
+            echo <<<HTML
+                <p align="justify">
+                    This achievement set is either a subset, test kit, or an event. For this reason, it does not support types.
+                </p>
+            HTML;
+        }
 
         if ($fullModifyOK) {
             echo "<p>You can " . ($flag === AchievementFlag::Unofficial ? "promote" : "demote") . " multiple achievements at the same time from this page by checking " .
@@ -175,12 +191,14 @@ if ($gameIDSpecified) {
 
         $typeLabelClassNames = !$achType ? "text-muted" : "";
 
-        echo <<<HTML
-            <tr class="$bgColorClassNames[$currentBgColorIndex]">
-                <td><span class="font-bold">Type:</span></td>
-                <td colspan="7" class="p-2.5 $typeLabelClassNames">$achTypeLabel</td>
-            </tr>
-        HTML;
+        if ($canHaveTypes) {
+            echo <<<HTML
+                <tr class="$bgColorClassNames[$currentBgColorIndex]">
+                    <td><span class="font-bold">Type:</span></td>
+                    <td colspan="7" class="p-2.5 $typeLabelClassNames">$achTypeLabel</td>
+                </tr>
+            HTML;
+        }
 
         echo "<tr class='code-row hidden $bgColorClassNames[$currentBgColorIndex]'>";
         echo "<td><b>Code:</b></td>";
@@ -235,11 +253,6 @@ if ($gameIDSpecified) {
     } elseif ($fullModifyOK) {
         $modificationLevel = 'full';
     }
-
-    $canHaveTypes = (
-        mb_strpos($gameTitle, "[Subset") === false
-        && mb_strpos($gameTitle, "~Test Kit~") === false
-    );
 
     echo "<div>";
     echo Blade::render('

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -31,6 +31,7 @@ $consoleName = null;
 $gameIcon = null;
 $gameTitle = null;
 $gameIDSpecified = isset($gameID) && $gameID != 0;
+$canHaveTypes = false;
 if ($gameIDSpecified) {
     getGameMetadata($gameID, null, $achievementData, $gameData, 0, null, $flag);
     $gameTitle = $gameData['Title'];
@@ -39,18 +40,18 @@ if ($gameIDSpecified) {
     sanitize_outputs($gameTitle, $consoleName);
 
     getCodeNotes($gameID, $codeNotes);
+
+    $canHaveTypes = (
+        mb_strpos($gameTitle, "[Subset") === false
+        && mb_strpos($gameTitle, "~Test Kit~") === false
+        && $gameData['ConsoleID'] !== 101
+    );
 } else {
     getGamesList(null, $gamesList);
 }
 
 $progressionLabel = __('achievement-type.' . AchievementType::Progression);
 $winConditionLabel = __('achievement-type.' . AchievementType::WinCondition);
-
-$canHaveTypes = (
-    mb_strpos($gameTitle, "[Subset") === false
-    && mb_strpos($gameTitle, "~Test Kit~") === false
-    && $gameData['ConsoleID'] !== 101
-);
 
 RenderContentStart("Manage Achievements");
 ?>

--- a/resources/views/platform/components/developer/inspector-toolbox.blade.php
+++ b/resources/views/platform/components/developer/inspector-toolbox.blade.php
@@ -82,7 +82,7 @@ $unofficialFlag = AchievementFlag::Unofficial;
                     }
                 }
 
-                if (!achievements.length || !confirm(getConfirmMessage(property, newValue, achievements.length))) {
+                if (!achievements.length || !confirm(this.getConfirmMessage(property, newValue, achievements.length))) {
                     return;
                 }
 
@@ -149,14 +149,14 @@ $unofficialFlag = AchievementFlag::Unofficial;
             >
                 Set Selected to Win Condition
             </button>
-        @endif
 
-        <button
-            class="btn"
-            @click="updateAchievementsProperty('type', null)"
-        >
-            Set Selected to No Type
-        </button>
+            <button
+                class="btn"
+                @click="updateAchievementsProperty('type', null)"
+            >
+                Set Selected to No Type
+            </button>
+        @endif
 
         @if ($modificationLevel === 'full')
             <button class="btn" @click="toggleAllCodeRows">Toggle Code Rows</button>

--- a/resources/views/platform/components/developer/inspector-toolbox.blade.php
+++ b/resources/views/platform/components/developer/inspector-toolbox.blade.php
@@ -1,0 +1,167 @@
+@props([
+    'canHaveTypes' => true,
+    'gameId' => 0,
+    'modificationLevel' => 'none', // 'none' | 'partial' | 'full'
+    'isManagingCoreAchievements' => true,
+])
+
+<?php
+use App\Platform\Enums\AchievementFlag;
+use App\Platform\Enums\AchievementType;
+
+$progressionType = AchievementType::Progression;
+$winConditionType = AchievementType::WinCondition;
+$officialFlag = AchievementFlag::OfficialCore;
+$unofficialFlag = AchievementFlag::Unofficial;
+?>
+
+@if ($modificationLevel !== 'none')
+    <script>
+    function toolboxComponent() {
+        return {
+            areCodeRowsHidden: true,
+
+            /**
+             * @param {'flag' | 'type'} property
+             * @param {3 | 5 | 'progression' | 'win_condition' | null} newValue
+             * @param {number} selectedCount
+             */
+            getConfirmMessage(property, newValue, selectedCount) {
+                let message = 'Are you sure you want to make this change?';
+
+                if (property === 'flag') {
+                    if (newValue === {{ $officialFlag }}) {
+                        message = `Are you sure you want to promote ${selectedCount === 1 ? 'this achievement' : 'these achievements'}?`;
+                    } else {
+                        message = `Are you sure you want to demote ${selectedCount === 1 ? 'this achievement' : 'these achievements'}?`;
+                    }
+                }
+
+                if (property === 'type') {
+                    if (newValue === '{{ $progressionType }}') {
+                        message = `Are you sure you want to set ${selectedCount === 1 ? 'this achievement' : 'these achievements'} to Progression?`;
+                    } else if (newValue === '{{ $winConditionType }}') {
+                        message = `Are you sure you want to set ${selectedCount === 1 ? 'this achievement' : 'these achievements'} to Win Condition?`;
+                    } else {
+                        message = `Are you sure you want to remove the type from ${selectedCount === 1 ? 'this achievement' : 'these achievements'}?`;
+                    }
+                }
+
+                return message;
+            },
+
+            toggleAllCodeRows() {
+                const codeRowEls = document.querySelectorAll('.code-row');
+
+                for (const codeRowEl of codeRowEls) {
+                    if (this.areCodeRowsHidden) {
+                        codeRowEl.classList.remove('hidden');
+                    } else {
+                        codeRowEl.classList.add('hidden');
+                    }
+                }
+
+                this.areCodeRowsHidden = !this.areCodeRowsHidden;
+            },
+
+            refreshPage() {
+                window.location.reload();
+            },
+
+            /**
+             * @param {'flag' | 'type'} property
+             * @param {3 | 5 | 'progression' | 'win_condition' | null} newValue
+             */
+            updateAchievementsProperty(property, newValue) {
+                // Creates an array of checked achievement IDs and sends it to the updateAchievements function
+                const checkboxes = document.querySelectorAll('[name^=\'achievement\']');
+                const achievements = [];
+                for (let i = 0, n = checkboxes.length; i < n; i += 1) {
+                    if (checkboxes[i].checked) {
+                        achievements.push(checkboxes[i].getAttribute('value'));
+                    }
+                }
+
+                if (!achievements.length || !confirm(getConfirmMessage(property, newValue, achievements.length))) {
+                    return;
+                }
+
+                window.showStatusMessage('Updating...');
+
+                const requestUrl = property === 'flag'
+                    ? '/request/achievement/update-flag.php'
+                    : '/request/achievement/update-type.php';
+
+                $.post(requestUrl, {
+                    achievements,
+                    [property]: newValue
+                }).done(function () {
+                    location.reload();
+                });
+            },
+        }
+    }
+    </script>
+
+    <h3>Toolbox</h3>
+
+    <div
+        class="flex flex-col gap-y-1 [&>button]:flex [&>a]:flex [&>button]:justify-center [&>a]:justify-center [&>button]:py-2 [&>a]:py-2 [&>a]:w-full"
+        x-data="toolboxComponent()"
+    >
+        <button class="btn" @click="refreshPage">Refresh Page</button>
+
+        @if ($modificationLevel === 'full')
+            <button
+                class="btn"
+                @click="updateAchievementsProperty('flag', {{ $isManagingCoreAchievements ? $unofficialFlag : $officialFlag }})"
+            >
+                @if ($isManagingCoreAchievements)
+                    Demote Selected
+                @else
+                    Promote Selected
+                @endif
+            </button>
+        @endif
+
+        <a
+            class="btn"
+            href="/achievementinspector.php?g={{ $gameId }}{{ $isManagingCoreAchievements ? '&f=' . $unofficialFlag : '' }}"
+        >
+            @if ($isManagingCoreAchievements)
+                Unofficial Achievement Inspector
+            @else
+                Core Achievement Inspector
+            @endif
+        </a>
+
+        @if ($canHaveTypes)
+            <button
+                class="btn"
+                @click="updateAchievementsProperty('type', '{{ $progressionType }}')"
+            >
+                Set Selected to Progression
+            </button>
+
+            <button
+                class="btn"
+                @click="updateAchievementsProperty('type', '{{ $winConditionType }}')"
+            >
+                Set Selected to Win Condition
+            </button>
+        @endif
+
+        <button
+            class="btn"
+            @click="updateAchievementsProperty('type', null)"
+        >
+            Set Selected to No Type
+        </button>
+
+        @if ($modificationLevel === 'full')
+            <button class="btn" @click="toggleAllCodeRows">Toggle Code Rows</button>
+        @endif
+
+        <a class="btn" href="/achievementinspector.php">Back to List</a>
+    </div>
+@endif


### PR DESCRIPTION
This PR migrates the achievement inspector toolbox component (`/achievementinspector.php?g=1`) to Blade. It also hides the "Set Selected to Progression" and "Set Selected to Win Condition" buttons if the game is either a subset or a test kit.

In a subsequent PR, I will also adjust the logic for these cases in _achievementinfo.php_ and our API calls.