### PR TITLE
fix(user): remediate achievement badge clipping on mobile animation

### DIFF
--- a/resources/views/platform/components/game-list-item/index.blade.php
+++ b/resources/views/platform/components/game-list-item/index.blade.php
@@ -117,7 +117,7 @@ $doesGameHaveAchievements = !!$game['MaxPossible'];
         >
             <hr class="mt-2 border-embed-highlight">
 
-            <div class="py-4 @if ($variant === 'user-recently-played') flex flex-wrap -mx-1 sm:mx-0 sm:px-4 @endif">
+            <div class="py-4 @if ($variant === 'user-recently-played') flex flex-wrap px-0.5 sm:px-4 @endif">
                 {{ $slot }}
             </div>
         </div>


### PR DESCRIPTION
Resolves a minor issue on user profiles, specifically with mobile. The animation to expand a game's list of achievements clips the edges of the badges while the animation is running.

**Before**

https://github.com/RetroAchievements/RAWeb/assets/3984985/cad81e7a-d76b-4e58-9761-3f30ab13ddc7



**After**

https://github.com/RetroAchievements/RAWeb/assets/3984985/2100ab32-dec9-4eca-aac1-9f467f80354c

