### PR TITLE
feat(api): add 'Type' to more endpoint responses

### DIFF
--- a/app/Helpers/database/player-history.php
+++ b/app/Helpers/database/player-history.php
@@ -61,7 +61,7 @@ function getAchievementsEarnedBetween(string $dateStart, string $dateEnd, User $
     $query = "SELECT COALESCE(pa.unlocked_hardcore_at, pa.unlocked_at) AS Date,
                      CASE WHEN pa.unlocked_hardcore_at IS NOT NULL THEN 1 ELSE 0 END AS HardcoreMode,
                      ach.ID AS AchievementID, ach.Title, ach.Description,
-                     ach.BadgeName, ach.Points, ach.Author,
+                     ach.BadgeName, ach.Points, ach.type as Type, ach.Author,
                      gd.Title AS GameTitle, gd.ImageIcon AS GameIcon, ach.GameID,
                      c.Name AS ConsoleName
               FROM player_achievements pa

--- a/public/API/API_GetAchievementOfTheWeek.php
+++ b/public/API/API_GetAchievementOfTheWeek.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Carbon;
  *   string     Description    description of the achievement
  *   int        Points         number of points the achievement is worth
  *   int        TrueRatio      number of "white" points the achievement is worth
+ *   string     Type           null, "progression", "win_condition", or "missable"
  *   string     Author         user who first created the achievement
  *   datetime   DateCreated    when the achievement was created
  *   datetime   DateModified   when the achievement was last modified
@@ -59,6 +60,7 @@ $achievement = [
     'Description' => $achievementData['Description'] ?? null,
     'Points' => $achievementData['Points'] ?? null,
     'TrueRatio' => $achievementData['TrueRatio'] ?? null,
+    'Type' => $achievementData['Type'] ?? null,
     'Author' => $achievementData['Author'] ?? null,
     'DateCreated' => $achievementData['DateCreated'] ?? null,
     'DateModified' => $achievementData['DateModified'] ?? null,

--- a/public/API/API_GetAchievementsEarnedBetween.php
+++ b/public/API/API_GetAchievementsEarnedBetween.php
@@ -16,6 +16,7 @@
  *    int        Points                   number of points the achievement is worth
  *    string     BadgeName                unique identifier of the badge image for the achievement
  *    string     BadgeURL                 site-relative path to the badge image for the achievement
+ *    string     Type                     null, "progression", "win_condition", or "missable"
  *    string     Author                   user who originally created the achievement
  *    int        GameID                   unique identifier of the game associated to the achievement
  *    string     GameTitle                title of the game associated to the achievement

--- a/public/API/API_GetAchievementsEarnedOnDay.php
+++ b/public/API/API_GetAchievementsEarnedOnDay.php
@@ -13,6 +13,7 @@
  *    string     Title                    title of the achievement
  *    string     Description              description of the achievement
  *    int        Points                   number of points the achievement is worth
+ *    string     Type                     null, "progression", "win_condition", or "missable"
  *    string     BadgeName                unique identifier of the badge image for the achievement
  *    string     BadgeURL                 site-relative path to the badge image for the achievement
  *    string     Author                   user who originally created the achievement

--- a/public/API/API_GetUserRecentAchievements.php
+++ b/public/API/API_GetUserRecentAchievements.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Carbon;
  *    int        Points                   number of points the achievement is worth
  *    string     BadgeName                unique identifier of the badge image for the achievement
  *    string     BadgeURL                 site-relative path to the badge image for the achievement
+ *    string     Type                     null, "progression", "win_condition", or "missable"
  *    string     Author                   user who originally created the achievement
  *    int        GameID                   unique identifier of the game associated to the achievement
  *    string     GameTitle                title of the game associated to the achievement

--- a/tests/Feature/Api/V1/UserRecentAchievementsTest.php
+++ b/tests/Feature/Api/V1/UserRecentAchievementsTest.php
@@ -34,7 +34,7 @@ class UserRecentAchievementsTest extends TestCase
         /** @var Achievement $achievement2 */
         $achievement2 = Achievement::factory()->published()->create(['GameID' => $game2->ID, 'BadgeName' => '23456']);
         /** @var Achievement $achievement3 */
-        $achievement3 = Achievement::factory()->published()->create(['GameID' => $game2->ID, 'BadgeName' => '34567']);
+        $achievement3 = Achievement::factory()->published()->progression()->create(['GameID' => $game2->ID, 'BadgeName' => '34567']);
 
         $now = Carbon::now()->subSeconds(15); // 15-second offset so times aren't on the boundaries being queried
         $unlock1Date = $now->clone()->subMinutes(65);
@@ -93,6 +93,7 @@ class UserRecentAchievementsTest extends TestCase
                     'Description' => $achievement3->Description,
                     'HardcoreMode' => UnlockMode::Softcore,
                     'Points' => $achievement3->Points,
+                    'Type' => $achievement3->type,
                     'Title' => $achievement3->Title,
                     'GameID' => $game2->ID,
                     'GameTitle' => $game2->Title,
@@ -108,6 +109,7 @@ class UserRecentAchievementsTest extends TestCase
                     'Description' => $achievement2->Description,
                     'HardcoreMode' => UnlockMode::Hardcore,
                     'Points' => $achievement2->Points,
+                    'Type' => $achievement2->type,
                     'Title' => $achievement2->Title,
                     'GameID' => $game2->ID,
                     'GameTitle' => $game2->Title,
@@ -130,6 +132,7 @@ class UserRecentAchievementsTest extends TestCase
                     'Description' => $achievement3->Description,
                     'HardcoreMode' => UnlockMode::Softcore,
                     'Points' => $achievement3->Points,
+                    'Type' => $achievement3->type,
                     'Title' => $achievement3->Title,
                     'GameID' => $game2->ID,
                     'GameTitle' => $game2->Title,
@@ -145,6 +148,7 @@ class UserRecentAchievementsTest extends TestCase
                     'Description' => $achievement2->Description,
                     'HardcoreMode' => UnlockMode::Hardcore,
                     'Points' => $achievement2->Points,
+                    'Type' => $achievement2->type,
                     'Title' => $achievement2->Title,
                     'GameID' => $game2->ID,
                     'GameTitle' => $game2->Title,
@@ -167,6 +171,7 @@ class UserRecentAchievementsTest extends TestCase
                     'Description' => $achievement3->Description,
                     'HardcoreMode' => UnlockMode::Softcore,
                     'Points' => $achievement3->Points,
+                    'Type' => $achievement3->type,
                     'Title' => $achievement3->Title,
                     'GameID' => $game2->ID,
                     'GameTitle' => $game2->Title,
@@ -182,6 +187,7 @@ class UserRecentAchievementsTest extends TestCase
                     'Description' => $achievement2->Description,
                     'HardcoreMode' => UnlockMode::Hardcore,
                     'Points' => $achievement2->Points,
+                    'Type' => $achievement2->type,
                     'Title' => $achievement2->Title,
                     'GameID' => $game2->ID,
                     'GameTitle' => $game2->Title,
@@ -197,6 +203,7 @@ class UserRecentAchievementsTest extends TestCase
                     'Description' => $achievement1->Description,
                     'HardcoreMode' => UnlockMode::Hardcore,
                     'Points' => $achievement1->Points,
+                    'Type' => $achievement1->type,
                     'Title' => $achievement1->Title,
                     'GameID' => $game1->ID,
                     'GameTitle' => $game1->Title,

--- a/tests/Feature/Api/V1Test.php
+++ b/tests/Feature/Api/V1Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Api;
 
 use App\Platform\Enums\AchievementFlag;
+use App\Platform\Enums\AchievementType;
 use App\Platform\Enums\UnlockMode;
 use App\Platform\Models\Achievement;
 use App\Platform\Models\Game;
@@ -175,7 +176,7 @@ class V1Test extends TestCase
         /** @var Game $game */
         $game = Game::factory()->create(['ConsoleID' => $system->ID]);
         /** @var Achievement $achievement */
-        $achievement = Achievement::factory()->published()->create(['GameID' => $game->ID, 'Points' => 100]);
+        $achievement = Achievement::factory()->published()->progression()->create(['GameID' => $game->ID, 'Points' => 100]);
 
         $unlockTime = Carbon::now()->subMinutes(5);
         $this->addSoftcoreUnlock($this->user, $achievement, $unlockTime);
@@ -202,6 +203,7 @@ class V1Test extends TestCase
                     'GameURL' => '/game/' . $game->ID,
                     'HardcoreMode' => UnlockMode::Softcore,
                     'Points' => $achievement->Points,
+                    'Type' => AchievementType::Progression,
                     'Title' => $achievement->Title,
                 ],
             ]);
