### PR TITLE
fix: always hash passwords with the configured algorithm

### DIFF
--- a/app/Helpers/database/user-password-reset.php
+++ b/app/Helpers/database/user-password-reset.php
@@ -2,18 +2,9 @@
 
 use Illuminate\Support\Str;
 
-function RemovePasswordResetToken(string $username): bool
-{
-    $db = getMysqliConnection();
-
-    sanitize_sql_inputs($username);
-
-    $query = "UPDATE UserAccounts AS ua SET ua.PasswordResetToken = '' WHERE ua.User='$username'";
-    s_mysql_query($query);
-
-    return mysqli_affected_rows($db) >= 1;
-}
-
+/**
+ * @deprecated replace with Laravel standard features and/or Fortify
+ */
 function isValidPasswordResetToken(string $usernameIn, string $passwordResetToken): bool
 {
     sanitize_sql_inputs($usernameIn, $passwordResetToken);
@@ -32,6 +23,9 @@ function isValidPasswordResetToken(string $usernameIn, string $passwordResetToke
     return false;
 }
 
+/**
+ * @deprecated replace with Laravel standard features and/or Fortify
+ */
 function RequestPasswordReset(string $usernameIn): bool
 {
     sanitize_sql_inputs($usernameIn);

--- a/app/Site/FortifyServiceProvider.php
+++ b/app/Site/FortifyServiceProvider.php
@@ -76,7 +76,7 @@ class FortifyServiceProvider extends ServiceProvider
                                 Fortify::username() => [trans('auth.failed')],
                             ]);
                         }
-                        migratePassword($user->User, $request->input('password'));
+                        changePassword($user->User, $request->input('password'));
                     }
 
                     return $next($request);

