### PR TITLE
fix(history): remediate chart incorrect x-axis

### DIFF
--- a/public/history.php
+++ b/public/history.php
@@ -68,7 +68,7 @@ RenderContentStart("$userPage's Legacy");
             $hardcoreValue = $dayInfo['CumulHardcoreScore'];
             $softcoreValue = $dayInfo['CumulSoftcoreScore'];
 
-            echo "[ {v:new Date($nextYear,$nextMonth,$nextDay), f:'$dateStr'}, $hardcoreValue, $softcoreValue ]";
+            echo "[ {v:new Date($nextYear," . ($nextMonth - 1) . ",$nextDay), f:'$dateStr'}, $hardcoreValue, $softcoreValue ]";
         }
         ?>
     ]);


### PR DESCRIPTION
Resolves #2101.

Currently, the Google Chart on _history.php_ is shifted 1 month into the future. For example, at https://retroachievements.org/history.php?u=Jamiras:

![Screenshot 2023-12-11 at 4 30 29 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/92b32b3b-22ab-4707-a5d2-71e2f1cfec3d)

**Root Cause**
Months in JavaScript date objects are 0-indexed. We need to compensate for this when constructing the x-axis values.