### PR TITLE
refactor(user): migrate Recent Progress chart to blade

### DIFF
--- a/resources/views/community/components/user/recent-progress.blade.php
+++ b/resources/views/community/components/user/recent-progress.blade.php
@@ -1,0 +1,85 @@
+@props([
+    'username' => '',
+    'userScoreData' => [],
+])
+
+<?php
+use Illuminate\Support\Carbon;
+?>
+
+<script defer src="https://www.gstatic.com/charts/loader.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    if (typeof google !== 'undefined') {
+        google.load('visualization', '1.0', { 'packages': ['corechart'] });
+        google.setOnLoadCallback(drawCharts);
+    }
+});
+
+function drawCharts() {
+    var dataRecentProgress = new google.visualization.DataTable();
+
+    // Declare columns
+    dataRecentProgress.addColumn('date', 'Date');    // NOT date! this is non-continuous data
+    dataRecentProgress.addColumn('number', 'Hardcore Score');
+    dataRecentProgress.addColumn('number', 'Softcore Score');
+
+    dataRecentProgress.addRows([
+        @php
+            $count = 0;
+            foreach ($userScoreData as $dayInfo) {
+                if ($count++ > 0) {
+                    echo ", ";
+                }
+
+                $nextDate = Carbon::parse($dayInfo['Date']);
+                $nextYear = $nextDate->year;
+                $nextMonth = $nextDate->month;
+                $nextDay = $nextDate->day;
+                $dateStr = $nextDate->format('d M Y');
+
+                $hardcoreValue = $dayInfo['CumulHardcoreScore'];
+                $softcoreValue = $dayInfo['CumulSoftcoreScore'];
+
+                echo "[ {v:new Date($nextYear,$nextMonth,$nextDay), f:'$dateStr'}, $hardcoreValue, $softcoreValue ]";
+            }
+        @endphp
+    ]);
+
+    var optionsRecentProcess = {
+        backgroundColor: 'transparent',
+        title: 'Recent Progress',
+        titleTextStyle: { color: '#186DEE' },
+        hAxis: {
+            textStyle: { color: '#186DEE' },
+            slantedTextAngle: 90
+        },
+        vAxis: { textStyle: { color: '#186DEE' } },
+        legend: { position: 'none' },
+        chartArea: {
+            left: 42,
+            width: 458,
+            'height': '100%'
+        },
+        showRowNumber: false,
+        view: { columns: [0, 1] },
+        colors: ['#cc9900', '#737373'],
+    };
+
+    function resize() {
+        chartRecentProgress = new google.visualization.AreaChart(document.getElementById('chart_recentprogress'));
+        chartRecentProgress.draw(dataRecentProgress, optionsRecentProcess);
+    }
+
+    window.onload = resize();
+    window.onresize = resize;
+}
+</script>
+
+<div class="component">
+    <h3>Recent Progress</h3>
+    <div id="chart_recentprogress" class="mb-5 min-h-[200px]"></div>
+    <div class="text-right">
+        <a href="/history.php?u={{ $username }}">more...</a>
+    </div>
+</div>

--- a/resources/views/community/components/user/recent-progress.blade.php
+++ b/resources/views/community/components/user/recent-progress.blade.php
@@ -7,79 +7,84 @@
 use Illuminate\Support\Carbon;
 ?>
 
-<script defer src="https://www.gstatic.com/charts/loader.js"></script>
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    if (typeof google !== 'undefined') {
-        google.load('visualization', '1.0', { 'packages': ['corechart'] });
-        google.setOnLoadCallback(drawCharts);
-    }
-});
-
-function drawCharts() {
-    var dataRecentProgress = new google.visualization.DataTable();
-
-    // Declare columns
-    dataRecentProgress.addColumn('date', 'Date');    // NOT date! this is non-continuous data
-    dataRecentProgress.addColumn('number', 'Hardcore Score');
-    dataRecentProgress.addColumn('number', 'Softcore Score');
-
-    dataRecentProgress.addRows([
-        @php
-            $count = 0;
-            foreach ($userScoreData as $dayInfo) {
-                if ($count++ > 0) {
-                    echo ", ";
-                }
-
-                $nextDate = Carbon::parse($dayInfo['Date']);
-                $nextYear = $nextDate->year;
-                $nextMonth = $nextDate->month;
-                $nextDay = $nextDate->day;
-                $dateStr = $nextDate->format('d M Y');
-
-                $hardcoreValue = $dayInfo['CumulHardcoreScore'];
-                $softcoreValue = $dayInfo['CumulSoftcoreScore'];
-
-                echo "[ {v:new Date($nextYear,$nextMonth,$nextDay), f:'$dateStr'}, $hardcoreValue, $softcoreValue ]";
-            }
-        @endphp
-    ]);
-
-    var optionsRecentProcess = {
-        backgroundColor: 'transparent',
-        title: 'Recent Progress',
-        titleTextStyle: { color: '#186DEE' },
-        hAxis: {
-            textStyle: { color: '#186DEE' },
-            slantedTextAngle: 90
-        },
-        vAxis: { textStyle: { color: '#186DEE' } },
-        legend: { position: 'none' },
-        chartArea: {
-            left: 42,
-            width: 458,
-            'height': '100%'
-        },
-        showRowNumber: false,
-        view: { columns: [0, 1] },
-        colors: ['#cc9900', '#737373'],
-    };
-
-    function resize() {
-        chartRecentProgress = new google.visualization.AreaChart(document.getElementById('chart_recentprogress'));
-        chartRecentProgress.draw(dataRecentProgress, optionsRecentProcess);
-    }
-
-    window.onload = resize();
-    window.onresize = resize;
-}
-</script>
-
 <div class="component">
     <h3>Recent Progress</h3>
