### PR TITLE
fix: block adding types to subsets via web api calls

### DIFF
--- a/app/Helpers/database/achievement.php
+++ b/app/Helpers/database/achievement.php
@@ -197,10 +197,24 @@ function UploadNewAchievement(
         return false;
     }
 
-    if ($type !== null && (!AchievementType::isValid($type) && $type !== 'not-given')) {
-        $errorOut = "Invalid achievement type";
+    if ($type !== null && $type !== 'not-given') {
+        if (!AchievementType::isValid($type)) {
+            $errorOut = "Invalid achievement type";
 
-        return false;
+            return false;
+        }
+
+        $isForSubsetOrTestKit = (
+            mb_strpos($gameData['Title'], '[Subset') !== false
+            || mb_strpos($gameData['Title'], '~Test Kit~') !== false
+        );
+        $isEventGame = $gameData['ConsoleID'] == 101;
+
+        if ($isForSubsetOrTestKit || $isEventGame) {
+            $errorOut = "Cannot set type on achievement in subset, test kit, or event.";
+
+            return false;
+        }
     }
 
     $typeValue = "";

--- a/app/Platform/Models/Game.php
+++ b/app/Platform/Models/Game.php
@@ -165,6 +165,18 @@ class Game extends BaseModel implements HasComments, HasMedia
 
     // == accessors
 
+    public function getCanHaveTypes(): bool
+    {
+        $isSubsetOrTestKit = (
+            mb_strpos($this->Title, "[Subset") !== false
+            || mb_strpos($this->Title, "~Test Kit~") !== false
+        );
+
+        $isEventGame = $this->ConsoleID === 101;
+
+        return !$isSubsetOrTestKit && !$isEventGame;
+    }
+
     public function getCanonicalUrlAttribute(): string
     {
         return route('game.show', [$this, $this->getSlugAttribute()]);

--- a/public/request/achievement/update-base.php
+++ b/public/request/achievement/update-base.php
@@ -1,8 +1,8 @@
 <?php
 
-use App\Platform\Models\Game;
 use App\Platform\Enums\AchievementType;
 use App\Platform\Models\Achievement;
+use App\Platform\Models\Game;
 use App\Site\Enums\Permissions;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;

--- a/public/request/achievement/update-base.php
+++ b/public/request/achievement/update-base.php
@@ -2,7 +2,6 @@
 
 use App\Platform\Enums\AchievementType;
 use App\Platform\Models\Achievement;
-use App\Platform\Models\Game;
 use App\Site\Enums\Permissions;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
@@ -25,15 +24,6 @@ $achievement = Achievement::find($input['achievement']);
 // Only allow jr. devs to update base data if they are the author
 if ($permissions == Permissions::JuniorDeveloper && $user != $achievement['Author']) {
     abort(403);
-}
-
-// Don't allow adding types to subsets or test kits.
-$game = Game::find((int) $achievement['GameID']);
-if ($game) {
-    $canHaveTypes = mb_strpos($game->Title, "[Subset") === false && mb_strpos($game->Title, "~Test Kit~") === false;
-    if (!$canHaveTypes && $input['type']) {
-        abort(400);
-    }
 }
 
 $achievementId = $achievement['ID'];

--- a/public/request/achievement/update-base.php
+++ b/public/request/achievement/update-base.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Platform\Models\Game;
 use App\Platform\Enums\AchievementType;
 use App\Platform\Models\Achievement;
 use App\Site\Enums\Permissions;
@@ -24,6 +25,15 @@ $achievement = Achievement::find($input['achievement']);
 // Only allow jr. devs to update base data if they are the author
 if ($permissions == Permissions::JuniorDeveloper && $user != $achievement['Author']) {
     abort(403);
+}
+
+// Don't allow adding types to subsets or test kits.
+$game = Game::find((int) $achievement['GameID']);
+if ($game) {
+    $canHaveTypes = mb_strpos($game->Title, "[Subset") === false && mb_strpos($game->Title, "~Test Kit~") === false;
+    if (!$canHaveTypes && $input['type']) {
+        abort(400);
+    }
 }
 
 $achievementId = $achievement['ID'];

--- a/public/request/achievement/update-type.php
+++ b/public/request/achievement/update-type.php
@@ -1,9 +1,9 @@
 <?php
 
-use App\Platform\Models\Game;
 use App\Community\Enums\ArticleType;
 use App\Platform\Enums\AchievementType;
 use App\Platform\Models\Achievement;
+use App\Platform\Models\Game;
 use App\Site\Enums\Permissions;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;

--- a/public/request/achievement/update-type.php
+++ b/public/request/achievement/update-type.php
@@ -25,11 +25,8 @@ $foundAchievements = Achievement::find($achievementIds);
 
 // Don't allow adding types to subsets or test kits.
 $game = Game::find($foundAchievements->get(0)->GameID);
-if ($game) {
-    $canHaveTypes = mb_strpos($game->Title, "[Subset") === false && mb_strpos($game->Title, "~Test Kit~") === false;
-    if (!$canHaveTypes && $value) {
-        abort(400);
-    }
+if ($game && !$game->getCanHaveTypes()) {
+    abort(400);
 }
 
 // Check for authorship on achievements if a Jr. is editing the type


### PR DESCRIPTION
This PR updates _update-base.php_ and _update-type.php_ such that if the target game is a subset or test kit, the user cannot set any achievements to Progression or Win Condition. Type removal is still allowed.

**How to test this PR**
Since this PR does not contain the front-end changes of #2014 or #2015, simply open a subset and try to give one of its core achievements a type.