### PR TITLE
feat: add 'missable' type

### DIFF
--- a/app/Helpers/database/achievement.php
+++ b/app/Helpers/database/achievement.php
@@ -210,8 +210,11 @@ function UploadNewAchievement(
         );
         $isEventGame = $gameData['ConsoleID'] == 101;
 
-        if ($isForSubsetOrTestKit || $isEventGame) {
-            $errorOut = "Cannot set type on achievement in subset, test kit, or event.";
+        if (
+            ($isForSubsetOrTestKit || $isEventGame)
+            && ($type === AchievementType::Progression || $type === AchievementType::WinCondition)
+        ) {
+            $errorOut = "Cannot set progression or win condition type on achievement in subset, test kit, or event.";
 
             return false;
         }

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -65,8 +65,9 @@ function getGameMetadata(
             CASE
                 WHEN ach.type = 'progression' THEN 0
                 WHEN ach.type = 'win_condition' THEN 1
-                WHEN ach.type IS NULL THEN 2
-                ELSE 3
+                WHEN ach.type = 'missable' THEN 2
+                WHEN ach.type IS NULL THEN 3
+                ELSE 4
             END,
             ach.DisplayOrder,
             ach.ID ASC ",
@@ -75,8 +76,9 @@ function getGameMetadata(
             CASE
                 WHEN ach.type = 'progression' THEN 0
                 WHEN ach.type = 'win_condition' THEN 1
-                WHEN ach.type IS NULL THEN 2
-                ELSE 3
+                WHEN ach.type = 'missable' THEN 2
+                WHEN ach.type IS NULL THEN 3
+                ELSE 4
             END DESC,
             ach.DisplayOrder DESC,
             ach.ID DESC ",

--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Platform;
 
 use App\Platform\Commands\DeleteOrphanedLeaderboardEntries;
+use App\Platform\Commands\MigrateMissableAchievementsToType;
 use App\Platform\Commands\NoIntroImport;
 use App\Platform\Commands\ResetPlayerAchievement;
 use App\Platform\Commands\SyncAchievements;
@@ -67,6 +68,9 @@ class AppServiceProvider extends ServiceProvider
 
                 // Game Hashes
                 NoIntroImport::class,
+
+                // Achievements
+                MigrateMissableAchievementsToType::class,
 
                 // Leaderboards
                 UpdateLeaderboardMetrics::class,

--- a/app/Platform/Commands/MigrateMissableAchievementsToType.php
+++ b/app/Platform/Commands/MigrateMissableAchievementsToType.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Commands;
+
+use App\Platform\Enums\AchievementType;
+use App\Platform\Models\Achievement;
+use Illuminate\Console\Command;
+
+class MigrateMissableAchievementsToType extends Command
+{
+    protected $signature = "ra:platform:achievement:migrate-missables
+                            {achievementId? : Target a single achievement}";
+    protected $description = "Migrate '[m]' tagged achievement(s) to the 'missable' type value";
+
+    public function handle(): void
+    {
+        $achievementId = $this->argument('achievementId');
+
+        if ($achievementId !== null) {
+            $achievement = Achievement::findOrFail($achievementId);
+
+            $this->info('Updating missable type for achievement [' . $achievement->id . ']');
+
+            $this->syncMissableTypeForAchievement($achievement);
+        } else {
+            $allTaggedMissables = Achievement::where('Title', 'like', '%[m]%')->get();
+
+            $this->info('Updating missable types for ' . $allTaggedMissables->count() . ' achievements.');
+
+            foreach ($allTaggedMissables as $achievement) {
+                $this->syncMissableTypeForAchievement($achievement);
+            }
+
+            $this->info('All achievements have been updated.');
+        }
+    }
+
+    private function syncMissableTypeForAchievement(Achievement $achievement): void
+    {
+        $usesLegacyMissableTag = mb_strpos($achievement->Title, '[m]');
+
+        // Is this achievement eligible for syncing? It must contain the legacy
+        // missable tag and must not already have a type.
+        if ($usesLegacyMissableTag && !$achievement->type) {
+            $achievement->type = AchievementType::Missable;
+
+            // Remove the [m] tag and trim whitespace
+            $achievement->Title = trim(str_replace('[m]', '', $achievement->Title));
+        }
+
+        $achievement->save();
+    }
+}

--- a/app/Platform/Enums/AchievementType.php
+++ b/app/Platform/Enums/AchievementType.php
@@ -10,11 +10,14 @@ abstract class AchievementType
 
     public const WinCondition = 'win_condition';
 
+    public const Missable = 'missable';
+
     public static function cases(): array
     {
         return [
             self::Progression,
             self::WinCondition,
+            self::Missable,
         ];
     }
 

--- a/app/Platform/Models/Achievement.php
+++ b/app/Platform/Models/Achievement.php
@@ -308,6 +308,15 @@ class Achievement extends BaseModel implements HasComments
      * @param Builder<Achievement> $query
      * @return Builder<Achievement>
      */
+    public function scopeMissable(Builder $query): Builder
+    {
+        return $this->scopeType($query, AchievementType::Missable);
+    }
+
+    /**
+     * @param Builder<Achievement> $query
+     * @return Builder<Achievement>
+     */
     public function scopeWithUnlocksByUser(Builder $query, User $user): Builder
     {
         $query->leftJoin('player_achievements', function ($join) use ($user) {

--- a/app/Platform/Models/Game.php
+++ b/app/Platform/Models/Game.php
@@ -165,7 +165,7 @@ class Game extends BaseModel implements HasComments, HasMedia
 
     // == accessors
 
-    public function getCanHaveTypes(): bool
+    public function getCanHaveBeatenTypes(): bool
     {
         $isSubsetOrTestKit = (
             mb_strpos($this->Title, "[Subset") !== false

--- a/database/factories/AchievementFactory.php
+++ b/database/factories/AchievementFactory.php
@@ -62,4 +62,11 @@ class AchievementFactory extends Factory
             'type' => AchievementType::WinCondition,
         ]);
     }
+
+    public function missable(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => AchievementType::Missable,
+        ]);
+    }
 }

--- a/lang/en/achievement-type.php
+++ b/lang/en/achievement-type.php
@@ -3,6 +3,7 @@
 use App\Platform\Enums\AchievementType;
 
 return [
+    AchievementType::Missable => __('Missable'),
     AchievementType::Progression => __('Progression'),
     AchievementType::WinCondition => __('Win Condition'),
 ];

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -122,7 +122,7 @@ RenderContentStart($pageTitle);
 ?>
 <?php if ($permissions >= Permissions::Developer || ($permissions >= Permissions::JuniorDeveloper && $isAuthor)): ?>
     <?php
-        $canHaveTypes = (
+        $canHaveBeatenTypes = (
             mb_strpos($gameTitle, "[Subset") === false
             && mb_strpos($gameTitle, "~Test Kit~") === false
             && $consoleID != 101
@@ -342,9 +342,9 @@ RenderContentStart($pageTitle);
             echo "</select>";
             echo "</td></tr>";
 
-            if ($canHaveTypes) {
-                $typeHelperContent = "A game is considered beaten if ALL " . __('achievement-type.' . AchievementType::Progression) . " achievements are unlocked and ANY " . __('achievement-type.' . AchievementType::WinCondition) . " achievements are unlocked.";
-                echo "<tr><td>";
+            $typeHelperContent = "A game is considered beaten if ALL " . __('achievement-type.' . AchievementType::Progression) . " achievements are unlocked and ANY " . __('achievement-type.' . AchievementType::WinCondition) . " achievements are unlocked.";
+            echo "<tr><td>";
+            if ($canHaveBeatenTypes) {
                 echo "<label class='cursor-help flex items-center gap-x-1' for='typeinput' title='$typeHelperContent' aria-label='Type, $typeHelperContent'>";
                 echo "Type";
                 echo "<span>";
@@ -352,16 +352,24 @@ RenderContentStart($pageTitle);
                 echo ":";
                 echo "</span>";
                 echo "</label>";
-                echo "</td><td>";
-                echo "<select id='typeinput' name='k'>";
-                echo "<option value=''>None</option>";
-                foreach (AchievementType::cases() as $typeOption) {
-                    echo "<option value='$typeOption' " . ($achType === $typeOption ? 'selected' : '') . ">";
-                    echo __('achievement-type.' . $typeOption);
-                    echo "</option>";
-                }
-                echo "</select></td></tr>";
+            } else {
+                echo "<label for='typeinput'>Type:</label>";
             }
+            echo "</td><td>";
+            echo "<select id='typeinput' name='k'>";
+            echo "<option value=''>None</option>";
+            $allTypes = AchievementType::cases();
+            $validTypes = $canHaveBeatenTypes
+                ? $allTypes
+                : array_filter($allTypes, function ($type) {
+                    return $type !== AchievementType::Progression && $type !== AchievementType::WinCondition;
+                });
+            foreach ($validTypes as $typeOption) {
+                echo "<option value='$typeOption' " . ($achType === $typeOption ? 'selected' : '') . ">";
+                echo __('achievement-type.' . $typeOption);
+                echo "</option>";
+            }
+            echo "</select></td></tr>";
 
             echo "</tbody></table>";
             echo "&nbsp;<button type='button' class='btn' style='float: right;' onclick=\"updateAchievementDetails()\">Update</button><br><br>";

--- a/public/achievementinspector.php
+++ b/public/achievementinspector.php
@@ -31,7 +31,7 @@ $consoleName = null;
 $gameIcon = null;
 $gameTitle = null;
 $gameIDSpecified = isset($gameID) && $gameID != 0;
-$canHaveTypes = false;
+$canHaveBeatenTypes = false;
 if ($gameIDSpecified) {
     getGameMetadata($gameID, null, $achievementData, $gameData, 0, null, $flag);
     $gameTitle = $gameData['Title'];
@@ -41,7 +41,7 @@ if ($gameIDSpecified) {
 
     getCodeNotes($gameID, $codeNotes);
 
-    $canHaveTypes = (
+    $canHaveBeatenTypes = (
         mb_strpos($gameTitle, "[Subset") === false
         && mb_strpos($gameTitle, "~Test Kit~") === false
         && $gameData['ConsoleID'] !== 101
@@ -102,7 +102,7 @@ if ($gameIDSpecified) {
             </p>
         HTML;
 
-        if ($canHaveTypes) {
+        if ($canHaveBeatenTypes) {
             echo <<<HTML
                 <p align="justify">
                     You can mark multiple achievements as '$progressionLabel' or '$winConditionLabel'. To do this, check the desired
@@ -192,7 +192,7 @@ if ($gameIDSpecified) {
 
         $typeLabelClassNames = !$achType ? "text-muted" : "";
 
-        if ($canHaveTypes) {
+        if ($canHaveBeatenTypes) {
             echo <<<HTML
                 <tr class="$bgColorClassNames[$currentBgColorIndex]">
                     <td><span class="font-bold">Type:</span></td>
@@ -258,13 +258,13 @@ if ($gameIDSpecified) {
     echo "<div>";
     echo Blade::render('
         <x-developer.inspector-toolbox
-            :canHaveTypes="$canHaveTypes"
+            :canHaveBeatenTypes="$canHaveBeatenTypes"
             :gameId="$gameId"
             :isManagingCoreAchievements="$isManagingCoreAchievements"
             :modificationLevel="$modificationLevel"
         />
     ', [
-        'canHaveTypes' => $canHaveTypes,
+        'canHaveBeatenTypes' => $canHaveBeatenTypes,
         'gameId' => $gameID,
         'isManagingCoreAchievements' => $flag === AchievementFlag::OfficialCore,
         'modificationLevel' => $modificationLevel,

--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1343,19 +1343,15 @@ sanitize_outputs(
                         :achievements="$achievements"
                         :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
                         :isCreditDialogEnabled="$isCreditDialogEnabled"
-                        :progressionTypeValue="$progressionTypeValue"
                         :showAuthorNames="$showAuthorNames"
                         :totalPlayerCount="$totalPlayerCount"
-                        :winConditionTypeValue="$winConditionTypeValue"
                     />
                 ', [
                     'achievements' => $achievementData,
                     'beatenGameCreditDialogContext' => $beatenGameCreditDialogContext,
                     'isCreditDialogEnabled' => $user && $flagParam != $unofficialFlag,
-                    'progressionTypeValue' => AchievementType::Progression,
                     'showAuthorNames' => !$isOfficial && isset($user) && $permissions >= Permissions::JuniorDeveloper,
                     'totalPlayerCount' => $numDistinctPlayers,
-                    'winConditionTypeValue' => AchievementType::WinCondition,
                 ]);
             }
         }

--- a/public/request/achievement/update-type.php
+++ b/public/request/achievement/update-type.php
@@ -23,9 +23,13 @@ $value = $input['type'];
 
 $foundAchievements = Achievement::find($achievementIds);
 
-// Don't allow adding types to subsets or test kits.
+// Don't allow adding beaten types to subsets or test kits.
 $game = Game::find($foundAchievements->get(0)->GameID);
-if ($game && !$game->getCanHaveTypes()) {
+if (
+    $game
+    && !$game->getCanHaveBeatenTypes()
+    && ($value === AchievementType::Progression || $value === AchievementType::WinCondition)
+) {
     abort(400);
 }
 
@@ -42,6 +46,9 @@ if (updateAchievementType($achievementIds, $value)) {
     }
     if ($value === AchievementType::WinCondition) {
         $commentText = "set this achievement's type to Win Condition";
+    }
+    if ($value === AchievementType::Missable) {
+        $commentText = "set this achievement's type to Missable";
     }
     if (!$value) {
         $commentText = "removed this achievement's type";

--- a/resources/views/components/icon/missable.blade.php
+++ b/resources/views/components/icon/missable.blade.php
@@ -1,0 +1,3 @@
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path d="M10 3H14V14H10V3M10 21V17H14V21H10Z" fill="currentColor"></path>
+</svg>

--- a/resources/views/components/modal-trigger.blade.php
+++ b/resources/views/components/modal-trigger.blade.php
@@ -10,8 +10,10 @@
 ])
 
 <div
-    x-data="window.modalComponent('{{ $resourceApiRoute }}', '{{ $resourceId }}', '{{ $resourceContext }}')"
-    @keydown.escape.window="closeModal"
+    @if (!$disabled)
+        x-data="window.modalComponent('{{ $resourceApiRoute }}', '{{ $resourceId }}', '{{ $resourceContext }}')"
+        @keydown.escape.window="closeModal"
+    @endif
     class="relative w-auto h-auto inline"
 >
     @isset ($trigger)

--- a/resources/views/platform/components/developer/inspector-toolbox.blade.php
+++ b/resources/views/platform/components/developer/inspector-toolbox.blade.php
@@ -1,5 +1,5 @@
 @props([
-    'canHaveTypes' => true,
+    'canHaveBeatenTypes' => true,
     'gameId' => 0,
     'modificationLevel' => 'none', // 'none' | 'partial' | 'full'
     'isManagingCoreAchievements' => true,
@@ -11,6 +11,7 @@ use App\Platform\Enums\AchievementType;
 
 $progressionType = AchievementType::Progression;
 $winConditionType = AchievementType::WinCondition;
+$missableType = AchievementType::Missable;
 $officialFlag = AchievementFlag::OfficialCore;
 $unofficialFlag = AchievementFlag::Unofficial;
 ?>
@@ -23,7 +24,7 @@ $unofficialFlag = AchievementFlag::Unofficial;
 
             /**
              * @param {'flag' | 'type'} property
-             * @param {3 | 5 | 'progression' | 'win_condition' | null} newValue
+             * @param {3 | 5 | 'progression' | 'win_condition' | 'missable' | null} newValue
              * @param {number} selectedCount
              */
             getConfirmMessage(property, newValue, selectedCount) {
@@ -42,6 +43,8 @@ $unofficialFlag = AchievementFlag::Unofficial;
                         message = `Are you sure you want to set ${selectedCount === 1 ? 'this achievement' : 'these achievements'} to Progression?`;
                     } else if (newValue === '{{ $winConditionType }}') {
                         message = `Are you sure you want to set ${selectedCount === 1 ? 'this achievement' : 'these achievements'} to Win Condition?`;
+                    } else if (newValue === '{{ $missableType }}') {
+                        message = `Are you sure you want to set ${selectedCount === 1 ? 'this achievement' : 'these achievements'} to Missable?`;
                     } else {
                         message = `Are you sure you want to remove the type from ${selectedCount === 1 ? 'this achievement' : 'these achievements'}?`;
                     }
@@ -70,7 +73,7 @@ $unofficialFlag = AchievementFlag::Unofficial;
 
             /**
              * @param {'flag' | 'type'} property
-             * @param {3 | 5 | 'progression' | 'win_condition' | null} newValue
+             * @param {3 | 5 | 'progression' | 'win_condition' | 'missable' | null} newValue
              */
             updateAchievementsProperty(property, newValue) {
                 // Creates an array of checked achievement IDs and sends it to the updateAchievements function
@@ -135,7 +138,7 @@ $unofficialFlag = AchievementFlag::Unofficial;
             @endif
         </a>
 
-        @if ($canHaveTypes)
+        @if ($canHaveBeatenTypes)
             <button
                 class="btn"
                 @click="updateAchievementsProperty('type', '{{ $progressionType }}')"
@@ -149,14 +152,21 @@ $unofficialFlag = AchievementFlag::Unofficial;
             >
                 Set Selected to Win Condition
             </button>
-
-            <button
-                class="btn"
-                @click="updateAchievementsProperty('type', null)"
-            >
-                Set Selected to No Type
-            </button>
         @endif
+
+        <button
+            class="btn"
+            @click="updateAchievementsProperty('type', '{{ $missableType }}')"
+        >
+            Set Selected to Missable
+        </button>
+
+        <button
+            class="btn"
+            @click="updateAchievementsProperty('type', null)"
+        >
+            Set Selected to No Type
+        </button>
 
         @if ($modificationLevel === 'full')
             <button class="btn" @click="toggleAllCodeRows">Toggle Code Rows</button>

--- a/resources/views/platform/components/game/achievements-list/achievements-list-item.blade.php
+++ b/resources/views/platform/components/game/achievements-list/achievements-list-item.blade.php
@@ -2,8 +2,6 @@
     'achievement' => [],
     'beatenGameCreditDialogContext' => 's:|h:',
     'totalPlayerCount' => 0,
-    'progressionTypeValue' => 'progression', // `AchievementType`
-    'winConditionTypeValue' => 'win_condition', // `AchievementType`
     'useMinimalLayout' => false,
     'isUnlocked' => false,
     'isUnlockedHardcore' => false,
@@ -73,8 +71,6 @@ if (isset($achievement['DateEarnedHardcore'])) {
                             <div class="-mt-1.5">
                                 <x-game.achievements-list.type-indicator
                                     :achievementType="$achievement['type']"
-                                    :progressionTypeValue="$progressionTypeValue"
-                                    :winConditionTypeValue="$winConditionTypeValue"
                                     :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
                                     :isCreditDialogEnabled="$isCreditDialogEnabled"
                                 />
@@ -111,8 +107,6 @@ if (isset($achievement['DateEarnedHardcore'])) {
                     <div class="hidden md:flex items-center justify-end gap-x-1">
                         <x-game.achievements-list.type-indicator
                             :achievementType="$achievement['type']"
-                            :progressionTypeValue="$progressionTypeValue"
-                            :winConditionTypeValue="$winConditionTypeValue"
                             :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
                             :isCreditDialogEnabled="$isCreditDialogEnabled"    
                         />

--- a/resources/views/platform/components/game/achievements-list/root.blade.php
+++ b/resources/views/platform/components/game/achievements-list/root.blade.php
@@ -2,23 +2,20 @@
     'achievements' => [],
     'beatenGameCreditDialogContext' => 's:|h:',
     'totalPlayerCount' => 0,
-    'progressionTypeValue' => 'progression', // `AchievementType`
-    'winConditionTypeValue' => 'win_condition', // `AchievementType`
     'isCreditDialogEnabled' => true,
     'showAuthorNames' => false,
 ])
 
 <?php
+use App\Platform\Enums\AchievementType;
+
+
 $unlockedAchievements = array_filter($achievements, function ($achievement) {
     return !empty($achievement['DateEarned']) || !empty($achievement['DateEarnedHardcore']);
 });
 
 $lockedAchievements = array_filter($achievements, function ($achievement) {
     return empty($achievement['DateEarned']) && empty($achievement['DateEarnedHardcore']);
-});
-
-$winConditionAchievements = array_filter($achievements, function ($achievement) use ($winConditionTypeValue) {
-    return isset($achievement['type']) && $achievement['type'] === $winConditionTypeValue;
 });
 ?>
 
@@ -29,10 +26,8 @@ $winConditionAchievements = array_filter($achievements, function ($achievement) 
                 :achievement="$achievement"
                 :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
                 :isCreditDialogEnabled="$isCreditDialogEnabled"
-                :progressionTypeValue="$progressionTypeValue"
                 :showAuthorName="$showAuthorNames"
                 :totalPlayerCount="$totalPlayerCount"
-                :winConditionTypeValue="$winConditionTypeValue"
             />
         @endforeach
 
@@ -41,10 +36,8 @@ $winConditionAchievements = array_filter($achievements, function ($achievement) 
                 :achievement="$achievement"
                 :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
                 :isCreditDialogEnabled="$isCreditDialogEnabled"
-                :progressionTypeValue="$progressionTypeValue"
                 :showAuthorName="$showAuthorNames"
                 :totalPlayerCount="$totalPlayerCount"
-                :winConditionTypeValue="$winConditionTypeValue"
             />
         @endforeach
     </ul>

--- a/resources/views/platform/components/game/achievements-list/type-indicator.blade.php
+++ b/resources/views/platform/components/game/achievements-list/type-indicator.blade.php
@@ -2,55 +2,78 @@
     'achievementType' => null,
     'beatenGameCreditDialogContext' => 's:|h:',
     'gameId' => null,
-    'progressionTypeValue' => 'progression', // `AchievementType`
-    'winConditionTypeValue' => 'win_condition', // `AchievementType`
     'isCreditDialogEnabled' => true,
 ])
 
 <?php
+use App\Platform\Enums\AchievementType;
 use Illuminate\Http\Request;
 
 $gameId ??= request()->route('game');
+
+$progressionTypeValue = AchievementType::Progression;
+$winConditionTypeValue = AchievementType::WinCondition;
+$missableTypeValue = AchievementType::Missable;
+
+$backgroundColorClassName = "bg-embed light:bg-neutral-50";
+if ($achievementType === $missableTypeValue) {
+    $backgroundColorClassName = "bg-amber-950 light:bg-amber-100";
+}
 ?>
 
-@if ($achievementType === $progressionTypeValue || $achievementType === $winConditionTypeValue)
-    <x-modal-trigger
-        modalTitleLabel="Beaten Game Credit"
-        resourceApiRoute="/request/game/beaten-credit.php"
-        :resourceId="$gameId"
-        :resourceContext="$beatenGameCreditDialogContext"
-        :disabled="!$isCreditDialogEnabled"
-    >
-        <x-slot name="trigger">
-            <div class="flex items-center group bg-embed light:bg-neutral-50 light:border light:border-neutral-300 p-1 rounded-full text-neutral-200 light:text-neutral-500 overflow-hidden">
-                @if ($achievementType === $progressionTypeValue)
-                    <span class="
-                        text-[0.6rem] transition translate-x-4 duration-300 ease-out w-0 opacity-0 invisible 
-                        group-hover:md:visible group-hover:md:w-[60px] group-hover:md:opacity-100
-                        group-hover:md:ml-1 group-hover:md:mr-2 group-hover:md:translate-x-0
-                        select-none font-semibold
-                    ">
-                        Progression
-                    </span>
-                    <div class="w-[18px] h-[18px]" aria-label="Progression">
-                        <x-icon.progression />
-                    </div>
-                @endif
+<x-modal-trigger
+    modalTitleLabel="Beaten Game Credit"
+    resourceApiRoute="/request/game/beaten-credit.php"
+    :resourceId="$gameId"
+    :resourceContext="$beatenGameCreditDialogContext"
+    :disabled="!$isCreditDialogEnabled || $achievementType === $missableTypeValue"
+>
+    <x-slot name="trigger">
+        <div class="flex items-center {{ $backgroundColorClassName }} group light:border light:border-neutral-300 p-1 rounded-full text-neutral-200 light:text-neutral-500 overflow-hidden">
+            @if ($achievementType === $progressionTypeValue)
+                <span class="
+                    text-[0.6rem] transition translate-x-4 duration-300 ease-out w-0 opacity-0 invisible 
+                    group-hover:md:visible group-hover:md:w-[60px] group-hover:md:opacity-100
+                    group-hover:md:ml-1 group-hover:md:mr-2 group-hover:md:translate-x-0
+                    select-none font-semibold
+                ">
+                    Progression
+                </span>
+                <div class="w-[18px] h-[18px]" aria-label="Progression">
+                    <x-icon.progression />
+                </div>
+            @endif
 
-                @if ($achievementType === $winConditionTypeValue)
-                    <span class="
-                        text-[0.6rem] transition translate-x-3 duration-300 ease-out w-0 opacity-0 invisible 
-                        group-hover:md:visible group-hover:md:w-[60px] group-hover:md:opacity-100 
-                        group-hover:md:ml-1 group-hover:md:mr-[18px] group-hover:md:translate-x-0
-                        select-none whitespace-nowrap font-semibold
-                    ">
-                        Win Condition
-                    </span>
-                    <div class="w-[18px] h-[18px]" aria-label="Win Condition">
-                        <x-icon.win-condition />
-                    </div>
-                @endif
-            </div>
-        </x-slot>
-    </x-modal-trigger>
-@endif
+            @if ($achievementType === $winConditionTypeValue)
+                <span class="
+                    text-[0.6rem] transition translate-x-3 duration-300 ease-out w-0 opacity-0 invisible 
+                    group-hover:md:visible group-hover:md:w-[60px] group-hover:md:opacity-100 
+                    group-hover:md:ml-1 group-hover:md:mr-[18px] group-hover:md:translate-x-0
+                    select-none whitespace-nowrap font-semibold
+                ">
+                    Win Condition
+                </span>
+                <div class="w-[18px] h-[18px]" aria-label="Win Condition">
+                    <x-icon.win-condition />
+                </div>
+            @endif
+
+            @if ($achievementType === $missableTypeValue)
+                <span class="
+                    text-[0.6rem] transition translate-x-4 duration-300 ease-out w-0 opacity-0 invisible 
+                    group-hover:md:visible group-hover:md:w-[44px] group-hover:md:opacity-100
+                    group-hover:md:ml-1 group-hover:md:mr-2 group-hover:md:translate-x-0
+                    select-none font-semibold z-10
+                ">
+                    Missable
+                </span>
+                <div class="w-[18px] h-[18px] z-10" aria-label="Progression">
+                    <x-icon.missable />
+                </div>
+
+                {{-- Backwards compatibility for users who search the page by "[m]" --}}
+                <span class="absolute text-amber-950 light:text-amber-100 text-2xs">[m]</span>
+            @endif
+        </div>
+    </x-slot>
+</x-modal-trigger>

--- a/tests/Feature/Connect/UploadAchievementTest.php
+++ b/tests/Feature/Connect/UploadAchievementTest.php
@@ -812,7 +812,7 @@ class UploadAchievementTest extends TestCase
         $this->assertEquals($game->points_total, 5);
 
         // ====================================================
-        // cannot set type on achievement in subset
+        // cannot set progression or win condition type on achievement in subset
         $params['n'] = 'Title2';
         $params['d'] = 'Description2';
         $params['z'] = 10;
@@ -823,7 +823,7 @@ class UploadAchievementTest extends TestCase
             ->assertExactJson([
                 'Success' => false,
                 'AchievementID' => $achievement2->ID,
-                'Error' => 'Cannot set type on achievement in subset, test kit, or event.',
+                'Error' => 'Cannot set progression or win condition type on achievement in subset, test kit, or event.',
             ]);
 
         // ====================================================


### PR DESCRIPTION
This PR adds a third possible achievement type: "missable".

**Why?**
The existing "[m]" magic string is a workaround which the site, emulators, and third-party consumers should not rely on to determine if an achievement is missable. What would be much more appropriate is a structured value, and `type` is a good fit. Something that is progression cannot by definition be missable. Win conditions marked as missable are stretching the definition of missable, as it goes without saying that a conditional ending can be missed in a single playthrough.

**How it works**
A third type on core sets, "Missable", can now be set. Subsets can also use the type on their achievements (but they still do not support progression/win).

![Screenshot 2023-11-30 at 5 54 20 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/44207ee0-277b-4574-95dc-670b0345c7a3)

When an achievement is marked as missable, it receives a new type indicator, which is visually distinct from the beaten credit indicators:


https://github.com/RetroAchievements/RAWeb/assets/3984985/b1f8ff55-4d1e-4eed-993e-6140ba453358

Because it is a type, the "Type" sort on game pages allows users to sort the achievements list to easily see all the missables.

Additionally, there is a hidden "[m]" for users accustomed to manually searching in their browser and 3rd party extensions:

![Screenshot 2023-11-30 at 5 57 54 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/33214e2e-79c1-4310-b087-c2db21cdd183)

**Migration command**
A new command has been added to the project which migrates all existing "[m]" tagged achievements over to the new type:

```
ra:platform:achievement:migrate-missables 12345
```

It can target any specific achievement via an achievement ID. If no achievement ID is given, it does a full migration of all the achievements in the database.