### PR TITLE
fix(game): remove distribution chart when viewing unofficial achievements

### DIFF
--- a/public/gameInfo.php
+++ b/public/gameInfo.php
@@ -1224,7 +1224,7 @@ sanitize_outputs(
             RenderGameCompare($user, $gameID, $friendScores, $totalPossible);
         }
 
-        if ($numAchievements > 0) {
+        if ($numAchievements > 0 && $isOfficial) {
             echo "<div id='achdistribution' class='component' >";
             echo "<h2 class='text-h3'>Achievement Distribution</h2>";
             echo "<div id='chart_distribution' class='min-h-[260px]'></div>";


### PR DESCRIPTION
Simple tweak to the game page to remove the Achievements Distribution chart when viewing unofficial achievements.

Right now, the component is a bit disorienting when viewing unofficial. Unlocks are not shown on the achievements list (I believe this is correct), but they are shown on the distribution chart.