### PR TITLE
feat: enable Standalone system and Final Fantasy XI

### DIFF
--- a/app/Helpers/database/release.php
+++ b/app/Helpers/database/release.php
@@ -94,8 +94,8 @@ function isValidConsoleId(int $consoleId): bool
         // 79, // TI-83
         80, // Uzebox
         // 100, // Hubs (not an actual console)
-        101 => true, // Events (not an actual console)
-        // 102, // Standalone (not an actual console)
+        101, // Events (not an actual console)
+        102 => true, // Standalone (not an actual console)
         default => false,
     };
 }

--- a/resources/views/components/menu/main.blade.php
+++ b/resources/views/components/menu/main.blade.php
@@ -69,7 +69,7 @@ $menuSystemsList = [
             23, // Magnavox Odyssey 2
             69, // Mega Duck
             29, // MSX
-            // 102, // Standalone
+            102, // Standalone
             80, // Uzebox
             46, // Vectrex
             72, // WASM-4


### PR DESCRIPTION
Adds system 102 to the valid systems list and enables the "Standalone" nav option under the Games menu.

![Screenshot 2024-02-01 at 5 20 51 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/d39640be-1450-4567-81c5-61e074a00edf)
