### PR TITLE
fix: remediate encoding issue with game titles [V5.2]

### DIFF
--- a/resources/views/platform/components/game/title.blade.php
+++ b/resources/views/platform/components/game/title.blade.php
@@ -18,7 +18,7 @@
         <span class="tag">
             <span class="tag-label">Subset</span>
             <span class="tag-arrow"></span>
-            <span>{{ $subsetKind }}</span>
+            <span>{!! $subsetKind !!}</span>
         </span>
     @endif
 @endif


### PR DESCRIPTION
**Before**
![Screenshot 2023-11-16 at 4 37 29 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/afee403f-fb8a-44f9-9cd9-e0422dee9d0b)

**After**
![Screenshot 2023-11-16 at 4 36 54 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/65720968-cf8b-4573-8237-ca1ab5c32dbb)