-    <div id="chart_recentprogress" class="mb-5 min-h-[200px]"></div>
-    <div class="text-right">
-        <a href="/history.php?u={{ $username }}">more...</a>
-    </div>
+
+    @if (empty($userScoreData))
+        <p>No points earned in the last 14 days.</p>
+    @else
+        <script defer src="https://www.gstatic.com/charts/loader.js"></script>
+        <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            if (typeof google !== 'undefined') {
+                google.load('visualization', '1.0', { 'packages': ['corechart'] });
+                google.setOnLoadCallback(drawCharts);
+            }
+        });
+
+        function drawCharts() {
+            var dataRecentProgress = new google.visualization.DataTable();
+
+            // Declare columns
+            dataRecentProgress.addColumn('date', 'Date');    // NOT date! this is non-continuous data
+            dataRecentProgress.addColumn('number', 'Hardcore Score');
+            dataRecentProgress.addColumn('number', 'Softcore Score');
+
+            dataRecentProgress.addRows([
+                @php
+                    $count = 0;
+                    foreach ($userScoreData as $dayInfo) {
+                        if ($count++ > 0) {
+                            echo ", ";
+                        }
+
+                        $nextDate = Carbon::parse($dayInfo['Date']);
+                        $nextYear = $nextDate->year;
+                        $nextMonth = $nextDate->month;
+                        $nextDay = $nextDate->day;
+                        $dateStr = $nextDate->format('d M Y');
+
+                        $hardcoreValue = $dayInfo['CumulHardcoreScore'];
+                        $softcoreValue = $dayInfo['CumulSoftcoreScore'];
+
+                        echo "[ {v:new Date($nextYear,$nextMonth,$nextDay), f:'$dateStr'}, $hardcoreValue, $softcoreValue ]";
+                    }
+                @endphp
+            ]);
+
+            var optionsRecentProcess = {
+                backgroundColor: 'transparent',
+                title: 'Recent Progress',
+                titleTextStyle: { color: '#186DEE' },
+                hAxis: {
+                    textStyle: { color: '#186DEE' },
+                    slantedTextAngle: 90
+                },
+                vAxis: { textStyle: { color: '#186DEE' } },
+                legend: { position: 'none' },
+                chartArea: {
+                    left: 42,
+                    width: 458,
+                    'height': '100%'
+                },
+                showRowNumber: false,
+                view: { columns: [0, 1] },
+                colors: ['#cc9900', '#737373'],
+            };
+
+            function resize() {
+                chartRecentProgress = new google.visualization.AreaChart(document.getElementById('chart_recentprogress'));
+                chartRecentProgress.draw(dataRecentProgress, optionsRecentProcess);
+            }
+
+            window.onload = resize();
+            window.onresize = resize;
+        }
+        </script>
+
+        <div id="chart_recentprogress" class="mb-5 min-h-[200px]"></div>
+        <div class="text-right">
+            <a href="/history.php?u={{ $username }}">more...</a>
+        </div>
+    @endif
 </div>


### PR DESCRIPTION
Migrates the user profile Recent Progress chart to Blade. Chart colors have been changed to mirror the distribution chart on game pages (gold for hardcore, gray for softcore). Other than that, implementation details are unchanged.

**Before**
![Screenshot 2024-01-20 at 5 41 22 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/a6018d13-be4d-4bae-b61a-cae899202e19)


**After**
![Screenshot 2024-01-20 at 5 41 14 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/e317a343-0f94-4650-af4f-872175d78fbb)