### PR TITLE
fix(forum): dont normalize user links with path params

### DIFF
--- a/app/Helpers/shortcode.php
+++ b/app/Helpers/shortcode.php
@@ -76,11 +76,11 @@ function normalize_user_shortcodes(string $value): string
      * ignores urls that contain path or query params
      */
     $find = [
-        "~\<a [^/>]*retroachievements\.org/user/([\w]{1,20})(?![\w/?])[^/>]*\][^</a>]*</a>~si",
-        "~\[url[^\]]*retroachievements\.org/user/([\w]{1,20})(?![\w/?])[^\]]*\][^\[]*\[/url\]~si",
-        "~\[url[^\]]*?user/([\w]{1,20})(?![\w/?]).*?\[/url\]~si",
-        "~https?://(?:[\w\-]+\.)?retroachievements\.org/user/([\w]{1,20})(?![\w/?])~si",
-        "~https?://localhost(?::\d{1,5})?/user/([\w]{1,20})(?![\w/?])~si",
+        "~\<a [^/>]*retroachievements\.org/user/([\w]{1,20})(/?(?![\w/?]))[^/>]*\][^</a>]*</a>~si",
+        "~\[url[^\]]*retroachievements\.org/user/([\w]{1,20})(/?(?![\w/?]))[^\]]*\][^\[]*\[/url\]~si",
+        "~\[url[^\]]*?user/([\w]{1,20})(/?(?![\w/?])).*?\[/url\]~si",
+        "~https?://(?:[\w\-]+\.)?retroachievements\.org/user/([\w]{1,20})(/?(?![\w/?]))~si",
+        "~https?://localhost(?::\d{1,5})?/user/([\w]{1,20})(/?(?![\w/?]))~si",
     ];
     $replace = '[user=$1]';
     $value = preg_replace($find, $replace, $value);

--- a/app/Helpers/shortcode.php
+++ b/app/Helpers/shortcode.php
@@ -75,11 +75,11 @@ function normalize_user_shortcodes(string $value): string
      * find any url variants of user links and transform them into tags
      */
     $find = [
-        "~\<a [^/>]*retroachievements\.org/user/([\w]{1,20})[^/>]*\][^</a>]*</a>~si",
-        "~\[url[^\]]*retroachievements\.org/user/([\w]{1,20})[^\]]*\][^\[]*\[/url\]~si",
-        "~\[url[^\]]*?user/([\w]*).*?\[/url\]~si",
-        "~https?://(?:[\w\-]+\.)?retroachievements\.org/user/([\w]{1,20})~si",
-        "~https?://localhost(?::\d{1,5})?/user/([\w]{1,20})~si",
+        "~\<a [^/>]*retroachievements\.org/user/([\w]{1,20})(?![\w/])[^/>]*\][^</a>]*</a>~si",
+        "~\[url[^\]]*retroachievements\.org/user/([\w]{1,20})(?![\w/])[^\]]*\][^\[]*\[/url\]~si",
+        "~\[url[^\]]*?user/([\w]{1,20})(?![\w/]).*?\[/url\]~si",
+        "~https?://(?:[\w\-]+\.)?retroachievements\.org/user/([\w]{1,20})(?![\w/])~si",
+        "~https?://localhost(?::\d{1,5})?/user/([\w]{1,20})(?![\w/])~si",
     ];
     $replace = '[user=$1]';
     $value = preg_replace($find, $replace, $value);

--- a/app/Helpers/shortcode.php
+++ b/app/Helpers/shortcode.php
@@ -73,13 +73,14 @@ function normalize_user_shortcodes(string $value): string
 {
     /**
      * find any url variants of user links and transform them into tags
+     * ignores urls that contain path or query params
      */
     $find = [
-        "~\<a [^/>]*retroachievements\.org/user/([\w]{1,20})(?![\w/])[^/>]*\][^</a>]*</a>~si",
-        "~\[url[^\]]*retroachievements\.org/user/([\w]{1,20})(?![\w/])[^\]]*\][^\[]*\[/url\]~si",
-        "~\[url[^\]]*?user/([\w]{1,20})(?![\w/]).*?\[/url\]~si",
-        "~https?://(?:[\w\-]+\.)?retroachievements\.org/user/([\w]{1,20})(?![\w/])~si",
-        "~https?://localhost(?::\d{1,5})?/user/([\w]{1,20})(?![\w/])~si",
+        "~\<a [^/>]*retroachievements\.org/user/([\w]{1,20})(?![\w/?])[^/>]*\][^</a>]*</a>~si",
+        "~\[url[^\]]*retroachievements\.org/user/([\w]{1,20})(?![\w/?])[^\]]*\][^\[]*\[/url\]~si",
+        "~\[url[^\]]*?user/([\w]{1,20})(?![\w/?]).*?\[/url\]~si",
+        "~https?://(?:[\w\-]+\.)?retroachievements\.org/user/([\w]{1,20})(?![\w/?])~si",
+        "~https?://localhost(?::\d{1,5})?/user/([\w]{1,20})(?![\w/?])~si",
     ];
     $replace = '[user=$1]';
     $value = preg_replace($find, $replace, $value);


### PR DESCRIPTION
Resolves an issue where posting a link in the forum like:

`https://retroachievements.org/user/Jamiras/progress`

causes username normalization to kick in and submit as `[user=Jamiras]/progress`.

Now, URLs with path params are not normalized.