### PR TITLE
fix(beaten-leaderboard): remediate manual pagination with console filter

### DIFF
--- a/resources/views/platform/components/beaten-games-leaderboard/pagination-controls.blade.php
+++ b/resources/views/platform/components/beaten-games-leaderboard/pagination-controls.blade.php
@@ -35,7 +35,7 @@ function handlePageChanged(event) {
 function goToPage(pageNumber) {
     const page = parseInt(pageNumber, 10);
     if (page !== NaN && page > 0 && page <= {{ $paginator->lastPage() }}) {
-        window.location.href = `{{ $baseUrl }}?page[number]=${page}`;
+        window.updateUrlParameter('page[number]', page);
     } else {
         alert('Please enter a valid page number.');
     }


### PR DESCRIPTION
This PR remediates an issue where manual pagination on the beaten leaderboard resets a currently active console filter.

**To reproduce**
Navigate to:
```
http://localhost:64000/ranking/beaten-games?page%5Bnumber%5D=1&filter%5Bsystem%5D=7
```

Attempt to visit page 4 via the pagination control at the bottom of the page.
Observe that your system filter is no longer applied.

**Root Cause**
The JS code was stripping the currently applied system filter.