### PR TITLE
perf(connect): optimize gameslist and officialgameslist routines

### DIFF
--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -559,7 +559,7 @@ function getGamesListDataNamesOnly(int $consoleId, bool $officialFlag = false): 
             return $query->where('GameData.achievements_published', '>', 0);
         })
         ->orderBy('Console.Name')
-        ->orderBy('GameData.title')
+        ->orderBy('GameData.Title')
         ->select('GameData.Title', 'GameData.ID')
         ->pluck('GameData.Title', 'GameData.ID')
         ->toArray();

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -548,17 +548,21 @@ function getGamesList(?int $consoleID, ?array &$dataOut, bool $officialFlag = fa
     return count($dataOut);
 }
 
-function getGamesListDataNamesOnly(int $consoleID, bool $officialFlag = false): array
+function getGamesListDataNamesOnly(int $consoleId, bool $officialFlag = false): array
 {
-    $retval = [];
-
-    $data = getGamesListData($consoleID, $officialFlag);
-
-    foreach ($data as $element) {
-        $retval[$element['ID']] = utf8_encode($element['Title']);
-    }
-
-    return $retval;
+    return Game::with('system')
+        ->join('Console', 'GameData.ConsoleID', '=', 'Console.ID')
+        ->when($consoleId !== 0, function ($query) use ($consoleId) {
+            return $query->where('GameData.ConsoleID', '=', $consoleId);
+        })
+        ->when($officialFlag === true, function ($query) {
+            return $query->where('GameData.achievements_published', '>', 0);
+        })
+        ->orderBy('Console.Name')
+        ->orderBy('GameData.title')
+        ->select('GameData.Title', 'GameData.ID')
+        ->pluck('GameData.Title', 'GameData.ID')
+        ->toArray();
 }
 
 function getGameIDFromTitle(string $gameTitle, int $consoleID): int

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -550,8 +550,7 @@ function getGamesList(?int $consoleID, ?array &$dataOut, bool $officialFlag = fa
 
 function getGamesListDataNamesOnly(int $consoleId, bool $officialFlag = false): array
 {
-    return Game::with('system')
-        ->join('Console', 'GameData.ConsoleID', '=', 'Console.ID')
+    return Game::join('Console', 'GameData.ConsoleID', '=', 'Console.ID')
         ->when($consoleId !== 0, function ($query) use ($consoleId) {
             return $query->where('GameData.ConsoleID', '=', $consoleId);
         })


### PR DESCRIPTION
Implements @Jamiras's suggestion from https://github.com/RetroAchievements/RAWeb/pull/2179#discussion_r1468890568:

> [gameslist and officialgameslist] could be hugely improved by just querying the ID/Title instead of doing a full data dump and extracting the Title.

**`gameslist` Before (ms)**
1300ms
1230ms
1190ms
1170ms
1190ms
Average: 1216ms

**`gameslist` After (ms)**
359ms
358ms
352ms
357ms
355ms
Average: 356ms (around a 3.5x speed increase)