### PR TITLE
fix(achievementInfo): pluralize ticket count

### DIFF
--- a/public/achievementInfo.php
+++ b/public/achievementInfo.php
@@ -302,7 +302,7 @@ RenderContentStart($pageTitle);
         $countTickets = countOpenTicketsByAchievement($achievementID);
         echo "<div class='flex justify-between mb-2'>";
         if ($countTickets > 0) {
-            echo "<a href='/ticketmanager.php?a=$achievementID'>$countTickets open tickets</a>";
+            echo "<a href='/ticketmanager.php?a=$achievementID'>$countTickets open " . mb_strtolower(__res('ticket', $countTickets)) . "</a>";
         } else {
             echo "<i>No open tickets</i>";
         }


### PR DESCRIPTION
Fixes a minor issue on _achievementInfo.php_ where the current ticket count is not pluralized.

**Before**
<img width="127" alt="Screenshot 2024-01-28 at 10 21 50 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/5dfdf63f-d0ed-47d8-9f2b-8e6a0b38f2d3">


**After**
<img width="141" alt="Screenshot 2024-01-28 at 10 20 21 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/804dcf4a-9dd8-4d13-aa49-6bb6fdb73b42">
