### PR TITLE
feat: add award indicators to game lists

### DIFF
--- a/app/Platform/Services/GameListService.php
+++ b/app/Platform/Services/GameListService.php
@@ -526,16 +526,19 @@ class GameListService
                     $gameProgress = $this->userProgress[$game['ID']] ?? null;
                     $softcoreProgress = $gameProgress['achievements_unlocked'] ?? 0;
                     $hardcoreProgress = $gameProgress['achievements_unlocked_hardcore'] ?? 0;
+                    $highestAwardKind = $gameProgress['HighestAwardKind'] ?? 'unfinished';
                     $tooltip = "$softcoreProgress of {$game['achievements_published']} unlocked";
 
                     echo '<td class="text-center">';
                     echo Blade::render('
                         <x-game-progress-bar
+                            :awardIndicator="$awardIndicator"
                             :softcoreProgress="$softcoreProgress"
                             :hardcoreProgress="$hardcoreProgress"
                             :maxProgress="$maxProgress"
                             :tooltip="$tooltip"
                         />', [
+                            'awardIndicator' => $highestAwardKind,
                             'softcoreProgress' => $softcoreProgress,
                             'hardcoreProgress' => $hardcoreProgress,
                             'maxProgress' => $game['achievements_published'],


### PR DESCRIPTION
This PR adds award indicators to everything using `GameListService` that shows user progress.

**Before**
![Screenshot 2024-01-31 at 5 56 00 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/9b01786d-7347-454c-a30d-080744eb282b)


**After**
![Screenshot 2024-01-31 at 5 55 51 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/2f74dfbc-3500-4e55-b8f4-355bc76c68b4)
