### PR TITLE
feat(user): remove auth gating from completion progress

### DIFF
--- a/app/Platform/Controllers/PlayerCompletionProgressController.php
+++ b/app/Platform/Controllers/PlayerCompletionProgressController.php
@@ -40,10 +40,6 @@ class PlayerCompletionProgressController extends Controller
         $sortOrder = $validatedData['sort'] ?? 'unlock_date';
 
         $me = Auth::user() ?? null;
-        // TODO: Remove when denormalized data is ready.
-        if (!$me) {
-            abort(401);
-        }
 
         $foundTargetUser = User::firstWhere('User', $targetUsername);
         if (!$this->getCanViewTargetUser($foundTargetUser, $me)) {
@@ -253,7 +249,7 @@ class PlayerCompletionProgressController extends Controller
         }
 
         if ($user->toArray()['Permissions'] < Permissions::Unregistered) {
-            if ($me && $me->toArray()['Permissions'] >= Permissions::Moderator) {
+            if (isset($me) && $me->toArray()['Permissions'] >= Permissions::Moderator) {
                 return true;
             }
 

--- a/app/Platform/RouteServiceProvider.php
+++ b/app/Platform/RouteServiceProvider.php
@@ -74,6 +74,7 @@ class RouteServiceProvider extends ServiceProvider
             // Route::resource('leaderboard', LeaderboardController::class)->only('show');
 
             // Route::get('user/{user}/history', [PlayerHistoryController::class, 'show'])->name('user.history');
+            Route::get('user/{user}/progress', PlayerCompletionProgressController::class)->name('user.completion-progress');
             Route::get('user/{user}/developer/feed', DeveloperFeedController::class)->name('developer.feed');
             Route::get('user/{user}/developer/sets', DeveloperSetsController::class)->name('developer.sets');
 
@@ -144,7 +145,6 @@ class RouteServiceProvider extends ServiceProvider
             //     Route::resource('system', SystemController::class)->only('edit', 'update', 'destroy');
             //     Route::resource('game', GameController::class)->only('edit', 'update', 'destroy');
             //
-                Route::get('user/{user}/progress', PlayerCompletionProgressController::class)->name('user.completion-progress');
 
             //     Route::get('user/{user}/game/{game}/compare', [PlayerGameController::class, 'compare'])
             //         ->name('user.game.compare');

--- a/resources/views/platform/completion-progress-page.blade.php
+++ b/resources/views/platform/completion-progress-page.blade.php
@@ -2,7 +2,7 @@
 use App\Site\Models\User;
 
 $targetUsername = $user->User;
-$isMe = $me->User === $targetUsername;
+$isMe = $me?->User === $targetUsername;
 
 $headingLabel = '';
 if ($isMe) {
@@ -13,12 +13,10 @@ if ($isMe) {
     $headingLabel = $targetUsername . "'s Completion Progress";
 }
 
-// TODO: Once using denormalized data, come up with a good page description.
-// Doesn't matter right now because these pages don't generate any SEO juice.
-// $pageDescription = "";
+$pageDescription = "View {$targetUsername}'s game completion stats and milestones on RetroAchievements. Track their played, unfinished, and mastered games from various systems.";
 ?>
 
-<x-app-layout :pageTitle="$headingLabel">
+<x-app-layout :pageTitle="$headingLabel" :pageDescription="$pageDescription">
     <div>
         <x-user.breadcrumbs :targetUsername="$targetUsername" currentPage="Completion Progress" />
 

--- a/tests/Feature/Platform/PlayerCompletionProgressTest.php
+++ b/tests/Feature/Platform/PlayerCompletionProgressTest.php
@@ -32,13 +32,6 @@ class PlayerCompletionProgressTest extends TestCase
         $this->actingAs($user)->get('/user/MockUser/progress')->assertStatus(200);
     }
 
-    public function testItReturns401IfUnauthenticated(): void
-    {
-        User::factory()->create(['User' => 'mockUser']);
-
-        $this->get('/user/MockUser/progress')->assertStatus(401);
-    }
-
     public function testItReturns404IfTargetUserIsBanned(): void
     {
         /** @var User $me */


### PR DESCRIPTION
Right now, the Completion Progress page requires authentication to view.

This PR removes the auth gate and adds a meta description to the page for crawlers.