### PR TITLE
feat(beaten-leaderboard): exclude homebrew systems from retail games

### DIFF
--- a/resources/views/platform/components/beaten-games-leaderboard/meta-panel/game-kind-filter-radio.blade.php
+++ b/resources/views/platform/components/beaten-games-leaderboard/meta-panel/game-kind-filter-radio.blade.php
@@ -1,12 +1,14 @@
 @props([
+    'disabled' => false,
     'selectedValue' => '',
     'value' => '',
 ])
 
-<label class="transition lg:active:scale-95 cursor-pointer flex items-center gap-x-1 text-xs">
+<label class="@if (!$disabled) transition lg:active:scale-95 cursor-pointer @endif flex items-center gap-x-1 text-xs">
     <input
         type="radio"
-        class="cursor-pointer"
+        @if ($disabled) disabled @endif
+        @if (!$disabled) class="cursor-pointer" @endif
         name="game-kind"
         value="{{ $value }}"
         {{ $selectedValue == $value ? 'checked' : '' }}

--- a/resources/views/platform/components/beaten-games-leaderboard/meta-panel/game-kind-filters.blade.php
+++ b/resources/views/platform/components/beaten-games-leaderboard/meta-panel/game-kind-filters.blade.php
@@ -1,4 +1,5 @@
 @props([
+    'allowsRetail' => true,
     'gameKindFilterOptions' => [],
     'leaderboardKind' => 'retail',
 ])
@@ -7,6 +8,7 @@
 <div class="flex gap-x-4 text-2xs gap-y-0.5">
     <x-beaten-games-leaderboard.meta-panel.game-kind-filter-radio
         value="retail"
+        :disabled="!$allowsRetail"
         :selectedValue="$leaderboardKind"
     >
         Retail

--- a/resources/views/platform/components/beaten-games-leaderboard/meta-panel/index.blade.php
+++ b/resources/views/platform/components/beaten-games-leaderboard/meta-panel/index.blade.php
@@ -5,6 +5,16 @@
     'selectedConsoleId' => null,
 ])
 
+<?php
+// Arduboy, WASM-4, and Uzebox are homebrew consoles.
+// They do not have games that would conventionally be considered "retail".
+$allowsRetail = (
+    $selectedConsoleId !== 71
+    && $selectedConsoleId !== 72
+    && $selectedConsoleId !== 80
+);
+?>
+
 <script>
 function handleGameKindsChanged(event) {
     window.updateUrlParameter(
@@ -14,9 +24,21 @@ function handleGameKindsChanged(event) {
 }
 
 function handleConsoleChanged(event) {
+    // The "Retail" filter is automatically disabled on homebrew systems.
+    // Default to the "All" option.
+    const homebrewSystemIds = [71, 72, 80];
+    if (homebrewSystemIds.includes(Number(event.target.value))) {
+        window.updateUrlParameter(
+            ['page[number]', 'filter[system]', 'filter[kind]'],
+            [1, event.target.value, 'all'],
+        );
+
+        return;
+    }
+
     window.updateUrlParameter(
-        ['page[number]', 'filter[system]'],
-        [1, event.target.value],
+        ['page[number]', 'filter[system]', 'filter[kind]'],
+        [1, event.target.value, 'retail'],
     );
 }
 </script>
@@ -35,6 +57,7 @@ function handleConsoleChanged(event) {
 
             <div class="grid gap-y-1 sm:px-8">
                 <x-beaten-games-leaderboard.meta-panel.game-kind-filters
+                    :allowsRetail="$allowsRetail"
                     :gameKindFilterOptions="$gameKindFilterOptions"
                     :leaderboardKind="$leaderboardKind"
                 />

--- a/tests/Feature/Platform/Action/UpdatePlayerStatsTest.php
+++ b/tests/Feature/Platform/Action/UpdatePlayerStatsTest.php
@@ -171,6 +171,34 @@ class UpdatePlayerStatsTest extends TestCase
         $this->assertCount(0, $userStats);
     }
 
+    public function testItHandlesHomebrewSystems(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        $homebrewSystemOne = System::factory()->create(['ID' => 71]);
+        $homebrewSystemTwo = System::factory()->create(['ID' => 72]);
+        $homebrewSystemThree = System::factory()->create(['ID' => 80]);
+
+        $gameOne = Game::factory()->create(['ConsoleID' => $homebrewSystemOne->ID]);
+        $gameTwo = Game::factory()->create(['ConsoleID' => $homebrewSystemTwo->ID]);
+        $gameThree = Game::factory()->create(['ConsoleID' => $homebrewSystemThree->ID]);
+
+        $this->addGameBeatenAward($user, $gameOne, UnlockMode::Hardcore);
+        $this->addGameBeatenAward($user, $gameTwo, UnlockMode::Hardcore);
+        $this->addGameBeatenAward($user, $gameThree, UnlockMode::Hardcore);
+
+        // Act
+        (new UpdatePlayerStats())->execute($user);
+
+        // Assert
+        $userRetailStats = PlayerStat::where('user_id', $user->id)->where('type', 'games_beaten_hardcore_retail')->get();
+        $userHomebrewStats = PlayerStat::where('user_id', $user->id)->where('type', 'games_beaten_hardcore_homebrew')->get();
+
+        $this->assertCount(0, $userRetailStats);
+        $this->assertCount(4, $userHomebrewStats);
+    }
+
     protected function assertPlayerStatDetails(
         mixed $playerStats,
         int $gameId,


### PR DESCRIPTION
This PR makes a slight adjustment to the logic in the `UpdatePlayerStats` action which is responsible for determining a game's kind (retail, homebrew, hack, etc.)

Three systems we support: Arduboy, Uzebox, and WASM-4 never had retail games in the conventional sense. These are homebrew systems. Therefore, it is reasonable that the fallback value for game kinds on these systems is not "retail", but is instead "homebrew".

* Arduboy, Uzebox, and WASM-4 games are now classed in player_stats as homebrew.
* When selecting one of these systems on the beaten leaderboard, the filter changes to "All" and the "Retail" radio button is disabled.

![Screenshot 2023-11-20 at 7 27 19 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/b53ac185-2a4e-4451-9ccd-97259690260b)
