### PR TITLE
fix(beaten-leaderboard): add 'last_affected_at' column to player_stats

### DIFF
--- a/app/Platform/Actions/UpdatePlayerStats.php
+++ b/app/Platform/Actions/UpdatePlayerStats.php
@@ -149,10 +149,10 @@ class UpdatePlayerStats
             // Now, loop through each stat type for this system.
             foreach ($systemStats as $statType => $values) {
                 // Extract the value and most recent game ID.
-                [$value, $lastGameId, $updatedAt] = $values;
+                [$value, $lastGameId, $affectedAt] = $values;
 
                 if ($value > 0) {
-                    $this->upsertPlayerStat($user, $statType, $value, $systemId, $lastGameId, $updatedAt);
+                    $this->upsertPlayerStat($user, $statType, $value, $systemId, $lastGameId, $affectedAt);
                     $updatedCount++;
                 }
             }
@@ -167,7 +167,7 @@ class UpdatePlayerStats
         int $value,
         ?int $systemId,
         ?int $lastGameId,
-        ?string $updatedAt
+        ?string $affectedAt
     ): void {
         PlayerStat::updateOrCreate(
             [
@@ -178,7 +178,7 @@ class UpdatePlayerStats
             [
                 'last_game_id' => $lastGameId,
                 'value' => $value,
-                'updated_at' => $updatedAt,
+                'last_affected_at' => $affectedAt,
             ]
         );
 

--- a/app/Platform/Models/PlayerStat.php
+++ b/app/Platform/Models/PlayerStat.php
@@ -18,13 +18,14 @@ class PlayerStat extends BaseModel
         'last_game_id',
         'type',
         'value',
-        'updated_at',
+        'last_affected_at',
     ];
 
     protected $casts = [
         'user_id' => 'integer',
         'system_id' => 'integer',
         'last_game_id' => 'integer',
+        'last_affected_at' => 'datetime',
         'value' => 'integer',
     ];
 

--- a/database/migrations/platform/2023_11_20_000000_update_player_stats_table.php
+++ b/database/migrations/platform/2023_11_20_000000_update_player_stats_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('player_stats', function (Blueprint $table) {
+            $table->timestampTz('last_affected_at')->nullable()->after('last_game_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_stats', function (Blueprint $table) {
+            $table->dropColumn('last_affected_at');
+        });
+    }
+};

--- a/tests/Feature/Platform/Action/UpdatePlayerStatsTest.php
+++ b/tests/Feature/Platform/Action/UpdatePlayerStatsTest.php
@@ -73,7 +73,7 @@ class UpdatePlayerStatsTest extends TestCase
         $this->assertEquals($game->id, $overallStats->last_game_id);
         $this->assertEquals(PlayerStatType::GamesBeatenHardcoreRetail, $overallStats->type);
         $this->assertEquals(1, $overallStats->value);
-        $this->assertEquals(Carbon::create(2023, 1, 1), $overallStats->updated_at);
+        $this->assertEquals(Carbon::create(2023, 1, 1), $overallStats->last_affected_at);
 
         $systemStats = $userStats->whereNotNull('system_id')->first();
         $this->assertEquals($system->ID, $systemStats->system_id);
@@ -81,7 +81,7 @@ class UpdatePlayerStatsTest extends TestCase
         $this->assertEquals($game->id, $systemStats->last_game_id);
         $this->assertEquals(PlayerStatType::GamesBeatenHardcoreRetail, $systemStats->type);
         $this->assertEquals(1, $systemStats->value);
-        $this->assertEquals(Carbon::create(2023, 1, 1), $systemStats->updated_at);
+        $this->assertEquals(Carbon::create(2023, 1, 1), $systemStats->last_affected_at);
     }
 
     public function testItUpsertsDifferentTypesOfStats(): void
@@ -183,6 +183,6 @@ class UpdatePlayerStatsTest extends TestCase
 
         $stat = $query->first();
         $this->assertNotNull($stat);
-        $this->assertEquals($expectedDate->toDateTimeString(), $stat->updated_at->toDateTimeString());
+        $this->assertEquals($expectedDate->toDateTimeString(), $stat->last_affected_at->toDateTimeString());
     }
 }


### PR DESCRIPTION
This PR attempts to remediate a data integrity issue currently affecting the `player_stats` table on prod.

The issue can be seen by running the following query:
```sql
SELECT * FROM player_stats WHERE user_id = 117089 ORDER BY last_affected_at DESC;
```

The `updated_at` value for the first row returned is not correct (in the sense of how we're using it). It's showing November 19, but the game was actually beaten around August 29.

I believe this issue is occurring because we're overloading the purpose of the `updated_at` column. This column is used by Laravel for when the row itself is updated, and I believe that is what's causing this spurious data integrity issue.

Locally, I was able to repro the issue once, but after many tries I could never repro it again.

This PR attempts to resolve the problem by creating a new `last_affected_at` timestamp column, which the beaten leaderboard uses instead of `updated_at`.