### PR TITLE
fix: move suggestions route

### DIFF
--- a/app/Platform/RouteServiceProvider.php
+++ b/app/Platform/RouteServiceProvider.php
@@ -65,12 +65,12 @@ class RouteServiceProvider extends ServiceProvider
             // Route::get('game/{game}{slug?}', [GameController::class, 'show'])->name('game.show');
             // Route::resource('games', GameController::class)->only('index')->names(['index' => 'game.index']);
             // Route::get('games/popular', [GameController::class, 'popular'])->name('games.popular');
+            Route::get('games/suggest', SuggestGameController::class)->name('games.suggest');
             // Route::get('game/{game}/badges', [GameBadgeController::class, 'index'])->name('game.badge.index');
             // Route::get('game/{game}/assets', [GameAssetsController::class, 'index'])->name('game.asset.index');
             // Route::get('game/{game}/players', [GamePlayerController::class, 'index'])->name('game.player.index');
             Route::get('game/{game}/dev-interest', GameDevInterestController::class)->name('game.dev-interest');
-            Route::get('game/{game}/suggest', [SuggestGameController::class, 'forGame'])->name('game.suggest-for-game');
-            Route::get('game/suggest', SuggestGameController::class)->name('game.suggest');
+            Route::get('game/{game}/suggest', [SuggestGameController::class, 'forGame'])->name('game.suggest');
 
             // Route::get('create', CreateController::class)->name('create');
             // Route::resource('developers', DeveloperController::class)->only('index');

--- a/config/missing-page-redirector.php
+++ b/config/missing-page-redirector.php
@@ -24,6 +24,8 @@ return [
      * You can use Laravel's route parameters here.
      */
     'redirects' => [
+        // temp
+        '/game/suggest' => '/games/suggest',
         /*
          * lowercase routes
          */

--- a/resources/views/components/menu/account.blade.php
+++ b/resources/views/components/menu/account.blade.php
@@ -55,7 +55,7 @@ $user = request()->user();
         
         @if($user->Permissions >= Permissions::Registered)
             <x-dropdown-item :link="url('gameList.php?t=play')">Want to Play Games</x-dropdown-item>
-            <x-dropdown-item :link="route('game.suggest')">Game Suggestions</x-dropdown-item>
+            <x-dropdown-item :link="route('games.suggest')">Game Suggestions</x-dropdown-item>
         @endif
         @if($user->ContribCount > 0 || $user->Permissions >= Permissions::JuniorDeveloper)
             <div class="dropdown-divider"></div>

--- a/resources/views/platform/components/game/link-buttons/index.blade.php
+++ b/resources/views/platform/components/game/link-buttons/index.blade.php
@@ -112,7 +112,7 @@ $ticketManagerUrl = url('/ticketmanager.php') . '?' . http_build_query($ticketMa
     @if ($canSeeSuggestedGames)
         <x-game.link-buttons.game-link-button
             icon="🕹️"
-            href="{{ route('game.suggest-for-game', $gameId) }}"
+            href="{{ route('game.suggest', $gameId) }}"
         >
             Find Something Similar to Play
         </x-game.link-buttons.game-link-button>


### PR DESCRIPTION
REST routes should stay clean to not cause potential conflicts with `game/{id}`.

Temporarily redirects `/game/suggest` to `/games/suggest` so nobody currently accessing the page should notice. Redirect can be removed in the next release.