### PR TITLE
fix(forum): remediate shortcode rendering for games and achievements [V5.2]

### DIFF
--- a/app/Helpers/render/achievement.php
+++ b/app/Helpers/render/achievement.php
@@ -86,7 +86,7 @@ function renderAchievementCard(int|string|array $achievement, ?string $context =
     $badgeName = $data['BadgeName'] ?? null;
     $unlock = $data['Unlock'] ?? null;
     $badgeImgSrc = $iconUrl ?? media_asset("Badge/{$badgeName}.png");
-    $gameTitle = Blade::render('<x-game-title :rawTitle="$rawTitle" />', ['rawTitle' => $data['GameTitle'] ?? '']);
+    $gameTitle = str_replace("\n", '', Blade::render('<x-game-title :rawTitle="$rawTitle" />', ['rawTitle' => $data['GameTitle'] ?? '']));
 
     $tooltip = "<div class='tooltip-body flex items-start gap-2 p-2' style='max-width: 400px'>";
     $tooltip .= "<img src='$badgeImgSrc' width='64' height='64' />";

--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -238,7 +238,7 @@ final class Shortcode
             return '';
         }
 
-        return gameAvatar($data, iconSize: 24);
+        return str_replace("\n", '', gameAvatar($data, iconSize: 24));
     }
 
     private function embedTicket(int $id): string


### PR DESCRIPTION
**Before**
![Screenshot 2023-11-16 at 4 33 49 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/9c7d7110-d693-4733-a233-342b087b276d)

**After**
![Screenshot 2023-11-16 at 4 33 40 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/44b0e3a6-0f1d-4083-b37f-98f42d674b9f)

There is still a minor issue with the "Homebrew" tag floating to the right in the [code] block.