### PR TITLE
fix(feed): ignore default active players filter [V5.2]

### DIFF
--- a/app/Community/Components/ActivePlayers.php
+++ b/app/Community/Components/ActivePlayers.php
@@ -21,7 +21,7 @@ class ActivePlayers extends Component
         ?array $targetGameIds = null,
         ?string $variant = 'home',
     ) {
-        $this->initialSearch = $request->cookie('active_players_search');
+        $this->initialSearch = $variant !== 'focused' ? $request->cookie('active_players_search') : null;
 
         $this->targetGameIds = $targetGameIds;
         $this->variant = $variant;


### PR DESCRIPTION
Right now, the active players shown on the dev feed pages still uses the user's cookie-driven saved search for the home page active players. This will result in the wrong results being shown.

After this change, the filter is ignored for this variant of the active players component.