### PR TITLE
fix: add achievement descriptions to unlocks table in dev feed [V5.2]

### DIFF
--- a/resources/views/platform/components/developer-feed/recently-obtained-achievements.blade.php
+++ b/resources/views/platform/components/developer-feed/recently-obtained-achievements.blade.php
@@ -29,6 +29,7 @@
                                     achievementAvatar([
                                         'ID' => $recentUnlock->achievement_id,
                                         'Title' => $recentUnlock->Title,
+                                        'Description' => $recentUnlock->Description,
                                         'Points' => $recentUnlock->Points,
                                         'BadgeName' => $recentUnlock->BadgeName,
                                         'HardcoreMode' => !!$recentUnlock->unlocked_hardcore_at,


### PR DESCRIPTION
The descriptions are currently missing on the achievement cards in this table.

**Before**
![Screenshot 2023-11-16 at 4 40 25 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/93e6b037-58f7-46db-90f0-5ad0902b8832)


**After**
![Screenshot 2023-11-16 at 4 39 47 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/38156303-78e1-4cf9-8735-05d7a9cc0be3)
