### PR TITLE
feat(forum): migrate post history to blade & improve mobile-friendliness

### DIFF
--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -88,7 +88,6 @@ RenderContentStart("Forum Post History");
                 :postedAt="$postedAt"
                 :summary="$summary"
                 :tooltipLabel="$tooltipLabel"
-                :variant="$variant"
                 :viewLabel="$viewLabel"
                 :viewHref="$viewHref"
                 :view2Label="$view2Label"
@@ -102,7 +101,6 @@ RenderContentStart("Forum Post History");
             'postedAt' => $postedAt,
             'summary' => Shortcode::stripAndClamp($postMessage, $messageLength),
             'tooltipLabel' => Carbon::parse($topicPostData['PostedAt'])->format('F j Y, g:ia'),
-            'variant' => 'desktop-slim',
             'viewLabel' => $viewLabel,
             'viewHref' => $viewHref,
             'view2Label' => $view2Label,

--- a/public/forumposthistory.php
+++ b/public/forumposthistory.php
@@ -88,6 +88,7 @@ RenderContentStart("Forum Post History");
                 :postedAt="$postedAt"
                 :summary="$summary"
                 :tooltipLabel="$tooltipLabel"
+                :variant="$variant"
                 :viewLabel="$viewLabel"
                 :viewHref="$viewHref"
                 :view2Label="$view2Label"
@@ -101,6 +102,7 @@ RenderContentStart("Forum Post History");
             'postedAt' => $postedAt,
             'summary' => Shortcode::stripAndClamp($postMessage, $messageLength),
             'tooltipLabel' => Carbon::parse($topicPostData['PostedAt'])->format('F j Y, g:ia'),
+            'variant' => 'desktop-slim',
             'viewLabel' => $viewLabel,
             'viewHref' => $viewHref,
             'view2Label' => $view2Label,

--- a/resources/views/community/components/forum/recent-post-item.blade.php
+++ b/resources/views/community/components/forum/recent-post-item.blade.php
@@ -6,7 +6,6 @@
     'postedAt' => '',
     'summary' => '',
     'tooltipLabel' => null, // ?string
-    'variant' => 'base', // 'base' | 'desktop-slim'
     'viewHref' => null, // ?string
     'viewLabel' => 'View',
     'view2Href' => null, // ?string
@@ -15,7 +14,7 @@
 
 <div class="embedded">
     <div class="relative flex justify-between items-center">
-        <div @if ($variant === 'desktop-slim') class="lg:flex items-center gap-x-1" @endif>
+        <div>
             {!! userAvatar($authorUsername, iconSize: 16) !!}
             <span
                 class="smalldate {{ $hasDateTooltip ? 'cursor-help' : '' }}"
@@ -23,10 +22,6 @@
             >
                 {{ $postedAt }}
             </span>
-
-            @if ($variant === 'desktop-slim')
-                <p class="hidden lg:block">in <a href="{{ $href }}">{{ $forumTopicTitle }}</a></p>
-            @endif
         </div>
 
         @if ($viewLabel !== '')
@@ -44,9 +39,7 @@
         @endif
     </div>
 
-    <p @if ($variant === 'desktop-slim') class="lg:hidden" @endif>
-        in <a href="{{ $href }}">{{ $forumTopicTitle }}</a>
-    </p>
+    <p>in <a href="{{ $href }}">{{ $forumTopicTitle }}</a></p>
 
     <p class="comment text-overflow-wrap">
         {{ $summary }}

--- a/resources/views/community/components/forum/recent-post-item.blade.php
+++ b/resources/views/community/components/forum/recent-post-item.blade.php
@@ -1,0 +1,47 @@
+@props([
+    'authorUsername' => '',
+    'forumTopicTitle' => '',
+    'hasDateTooltip' => false,
+    'href' => '',
+    'postedAt' => '',
+    'summary' => '',
+    'tooltipLabel' => null, // ?string
+    'viewHref' => null, // ?string
+    'viewLabel' => 'View',
+    'view2Href' => null, // ?string
+    'view2Label' => null, // ?string
+])
+
+<div class="embedded">
+    <div class="relative flex justify-between items-center">
+        <div>
+            {!! userAvatar($authorUsername, iconSize: 16) !!}
+            <span
+                class="smalldate {{ $hasDateTooltip ? 'cursor-help' : '' }}"
+                @if ($tooltipLabel) title="{{ $tooltipLabel }}" @endif
+            >
+                {{ $postedAt }}
+            </span>
+        </div>
+
+        @if ($viewLabel !== '')
+            <div class="flex flex-col">
+                <a class="text-right text-2xs" href="{{ $viewHref ?? $href }}">
+                    {{ $viewLabel }}
+                </a>
+
+                @if ($view2Href && $view2Label)
+                    <a class="text-right text-2xs" href="{{ $view2Href }}">
+                        {{ $view2Label }}
+                    </a>
+                @endif
+            </div>
+        @endif
+    </div>
+
+    <p>in <a href="{{ $href }}">{{ $forumTopicTitle }}</a></p>
+
+    <p class="comment text-overflow-wrap">
+        {{ $summary }}
+    </p>
+</div>

