### PR TITLE
feat(permissions): store new permissions related timestamps

### DIFF
--- a/app/Helpers/database/user-email-verify.php
+++ b/app/Helpers/database/user-email-verify.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Site\Enums\Permissions;
+use App\Site\Models\User;
 use Illuminate\Support\Str;
 
 function generateEmailVerificationToken(string $user): ?string
@@ -24,6 +25,9 @@ function generateEmailVerificationToken(string $user): ?string
     return $emailCookie;
 }
 
+/**
+ * @deprecated will be replaced by Fortify and default framework features
+ */
 function validateEmailVerificationToken(string $emailCookie, ?string &$user): bool
 {
     sanitize_sql_inputs($emailCookie);
@@ -57,6 +61,8 @@ function validateEmailVerificationToken(string $emailCookie, ?string &$user): bo
         if ($response['Success']) {
             static_addnewregistereduser($user);
             generateAPIKey($user);
+
+            User::where('User', $user)->update(['email_verified_at' => now()]);
 
             // SUCCESS: validated email address for $user
             return true;

--- a/app/Helpers/database/user-permission.php
+++ b/app/Helpers/database/user-permission.php
@@ -152,7 +152,7 @@ function setAccountForumPostAuth(string $sourceUser, int $sourcePermissions, str
 
     if (!$authorize) {
         // This user is a spam user: remove all their posts and set their account as banned.
-        $query = "UPDATE UserAccounts SET ManuallyVerified = 0, forum_verified_at = NOW(), Updated=NOW() WHERE User='$user'";
+        $query = "UPDATE UserAccounts SET ManuallyVerified = 0, forum_verified_at = null, Updated=NOW() WHERE User='$user'";
         $dbResult = s_mysql_query($query);
         if (!$dbResult) {
             return false;

--- a/app/Helpers/database/user-permission.php
+++ b/app/Helpers/database/user-permission.php
@@ -152,7 +152,7 @@ function setAccountForumPostAuth(string $sourceUser, int $sourcePermissions, str
 
     if (!$authorize) {
         // This user is a spam user: remove all their posts and set their account as banned.
-        $query = "UPDATE UserAccounts SET ManuallyVerified = 0, Updated=NOW() WHERE User='$user'";
+        $query = "UPDATE UserAccounts SET ManuallyVerified = 0, forum_verified_at = NOW(), Updated=NOW() WHERE User='$user'";
         $dbResult = s_mysql_query($query);
         if (!$dbResult) {
             return false;
@@ -166,7 +166,7 @@ function setAccountForumPostAuth(string $sourceUser, int $sourcePermissions, str
         return true;
     }
 
-    $query = "UPDATE UserAccounts SET ManuallyVerified = 1, Updated=NOW() WHERE User='$user'";
+    $query = "UPDATE UserAccounts SET ManuallyVerified = 1, forum_verified_at = NOW(), Updated=NOW() WHERE User='$user'";
     $dbResult = s_mysql_query($query);
     if (!$dbResult) {
         return false;
@@ -185,6 +185,8 @@ function setAccountForumPostAuth(string $sourceUser, int $sourcePermissions, str
 
 /**
  * APIKey doesn't have to be reset -> permission >= Registered
+ *
+ * @deprecated TODO move to filament user management
  */
 function banAccountByUsername(string $username, int $permissions): void
 {
@@ -213,7 +215,9 @@ function banAccountByUsername(string $username, int $permissions): void
         u.UserWallActive = 0,
         u.RichPresenceMsg = null,
         u.RichPresenceMsgDate = null,
-        u.PasswordResetToken = ''
+        u.PasswordResetToken = '',
+        u.banned_at = NOW(),
+        u.Updated = NOW()
         WHERE u.User='$username'"
     );
     if (!$dbResult) {


### PR DESCRIPTION
Allows to use `$user->isForumVerified()`, `$user->hasVerifiedEmail()`, and `$user->isBanned()` in upcoming PRs.

Preparation for `TODO drop ManuallyVerified in favor of forum_verified_at`.

Backfill timestamps - low precision is acceptable in this case:

```sql
UPDATE
    UserAccounts
SET
    email_verified_at = Created
WHERE
    Permissions > 0
    AND email_verified_at IS NULL;

UPDATE
    UserAccounts
SET
    forum_verified_at = Created
WHERE
    ManuallyVerified = 1
    AND forum_verified_at IS NULL;

UPDATE
    UserAccounts
SET
    banned_at = Updated
WHERE
    Permissions < 0
    AND banned_at IS NULL;
```