### PR TITLE
fix(beaten-leaderboard): dont show the same user multiple times

### DIFF
--- a/app/Platform/Controllers/BeatenGamesLeaderboardController.php
+++ b/app/Platform/Controllers/BeatenGamesLeaderboardController.php
@@ -127,7 +127,10 @@ class BeatenGamesLeaderboardController extends Controller
         $includedTypes = $this->getIncludedTypes($gameKindFilterOptions);
 
         $aggregateSubquery = PlayerStat::selectRaw(
-            'user_id, SUM(value) AS total_awards, MAX(updated_at) AS last_beaten_date'
+            'user_id, 
+            SUM(value) AS total_awards, 
+            MAX(updated_at) AS last_beaten_date, 
+            MAX(id) AS last_activity_id',
         )
             ->when($targetSystemId, function ($query) use ($targetSystemId) {
                 return $query->where('system_id', $targetSystemId);
@@ -147,7 +150,7 @@ class BeatenGamesLeaderboardController extends Controller
         )
             ->joinSub($aggregateSubquery, 'sub', function ($join) use ($targetSystemId) {
                 $join->on('sub.user_id', '=', 'player_stats.user_id')
-                    ->on('sub.last_beaten_date', '=', 'player_stats.updated_at');
+                    ->on('sub.last_activity_id', '=', 'player_stats.id');
 
                 if (isset($targetSystemId) && $targetSystemId > 0) {
                     $join->where('player_stats.system_id', '=', $targetSystemId);


### PR DESCRIPTION
This PR resolves an issue where the same user can appear on the beaten leaderboard multiple times on the same page. The issue is easily reproducible by visiting the following route:

```
/ranking/beaten-games?page%5Bnumber%5D=1&filter%5Bsystem%5D=2&filter%5Bkind%5D=all
```

**Before**
![Screenshot 2023-11-17 at 5 18 03 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/64d60424-7e92-487a-a165-383271f2502d)

**After**
![Screenshot 2023-11-17 at 5 18 45 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/ab61d356-cc68-4190-8233-e706add1cce5)

**Root Cause**
This issue occurs when a user has two beaten game awards that occurred at exactly the same timestamp.