### PR TITLE
fix: remediate subset achievement update error

### DIFF
--- a/public/request/achievement/update-base.php
+++ b/public/request/achievement/update-base.php
@@ -34,7 +34,7 @@ if (UploadNewAchievement(
     title: $input['title'],
     desc: $input['description'],
     points: $input['points'],
-    type: isset($input['type']) ? $input['type'] : null,
+    type: $input['type'] ?? null,
     mem: $achievement['MemAddr'],
     flag: $achievement['Flags'],
     idInOut: $achievementId,

--- a/public/request/achievement/update-base.php
+++ b/public/request/achievement/update-base.php
@@ -34,7 +34,7 @@ if (UploadNewAchievement(
     title: $input['title'],
     desc: $input['description'],
     points: $input['points'],
-    type: $input['type'],
+    type: isset($input['type']) ? $input['type'] : null,
     mem: $achievement['MemAddr'],
     flag: $achievement['Flags'],
     idInOut: $achievementId,


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/310195377993416714/1175593754028158986.

**Root Cause**
When editing an achievement belonging to a subset, there isn't a type field anymore. Therefore, we need to add some safety before we navigate into the "type" array key of the `$input` variable.