### PR TITLE
feat(api): replace max validation on API_GetUserSummary with a cap

### DIFF
--- a/public/API/API_GetUserSummary.php
+++ b/public/API/API_GetUserSummary.php
@@ -91,13 +91,18 @@ use Illuminate\Support\Facades\Validator;
 
 $input = Validator::validate(Arr::wrap(request()->query()), [
     'u' => ['required', 'min:2', 'max:20', new CtypeAlnum()],
-    'g' => 'nullable|integer|min:0|max:100',
+    'g' => 'nullable|integer|min:0',
     'a' => 'nullable|integer|min:0',
 ]);
 
 $user = request()->query('u');
 $recentGamesPlayed = (int) request()->query('g', '0');
 $recentAchievementsEarned = (int) request()->query('a', '10');
+
+// Cap `$recentGamesPlayed` to a maximum of 100.
+if ($recentGamesPlayed > 100) {
+    $recentGamesPlayed = 100;
+}
 
 $retVal = getUserPageInfo($user, $recentGamesPlayed, $recentAchievementsEarned);
 


### PR DESCRIPTION
Replaces `max` validation on API_GetUserSummary.php to better support backwards compatibility with legacy clients.

Now, if a consumer asks for a large sum of recent games, we force a cap of 100 and do not error the response.