### PR TITLE
feat(api): add API_GetGameFromHash endpoint

### DIFF
--- a/app/Platform/Models/GameHash.php
+++ b/app/Platform/Models/GameHash.php
@@ -133,6 +133,15 @@ class GameHash extends BaseModel
         return $this->belongsTo(System::class);
     }
 
+    // TODO update after dropping GameID and migrating to game_hash_sets relation
+    /**
+     * @return BelongsTo<Game, GameHash>
+     */
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class, 'GameID', 'ID');
+    }
+
     /**
      * @return BelongsToMany<GameHashSet>
      */

--- a/database/factories/GameHashFactory.php
+++ b/database/factories/GameHashFactory.php
@@ -22,6 +22,7 @@ class GameHashFactory extends Factory
         return [
             'system_id' => 1,
             'hash' => fake()->md5,
+            'MD5' => fake()->md5,
         ];
     }
 }

--- a/public/API/API_GetGameFromHash.php
+++ b/public/API/API_GetGameFromHash.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ *  API_GetGameFromHash - looks up a game from a given hash string
+ *    h : game hash
+ *
+ *  int        ID                         id of the game
+ *  string     Title                      name of the game
+ *  int        ConsoleID                  unique identifier of the console associated to the game
+ *  string     ConsoleName                name of the console associated to the game
+ */
+
+use App\Platform\Models\GameHash;
+use App\Platform\Models\System;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+
+$input = Validator::validate(Arr::wrap(request()->query()), [
+    'h' => ['required', 'size:32'],
+]);
+
+$givenHash = request()->query('h');
+
+$foundHash = GameHash::with('game')->where('MD5', $givenHash)->first();
+
+if (!$foundHash) {
+    return response()->json(['message' => 'Could not find a game matching the given hash.'], 400);
+}
+
+$foundSystem = System::find($foundHash->game->ConsoleID);
+
+return response()->json([
+    'ID' => $foundHash->game->ID,
+    'Title' => $foundHash->game->Title,
+    'ConsoleID' => $foundHash->game->ConsoleID,
+    'ConsoleName' => $foundSystem?->Name ?? null,
+]);

--- a/public/API/API_GetGameFromHash.php
+++ b/public/API/API_GetGameFromHash.php
@@ -24,7 +24,11 @@ $givenHash = request()->query('h');
 $foundHash = GameHash::with('game')->where('MD5', $givenHash)->first();
 
 if (!$foundHash) {
-    return response()->json(['message' => 'Could not find a game matching the given hash.'], 400);
+    return response()->json([
+        'status' => 404,
+        'code' => 'not_found',
+        'error' => "Unknown hash: $givenHash",
+    ], 404);
 }
 
 $foundSystem = System::find($foundHash->game->ConsoleID);
@@ -32,6 +36,7 @@ $foundSystem = System::find($foundHash->game->ConsoleID);
 return response()->json([
     'ID' => $foundHash->game->ID,
     'Title' => $foundHash->game->Title,
+    'Description' => $foundHash->Name,
     'ConsoleID' => $foundHash->game->ConsoleID,
     'ConsoleName' => $foundSystem?->Name ?? null,
 ]);

--- a/public/API/API_GetGameFromHash.php
+++ b/public/API/API_GetGameFromHash.php
@@ -6,6 +6,7 @@
  *
  *  int        ID                         id of the game
  *  string     Title                      name of the game
+ *  string     Description                description of the associated hash
  *  int        ConsoleID                  unique identifier of the console associated to the game
  *  string     ConsoleName                name of the console associated to the game
  */
@@ -25,9 +26,14 @@ $foundHash = GameHash::with('game')->where('MD5', $givenHash)->first();
 
 if (!$foundHash) {
     return response()->json([
-        'status' => 404,
-        'code' => 'not_found',
-        'error' => "Unknown hash: $givenHash",
+        'message' => "Unknown hash: $givenHash",
+        'errors' => [
+            [
+                'status' => 404,
+                'code' => 'not_found',
+                'title' => "Unknown hash: $givenHash",
+            ],
+        ],
     ], 404);
 }
 

--- a/tests/Feature/Api/V1/GameFromHashTest.php
+++ b/tests/Feature/Api/V1/GameFromHashTest.php
@@ -35,10 +35,14 @@ class GameFromHashTest extends TestCase
 
     public function testGetGameFromHashIfGameNotFound(): void
     {
-        $this->get($this->apiUrl('GetGameFromHash', ['h' => '1bc674be034e43c96b86487ac69d9293']))
-            ->assertStatus(400)
+        $targetHash = '1bc674be034e43c96b86487ac69d9293';
+
+        $this->get($this->apiUrl('GetGameFromHash', ['h' => $targetHash]))
+            ->assertStatus(404)
             ->assertJson([
-                'message' => 'Could not find a game matching the given hash.',
+                'status' => 404,
+                'code' => 'not_found',
+                'error' => "Unknown hash: $targetHash",
             ]);
     }
 
