### PR TITLE
feat(hashes): allow .7z patch urls

### DIFF
--- a/app/Platform/Controllers/GameHashController.php
+++ b/app/Platform/Controllers/GameHashController.php
@@ -59,7 +59,11 @@ class GameHashController extends Controller
         $input = $request->validate([
             'name' => 'required|string',
             'labels' => 'required|string',
-            'patch_url' => 'nullable|url|regex:/github\.com\/RetroAchievements\/RAPatches\/raw\/main\/.*\.zip$/i',
+            'patch_url' => [
+                'nullable',
+                'url',
+                'regex:/^https:\/\/github\.com\/RetroAchievements\/RAPatches\/raw\/main\/.*\.(zip|7z)$/i',
+            ],
             'source' => 'nullable|url',
         ]);
 

--- a/database/migrations/2023_12_16_000000_update_gamehashlibrary_table.php
+++ b/database/migrations/2023_12_16_000000_update_gamehashlibrary_table.php
@@ -11,7 +11,7 @@ return new class() extends Migration {
     {
         Schema::table('GameHashLibrary', function (Blueprint $table) {
             $table->string('compatibility')->nullable()->after('file_name_md5'); // `HashCompatibility`
-            $table->string('patch_url')->nullable()->after('source_version'); // RAPatches .zip File Link
+            $table->string('patch_url')->nullable()->after('source_version'); // RAPatches .zip/.7z File Link
         });
     }
 

--- a/resources/views/platform/components/manage-hashes/hash-entity.blade.php
+++ b/resources/views/platform/components/manage-hashes/hash-entity.blade.php
@@ -132,7 +132,7 @@ function unlinkHash(hash, hashName) {
                     <label
                         for="{{ 'HASH_' . $hashEntity->MD5 . '_PatchURL' }}"
                         class="text-2xs font-semibold cursor-help flex items-center gap-x-0.5"
-                        title="Optional. This MUST be a URL to a .zip file in the RAPatches GitHub repo, eg: https://github.com/RetroAchievements/RAPatches/raw/main/NES/Subset/5136-CastlevaniaIIBonus.zip"
+                        title="Optional. This MUST be a URL to a .zip or .7z file in the RAPatches GitHub repo, eg: https://github.com/RetroAchievements/RAPatches/raw/main/NES/Subset/5136-CastlevaniaIIBonus.zip"
                     >
                         RAPatches URL
                         <x-fas-info-circle class="text-sm" />


### PR DESCRIPTION
In addition to .zip, users can now use .7z URLs from the RAPatches repo on the new Manage Hashes page (`game/1/hashes/manage`).

