### PR TITLE
feat(filament): remove force delete feature from achievement resource and policy

### DIFF
--- a/app/Filament/Resources/AchievementResource.php
+++ b/app/Filament/Resources/AchievementResource.php
@@ -305,7 +305,6 @@ class AchievementResource extends Resource
                         Tables\Actions\EditAction::make(),
                         Tables\Actions\DeleteAction::make(),
                         Tables\Actions\RestoreAction::make(),
-                        Tables\Actions\ForceDeleteAction::make(),
                     ])->dropdown(false),
                     Tables\Actions\Action::make('audit-log')
                         ->url(fn ($record) => AchievementResource::getUrl('audit-log', ['record' => $record]))
@@ -315,7 +314,6 @@ class AchievementResource extends Resource
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     // Tables\Actions\DeleteBulkAction::make(),
-                    // Tables\Actions\ForceDeleteBulkAction::make(),
                     // Tables\Actions\RestoreBulkAction::make(),
                 ]),
             ]);

--- a/app/Platform/Policies/AchievementPolicy.php
+++ b/app/Platform/Policies/AchievementPolicy.php
@@ -99,8 +99,6 @@ class AchievementPolicy
 
     public function forceDelete(User $user, Achievement $achievement): bool
     {
-        return $user->hasAnyRole([
-            Role::HUB_MANAGER,
-        ]);
+        return false;
     }
 }


### PR DESCRIPTION
As discussed, there's no valid use-case for us to allow force deleting soft-deletable models.