### PR TITLE
feat: prettify query params like ?page[number]=1

### DIFF
--- a/app/Support/Url/UrlBuilder.php
+++ b/app/Support/Url/UrlBuilder.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Url;
+
+class UrlBuilder
+{
+    public static function prettyHttpBuildQuery(array $query): string
+    {
+        $queryString = http_build_query($query);
+        $queryString = str_replace(['%5B', '%5D'], ['[', ']'], $queryString);
+
+        return $queryString;
+    }
+}

--- a/resources/js/utils/updateUrlParameter.ts
+++ b/resources/js/utils/updateUrlParameter.ts
@@ -27,6 +27,6 @@ export function updateUrlParameter(
     params.set(currentParamName, currentNewQueryParamValue);
   }
 
-  url.search = params.toString();
+  url.search = params.toString().replace(/%5B/g, '[').replace(/%5D/g, ']');
   window.location.href = url.toString();
 }

--- a/resources/views/platform/components/beaten-games-leaderboard/pagination-controls.blade.php
+++ b/resources/views/platform/components/beaten-games-leaderboard/pagination-controls.blade.php
@@ -4,24 +4,26 @@
 ])
 
 <?php
+use App\Support\Url\UrlBuilder;
+
 $baseUrl = request()->url();
 $queryParams = request()->query();
 
 $previousPageNumber = $paginator->currentPage() - 1;
 $queryParams['page'] = ['number' => $previousPageNumber];
-$previousPageUrl = $baseUrl . '?' . http_build_query($queryParams);
+$previousPageUrl = $baseUrl . '?' . UrlBuilder::prettyHttpBuildQuery($queryParams);
 
 $nextPageNumber = $paginator->currentPage() + 1;
 $queryParams['page'] = ['number' => $nextPageNumber];
-$nextPageUrl = $baseUrl . '?' . http_build_query($queryParams);
+$nextPageUrl = $baseUrl . '?' . UrlBuilder::prettyHttpBuildQuery($queryParams);
 
 $queryParams['page'] = ['number' => 1];
-$firstPageUrl = $baseUrl . '?' . http_build_query($queryParams);
+$firstPageUrl = $baseUrl . '?' . UrlBuilder::prettyHttpBuildQuery($queryParams);
 
 $userPageUrl = null;
 if ($userPageNumber) {
     $queryParams['page'] = ['number' => $userPageNumber];
-    $userPageUrl = $baseUrl . '?' . http_build_query($queryParams);
+    $userPageUrl = $baseUrl . '?' . UrlBuilder::prettyHttpBuildQuery($queryParams);
 }
 
 $isHighlightedRankOnCurrentPage = $paginator->currentPage() === $userPageNumber;

--- a/resources/views/platform/components/completion-progress-page/awards-jumbobox.blade.php
+++ b/resources/views/platform/components/completion-progress-page/awards-jumbobox.blade.php
@@ -8,6 +8,8 @@
 ])
 
 <?php
