### PR TITLE
fix(achievementInfo): prevent adding types to subsets and test kits

### DIFF
--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -121,8 +121,21 @@ RenderOpenGraphMetadata(
 RenderContentStart($pageTitle);
 ?>
 <?php if ($permissions >= Permissions::Developer || ($permissions >= Permissions::JuniorDeveloper && $isAuthor)): ?>
+    <?php
+        $canHaveTypes = mb_strpos($gameTitle, "[Subset") === false && mb_strpos($gameTitle, "~Test Kit~") === false;
+    ?>
+
     <script>
     function updateAchievementDetails() {
+        const canHaveTypes = <?= $canHaveTypes ? 'true' : 'false' ?>;
+
+        const typeInputValue = $('#typeinput').val();
+
+        if (!canHaveTypes && typeInputValue) {
+            showStatusFailure('Error: Types are not supported on subsets or test kits.');
+            return;
+        }
+
         showStatusMessage('Updating...');
 
         var $title = $('#titleinput');

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -122,20 +122,15 @@ RenderContentStart($pageTitle);
 ?>
 <?php if ($permissions >= Permissions::Developer || ($permissions >= Permissions::JuniorDeveloper && $isAuthor)): ?>
     <?php
-        $canHaveTypes = mb_strpos($gameTitle, "[Subset") === false && mb_strpos($gameTitle, "~Test Kit~") === false;
+        $canHaveTypes = (
+            mb_strpos($gameTitle, "[Subset") === false
+            && mb_strpos($gameTitle, "~Test Kit~") === false
+            && $consoleID != 101
+        );
     ?>
 
     <script>
     function updateAchievementDetails() {
-        const canHaveTypes = <?= $canHaveTypes ? 'true' : 'false' ?>;
-
-        const typeInputValue = $('#typeinput').val();
-
-        if (!canHaveTypes && typeInputValue) {
-            showStatusFailure('Error: Types are not supported on subsets or test kits.');
-            return;
-        }
-
         showStatusMessage('Updating...');
 
         var $title = $('#titleinput');
@@ -347,24 +342,26 @@ RenderContentStart($pageTitle);
             echo "</select>";
             echo "</td></tr>";
 
-            $typeHelperContent = "A game is considered beaten if ALL " . __('achievement-type.' . AchievementType::Progression) . " achievements are unlocked and ANY " . __('achievement-type.' . AchievementType::WinCondition) . " achievements are unlocked.";
-            echo "<tr><td>";
-            echo "<label class='cursor-help flex items-center gap-x-1' for='typeinput' title='$typeHelperContent' aria-label='Type, $typeHelperContent'>";
-            echo "Type";
-            echo "<span>";
-            echo Blade::render("<x-fas-info-circle class='w-5 h-5' aria-hidden='true' />");
-            echo ":";
-            echo "</span>";
-            echo "</label>";
-            echo "</td><td>";
-            echo "<select id='typeinput' name='k'>";
-            echo "<option value=''>None</option>";
-            foreach (AchievementType::cases() as $typeOption) {
-                echo "<option value='$typeOption' " . ($achType === $typeOption ? 'selected' : '') . ">";
-                echo __('achievement-type.' . $typeOption);
-                echo "</option>";
+            if ($canHaveTypes) {
+                $typeHelperContent = "A game is considered beaten if ALL " . __('achievement-type.' . AchievementType::Progression) . " achievements are unlocked and ANY " . __('achievement-type.' . AchievementType::WinCondition) . " achievements are unlocked.";
+                echo "<tr><td>";
+                echo "<label class='cursor-help flex items-center gap-x-1' for='typeinput' title='$typeHelperContent' aria-label='Type, $typeHelperContent'>";
+                echo "Type";
+                echo "<span>";
+                echo Blade::render("<x-fas-info-circle class='w-5 h-5' aria-hidden='true' />");
+                echo ":";
+                echo "</span>";
+                echo "</label>";
+                echo "</td><td>";
+                echo "<select id='typeinput' name='k'>";
+                echo "<option value=''>None</option>";
+                foreach (AchievementType::cases() as $typeOption) {
+                    echo "<option value='$typeOption' " . ($achType === $typeOption ? 'selected' : '') . ">";
+                    echo __('achievement-type.' . $typeOption);
+                    echo "</option>";
+                }
+                echo "</select></td></tr>";
             }
-            echo "</select></td></tr>";
 
             echo "</tbody></table>";
             echo "&nbsp;<button type='button' class='btn' style='float: right;' onclick=\"updateAchievementDetails()\">Update</button><br><br>";


### PR DESCRIPTION
Related to #2014.

This PR prevents the user from adding types to an achievement if it is a subset or a test kit.

To test:
* You should be able to add types to `/achievement/9`.
* You should get an error if you try to add a type to `/achievement/241312`.
* You should always be able to remove a type, regardless of the game title.