### PR TITLE
feat(completion-progress): add 'Games without 100% completion' filter

### DIFF
--- a/app/Platform/Controllers/PlayerCompletionProgressController.php
+++ b/app/Platform/Controllers/PlayerCompletionProgressController.php
@@ -302,6 +302,8 @@ class PlayerCompletionProgressController extends Controller
 
             'gte-completed' => fn ($game) => isset($game['HighestAwardKind'])
                 && ($game['HighestAwardKind'] === 'completed' || $game['HighestAwardKind'] === 'mastered'),
+
+            'missing-unlocks' => fn ($game) => $game['PctWon'] < 1,
         ];
 
         if (isset($filters[$statusValue])) {

--- a/resources/views/platform/components/completion-progress-page/meta-panel/status-filter.blade.php
+++ b/resources/views/platform/components/completion-progress-page/meta-panel/status-filter.blade.php
@@ -12,6 +12,7 @@ $statuses = [
     'eq-mastered' => 'Mastered',
     'any-beaten' => 'Beaten, either hardcore or softcore',
     'gte-completed' => 'Completed or mastered',
+    'missing-unlocks' => 'Games without 100% completion',
     'awarded' => 'Games with any award',
     'eq-revised' => 'Games with awards for revised sets',
     'gte-beaten-softcore' => 'Games with softcore awards',


### PR DESCRIPTION
This PR adds a new Status filter option to the Completion Progress page: "Games without 100% completion".

The filter simply returns a list of games where `PctWon` is less than 100%.

Resolves https://discord.com/channels/310192285306454017/1197053238168535070.

![Screenshot 2024-01-21 at 11 07 00 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/e573a6d7-b288-4ce3-84c5-65be25284063)
