### PR TITLE
feat(user): prefetch achievement badges for recently played games

### DIFF
--- a/app/Community/Components/UserRecentlyPlayed.php
+++ b/app/Community/Components/UserRecentlyPlayed.php
@@ -100,6 +100,16 @@ class UserRecentlyPlayed extends Component
         }
     }
 
+    private function deriveAchievementBadgeUrl(array $achievementData): string
+    {
+        $isAwarded = $achievementData['IsAwarded'];
+        $rawBadgeName = $achievementData['BadgeName'];
+
+        $processedBadgeName = $isAwarded ? "{$rawBadgeName}.png" : "{$rawBadgeName}_lock.png";
+
+        return media_asset("Badge/{$processedBadgeName}");
+    }
+
     private function extractGameInformation(array $entity): array
     {
         return [
@@ -163,6 +173,10 @@ class UserRecentlyPlayed extends Component
 
         $processed['AchievementAvatars'] = collect($achievementEntities)
             ->map(fn ($achievement) => $this->buildAchievementAvatar($achievement))
+            ->all();
+
+        $processed['AchievementBadgeURLs'] = collect($achievementEntities)
+            ->map(fn ($achievement) => $this->deriveAchievementBadgeUrl($achievement))
             ->all();
 
         $processed['FirstWonDate'] = collect($achievementEntities)

--- a/app/Community/Components/UserRecentlyPlayed.php
+++ b/app/Community/Components/UserRecentlyPlayed.php
@@ -100,16 +100,6 @@ class UserRecentlyPlayed extends Component
         }
     }
 
-    private function deriveAchievementBadgeUrl(array $achievementData): string
-    {
-        $isAwarded = $achievementData['IsAwarded'];
-        $rawBadgeName = $achievementData['BadgeName'];
-
-        $processedBadgeName = $isAwarded ? "{$rawBadgeName}.png" : "{$rawBadgeName}_lock.png";
-
-        return media_asset("Badge/{$processedBadgeName}");
-    }
-
     private function extractGameInformation(array $entity): array
     {
         return [
@@ -173,10 +163,6 @@ class UserRecentlyPlayed extends Component
 
         $processed['AchievementAvatars'] = collect($achievementEntities)
             ->map(fn ($achievement) => $this->buildAchievementAvatar($achievement))
-            ->all();
-
-        $processed['AchievementBadgeURLs'] = collect($achievementEntities)
-            ->map(fn ($achievement) => $this->deriveAchievementBadgeUrl($achievement))
             ->all();
 
         $processed['FirstWonDate'] = collect($achievementEntities)

--- a/resources/views/community/components/user/recently-played/index.blade.php
+++ b/resources/views/community/components/user/recently-played/index.blade.php
@@ -9,20 +9,21 @@
 window.preloadedGameIds = {};
 
 /**
- * @param {Record<number, string>} badgeUrls
+ * @param {HTMLDivElement} element
  * @param {number} gameId
  */
-function preloadAchievementBadges(badgeUrls, gameId) {
+function preloadAchievementBadges(element, gameId) {
     // Only try to preload badges a single time per game.
     if (window.preloadedGameIds[gameId]) {
         return;
     }
 
-    for (const badgeUrl of Object.values(badgeUrls)) {
-        const img = new Image();
-        img.src = badgeUrl;
-
-        window.preloadedGameIds[gameId] = true;
+    const allChildImgEls = element.querySelectorAll('img');
+    for (const imgEl of allChildImgEls) {
+        if (imgEl.src) {
+            const preload = new Image();
+            preload.src = imgEl.src;
+        }
     }
 }
 </script>
@@ -38,7 +39,11 @@ function preloadAchievementBadges(badgeUrls, gameId) {
 
     <div class="flex flex-col gap-y-1">
         @foreach ($processedRecentlyPlayedEntities as $processedRecentlyPlayedEntity)
-            <div onmouseenter="preloadAchievementBadges({{ json_encode($processedRecentlyPlayedEntity['AchievementBadgeURLs']) }}, {{ $processedRecentlyPlayedEntity['GameID'] }})">
+            <div
+                @if ($loop->index !== 0 && !empty($processedRecentlyPlayedEntity['AchievementAvatars']))
+                    onmouseenter="preloadAchievementBadges(this, {{ $processedRecentlyPlayedEntity['GameID'] }})"
+                @endif
+            >
                 <x-game-list-item
                     :game="$processedRecentlyPlayedEntity"
                     :targetUserName="$targetUsername"

--- a/resources/views/community/components/user/recently-played/index.blade.php
+++ b/resources/views/community/components/user/recently-played/index.blade.php
@@ -4,6 +4,29 @@
     'targetUsername' => '',
 ])
 
+<script>
+/** @type {Record<number, boolean>} */
+window.preloadedGameIds = {};
+
+/**
+ * @param {Record<number, string>} badgeUrls
+ * @param {number} gameId
+ */
+function preloadAchievementBadges(badgeUrls, gameId) {
+    // Only try to preload badges a single time per game.
+    if (window.preloadedGameIds[gameId]) {
+        return;
+    }
+
+    for (const badgeUrl of Object.values(badgeUrls)) {
+        const img = new Image();
+        img.src = badgeUrl;
+
+        window.preloadedGameIds[gameId] = true;
+    }
+}
+</script>
+
 <div>
     <h4>
         @if ($recentlyPlayedCount === 1)
@@ -15,17 +38,19 @@
 
     <div class="flex flex-col gap-y-1">
         @foreach ($processedRecentlyPlayedEntities as $processedRecentlyPlayedEntity)
-            <x-game-list-item
-                :game="$processedRecentlyPlayedEntity"
-                :targetUserName="$targetUsername"
-                :isExpandable="true"
-                :isDefaultExpanded="$loop->index === 0 && !empty($processedRecentlyPlayedEntity['AchievementAvatars'])"
-                variant="user-recently-played"
-            >
-                @foreach ($processedRecentlyPlayedEntity['AchievementAvatars'] as $achievementAvatar)
-                    {!! $achievementAvatar !!}
-                @endforeach
-            </x-game-list-item>
+            <div onmouseenter="preloadAchievementBadges({{ json_encode($processedRecentlyPlayedEntity['AchievementBadgeURLs']) }}, {{ $processedRecentlyPlayedEntity['GameID'] }})">
+                <x-game-list-item
+                    :game="$processedRecentlyPlayedEntity"
+                    :targetUserName="$targetUsername"
+                    :isExpandable="true"
+                    :isDefaultExpanded="$loop->index === 0 && !empty($processedRecentlyPlayedEntity['AchievementAvatars'])"
+                    variant="user-recently-played"
+                >
+                    @foreach ($processedRecentlyPlayedEntity['AchievementAvatars'] as $achievementAvatar)
+                        {!! $achievementAvatar !!}
+                    @endforeach
+                </x-game-list-item>
+            </div>
         @endforeach
     </div>
 </div>


### PR DESCRIPTION
This PR attaches an event to these items on the user profile:

![Screenshot 2023-11-18 at 1 01 57 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/578af6ae-c530-452f-8924-45bf4fa8befe)

When hovering over the rows, an event now fires to preload the badge images. This should hopefully reduce some "pop in" that can currently happen due to badges loading the moment a user expands a row.