@@ -214,7 +216,7 @@ class V1Test extends TestCase
         /** @var Game $game */
         $game = Game::factory()->create(['ConsoleID' => $system->ID]);
         /** @var Achievement $achievement */
-        $achievement = Achievement::factory()->published()->create(['GameID' => $game->ID, 'Points' => 100, 'Author' => $this->user->User]);
+        $achievement = Achievement::factory()->published()->progression()->create(['GameID' => $game->ID, 'Points' => 100, 'Author' => $this->user->User]);
 
         $unlockTime = Carbon::now()->subMinutes(5);
         $this->addSoftcoreUnlock($this->user, $achievement, $unlockTime);
@@ -243,6 +245,7 @@ class V1Test extends TestCase
                     'GameURL' => '/game/' . $game->ID,
                     'HardcoreMode' => UnlockMode::Softcore,
                     'Points' => $achievement->Points,
+                    'Type' => AchievementType::Progression,
                     'Title' => $achievement->Title,
                 ],
             ]);
@@ -270,8 +273,8 @@ class V1Test extends TestCase
                     'Title' => $achievement->Title,
                     'Description' => $achievement->Description,
                     'Points' => $achievement->Points,
-                    'Author' => $achievement->Author,
                     'Type' => $achievement->type,
+                    'Author' => $achievement->Author,
                 ],
                 'Console' => [
                     'ID' => $system->ID,


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/discussions/2081#discussioncomment-7794278.

Adds "Type" value to achievements returned in:
* API_GetAchievementsEarnedBetween
* API_GetAchievementsEarnedOnDay
* API_GetUserRecentAchievements
* API_GetAchievementOfTheWeek