### PR TITLE
feat(home): use live Total Points Earned in global statistics

### DIFF
--- a/app/Community/AppServiceProvider.php
+++ b/app/Community/AppServiceProvider.php
@@ -19,6 +19,7 @@ use App\Community\Components\DeveloperGameStatsTable;
 use App\Community\Components\ForumRecentPosts;
 use App\Community\Components\GlobalStatistics;
 use App\Community\Components\MessageIcon;
+use App\Community\Components\TotalPointsEarned;
 use App\Community\Components\UserCard;
 use App\Community\Components\UserProgressionStatus;
 use App\Community\Components\UserRecentlyPlayed;
@@ -114,6 +115,8 @@ class AppServiceProvider extends ServiceProvider
         Blade::component('user-card', UserCard::class);
         Blade::component('user-progression-status', UserProgressionStatus::class);
         Blade::component('user-recently-played', UserRecentlyPlayed::class);
+
+        Livewire::component('total-points-earned', TotalPointsEarned::class);
 
         // Livewire::component('forum-topics', ForumTopics::class);
         //

--- a/app/Community/Components/TotalPointsEarned.php
+++ b/app/Community/Components/TotalPointsEarned.php
@@ -10,9 +10,9 @@ use Livewire\Component;
 
 class TotalPointsEarned extends Component
 {
-    public $totalPointsEarned = 0;
+    public int $totalPointsEarned = 0;
 
-    public function mount()
+    public function mount(): void
     {
         $this->totalPointsEarned = $this->getTotalPointsEarned();
     }

--- a/app/Community/Components/TotalPointsEarned.php
+++ b/app/Community/Components/TotalPointsEarned.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Community\Components;
+
+use App\Site\Models\StaticData;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class TotalPointsEarned extends Component
+{
+    public $totalPointsEarned = 0;
+
+    public function mount()
+    {
+        $this->totalPointsEarned = $this->getTotalPointsEarned();
+    }
+
+    public function render(): View
+    {
+        $this->totalPointsEarned = $this->getTotalPointsEarned();
+        $this->dispatch('updatePoints', $this->totalPointsEarned);
+
+        return view(
+            'community.components.global-statistics.total-points-earned', [
+                'totalPointsEarned' => $this->totalPointsEarned,
+            ]
+        );
+    }
+
+    public function getTotalPointsEarned(): int
+    {
+        $totalPointsEarned = 0;
+
+        $dbStaticData = StaticData::first();
+        if ($dbStaticData !== null) {
+            $totalPointsEarned = $dbStaticData['TotalPointsEarned'] ?? 0;
+        }
+
+        return $totalPointsEarned;
+    }
+}

--- a/resources/views/community/components/global-statistics/global-statistics.blade.php
+++ b/resources/views/community/components/global-statistics/global-statistics.blade.php
@@ -15,8 +15,9 @@
 
         <div class="w-full h-16 flex flex-col justify-center items-center">
             <p>Points earned since March 2nd, 2013</p>
-            <span class="text-2xl">{{ number_format($totalPointsEarned) }}</span>
+            <livewire:total-points-earned />
         </div>
+        <x-global-statistics.total-points-earned-javascript :totalPointsEarned="$totalPointsEarned" />
     </div>
 
     <hr class="mt-4 mb-5 border-embed-highlight">

--- a/resources/views/community/components/global-statistics/total-points-earned-javascript.blade.php
+++ b/resources/views/community/components/global-statistics/total-points-earned-javascript.blade.php
@@ -1,0 +1,15 @@
+{{--
+    This stuff shouldn't be in the Livewire component because
+    the template is sent to the browser on each re-render.
+--}}
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/countup.js/1.7.0/countUp.min.js"></script>
+
+<script>
+document.addEventListener('livewire:initialized', () => {
+    const counter = new CountUp('points-counter', {{ $totalPointsEarned }});
+    Livewire.on('updatePoints', (totalPoints) => {
+        counter.update(totalPoints);
+    });
+});
+</script>

--- a/resources/views/community/components/global-statistics/total-points-earned.blade.php
+++ b/resources/views/community/components/global-statistics/total-points-earned.blade.php
@@ -1,0 +1,7 @@
+@props([
+    'totalPointsEarned' => 0,
+])
+
+<span wire:poll.visible.1500ms class="text-2xl" id="points-counter">
+    {{ number_format($totalPointsEarned) }}
+</span>


### PR DESCRIPTION
Reimplements the "Points earned since March 2nd, 2013" using Livewire 3. The number now counts up in real-time as users unlock achievements and `StaticData` updates.


https://github.com/RetroAchievements/RAWeb/assets/3984985/61315292-db7a-475e-adcc-0c6e9ba612ae

To test this PR, in _TotalPointsEarned.php_, replace the first line in `render()` with `$this->totalPointsEarned += 18;`.
