### PR TITLE
refactor(viewtopic): migrate fetching comments to Eloquent ORM

### DIFF
--- a/app/Community/Models/ForumTopicComment.php
+++ b/app/Community/Models/ForumTopicComment.php
@@ -64,6 +64,6 @@ class ForumTopicComment extends BaseModel
      */
     public function user(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'AuthorID', 'ID');
+        return $this->belongsTo(User::class, 'AuthorID');
     }
 }

--- a/app/Community/Models/ForumTopicComment.php
+++ b/app/Community/Models/ForumTopicComment.php
@@ -64,6 +64,6 @@ class ForumTopicComment extends BaseModel
      */
     public function user(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'AuthorID');
+        return $this->belongsTo(User::class, 'AuthorID', 'ID');
     }
 }

--- a/app/Helpers/database/forum.php
+++ b/app/Helpers/database/forum.php
@@ -135,41 +135,6 @@ function getTopicDetails(int $topicID, ?array &$topicDataOut = []): bool
     return false;
 }
 
-function getTopicComments(int $topicID, int $offset, int $count, ?int &$maxCountOut): ?array
-{
-    $query = "    SELECT COUNT(*) FROM ForumTopicComment AS ftc
-                WHERE ftc.ForumTopicID = $topicID ";
-
-    $dbResult = s_mysql_query($query);
-    if ($dbResult !== false) {
-        $data = mysqli_fetch_assoc($dbResult);
-        $maxCountOut = (int) $data['COUNT(*)'];
-    }
-
-    $query = "SELECT ftc.ID, ftc.ForumTopicID, ftc.Payload, ftc.Author, ftc.AuthorID, ftc.DateCreated, ftc.DateModified, ftc.Authorised, ua.RAPoints, ua.Created AS AuthorJoined, ua.Deleted as AuthorDeleted, ua.Permissions as AuthorPermissions
-                FROM ForumTopicComment AS ftc
-                LEFT JOIN UserAccounts AS ua ON ua.ID = ftc.AuthorID
-                WHERE ftc.ForumTopicID = $topicID
-                ORDER BY DateCreated ASC
-                LIMIT $offset, $count";
-
-    $dbResult = s_mysql_query($query);
-    if ($dbResult !== false) {
-        $dataOut = [];
-
-        $numResults = 0;
-        while ($db_entry = mysqli_fetch_assoc($dbResult)) {
-            $dataOut[$numResults] = $db_entry;
-            $numResults++;
-        }
-
-        return $dataOut;
-    }
-    log_sql_fail();
-
-    return null;
-}
-
 function getSingleTopicComment(int $forumPostID, ?array &$dataOut): bool
 {
     $query = "    SELECT ID, ForumTopicID, Payload, Author, AuthorID, DateCreated, DateModified

--- a/app/Site/Models/User.php
+++ b/app/Site/Models/User.php
@@ -168,6 +168,7 @@ class User extends Authenticatable implements CommunityMember, Developer, HasCom
         "completion_percentage_average_hardcore",
         "ContribCount",
         "ContribYield",
+        "Deleted",
         "LastLogin",
         "ManuallyVerified",
         "Motto",

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -1,10 +1,10 @@
 <?php
 
 use App\Community\Enums\SubscriptionSubjectType;
+use App\Community\Models\ForumTopicComment;
 use App\Site\Enums\Permissions;
 use App\Support\Shortcode\Shortcode;
 use Illuminate\Support\Facades\Blade;
-use App\Community\Models\ForumTopicComment;
 
 authenticateFromCookie($user, $permissions, $userDetails);
 $userID = $userDetails['ID'] ?? 0;

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -4,6 +4,7 @@ use App\Community\Enums\SubscriptionSubjectType;
 use App\Site\Enums\Permissions;
 use App\Support\Shortcode\Shortcode;
 use Illuminate\Support\Facades\Blade;
+use App\Community\Models\ForumTopicComment;
 
 authenticateFromCookie($user, $permissions, $userDetails);
 $userID = $userDetails['ID'] ?? 0;
@@ -40,7 +41,13 @@ if (!empty($gotoCommentID)) {
 }
 
 // Fetch comments
-$commentList = getTopicComments($requestedTopicID, $offset, $count, $numTotalComments);
+$numTotalComments = ForumTopicComment::where('ForumTopicID', $requestedTopicID)->count();
+$commentList = ForumTopicComment::with('user')
+    ->where('ForumTopicID', $requestedTopicID)
+    ->orderBy('DateCreated', 'asc')
+    ->offset($offset)
+    ->limit($count)
+    ->get();
 
 // We CANNOT have a topic with no comments... this doesn't make sense.
 if (empty($commentList)) {
@@ -155,12 +162,10 @@ RenderContentStart($pageTitle);
     echo "<div class='mb-4'>";
     // Output all posts, and offer 'prev/next page'
     foreach ($commentList as $index => $commentData) {
-        $nextCommentID = $commentData['ID'];
-        $nextCommentPayload = $commentData['Payload'];
-        $nextCommentAuthor = $commentData['Author'];
+        $nextCommentID = $commentData->ID;
+        $nextCommentPayload = $commentData->Payload;
+        $nextCommentAuthor = $commentData->Author;
         $nextCommentIndex = ($index + 1) + $offset; // Account for the current page on the post #.
-
-        sanitize_outputs($nextCommentPayload, $nextCommentAuthor);
 
         $isOriginalPoster = $nextCommentAuthor === $thisTopicAuthor;
         $isHighlighted = isset($gotoCommentID) && $nextCommentID == $gotoCommentID;

--- a/resources/views/community/components/forum/post.blade.php
+++ b/resources/views/community/components/forum/post.blade.php
@@ -1,13 +1,13 @@
 @props([
-    'commentData',
-    'currentUser',
-    'currentUserPermissions',
-    'forumTopicId',
-    'isHighlighted',
-    'isOriginalPoster',
-    'isUnverified',
-    'parsedPostContent',
-    'threadPostNumber',
+    'commentData', // Collection|ForumTopicComment[]
+    'currentUser' => '',
+    'currentUserPermissions', // legacy permissions
+    'forumTopicId' => 0,
+    'isHighlighted' => false,
+    'isOriginalPoster' => false,
+    'isUnverified' => false,
+    'parsedPostContent' => '',
+    'threadPostNumber' => 0,
     'isPreview' => false,
 ])
 
@@ -24,15 +24,16 @@ $commentAuthorJoinDate = null;
 $commentAuthorPermissions = null;
 
 if (!$isPreview) {
-    $commentId = $commentData['ID'];
-    $commentAuthor = e($commentData['Author']);
-    $commentAuthorDeletedDate = $commentData['AuthorDeleted'];
-    $commentAuthorJoinDate = $commentData['AuthorJoined'];
-    $commentAuthorPermissions = $commentData['AuthorPermissions'];
-    $commentDateCreated = $commentData['DateCreated'];
-    $commentDateModified = $commentData['DateModified'];
-    $commentIsAuthorised = $commentData['Authorised'];
+    $commentId = $commentData->ID;
+    $commentAuthor = e($commentData->Author);
+    $commentAuthorDeletedDate = $commentData->user->Deleted;
+    $commentAuthorJoinDate = $commentData->user->Created;
+    $commentAuthorPermissions = $commentData->user->Permissions;
+    $commentDateCreated = $commentData->DateCreated;
+    $commentDateModified = $commentData->DateModified;
+    $commentIsAuthorised = $commentData->Authorised;
 
+    // FIXME: legacy permissions
     $isCurrentUserModerator = $currentUserPermissions >= Permissions::Moderator;
     $isCurrentUserAuthor = $currentUser === $commentAuthor;
 
@@ -45,7 +46,7 @@ if (!$isPreview) {
 }
 ?>
 
-@if($isPreview || $canShowPost)
+@if ($isPreview || $canShowPost)
     <x-forum.post-container
         :commentId="$commentId ?? null"
         :isHighlighted="$isHighlighted ?? false"
@@ -59,7 +60,7 @@ if (!$isPreview) {
         />
 
         <div class='comment w-full lg:py-0 px-1 lg:px-6 {{ $isPreview ? "py-2" : "pt-2 pb-4" }}'>
-            @if($isPreview)
+            @if ($isPreview)
                 <div class='{{ $metaContainerClassNames }}'>
                     <p class='smalltext !leading-[14px]'>Preview</p>
                 </div>
@@ -75,11 +76,11 @@ if (!$isPreview) {
                     </div>
 
                     <div class='flex gap-x-1 items-center lg:-mx-4 lg:pl-4 lg:w-[calc(100% + 32px)]'>
-                        @if($showAuthoriseTools)
+                        @if ($showAuthoriseTools)
                             <x-forum.post-moderation-tools :commentAuthor="$commentAuthor"/>
                         @endif
 
-                        @if($showEditButton)
+                        @if ($showEditButton)
                             <a href='/editpost.php?comment={{ $commentId }}' class='btn p-1 lg:text-xs'>Edit</a>
                         @endif
 


### PR DESCRIPTION
Purely to better prepare for rendering modern roles - rather than augmenting the legacy `mysqli` calls it would make more sense if we used Eloquent ORM relationships here to fetch the user's roles.