### PR TITLE
fix(recent-progress): remediate dates being out of order

### DIFF
--- a/resources/views/community/components/user/recent-progress.blade.php
+++ b/resources/views/community/components/user/recent-progress.blade.php
@@ -40,7 +40,7 @@ use Illuminate\Support\Carbon;
 
                         $nextDate = Carbon::parse($dayInfo['Date']);
                         $nextYear = $nextDate->year;
-                        $nextMonth = $nextDate->month;
+                        $nextMonth = $nextDate->month - 1;
                         $nextDay = $nextDate->day;
                         $dateStr = $nextDate->format('d M Y');
 


### PR DESCRIPTION
Resolves the "time travel" issue currently being exhibited in the Recent Progress chart on user profiles.

**Root Cause**
`$nextMonth` needs to account for JavaScript 0-indexing months in the native `Date` object.

**Before**
![Screenshot 2024-02-01 at 5 09 59 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/772c1d05-e345-435c-a01a-b46997d9f2f0)

**After**
![Screenshot 2024-02-01 at 5 09 53 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/94a59d9a-cc8a-425f-9e47-76ca91f41ee1)
