### PR TITLE
add additional leaderboard formats

### DIFF
--- a/app/Helpers/render/leaderboard.php
+++ b/app/Helpers/render/leaderboard.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Platform\Enums\ValueFormat;
+
 function RenderGameLeaderboardsComponent(array $lbData, ?int $forumTopicID): void
 {
     $numLBs = count($lbData);
@@ -39,7 +41,7 @@ function RenderGameLeaderboardsComponent(array $lbData, ?int $forumTopicID): voi
             if ($bestScoreUser == '') {
                 echo "No entries";
             } else {
-                echo GetFormattedLeaderboardEntry($scoreFormat, $bestScore);
+                echo ValueFormat::format($bestScore, $scoreFormat);
             }
             echo "</a>";
             echo "</div>";

--- a/app/Platform/Enums/ValueFormat.php
+++ b/app/Platform/Enums/ValueFormat.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Enums;
+
+abstract class ValueFormat
+{
+    // value padded to six digits with leading zeros
+    public const Score = 'SCORE';
+
+    // mm:ss.cc calculated by taking value / 60
+    public const TimeFrames = 'TIME';
+
+    // mm:ss.cc calculated by taking value / 100
+    public const TimeCentiseconds = 'MILLISECS';
+
+    // hhhmm:ss
+    public const TimeSeconds = 'TIMESECS';
+
+    // hhhmm
+    public const TimeMinutes = 'MINUTES';
+
+    // number followed by three zeroes
+    public const ValueThousands = 'THOUSANDS';
+
+    // number followed by two zeroes
+    public const ValueHundreds = 'HUNDREDS';
+
+    // number followed by one zero
+    public const ValueTens = 'TENS';
+
+    // number
+    public const Value = 'VALUE';
+
+    // unsigned number
+    public const ValueUnsigned = 'UNSIGNED';
+
+    // n.n calculated by taking number / 10
+    public const Fixed1 = 'FIXED1';
+
+    // n.nn calculated by taking number / 100
+    public const Fixed2 = 'FIXED2';
+
+    // n.nnn calculated by taking number / 1000
+    public const Fixed3 = 'FIXED3';
+
+    public static function cases(): array
+    {
+        return [
+            self::Score,
+            self::TimeFrames,
+            self::TimeCentiseconds,
+            self::TimeSeconds,
+            self::TimeMinutes,
+            self::ValueThousands,
+            self::ValueHundreds,
+            self::ValueTens,
+            self::Value,
+            self::ValueUnsigned,
+            self::Fixed1,
+            self::Fixed2,
+            self::Fixed3,
+        ];
+    }
+
+    public static function isValid(string $format): bool
+    {
+        return in_array($format, self::cases());
+    }
+
+    public static function toString(string $format): string
+    {
+        return match ($format) {
+            self::Score => 'Score',
+            self::TimeFrames => 'Time (Frames)',
+            self::TimeCentiseconds => 'Time (Centiseconds)',
+            self::TimeSeconds => 'Time (Seconds)',
+            self::TimeMinutes => 'Time (Minutes)',
+            self::ValueThousands => 'Value (Thousands)',
+            self::ValueHundreds => 'Value (Hundreds)',
+            self::ValueTens => 'Value (Tens)',
+            self::Value => 'Value',
+            self::ValueUnsigned => 'Value (unsigned)',
+            self::Fixed1 => 'Fixed1',
+            self::Fixed2 => 'Fixed2',
+            self::Fixed3 => 'Fixed3',
+            default => 'Unknown',
+        };
+    }
+
+    public static function format(int $value, string $format): string
+    {
+        if ($format === self::ValueUnsigned) {
+            return localized_number(ValueFormat::toUnsignedInt32($value));
+        }
+
+        $value = self::toSignedInt32($value);
+
+        // NOTE: a/b results in a float, a%b results in an integer
+        return match ($format) {
+            self::Score => sprintf("%06d", $value),
+            self::TimeFrames => sprintf("%s.%02d", ValueFormat::formatSeconds((int) ($value / 60)), ($value % 60) * 100 / 60),
+            self::TimeCentiseconds => sprintf("%s.%02d", ValueFormat::formatSeconds((int) ($value / 100)), $value % 100),
+            self::TimeSeconds => ValueFormat::formatSeconds($value),
+            self::TimeMinutes => sprintf("%01dh%02d", (int) $value / 60, $value % 60),
+            self::ValueThousands => localized_number($value * 1000),
+            self::ValueHundreds => localized_number($value * 100),
+            self::ValueTens => localized_number($value * 10),
+            self::Fixed1 => localized_number((float) $value / 10, fractionDigits: 1),
+            self::Fixed2 => localized_number((float) $value / 100, fractionDigits: 2),
+            self::Fixed3 => localized_number((float) $value / 1000, fractionDigits: 3),
+            default => localized_number($value),
+        };
+    }
+
+    private static function toUnsignedInt32(int $value): int
+    {
+        if ($value < 0) {
+            $value = 0xFFFFFFFF + $value + 1;
+        }
+
+        return min($value, 0xFFFFFFFF);
+    }
+
+    private static function toSignedInt32(int $value): int
+    {
+        if ($value >= 0x80000000) {
+            $value = -(0xFFFFFFFF - $value + 1);
+        }
+
+        return max($value, -0x80000000);
+    }
+
+    private static function formatSeconds(int $seconds): string
+    {
+        $hours = (int) ($seconds / 3600);
+        $mins = (int) ($seconds / 60) % 60;
+        $secs = $seconds % 60;
+
+        if ($hours === 0) {
+            return sprintf("%01d:%02d", $mins, $secs);
+        }
+
+        return sprintf("%01dh%02d:%02d", $hours, $mins, $secs);
+    }
+}

--- a/public/leaderboardList.php
+++ b/public/leaderboardList.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Platform\Enums\ValueFormat;
 use App\Platform\Models\System;
 use App\Site\Enums\Permissions;
 
@@ -166,18 +167,10 @@ foreach ($lbData as $nextLB) {
 
         echo "<td style='width: 20%;'>";
         echo "<select id='LB_" . $lbID . "_Format' name='i' " . ($editAllowed ? "" : "disabled='true'") . ">";
-        $selected = $lbFormat == "SCORE" ? "selected" : "";
-        echo "<option value='SCORE' $selected>Score</option>";
-        $selected = $lbFormat == "TIME" ? "selected" : "";
-        echo "<option value='TIME' $selected >Time (Frames)</option>";
-        $selected = $lbFormat == "MILLISECS" ? "selected" : "";
-        echo "<option value='MILLISECS' $selected >Time (Centiseconds)</option>";
-        $selected = $lbFormat == "TIMESECS" ? "selected" : "";
-        echo "<option value='TIMESECS' $selected >Time (Seconds)</option>";
-        $selected = $lbFormat == "MINUTES" ? "selected" : "";
-        echo "<option value='MINUTES' $selected >Time (Minutes)</option>";
-        $selected = $lbFormat == "VALUE" ? "selected" : "";
-        echo "<option value='VALUE' $selected>Value</option>";
+        foreach (ValueFormat::cases() as $format) {
+            $selected = $lbFormat === $format ? " selected" : "";
+            echo "<option value='$format'$selected>" . ValueFormat::toString($format) . "</option>";
+        }
         echo "</select>";
 
         // echo "<input type='text' value='$lbFormat' id='LB_" . $lbID . "_Format' />";

--- a/public/leaderboardinfo.php
+++ b/public/leaderboardinfo.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Community\Enums\ArticleType;
+use App\Platform\Enums\ValueFormat;
 use App\Site\Enums\Permissions;
 use Illuminate\Support\Facades\Blade;
 
@@ -156,7 +157,7 @@ RenderOpenGraphMetadata(
                     if (($user == $nextLBEntry['User'] && $permissions == Permissions::JuniorDeveloper) || $permissions >= Permissions::Developer) {
                         $nextUser = $nextLBEntry['User'];
                         $nextScore = $nextLBEntry['Score'];
-                        $nextScoreFormatted = GetFormattedLeaderboardEntry($lbFormat, $nextScore);
+                        $nextScoreFormatted = ValueFormat::format($nextScore, $lbFormat);
                         echo "<option value='$nextUser'>$nextUser ($nextScoreFormatted)</option>";
                     }
                 }
@@ -223,7 +224,7 @@ RenderOpenGraphMetadata(
             $nextUser = $nextEntry['User'];
             $nextScore = $nextEntry['Score'];
             $nextRank = $nextEntry['Rank'];
-            $nextScoreFormatted = GetFormattedLeaderboardEntry($lbFormat, $nextScore);
+            $nextScoreFormatted = ValueFormat::format($nextScore, $lbFormat);
             $nextSubmitAt = $nextEntry['DateSubmitted'];
             $nextSubmitAtNice = getNiceDate($nextSubmitAt);
 
@@ -258,7 +259,7 @@ RenderOpenGraphMetadata(
 
             echo "<td class='lb_result text-right'>$injectFmt1$nextScoreFormatted$injectFmt2</td>";
 
-            echo "<td class='lb_date text-right'>$injectFmt1$nextSubmitAtNice$injectFmt2</td>";
+            echo "<td class='lb_date text-right smalldate'>$injectFmt1$nextSubmitAtNice$injectFmt2</td>";
 
             echo "</tr>";
 

--- a/resources/views/platform/components/developer-feed/recent-leaderboard-entries.blade.php
+++ b/resources/views/platform/components/developer-feed/recent-leaderboard-entries.blade.php
@@ -2,6 +2,12 @@
     'recentLeaderboardEntries' => null, // Collection
 ])
 
+<?php
+
+use App\Platform\Enums\ValueFormat;
+
+?>
+
 <div>
     <h2 class="text-h4">Recent Leaderboard Entries</h2>
 
@@ -31,7 +37,7 @@
                                 </a>
                             </td>
 
-                            <td>{{ GetFormattedLeaderboardEntry($recentLeaderboardEntry->Format, $recentLeaderboardEntry->Score) }}</td>
+                            <td>{{ ValueFormat::format($recentLeaderboardEntry->Score, $recentLeaderboardEntry->Format) }}</td>
 
                             <td class="py-2">
                                 <x-game.multiline-avatar

--- a/tests/Unit/ValueFormatTest.php
+++ b/tests/Unit/ValueFormatTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Platform\Enums\ValueFormat;
+use Tests\TestCase;
+
+final class ValueFormatTest extends TestCase
+{
+    public function testFormatValue(): void
+    {
+        $this->assertEquals("Value", ValueFormat::toString(ValueFormat::Value));
+
+        $this->assertEquals("12,345", ValueFormat::format(12345, ValueFormat::Value));
+        $this->assertEquals("-12,345", ValueFormat::format(-12345, ValueFormat::Value));
+        $this->assertEquals("0", ValueFormat::format(0, ValueFormat::Value));
+        $this->assertEquals("1", ValueFormat::format(1, ValueFormat::Value));
+        $this->assertEquals("-1", ValueFormat::format(0xFFFFFFFF, ValueFormat::Value));
+    }
+
+    public function testFormatUnsignedValue(): void
+    {
+        $this->assertEquals("Value (unsigned)", ValueFormat::toString(ValueFormat::ValueUnsigned));
+
+        $this->assertEquals("12,345", ValueFormat::format(12345, ValueFormat::ValueUnsigned));
+        $this->assertEquals("4,294,954,951", ValueFormat::format(-12345, ValueFormat::ValueUnsigned));
+        $this->assertEquals("0", ValueFormat::format(0, ValueFormat::ValueUnsigned));
+        $this->assertEquals("1", ValueFormat::format(1, ValueFormat::ValueUnsigned));
+        $this->assertEquals("4,294,967,295", ValueFormat::format(0xFFFFFFFF, ValueFormat::ValueUnsigned));
+    }
+
+    public function testFormatScore(): void
+    {
+        $this->assertEquals("Score", ValueFormat::toString(ValueFormat::Score));
+
+        $this->assertEquals("012345", ValueFormat::format(12345, ValueFormat::Score));
+        $this->assertEquals("-12345", ValueFormat::format(-12345, ValueFormat::Score));
+        $this->assertEquals("000000", ValueFormat::format(0, ValueFormat::Score));
+        $this->assertEquals("000001", ValueFormat::format(1, ValueFormat::Score));
+        $this->assertEquals("-00001", ValueFormat::format(0xFFFFFFFF, ValueFormat::Score));
+    }
+
+    public function testFormatFrames(): void
+    {
+        $this->assertEquals("Time (Frames)", ValueFormat::toString(ValueFormat::TimeFrames));
+
+        $this->assertEquals("3:25.75", ValueFormat::format(12345, ValueFormat::TimeFrames));
+        $this->assertEquals("5h42:56.11", ValueFormat::format(1234567, ValueFormat::TimeFrames));
+        $this->assertEquals("0:00.00", ValueFormat::format(0, ValueFormat::TimeFrames));
+        $this->assertEquals("0:00.01", ValueFormat::format(1, ValueFormat::TimeFrames));
+    }
+
+    public function testFormatCentiseconds(): void
+    {
+        $this->assertEquals("Time (Centiseconds)", ValueFormat::toString(ValueFormat::TimeCentiseconds));
+
+        $this->assertEquals("2:03.45", ValueFormat::format(12345, ValueFormat::TimeCentiseconds));
+        $this->assertEquals("3h25:45.67", ValueFormat::format(1234567, ValueFormat::TimeCentiseconds));
+        $this->assertEquals("0:03.45", ValueFormat::format(345, ValueFormat::TimeCentiseconds));
+        $this->assertEquals("0:00.00", ValueFormat::format(0, ValueFormat::TimeCentiseconds));
+        $this->assertEquals("0:00.01", ValueFormat::format(1, ValueFormat::TimeCentiseconds));
+    }
+
+    public function testFormatSeconds(): void
+    {
+        $this->assertEquals("Time (Seconds)", ValueFormat::toString(ValueFormat::TimeSeconds));
+
+        $this->assertEquals("3h25:45", ValueFormat::format(12345, ValueFormat::TimeSeconds));
+        $this->assertEquals("5:45", ValueFormat::format(345, ValueFormat::TimeSeconds));
+        $this->assertEquals("0:00", ValueFormat::format(0, ValueFormat::TimeSeconds));
+        $this->assertEquals("0:01", ValueFormat::format(1, ValueFormat::TimeSeconds));
+    }
+
+    public function testFormatMinutes(): void
+    {
+        $this->assertEquals("Time (Minutes)", ValueFormat::toString(ValueFormat::TimeMinutes));
+
+        $this->assertEquals("205h45", ValueFormat::format(12345, ValueFormat::TimeMinutes));
+        $this->assertEquals("5h45", ValueFormat::format(345, ValueFormat::TimeMinutes));
+        $this->assertEquals("0h00", ValueFormat::format(0, ValueFormat::TimeMinutes));
+        $this->assertEquals("0h01", ValueFormat::format(1, ValueFormat::TimeMinutes));
+    }
+
+    public function testFormatThousands(): void
+    {
+        $this->assertEquals("Value (Thousands)", ValueFormat::toString(ValueFormat::ValueThousands));
+
+        $this->assertEquals("12,345,000", ValueFormat::format(12345, ValueFormat::ValueThousands));
+        $this->assertEquals("-12,345,000", ValueFormat::format(-12345, ValueFormat::ValueThousands));
+        $this->assertEquals("0", ValueFormat::format(0, ValueFormat::ValueThousands));
+        $this->assertEquals("1,000", ValueFormat::format(1, ValueFormat::ValueThousands));
+        $this->assertEquals("-1,000", ValueFormat::format(0xFFFFFFFF, ValueFormat::ValueThousands));
+        $this->assertEquals("2,147,483,647,000", ValueFormat::format(0x7FFFFFFF, ValueFormat::ValueThousands));
+    }
+
+    public function testFormatHundreds(): void
+    {
+        $this->assertEquals("Value (Hundreds)", ValueFormat::toString(ValueFormat::ValueHundreds));
+
+        $this->assertEquals("1,234,500", ValueFormat::format(12345, ValueFormat::ValueHundreds));
+        $this->assertEquals("-1,234,500", ValueFormat::format(-12345, ValueFormat::ValueHundreds));
+        $this->assertEquals("0", ValueFormat::format(0, ValueFormat::ValueHundreds));
+        $this->assertEquals("100", ValueFormat::format(1, ValueFormat::ValueHundreds));
+        $this->assertEquals("-100", ValueFormat::format(0xFFFFFFFF, ValueFormat::ValueHundreds));
+        $this->assertEquals("214,748,364,700", ValueFormat::format(0x7FFFFFFF, ValueFormat::ValueHundreds));
+    }
+
+    public function testFormatTens(): void
+    {
+        $this->assertEquals("Value (Tens)", ValueFormat::toString(ValueFormat::ValueTens));
+
+        $this->assertEquals("123,450", ValueFormat::format(12345, ValueFormat::ValueTens));
+        $this->assertEquals("-123,450", ValueFormat::format(-12345, ValueFormat::ValueTens));
+        $this->assertEquals("0", ValueFormat::format(0, ValueFormat::ValueTens));
+        $this->assertEquals("10", ValueFormat::format(1, ValueFormat::ValueTens));
+        $this->assertEquals("-10", ValueFormat::format(0xFFFFFFFF, ValueFormat::ValueTens));
+        $this->assertEquals("21,474,836,470", ValueFormat::format(0x7FFFFFFF, ValueFormat::ValueTens));
+    }
+
+    public function testFormatFixed1(): void
+    {
+        $this->assertEquals("Fixed1", ValueFormat::toString(ValueFormat::Fixed1));
+
+        $this->assertEquals("1,234.5", ValueFormat::format(12345, ValueFormat::Fixed1));
+        $this->assertEquals("-1,234.5", ValueFormat::format(-12345, ValueFormat::Fixed1));
+        $this->assertEquals("0.0", ValueFormat::format(0, ValueFormat::Fixed1));
+        $this->assertEquals("0.1", ValueFormat::format(1, ValueFormat::Fixed1));
+        $this->assertEquals("-0.1", ValueFormat::format(0xFFFFFFFF, ValueFormat::Fixed1));
+        $this->assertEquals("214,748,364.7", ValueFormat::format(0x7FFFFFFF, ValueFormat::Fixed1));
+    }
+
+    public function testFormatFixed2(): void
+    {
+        $this->assertEquals("Fixed2", ValueFormat::toString(ValueFormat::Fixed2));
+
+        $this->assertEquals("123.45", ValueFormat::format(12345, ValueFormat::Fixed2));
+        $this->assertEquals("-123.45", ValueFormat::format(-12345, ValueFormat::Fixed2));
+        $this->assertEquals("0.00", ValueFormat::format(0, ValueFormat::Fixed2));
+        $this->assertEquals("0.01", ValueFormat::format(1, ValueFormat::Fixed2));
+        $this->assertEquals("-0.01", ValueFormat::format(0xFFFFFFFF, ValueFormat::Fixed2));
+        $this->assertEquals("21,474,836.47", ValueFormat::format(0x7FFFFFFF, ValueFormat::Fixed2));
+    }
+
+    public function testFormatFixed3(): void
+    {
+        $this->assertEquals("Fixed3", ValueFormat::toString(ValueFormat::Fixed3));
+
+        $this->assertEquals("12.345", ValueFormat::format(12345, ValueFormat::Fixed3));
+        $this->assertEquals("-12.345", ValueFormat::format(-12345, ValueFormat::Fixed3));
+        $this->assertEquals("0.000", ValueFormat::format(0, ValueFormat::Fixed3));
+        $this->assertEquals("0.001", ValueFormat::format(1, ValueFormat::Fixed3));
+        $this->assertEquals("-0.001", ValueFormat::format(0xFFFFFFFF, ValueFormat::Fixed3));
+        $this->assertEquals("2,147,483.647", ValueFormat::format(0x7FFFFFFF, ValueFormat::Fixed3));
+    }
+}


### PR DESCRIPTION
Allows the use of new formats defined in https://github.com/RetroAchievements/rcheevos/pull/305 in leaderboards.

Consolidates labels and formatting functions into helpers on enum.