@@ -49,13 +53,14 @@ class GameFromHashTest extends TestCase
         /** @var Game $game */
         $game = Game::factory()->create(['ConsoleID' => $system->ID]);
         /** @var GameHash $gameHash */
-        $gameHash = GameHash::factory()->create(['GameID' => $game->ID]);
+        $gameHash = GameHash::factory()->create(['GameID' => $game->ID, 'Name' => 'foo']);
 
         $this->get($this->apiUrl('GetGameFromHash', ['h' => $gameHash->MD5]))
             ->assertSuccessful()
             ->assertJson([
                 'ID' => $game->ID,
                 'Title' => $game->Title,
+                'Description' => $gameHash->Name,
                 'ConsoleID' => $system->ID,
                 'ConsoleName' => $system->Name,
             ]);

--- a/tests/Feature/Api/V1/GameFromHashTest.php
+++ b/tests/Feature/Api/V1/GameFromHashTest.php
@@ -40,9 +40,14 @@ class GameFromHashTest extends TestCase
         $this->get($this->apiUrl('GetGameFromHash', ['h' => $targetHash]))
             ->assertStatus(404)
             ->assertJson([
-                'status' => 404,
-                'code' => 'not_found',
-                'error' => "Unknown hash: $targetHash",
+                'message' => "Unknown hash: $targetHash",
+                'errors' => [
+                    [
+                        'status' => 404,
+                        'code' => 'not_found',
+                        'title' => "Unknown hash: $targetHash",
+                    ],
+                ],
             ]);
     }
 

--- a/tests/Feature/Api/V1/GameFromHashTest.php
+++ b/tests/Feature/Api/V1/GameFromHashTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Platform\Models\Game;
+use App\Platform\Models\GameHash;
+use App\Platform\Models\System;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GameFromHashTest extends TestCase
+{
+    use RefreshDatabase;
+    use BootstrapsApiV1;
+
+    public function testGetGameFromHashIfNoHashParam(): void
+    {
+        $this->get($this->apiUrl('GetGameFromHash'))
+            ->assertStatus(422)
+            ->assertJson([
+                'message' => 'The h field is required.',
+            ]);
+    }
+
+    public function testGetGameFromHashIfInvalidHashParam(): void
+    {
+        $this->get($this->apiUrl('GetGameFromHash', ['h' => '12345']))
+            ->assertStatus(422)
+            ->assertJson([
+                'message' => 'The h must be 32 characters.',
+            ]);
+    }
+
+    public function testGetGameFromHashIfGameNotFound(): void
+    {
+        $this->get($this->apiUrl('GetGameFromHash', ['h' => '1bc674be034e43c96b86487ac69d9293']))
+            ->assertStatus(400)
+            ->assertJson([
+                'message' => 'Could not find a game matching the given hash.',
+            ]);
+    }
+
+    public function testGetGameMatchingKnownHash(): void
+    {
+        /** @var System $system */
+        $system = System::factory()->create();
+        /** @var Game $game */
+        $game = Game::factory()->create(['ConsoleID' => $system->ID]);
+        /** @var GameHash $gameHash */
+        $gameHash = GameHash::factory()->create(['GameID' => $game->ID]);
+
+        $this->get($this->apiUrl('GetGameFromHash', ['h' => $gameHash->MD5]))
+            ->assertSuccessful()
+            ->assertJson([
+                'ID' => $game->ID,
+                'Title' => $game->Title,
+                'ConsoleID' => $system->ID,
+                'ConsoleName' => $system->Name,
+            ]);
+    }
+}


### PR DESCRIPTION
This PR adds a new API endpoint: `API_GetGameFromHash.php`.

The endpoint accepts a single argument: `h`, which corresponds to a 32-character md5 string most commonly seen on the "Supported Game Files" page.

If a matching hash cannot be found, a 400 status code and message are returned.
If a matching hash is found, high-level minimal metadata regarding the game is returned.

```
GET http://localhost:64000/API/API_GetGameFromHash.php?z=Scott&y=x&h=2bc674be034e43c96b86487ac69d9293

{ "message": "Could not find a game matching the given hash." }
```

```
GET http://localhost:64000/API/API_GetGameFromHash.php?z=Scott&y=x&h=1bc674be034e43c96b86487ac69d9293

{
  "ID": 1,
  "Title": "Sonic the Hedgehog",
  "ConsoleID": 1,
  "ConsoleName": "Mega Drive"
}
```