### PR TITLE
feat(completion-progress): add alphabetical sorting

### DIFF
--- a/app/Platform/Controllers/PlayerCompletionProgressController.php
+++ b/app/Platform/Controllers/PlayerCompletionProgressController.php
@@ -133,13 +133,19 @@ class PlayerCompletionProgressController extends Controller
 
         if ($sortOrder === 'game_title') {
             usort($filteredAndJoinedGamesList, function ($a, $b) {
-                return strcmp($a['Title'], $b['Title']);
+                $titleA = $this->removeGameTitlePrefix($a['Title']);
+                $titleB = $this->removeGameTitlePrefix($b['Title']);
+
+                return strcmp($titleA, $titleB);
             });
         }
 
         if ($sortOrder === '-game_title') {
             usort($filteredAndJoinedGamesList, function ($a, $b) {
-                return strcmp($b['Title'], $a['Title']);
+                $titleA = $this->removeGameTitlePrefix($a['Title']);
+                $titleB = $this->removeGameTitlePrefix($b['Title']);
+
+                return strcmp($titleB, $titleA);
             });
         }
 
@@ -321,5 +327,17 @@ class PlayerCompletionProgressController extends Controller
         $allAvailableConsoleIds = array_filter($allAvailableConsoleIds, fn ($value) => !is_null($value));
 
         return $allAvailableConsoleIds;
+    }
+
+    private function removeGameTitlePrefix(string $gameTitle): string
+    {
+        if (substr($gameTitle, 0, 1) === '~') {
+            $endOfPrefixPos = strpos($gameTitle, '~', 1);
+            if ($endOfPrefixPos !== false) {
+                $gameTitle = substr($gameTitle, $endOfPrefixPos + 1);
+            }
+        }
+
+        return trim($gameTitle);
     }
 }

--- a/app/Platform/Controllers/PlayerCompletionProgressController.php
+++ b/app/Platform/Controllers/PlayerCompletionProgressController.php
@@ -31,7 +31,7 @@ class PlayerCompletionProgressController extends Controller
             'page.number' => 'sometimes|integer|min:1',
             'filter.system' => 'sometimes|integer|between:0,99|not_in:101',
             'filter.status' => 'sometimes|string|min:2|max:30',
-            'sort' => 'sometimes|string|in:unlock_date,pct_won,-unlock_date,-pct_won',
+            'sort' => 'sometimes|string|in:unlock_date,pct_won,-unlock_date,-pct_won,game_title,-game_title',
         ]);
 
         $currentPage = (int) ($validatedData['page']['number'] ?? 1);
@@ -128,6 +128,18 @@ class PlayerCompletionProgressController extends Controller
         if ($sortOrder === '-unlock_date') {
             usort($filteredAndJoinedGamesList, function ($a, $b) {
                 return strtotime($a['MostRecentWonDate'] ?? '') - strtotime($b['MostRecentWonDate'] ?? '');
+            });
+        }
+
+        if ($sortOrder === 'game_title') {
+            usort($filteredAndJoinedGamesList, function ($a, $b) {
+                return strcmp($a['Title'], $b['Title']);
+            });
+        }
+
+        if ($sortOrder === '-game_title') {
+            usort($filteredAndJoinedGamesList, function ($a, $b) {
+                return strcmp($b['Title'], $a['Title']);
             });
         }
 

--- a/resources/views/platform/completion-progress-page.blade.php
+++ b/resources/views/platform/completion-progress-page.blade.php
@@ -58,7 +58,7 @@ $pageDescription = "View {$targetUsername}'s game completion stats and milestone
             @endif
 
             @if ($isFiltering || $selectedSortOrder !== 'unlock_date')
-                <a href="{{ route('user.completion-progress', $targetUsername) }}" class="btn flex items-center gap-x-0.5">
+                <a href="{{ route('user.completion-progress', $targetUsername) }}" class="btn flex items-center gap-x-0.5 transition lg:active:scale-95">
                     <x-fas-undo />
                     <span>Reset filters/sort</span>
                 </a>

--- a/resources/views/platform/components/completion-progress-page/meta-panel/sort-order.blade.php
+++ b/resources/views/platform/components/completion-progress-page/meta-panel/sort-order.blade.php
@@ -10,18 +10,26 @@
     autocomplete="off"
 >
     <option value="unlock_date" @if ($selectedSortOrder === 'unlock_date') selected @endif>
-        Newest unlock
+        Unlock Date: Newest
     </option>
 
     <option value="-unlock_date" @if ($selectedSortOrder === '-unlock_date') selected @endif>
-        Oldest unlock 
+        Unlock Date: Oldest
     </option>
 
     <option value="pct_won" @if ($selectedSortOrder === 'pct_won') selected @endif>
-        Most achievements won
+        Achievements Won: Most
     </option>
 
     <option value="-pct_won" @if ($selectedSortOrder === '-pct_won') selected @endif>
-        Fewest achievements won
+        Achievements Won: Least
+    </option>
+
+    <option value="game_title" @if ($selectedSortOrder === 'game_title') selected @endif>
+        Game Title: A - Z
+    </option>
+
+    <option value="-game_title" @if ($selectedSortOrder === '-game_title') selected @endif>
+        Game Title: Z - A
     </option>
 </select>


### PR DESCRIPTION
This PR adds two new sort orders to the Completion Progress page:
Game Title: A - Z
Game Title: Z - A

All the sort options have also been relabeled to hopefully improve the intuitiveness of the sort select control.

![Screenshot 2023-11-18 at 10 23 26 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/ab973b38-60cb-4745-a4ae-5abfcc9592a2)