### PR TITLE
fix(game): adjust completion % rounding to match other pages

### DIFF
--- a/resources/views/platform/components/game/current-progress/progress-bar.blade.php
+++ b/resources/views/platform/components/game/current-progress/progress-bar.blade.php
@@ -16,11 +16,11 @@ if ($totalAchievementsCount > 0) {
     $hardcoreProgressWidth = ($numEarnedHardcoreAchievements / $totalAchievementsCount) * 100;
     $softcoreProgressWidth = ($numEarnedSoftcoreAchievements / $totalAchievementsCount) * 100;
 
-    $hardcoreCompletionPercentage = sprintf("%01.0f", floor($hardcoreProgressWidth));
-    $softcoreCompletionPercentage = sprintf("%01.0f", floor($softcoreProgressWidth + $hardcoreCompletionPercentage));
+    $hardcoreCompletionPercentage = sprintf("%01.0f", $hardcoreProgressWidth);
+    $softcoreCompletionPercentage = sprintf("%01.0f", $softcoreProgressWidth + $hardcoreCompletionPercentage);
 }
 
-$completionPercentage = sprintf("%01.0f", floor($hardcoreProgressWidth + $softcoreProgressWidth));
+$completionPercentage = sprintf("%01.0f", round($hardcoreProgressWidth + $softcoreProgressWidth));
 ?>
 
 <div


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1177243393735270532.

Currently, sometimes the progress component on game pages shows a different percentage than user pages. This is due to a difference in how the numbers are rounded.

**Before**
<img width="852" alt="Screenshot 2023-11-24 at 10 21 18 AM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/8bb7cff7-1e6c-4912-a8c4-175de9f60b69">

<img width="359" alt="Screenshot 2023-11-24 at 10 21 24 AM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/ca82a2ed-c73a-4133-8c00-a5b5c173d620">

**After**
<img width="354" alt="Screenshot 2023-11-24 at 10 22 12 AM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/42d21b70-5310-4b02-96c0-147fbfea86f5">
