### PR TITLE
feat(game): unify softcore and progress styles with other pages

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -567,7 +567,7 @@ sanitize_outputs(
                     'height': '78%'
                 },
                 height: 260,
-                colors: ['#cc9900', '#186DEE'],
+                colors: ['#cc9900', '#737373'],
                 pointSize: 4,
             };
 

--- a/resources/views/platform/components/game/achievements-list/list-item-global-progress.blade.php
+++ b/resources/views/platform/components/game/achievements-list/list-item-global-progress.blade.php
@@ -52,22 +52,22 @@ if ($totalPlayerCount > 0) {
     aria-valuemax="100"
     aria-valuenow="{{ $unlockRate }}"
     aria-labelledby="progress-label-{{ $achievement['ID'] }}"
-    class="w-full h-1 bg-embed rounded flex"
+    class="w-full h-1 bg-zinc-950 light:bg-zinc-300 rounded flex"
 >
-    <!-- Hardcore completion -->
+    {{-- Hardcore completion --}}
     <div
         style="width: {{ $hardcoreProgressBarWidth }}%"
-        class="bg-[#cc9900] h-full {{ $hardcoreProgressBarWidth > 0 ? "rounded-l" : "" }}"
+        class="bg-gradient-to-r from-amber-500 to-[gold] light:bg-yellow-500 h-full {{ $hardcoreProgressBarWidth > 0 ? "rounded-l" : "" }}"
     >
         <span class="sr-only">
             {{ $hardcoreProgressBarWidth }}% of players have earned the achievement in hardcore mode
         </span>
     </div>
 
-    <!-- Softcore completion -->
+    {{-- Softcore completion --}}
     <div
         style="width: {{ $softcoreProgressBarWidth }}%"
-        class="bg-[rgb(11,113,193)] h-full {{ $hardcoreProgressBarWidth === 0 ? "rounded-l" : "" }}"
+        class="bg-neutral-500 h-full {{ $hardcoreProgressBarWidth === 0 ? "rounded-l" : "" }}"
     >
         <span class="sr-only">
             {{ $softcoreUnlockRate }}% of players have earned the achievement in softcore mode

--- a/resources/views/platform/components/game/current-progress/progress-bar.blade.php
+++ b/resources/views/platform/components/game/current-progress/progress-bar.blade.php
@@ -40,7 +40,7 @@ $completionPercentage = sprintf("%01.0f", floor($hardcoreProgressWidth + $softco
 
     <!-- Hardcore progress bar -->
     <div 
-        class="bg-yellow-600 h-full lg:rounded-bl {{ $hardcoreProgressWidth === 100 ? 'lg:rounded-br' : '' }}" 
+        class="bg-yellow-500 h-full lg:rounded-bl {{ $hardcoreProgressWidth === 100 ? 'lg:rounded-br' : '' }}" 
         style="width: {{ $hardcoreProgressWidth }}%"
     >
         <span class="sr-only">{{ $numEarnedHardcoreAchievements }} hardcore achievements</span>


### PR DESCRIPTION
This PR adjusts some of the styles on the game page so softcore progress matches how it's displayed elsewhere on the site (eg: user profiles and the completion progress page). Right now on prod there is a discrepancy in how softcore progress is represented, which is fixed by this PR.

This is done by adjusting the colors on progress bars and the achievement distribution chart.

**Before**
<img width="873" alt="Screenshot 2023-11-24 at 8 08 01 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/83d8376f-f1f2-425e-b79a-e52ffe969263">

<img width="365" alt="Screenshot 2023-11-24 at 8 08 07 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/c50f1556-de09-4efd-949d-32fb9f913073">

---

**After**
<img width="883" alt="Screenshot 2023-11-24 at 8 04 15 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/8f5938d6-8c76-41c9-8a76-b2677fd02741">

<img width="367" alt="Screenshot 2023-11-24 at 8 04 24 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/a0081cbf-4fbb-4f5f-8533-76a4cd35a5cb">
