### PR TITLE
nit(role-label): remove un-needed bottom margin

### DIFF
--- a/resources/views/community/components/user/profile/primary-meta.blade.php
+++ b/resources/views/community/components/user/profile/primary-meta.blade.php
@@ -45,7 +45,7 @@ $shouldMoveRoleToNextLine =
             {{-- TODO: Support N roles. --}}
             @if ($hasVisibleRole)
                 <div class="flex h-4 items-center justify-center bg-neutral-700 text-neutral-300 px-1.5 rounded sm:-mt-1">
-                    <p class="text-2xs -mb-0.5">{{ $roleLabel }}</p>
+                    <p class="text-2xs">{{ $roleLabel }}</p>
                 </div>
             @endif
         </div>


### PR DESCRIPTION
Removes an un-needed class from the role box

Noticed here: https://discord.com/channels/310192285306454017/453242743292952578/1202674205007683685

Before:
<img width="117" alt="Screenshot 2024-02-01 192659" src="https://github.com/RetroAchievements/RAWeb/assets/2449110/44170523-a51e-4d78-bcff-2b302a59c4c9">

After:
<img width="114" alt="Screenshot 2024-02-01 192718" src="https://github.com/RetroAchievements/RAWeb/assets/2449110/ad805b40-ec20-4b57-a1ee-41d3cb7d07a0">

