### PR TITLE
chore(eslint): ignore Livewire any type

### DIFF
--- a/resources/js/livewire.d.ts
+++ b/resources/js/livewire.d.ts
@@ -1,3 +1,3 @@
 declare module 'livewire' {
-    export const Livewire: any;
+    export const Livewire: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }


### PR DESCRIPTION
Gets rid of `Unchanged files with check annotations` when reviewing PRs:
![Screenshot 2024-01-31 at 15 01 39](https://github.com/RetroAchievements/RAWeb/assets/1280590/fde23a2a-71ae-4e2d-b750-983628e1b418)

I couldn't find a better solution for now. 