### PR TITLE
fix error viewing want-to-play list sorted by date

### DIFF
--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -342,6 +342,7 @@ function getGamesListByDev(
         $orderBy = '';
         $foundRows = '';
         $listJoin = '';
+        $bindings = [];
     }
 
     $commonFields = 'gd.ID, gd.Title, gd.ImageIcon, gd.TotalTruePoints,


### PR DESCRIPTION
fixes
```
SQLSTATE[HY093]: Invalid parameter number (SQL: SELECT  gd.ID, gd.Title, gd.ImageIcon, gd.TotalTruePoints,
...
#7 /home/forge/retroachievements.org/releases/2023-11-17T040722-5.2.1-054ded59/public/gameList.php(31): getGamesListByDev()
```

bindings left over from preliminary query were confounding primary query