--- a/public/request/auth/register.php
+++ b/public/request/auth/register.php
@@ -2,6 +2,7 @@
 
 use App\Support\Rules\CtypeAlnum;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 
 $input = Validator::validate(Arr::wrap(request()->post()), [
@@ -45,7 +46,7 @@ if (config('services.google.recaptcha_secret')) {
     }
 }
 
-$hashedPassword = hashPassword($pass);
+$hashedPassword = Hash::make($pass);
 
 $query = "INSERT INTO UserAccounts (User, Password, SaltedPass, EmailAddress, Permissions, RAPoints, fbUser, fbPrefs, cookie, appToken, appTokenExpiry, websitePrefs, LastLogin, LastActivityID, Motto, ContribCount, ContribYield, APIKey, APIUses, LastGameID, RichPresenceMsg, RichPresenceMsgDate, ManuallyVerified, UnreadMessageCount, TrueRAPoints, UserWallActive, PasswordResetToken, Untracked, email_backup)
 VALUES ( '$username', '$hashedPassword', '', '$email', 0, 0, 0, 0, '', '', NULL, 63, null, 0, '', 0, 0, '', 0, 0, '', NULL, 0, 0, 0, 1, NULL, false, '$email')";

--- a/public/request/auth/reset-password.php
+++ b/public/request/auth/reset-password.php
@@ -17,15 +17,11 @@ if (!isValidPasswordResetToken($user, $passResetToken)) {
     return back()->withErrors(__('legacy.error.token'));
 }
 
-RemovePasswordResetToken($user);
+changePassword($user, $newPass);
 
-if (changePassword($user, $newPass)) {
-    // Perform auto-login:
-    if (authenticateFromCookie($user, $permissions, $userDetails)) {
-        generateAppToken($user, $tokenInOut);
-    }
-
-    return back()->with('success', __('legacy.success.password_change'));
+// Perform auto-login:
+if (authenticateFromCookie($user, $permissions, $userDetails)) {
+    generateAppToken($user, $tokenInOut);
 }
 
-return back()->withErrors(__('legacy.error.error'));
+return back()->with('success', __('legacy.success.password_change'));

--- a/public/request/auth/update-password.php
+++ b/public/request/auth/update-password.php
@@ -17,16 +17,11 @@ $input = Validator::validate(Arr::wrap(request()->post()), [
 
 $username = $user->User;
 
-if (!authenticateFromPassword($username, $input['password_current'])) {
+if (!Hash::check($input['password_current'], $user->Password)) {
     return back()->withErrors(__('legacy.error.credentials'));
 }
 
-RemovePasswordResetToken($username);
+changePassword($username, $input['password']);
+generateAppToken($username, $tokenInOut);
 
-if (changePassword($username, $input['password'])) {
-    generateAppToken($username, $tokenInOut);
-
-    return back()->with('success', __('legacy.success.password_change'));
-}
-
-return back()->withErrors(__('legacy.error.error'));
+return back()->with('success', __('legacy.success.password_change'));

--- a/tests/Feature/Connect/LoginTest.php
+++ b/tests/Feature/Connect/LoginTest.php
@@ -8,6 +8,7 @@ use App\Site\Enums\Permissions;
 use App\Site\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -26,7 +27,7 @@ class LoginTest extends TestCase
         /** @var User $user */
         $user = User::factory()->create([
             'appToken' => Str::random(16),
-            'Password' => hashPassword($password),
+            'Password' => Hash::make($password),
             'Permissions' => Permissions::JuniorDeveloper,
             'RAPoints' => 12345,
             'RASoftcorePoints' => 4321,
@@ -81,7 +82,7 @@ class LoginTest extends TestCase
         $data = legacyDbFetch('SELECT appToken, SaltedPass, Password FROM UserAccounts WHERE User=:user', ['user' => $user2->User]);
         $this->assertNotEquals('', $data['appToken']);
         $this->assertEquals('', $data['SaltedPass']);
-        $this->assertTrue(password_verify($password, $data['Password']));
+        $this->assertTrue(Hash::check($password, $data['Password']));
 
         $response->assertStatus(200)->assertExactJson([
             'Success' => true,
@@ -104,7 +105,7 @@ class LoginTest extends TestCase
         /** @var User $user */
         $user = User::factory()->create([
             'appToken' => Str::random(16),
-            'Password' => hashPassword($password),
+            'Password' => Hash::make($password),
         ]);
 
         // invalid password
@@ -178,7 +179,7 @@ class LoginTest extends TestCase
 
         // try with banned user - response should be the same as a non-existant user
         /** @var User $user2 */
-        $user2 = User::factory()->create(['Permissions' => Permissions::Banned, 'Password' => hashPassword($password)]);
+        $user2 = User::factory()->create(['Permissions' => Permissions::Banned, 'Password' => Hash::make($password)]);
         $this->post('dorequest.php', ['r' => 'login2', 'u' => $user2->User, 'p' => $password])
             ->assertStatus(401)
             ->assertHeader('WWW-Authenticate', 'Bearer')
@@ -191,7 +192,7 @@ class LoginTest extends TestCase
 
         // try with unregistered user - expect permissions error
         /** @var User $user3 */
-        $user3 = User::factory()->create(['Permissions' => Permissions::Unregistered, 'Password' => hashPassword($password)]);
+        $user3 = User::factory()->create(['Permissions' => Permissions::Unregistered, 'Password' => Hash::make($password)]);
         $this->post('dorequest.php', ['r' => 'login2', 'u' => $user3->User, 'p' => $password])
             ->assertStatus(403)
             ->assertExactJson([
@@ -215,7 +216,7 @@ class LoginTest extends TestCase
         /** @var User $user */
         $user = User::factory()->create([
             'appToken' => Str::random(16),
-            'Password' => hashPassword($password),
+            'Password' => Hash::make($password),
         ]);
 
         // invalid password
@@ -283,7 +284,7 @@ class LoginTest extends TestCase
 
         // try with banned user - response should be the same as a non-existant user
         /** @var User $user2 */
-        $user2 = User::factory()->create(['Permissions' => Permissions::Banned, 'Password' => hashPassword($password)]);
+        $user2 = User::factory()->create(['Permissions' => Permissions::Banned, 'Password' => Hash::make($password)]);
         $this->get($this->apiUrl('login', ['u' => $user2->User, 'p' => $password], credentials: false))
             ->assertStatus(200)
             ->assertExactJson([
@@ -295,7 +296,7 @@ class LoginTest extends TestCase
 
         // try with unregistered user - expect permissions error
         /** @var User $user3 */
-        $user3 = User::factory()->create(['Permissions' => Permissions::Unregistered, 'Password' => hashPassword($password)]);
+        $user3 = User::factory()->create(['Permissions' => Permissions::Unregistered, 'Password' => Hash::make($password)]);
         $this->get($this->apiUrl('login', ['u' => $user3->User, 'p' => $password], credentials: false))
             ->assertStatus(200)
             ->assertExactJson([


### PR DESCRIPTION
Makes sure that resetting passwords locally does not subsequently use the wrong algorithm. Changing the hashing configuration for verification is not required.

Pretty much all of the affected code will be replaced with standard Laravel/Fortify features.