+use App\Support\Url\UrlBuilder;
+
 $currentQueryParams = request()->query();
 
 if (isset($currentQueryParams['filter']['status'])) {
@@ -19,12 +21,12 @@ $canShowBeatenHardcore = $beatenHardcoreCount > 0 || ($beatenHardcoreCount === 0
 $canShowCompleted = $completedCount > 0;
 $canShowMastered = $masteredCount > 0 || ($masteredCount === 0 && $completedCount === 0);
 
-$playedUrl = url()->current() . '?' . http_build_query(array_merge($currentQueryParams, ['filter[status]' => 'null']));
-$unfinishedUrl = url()->current() . '?' . http_build_query(array_merge($currentQueryParams, ['filter[status]' => 'unawarded']));
-$beatenSoftcoreUrl = url()->current() . '?' . http_build_query(array_merge($currentQueryParams, ['filter[status]' => 'eq-beaten-softcore']));
-$beatenHardcoreUrl = url()->current() . '?' . http_build_query(array_merge($currentQueryParams, ['filter[status]' => 'eq-beaten-hardcore']));
-$completedUrl = url()->current() . '?' . http_build_query(array_merge($currentQueryParams, ['filter[status]' => 'eq-completed']));
-$masteredUrl = url()->current() . '?' . http_build_query(array_merge($currentQueryParams, ['filter[status]' => 'eq-mastered']));
+$playedUrl = url()->current() . '?' . UrlBuilder::prettyHttpBuildQuery(array_merge($currentQueryParams, ['filter[status]' => 'null']));
+$unfinishedUrl = url()->current() . '?' . UrlBuilder::prettyHttpBuildQuery(array_merge($currentQueryParams, ['filter[status]' => 'unawarded']));
+$beatenSoftcoreUrl = url()->current() . '?' . UrlBuilder::prettyHttpBuildQuery(array_merge($currentQueryParams, ['filter[status]' => 'eq-beaten-softcore']));
+$beatenHardcoreUrl = url()->current() . '?' . UrlBuilder::prettyHttpBuildQuery(array_merge($currentQueryParams, ['filter[status]' => 'eq-beaten-hardcore']));
+$completedUrl = url()->current() . '?' . UrlBuilder::prettyHttpBuildQuery(array_merge($currentQueryParams, ['filter[status]' => 'eq-completed']));
+$masteredUrl = url()->current() . '?' . UrlBuilder::prettyHttpBuildQuery(array_merge($currentQueryParams, ['filter[status]' => 'eq-mastered']));
 ?>
 
 <div class="bg-embed rounded px-4 py-2">

--- a/resources/views/platform/components/completion-progress-page/paginator.blade.php
+++ b/resources/views/platform/components/completion-progress-page/paginator.blade.php
@@ -4,24 +4,26 @@
 ])
 
 <?php
+use App\Support\Url\UrlBuilder;
+
 $baseUrl = request()->url();
 $queryParams = request()->query();
 
 $previousPageNumber = $currentPage - 1;
 $queryParams['page'] = ['number' => $previousPageNumber];
-$previousPageUrl = $baseUrl . '?' . http_build_query($queryParams);
+$previousPageUrl = $baseUrl . '?' . UrlBuilder::prettyHttpBuildQuery($queryParams);
 
 $nextPageNumber = $currentPage + 1;
 $queryParams['page'] = ['number' => $nextPageNumber];
-$nextPageUrl = $baseUrl . '?' . http_build_query($queryParams);
+$nextPageUrl = $baseUrl . '?' . UrlBuilder::prettyHttpBuildQuery($queryParams);
 
 $firstPageNumber = 1;
 $queryParams['page'] = ['number' => $firstPageNumber];
-$firstPageUrl = $baseUrl . '?' . http_build_query($queryParams);
+$firstPageUrl = $baseUrl . '?' . UrlBuilder::prettyHttpBuildQuery($queryParams);
 
 $lastPageNumber = $totalPages;
 $queryParams['page'] = ['number' => $lastPageNumber];
-$lastPageUrl = $baseUrl . '?' . http_build_query($queryParams);
+$lastPageUrl = $baseUrl . '?' . UrlBuilder::prettyHttpBuildQuery($queryParams);
 ?>
 
 <script>

--- a/tests/Unit/UrlBuilderTest.php
+++ b/tests/Unit/UrlBuilderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Support\Url\UrlBuilder;
+use Tests\TestCase;
+
+final class UrlBuilderTest extends TestCase
+{
+    public function testPrettifiesQueryParams(): void
+    {
+        $originalQueryParams = [
+            'page' => ['number' => 2],
+            'filter' => ['status' => 'unawarded'],
+            'sort' => 'pct_won',
+        ];
+
+        $prettifiedQueryParams = UrlBuilder::prettyHttpBuildQuery($originalQueryParams);
+
+        $this->assertEquals("page[number]=2&filter[status]=unawarded&sort=pct_won", $prettifiedQueryParams);
+    }
+}


### PR DESCRIPTION
This PR results in human-readable query params being produced on some of our newer pages, via string replacement of "%5B" and "%5D" to their respective brackets: "[" and "]".

**How to test this PR:**
Visit either the developer sets page, the completion progress page, or the beaten games leaderboard. Apply any combination of filters and observe the produced URL in the browser navbar.

**Before**
```
/progress?filter%5Bsystem%5D=38&page%5Bnumber%5D=1&filter%5Bstatus%5D=unawarded
```

**After**
```
/progress?filter[system]=38&page[number]=1&filter[status]=unawarded
```