--- a/resources/views/community/components/forum/recent-post-item.blade.php
+++ b/resources/views/community/components/forum/recent-post-item.blade.php
@@ -25,7 +25,7 @@
         </div>
 
         @if ($viewLabel !== '')
-            <div class="flex flex-col">
+            <div class="flex flex-col whitespace-nowrap">
                 <a class="text-right text-2xs" href="{{ $viewHref ?? $href }}">
                     {{ $viewLabel }}
                 </a>

--- a/resources/views/community/components/forum/recent-post-item.blade.php
+++ b/resources/views/community/components/forum/recent-post-item.blade.php
@@ -6,6 +6,7 @@
     'postedAt' => '',
     'summary' => '',
     'tooltipLabel' => null, // ?string
+    'variant' => 'base', // 'base' | 'desktop-slim'
     'viewHref' => null, // ?string
     'viewLabel' => 'View',
     'view2Href' => null, // ?string
@@ -14,7 +15,7 @@
 
 <div class="embedded">
     <div class="relative flex justify-between items-center">
-        <div>
+        <div @if ($variant === 'desktop-slim') class="lg:flex items-center gap-x-1" @endif>
             {!! userAvatar($authorUsername, iconSize: 16) !!}
             <span
                 class="smalldate {{ $hasDateTooltip ? 'cursor-help' : '' }}"
@@ -22,6 +23,10 @@
             >
                 {{ $postedAt }}
             </span>
+
+            @if ($variant === 'desktop-slim')
+                <p class="hidden lg:block">in <a href="{{ $href }}">{{ $forumTopicTitle }}</a></p>
+            @endif
         </div>
 
         @if ($viewLabel !== '')
@@ -39,7 +44,9 @@
         @endif
     </div>
 
-    <p>in <a href="{{ $href }}">{{ $forumTopicTitle }}</a></p>
+    <p @if ($variant === 'desktop-slim') class="lg:hidden" @endif>
+        in <a href="{{ $href }}">{{ $forumTopicTitle }}</a>
+    </p>
 
     <p class="comment text-overflow-wrap">
         {{ $summary }}

--- a/resources/views/community/components/forum/recent-posts.blade.php
+++ b/resources/views/community/components/forum/recent-posts.blade.php
@@ -8,28 +8,15 @@
 
     <div class="flex flex-col gap-y-1">
         @foreach ($recentForumPosts as $recentForumPost)
-            <div class="embedded">
-                <div class="flex justify-between items-center">
-                    <div>
-                        {!! userAvatar($recentForumPost['Author'], iconSize: 16) !!}
-                        <span
-                            class="smalldate
-                            {{ $recentForumPost['HasDateTooltip'] ? 'cursor-help' : '' }}"
-                            @if ($recentForumPost['TitleAttribute']) title="{{ $recentForumPost['TitleAttribute'] }}" @endif
-                        >
-                            {{ $recentForumPost['PostedAt'] }}
-                        </span>
-                    </div>
-
-                    <a class="btn btn-link" href="{{ $recentForumPost['URL'] }}">View</a>
-                </div>
-
-                <p>in <a href="{{ $recentForumPost['URL'] }}">{{ $recentForumPost['ForumTopicTitle'] }}</a></p>
-
-                <p class="comment text-overflow-wrap">
-                    {{ $recentForumPost['ShortMsg'] }}
-                </p>
-            </div>
+            <x-forum.recent-post-item
+                :authorUsername="$recentForumPost['Author']"
+                :forumTopicTitle="$recentForumPost['ForumTopicTitle']"
+                :hasDateTooltip="$recentForumPost['HasDateTooltip']"
+                :href="$recentForumPost['URL']"
+                :postedAt="$recentForumPost['PostedAt']"
+                :summary="$recentForumPost['ShortMsg']"
+                :tooltipLabel="$recentForumPost['TitleAttribute'] ?? null"
+            />
         @endforeach
     </div>
 


### PR DESCRIPTION
This PR migrates the inner content of `/forumposthistory.php` to Blade, specifically reusing the post history component already leveraged on the homepage.

Resolves https://discord.com/channels/310192285306454017/1183823595978362880.

**Before**
![Screenshot 2024-01-14 at 6 37 16 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/05efaabe-ae1a-4431-91db-c6265cb06da1)

![Screenshot 2024-01-14 at 6 37 25 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/7c3a786e-97a9-4208-8db9-a24107ae0b44)

**After**
![Screenshot 2024-01-14 at 6 36 39 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/ba877bde-f49e-46fc-9561-50c0f4e2c801)

![Screenshot 2024-01-14 at 6 35 47 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/370f5f7a-fa85-4c62-8876-f79830fd42bc)
