### PR TITLE
feat(achievement): show type indicators on the info page

### DIFF
--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -118,6 +118,7 @@ function getAchievementUnlocksData(
     int $achievementId,
     ?string $username,
     ?int &$numWinners,
+    ?int &$numWinnersHardcore,
     ?int &$numPossibleWinners,
     ?int $parentGameId = null,
     int $offset = 0,
@@ -130,6 +131,7 @@ function getAchievementUnlocksData(
     }
 
     $numWinners = $achievement->unlocks_total ?? 0;
+    $numWinnersHardcore = $achievement->unlocks_hardcore_total ?? 0;
     $numPossibleWinners = $achievement->game->players_total ?? 0;
 
     // Get recent winners, and their most recent activity

--- a/public/API/API_GetAchievementOfTheWeek.php
+++ b/public/API/API_GetAchievementOfTheWeek.php
@@ -7,32 +7,33 @@ use Illuminate\Support\Carbon;
  *  API_GetAchievementOfTheWeek
  *   (no inputs)
  *
- *  object     Achievement     information about the achievement
- *   int        ID             unique identifier of the achievement
- *   string     Title          title of the achievement
- *   string     Description    description of the achievement
- *   int        Points         number of points the achievement is worth
- *   int        TrueRatio      number of "white" points the achievement is worth
- *   string     Type           null, "progression", "win_condition", or "missable"
- *   string     Author         user who first created the achievement
- *   datetime   DateCreated    when the achievement was created
- *   datetime   DateModified   when the achievement was last modified
- *  object     Console         information about the console associated to the game associated to the achievemnt
- *   int        ID             unique identifier of the console
- *   string     Title          name of the console
- *  object     Game            information about the game associated to the achievement
- *   int        ID             unique identifier of the game
- *   string     Title          name of the game
- *  object     ForumTopic      information about the game's official forum topic
- *   int        ID             unique identifier of the game's official forum topic
- *  datetime   StartAt         when the achievement was set as the achievement of the week
- *  int        UnlocksCount    number of times the achievement has been unlocked
- *  int        TotalPlayers    number of players who have played the game associated to the achievement
- *  array      Unlocks         requested unlock information
- *   string     User           user who unlocked the achievement
- *   int        RAPoints       number of points the user has
- *   datetime   DateAwarded    when the achievement was unlocked
- *   int        HardcoreMode   1 if unlocked in hardcore, otherwise 0
+ *  object     Achievement              information about the achievement
+ *   int        ID                      unique identifier of the achievement
+ *   string     Title                   title of the achievement
+ *   string     Description             description of the achievement
+ *   int        Points                  number of points the achievement is worth
+ *   int        TrueRatio               number of "white" points the achievement is worth
+ *   string     Type                    null, "progression", "win_condition", or "missable"
+ *   string     Author                  user who first created the achievement
+ *   datetime   DateCreated             when the achievement was created
+ *   datetime   DateModified            when the achievement was last modified
+ *  object     Console                  information about the console associated to the game associated to the achievemnt
+ *   int        ID                      unique identifier of the console
+ *   string     Title                   name of the console
+ *  object     Game                     information about the game associated to the achievement
+ *   int        ID                      unique identifier of the game
+ *   string     Title                   name of the game
+ *  object     ForumTopic               information about the game's official forum topic
+ *   int        ID                      unique identifier of the game's official forum topic
+ *  datetime   StartAt                  when the achievement was set as the achievement of the week
+ *  int        UnlocksCount             number of times the achievement has been unlocked
+ *  int        UnlocksHardcoreCount     number of times the achievement has been unlocked in hardcore mode
+ *  int        TotalPlayers             number of players who have played the game associated to the achievement
+ *  array      Unlocks                  requested unlock information
+ *   string     User                    user who unlocked the achievement
+ *   int        RAPoints                number of points the user has
+ *   datetime   DateAwarded             when the achievement was unlocked
+ *   int        HardcoreMode            1 if unlocked in hardcore, otherwise 0
  */
 
 /*
@@ -82,7 +83,7 @@ $forumTopic = [
 
 $parentGameID = getParentGameIdFromGameTitle($game['Title'], $achievementData['ConsoleID']);
 
-$unlocks = getAchievementUnlocksData((int) $achievementID, null, $numWinners, $numPossibleWinners, $parentGameID, 0, 500);
+$unlocks = getAchievementUnlocksData((int) $achievementID, null, $numWinners, $numWinnersHardcore, $numPossibleWinners, $parentGameID, 0, 500);
 
 /*
  * reset unlocks if there is no start date to prevent listing invalid entries
@@ -107,4 +108,5 @@ return response()->json([
     'TotalPlayers' => $numPossibleWinners ?? 0,
     'Unlocks' => $unlocks->values(),
     'UnlocksCount' => $numWinners ?? 0,
+    'UnlocksHardcoreCount' => $numWinnersHardcore ?? 0,
 ]);

--- a/public/API/API_GetAchievementUnlocks.php
+++ b/public/API/API_GetAchievementUnlocks.php
@@ -6,29 +6,30 @@
  *    o : offset - number of entries to skip (default: 0)
  *    c : count - number of entries to return (default: 50, max: 500)
  *
- *  object     Achievement     information about the achievement
- *   string     ID             unique identifier of the achievement
- *   string     Title          title of the achievement
- *   string     Description    description of the achievement
- *   string     Points         number of points the achievement is worth
- *   string     TrueRatio      number of "white" points the achievement is worth
- *   string     Author         user who first created the achievement
- *   datetime   DateCreated    when the achievement was created
- *   datetime   DateModified   when the achievement was last modified
- *   string     Type           null, "progression", "win_condition", or "missable"
- *  object     Console         information about the console associated to the game associated to the achievemnt
- *   string     ID             unique identifier of the console
- *   string     Title          name of the console
- *  object     Game            information about the game associated to the achievement
- *   string     ID             unique identifier of the game
- *   string     Title          name of the game
- *  int        UnlocksCount    number of times the achievement has been unlocked
- *  int        TotalPlayers    number of players who have played the game associated to the achievement
- *  array      Unlocks         requested unlock information
- *   string     User           user who unlocked the achievement
- *   string     RAPoints       number of points the user has
- *   datetime   DateAwarded    when the achievement was unlocked
- *   string     HardcoreMode   "1" if unlocked in hardcore, otherwise "0"
+ *  object     Achievement              information about the achievement
+ *   string     ID                      unique identifier of the achievement
+ *   string     Title                   title of the achievement
+ *   string     Description             description of the achievement
+ *   string     Points                  number of points the achievement is worth
+ *   string     TrueRatio               number of "white" points the achievement is worth
+ *   string     Author                  user who first created the achievement
+ *   datetime   DateCreated             when the achievement was created
+ *   datetime   DateModified            when the achievement was last modified
+ *   string     Type                    null, "progression", "win_condition", or "missable"
+ *  object     Console                  information about the console associated to the game associated to the achievemnt
+ *   string     ID                      unique identifier of the console
+ *   string     Title                   name of the console
+ *  object     Game                     information about the game associated to the achievement
+ *   string     ID                      unique identifier of the game
+ *   string     Title                   name of the game
+ *  int        UnlocksCount             number of times the achievement has been unlocked
+ *  int        UnlocksHardcoreCount     number of times the achievement has been unlocked in hardcore mode
+ *  int        TotalPlayers             number of players who have played the game associated to the achievement
+ *  array      Unlocks                  requested unlock information
+ *   string     User                    user who unlocked the achievement
+ *   string     RAPoints                number of points the user has
+ *   datetime   DateAwarded             when the achievement was unlocked
+ *   string     HardcoreMode            "1" if unlocked in hardcore, otherwise "0"
  */
 
 $achievementID = (int) request()->query('a');
@@ -46,6 +47,7 @@ if ($achievementData === null) {
     return response()->json([
         'Achievement' => [],
         'UnlocksCount' => 0,
+        'UnlocksHardcoreCount' => 0,
         'TotalPlayers' => 0,
         'Unlocks' => [],
     ], 404);
@@ -75,13 +77,14 @@ $console = [
 
 $parentGameID = getParentGameIdFromGameTitle($game['Title'], $achievementData['ConsoleID']);
 
-$unlocks = getAchievementUnlocksData($achievementID, null, $numWinners, $numPossibleWinners, $parentGameID, $offset, $count);
+$unlocks = getAchievementUnlocksData($achievementID, null, $numWinners, $numWinnersHardcore, $numPossibleWinners, $parentGameID, $offset, $count);
 
 return response()->json([
     'Achievement' => $achievement,
     'Console' => $console,
     'Game' => $game,
     'UnlocksCount' => $numWinners ?? 0,
+    'UnlocksHardcoreCount' => $numWinnersHardcore ?? 0,
     'TotalPlayers' => $numPossibleWinners ?? 0,
     'Unlocks' => $unlocks->values(),
 ]);

--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -26,7 +26,6 @@ $achievementTitle = $dataOut['Title'];
 $desc = $dataOut['Description'];
 $achFlags = (int) $dataOut['Flags'];
 $achPoints = (int) $dataOut['Points'];
-$achTruePoints = (int) $dataOut['TrueRatio'];
 $achType = $dataOut['type'];
 $gameTitle = $dataOut['GameTitle'];
 $badgeName = $dataOut['BadgeName'];
@@ -62,14 +61,34 @@ sanitize_outputs(
 $numLeaderboards = getLeaderboardsForGame($gameID, $lbData, $user);
 
 $numWinners = 0;
+$numWinnersHardcore = 0;
 $numPossibleWinners = 0;
 
-$unlocks = getAchievementUnlocksData($achievementID, $user, $numWinners, $numPossibleWinners, $parentGameID, 0, 50);
+$unlocks = getAchievementUnlocksData(
+    $achievementID,
+    $user,
+    $numWinners,
+    $numWinnersHardcore,
+    $numPossibleWinners,
+    $parentGameID,
+    0,
+    50
+);
+
+$dataOut['NumAwarded'] = $numWinners;
+$dataOut['NumAwardedHardcore'] = $numWinnersHardcore;
 
 $dateWonLocal = "";
 foreach ($unlocks as $userObject) {
     if ($userObject['User'] == $user) {
         $dateWonLocal = $userObject['DateAwarded'];
+
+        if ($userObject['HardcoreMode'] === 1) {
+            $dataOut['DateEarnedHardcore'] = $dateWonLocal;
+        } else {
+            $dataOut['DateEarned'] = $dateWonLocal;
+        }
+
         break;
     }
 }
@@ -83,8 +102,10 @@ if ($dateWonLocal === "" && isset($user)) {
         if ($playerAchievement) {
             if ($playerAchievement->unlocked_hardcore_at) {
                 $dateWonLocal = $playerAchievement->unlocked_hardcore_at->__toString();
+                $dataOut['DateEarnedHardcore'] = $dateWonLocal;
             } elseif ($playerAchievement->unlocked_at) {
                 $dateWonLocal = $playerAchievement->unlocked_at->__toString();
+                $dataOut['DateEarned'] = $dateWonLocal;
             }
         }
     }
@@ -236,52 +257,19 @@ RenderContentStart($pageTitle);
         'gameTitle' => $gameTitle,
     ]);
 
-    $fileSuffix = ($user == "" || !$achievedLocal) ? '_lock' : '';
-    $badgeFullPath = media_asset("Badge/$badgeName$fileSuffix.png");
-
-    echo "<table class='nicebox mb-1'><tbody>";
-
-    $descAttr = attributeEscape($desc);
-    echo "<tr>";
-    echo "<td style='width:70px'>";
-    echo "<div id='achievemententryicon'>";
-    echo "<a href=\"/achievement/$achievementID\"><img src=\"$badgeFullPath\" title=\"$gameTitle ($achPoints)\n$descAttr\" alt=\"$descAttr\" align=\"left\" width=\"64\" height=\"64\" /></a>";
-    echo "</div>"; // achievemententryicon
-    echo "</td>";
-
-    echo "<td>";
-    echo "<div id='achievemententry'>";
-
-    $renderedTitle = Blade::render('<x-achievement.title :rawTitle="$rawTitle" />', [
-        'rawTitle' => $achievementTitle,
+    echo Blade::render('
+        <x-game.achievements-list.achievements-list-item
+            :achievement="$achievement"
+            :isCreditDialogEnabled="$isCreditDialogEnabled"
+            :totalPlayerCount="$totalPlayerCount"
+            :isUnlocked="$isUnlocked"
+        />
+    ', [
+        'achievement' => $dataOut,
+        'isCreditDialogEnabled' => false,
+        'totalPlayerCount' => $numPossibleWinners,
+        'isUnlocked' => $achievedLocal,
     ]);
-
-    echo "<div class='flex flex-col justify-between gap-y-2'>";
-    echo "<div>";
-    echo "<a href='/achievement/$achievementID'><strong>$renderedTitle</strong></a>";
-    if ($achPoints !== 0) {
-        echo " ($achPoints)<span class='TrueRatio'> ($achTruePoints)</span>";
-    }
-    echo "<br>";
-    echo "$desc";
-    echo "</div>";
-    if ($achievedLocal) {
-        $niceDateWon = date("d M, Y H:i", strtotime($dateWonLocal));
-        echo "<div class='date smalltext'>Unlocked $niceDateWon</div>";
-    }
-    echo "</div>";
-
-    echo "</div>";
-    echo "</td>";
-
-    echo "</tr>";
-    echo "</tbody></table>";
-
-    if ($numPossibleWinners > 0) {
-        $recentWinnersPct = sprintf("%01.2f", ($numWinners / $numPossibleWinners) * 100);
-    } else {
-        $recentWinnersPct = sprintf("%01.0f", 0);
-    }
 
     $niceDateCreated = date("d M, Y H:i", strtotime($dateCreated));
     $niceDateModified = date("d M, Y H:i", strtotime($dateModified));
@@ -294,8 +282,6 @@ RenderContentStart($pageTitle);
     echo "Created by " . userAvatar($author, icon: false) . " on: $niceDateCreated<br>Last modified: $niceDateModified<br>";
     echo "</small>";
     echo "</p>";
-
-    echo "<p class='mb-2'>Unlocked by <span class='font-bold'>" . localized_number($numWinners) . "</span> of <span class='font-bold'>" . localized_number($numPossibleWinners) . "</span> possible players ($recentWinnersPct%)</p>";
 
     if (isset($user) && $permissions >= Permissions::Registered) {
         $countTickets = countOpenTicketsByAchievement($achievementID);

--- a/resources/views/platform/components/game/achievements-list/achievements-list-item.blade.php
+++ b/resources/views/platform/components/game/achievements-list/achievements-list-item.blade.php
@@ -1,13 +1,12 @@
 @props([
     'achievement' => [],
     'beatenGameCreditDialogContext' => 's:|h:',
-    'totalPlayerCount' => 0,
-    'useMinimalLayout' => false,
+    'isCreditDialogEnabled' => true,
     'isUnlocked' => false,
     'isUnlockedHardcore' => false,
-    'isCreditDialogEnabled' => true,
     'showAuthorName' => false,
     'totalPlayerCount' => 0,
+    'useMinimalLayout' => false,
 ])
 
 <?php

--- a/tests/Feature/Api/V1/AchievementOfTheWeekTest.php
+++ b/tests/Feature/Api/V1/AchievementOfTheWeekTest.php
@@ -37,7 +37,7 @@ class AchievementOfTheWeekTest extends TestCase
         $now = Carbon::now();
         $this->addSoftcoreUnlock($this->user, $achievement, $now);
         $this->addSoftcoreUnlock($user2, $achievement, $now->copy()->subMinutes(5));
-        $this->addSoftcoreUnlock($user3, $achievement, $now->copy()->addMinutes(5));
+        $this->addHardcoreUnlock($user3, $achievement, $now->copy()->addMinutes(5));
 
         $staticData = StaticData::factory()->create([
             'Event_AOTW_AchievementID' => $achievement->ID,
@@ -65,7 +65,7 @@ class AchievementOfTheWeekTest extends TestCase
                     [
                         'User' => $user3->User,
                         'RAPoints' => $user3->RAPoints,
-                        'HardcoreMode' => 0,
+                        'HardcoreMode' => 1,
                     ],
                     [
                         'User' => $this->user->User,
@@ -79,6 +79,7 @@ class AchievementOfTheWeekTest extends TestCase
                     ],
                 ],
                 'UnlocksCount' => 3,
+                'UnlocksHardcoreCount' => 1,
             ]);
     }
 }

--- a/tests/Feature/Api/V1Test.php
+++ b/tests/Feature/Api/V1Test.php
@@ -159,6 +159,7 @@ class V1Test extends TestCase
                     ],
                 ],
                 'UnlocksCount' => 1,
+                'UnlocksHardcoreCount' => 0,
             ]);
     }
 
@@ -291,6 +292,7 @@ class V1Test extends TestCase
                     ],
                 ],
                 'UnlocksCount' => 1,
+                'UnlocksHardcoreCount' => 0,
             ]);
 
         $this->get($this->apiUrl('GetAchievementUnlocks', ['a' => 999999999]))
@@ -300,6 +302,7 @@ class V1Test extends TestCase
                 'TotalPlayers' => 0,
                 'Unlocks' => [],
                 'UnlocksCount' => 0,
+                'UnlocksHardcoreCount' => 0,
             ]);
     }
 


### PR DESCRIPTION
This PR adds type indicators to the achievement info pages, eg:

```
/achievement/9
```

**Before**
![Screenshot 2023-12-11 at 5 24 29 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/dcc250b2-a455-4d70-80be-a706ffce842b)

**After**
![Screenshot 2023-12-11 at 5 24 18 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/f6a4d6e1-4d8d-40cc-acac-09a332223d9c)

From a technical POV, this is achieved by reusing the achievement list item component from game pages.

To facilitate displaying hardcore unlock progress in the component, a slight modification was made to `getAchievementUnlocksData()`, which has a minor impact on two API endpoints.