### PR TITLE
fix(user-card): dont show empty motto

### DIFF
--- a/resources/views/components/community/user-card.blade.php
+++ b/resources/views/components/community/user-card.blade.php
@@ -1,6 +1,6 @@
 <x-card.container imgSrc="{{ $avatarUrl }}">
     <div class="relative h-full text-2xs">
-        <!-- Role -->
+        {{-- Role --}}
         @if($canShowUserRole)
             <div class="absolute top-[-14px] right-[-21px]">
                 <div class="h-[25px] flex flex-col text-2xs tracking-tighter items-center justify-center pl-2 pr-5 pt-2 bg-menu-link text-box-bg rounded">
@@ -11,17 +11,17 @@
             </div>
         @endif
 
-        <!-- Username -->
+        {{-- Username --}}
         <p class="font-bold text-lg -mt-1 {{ $useExtraNamePadding ? "pt-3" : "" }}">{{ $username }}</p>
 
-        <!-- Motto -->
+        {{-- Motto --}}
         @if (!empty($motto))
             <div class="mb-1 rounded bg-bg text-text italic p-1 text-2xs hyphens-auto">
                 <p style="word-break: break-word;">{{ $motto }}</p>
             </div>
         @endif
 
-        <!-- Points -->
+        {{-- Points --}}
         @if($hardcorePoints > $softcorePoints)
             <x-card.info-row label="Points">
                 {{ localized_number($hardcorePoints) }}
@@ -33,7 +33,7 @@
             <x-card.info-row label="Points">0</x-card.info-row>
         @endif
 
-        <!-- Site Rank -->
+        {{-- Site Rank --}}
         <x-card.info-row :label="$rankLabel">
             @if($isUntracked)
                 <span>Untracked</span>
@@ -43,12 +43,12 @@
             @endif
         </x-card.info-row>
 
-        <!-- Last Activity -->
+        {{-- Last Activity --}}
         @if($lastActivity)
             <x-card.info-row label="Last Activity">{{ $lastActivity }}</x-card.info-row>
         @endif
 
-        <!-- Member Since -->
+        {{-- Member Since --}}
         @if($memberSince)
             <x-card.info-row label="Member Since">
                 {{ getNiceDate(strtotime($memberSince), $justDay = true) }}

--- a/resources/views/components/community/user-card.blade.php
+++ b/resources/views/components/community/user-card.blade.php
@@ -15,7 +15,7 @@
         <p class="font-bold text-lg -mt-1 {{ $useExtraNamePadding ? "pt-3" : "" }}">{{ $username }}</p>
 
         <!-- Motto -->
-        @if($motto !== null)
+        @if (!empty($motto))
             <div class="mb-1 rounded bg-bg text-text italic p-1 text-2xs hyphens-auto">
                 <p style="word-break: break-word;">{{ $motto }}</p>
             </div>


### PR DESCRIPTION
Resolves an issue where if a motto is empty, the space for the motto in the user card still appears:

![Screenshot 2024-01-13 at 9 34 07 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/b167fee2-549b-4e9c-8ae8-b3af4226906c)
