### PR TITLE
fix(feed): dont show all players on player list refresh [V5.2]

### DIFF
--- a/public/request/user/list-currently-active.php
+++ b/public/request/user/list-currently-active.php
@@ -6,6 +6,10 @@ $searchValue = request('search');
 $fetchAll = request('all', false);
 $targetGameIds = request('targetGameIds');
 
+if ($targetGameIds) {
+    $targetGameIds = explode(',', $targetGameIds);
+}
+
 $activePlayersService = new ActivePlayersService();
 $loadedActivePlayers = $activePlayersService->loadActivePlayers($searchValue, $fetchAll, $targetGameIds);
 

--- a/resources/views/community/components/active-players/active-players.blade.php
+++ b/resources/views/community/components/active-players/active-players.blade.php
@@ -110,6 +110,10 @@ function activePlayersComponent() {
                 params.set('all', true);
             }
 
+            if (this.targetGameIds) {
+                params.set('targetGameIds', Object.values(this.targetGameIds));
+            }
+
             if (params.size > 0) {
                 requestUrl = `${requestUrl}?${params}`;
             }

--- a/resources/views/community/components/active-players/active-players.blade.php
+++ b/resources/views/community/components/active-players/active-players.blade.php
@@ -106,7 +106,7 @@ function activePlayersComponent() {
                 params.set('search', this.searchInput);
             }
 
-            if (getFullList || this.hasFetchedFullList) {
+            if (this.variant !== 'focused' && (getFullList || this.hasFetchedFullList)) {
                 params.set('all', true);
             }
 


### PR DESCRIPTION
On its 5 minute refresh interval, the feed is loading all players rather than the filtered list for the developer's games. This PR ensures the list remains focused on only those game IDs.