### PR TITLE
fix(user): adjust capitalization of headings and remediate skip-levels

### DIFF
--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -298,7 +298,7 @@ RenderContentStart($userPage);
 
     echo "<div class='commentscomponent left mt-8'>";
 
-    echo "<h4>User Wall</h4>";
+    echo "<h2 class='text-h4'>User Wall</h2>";
 
     if ($userWallActive) {
         // passing 'null' for $user disables the ability to add comments

--- a/resources/views/community/components/user/profile/developer-stats.blade.php
+++ b/resources/views/community/components/user/profile/developer-stats.blade.php
@@ -24,7 +24,7 @@ $specialClaims = collect($userClaims)->filter(function ($entity) {
 })->toArray();
 ?>
 
-<p role="heading" aria-level="2" class="mb-0.5 text-2xs font-bold">Developer stats</p>
+<p role="heading" aria-level="2" class="mb-0.5 text-2xs font-bold">Developer Stats</p>
 <div class="relative w-full p-2 mb-6 bg-embed rounded">
     <div class="grid md:grid-cols-2 gap-x-12 gap-y-1 {{ !empty($userClaims) ? 'mb-4' : '' }}">
         <div class="flex flex-col gap-y-1">

--- a/resources/views/community/components/user/profile/last-seen-in.blade.php
+++ b/resources/views/community/components/user/profile/last-seen-in.blade.php
@@ -31,7 +31,7 @@ $parsedDate = Carbon::parse($mostRecentSession?->rich_presence_updated_at);
     <div class="mb-6">
         <div class="flex w-full items-center gap-x-1.5 mb-0.5">
             <p role="heading" aria-level="2" class="text-2xs font-bold">
-                Most recently played
+                Most Recently Played
 
                 @if ($mostRecentSession?->rich_presence_updated_at)
                     <p class="smalldate min-w-auto cursor-help" title="{{ $parsedDate->format('F j Y, g:ia') }}">

--- a/resources/views/community/components/user/profile/player-stats.blade.php
+++ b/resources/views/community/components/user/profile/player-stats.blade.php
@@ -23,7 +23,7 @@ $secondaryMode = $softcorePoints > $hardcorePoints ? 'hardcore' : 'softcore';
 $retroRatio = $weightedPoints ? sprintf("%01.2f", $weightedPoints / $hardcorePoints) : null;
 ?>
 
-<p role="heading" aria-level="2" class="mb-0.5 text-2xs font-bold">Player stats</p>
+<p role="heading" aria-level="2" class="mb-0.5 text-2xs font-bold">Player Stats</p>
 <div
     class="relative w-full px-2 pt-2 bg-embed rounded mb-6 pb-4 transition-all"
     x-data="{

--- a/resources/views/community/components/user/progression-status/root.blade.php
+++ b/resources/views/community/components/user/progression-status/root.blade.php
@@ -6,7 +6,7 @@ if ($widthMode !== 'equal' && $widthMode !== 'dynamic') {
 }
 ?>
 
-<h4 class="!leading-none mb-2">Progression Status</h4>
+<h2 class="text-h4 !leading-none mb-2">Progression Status</h2>
 
 <div x-data="{ widthMode: '{{ $widthMode }}' }">
     <div class="flex flex-col-reverse gap-y-2 sm:gap-y-0 sm:flex-row sm:justify-between w-full mb-2">

--- a/resources/views/community/components/user/recently-played/index.blade.php
+++ b/resources/views/community/components/user/recently-played/index.blade.php
@@ -5,13 +5,13 @@
 ])
 
 <div>
-    <h4>
+    <h2 class="text-h4">
         @if ($recentlyPlayedCount === 1)
             Last game played
         @else
-            Last {{ localized_number($recentlyPlayedCount) }} games played
+            Last {{ localized_number($recentlyPlayedCount) }} Games Played
         @endif
-    </h4>
+    </h2>
 
     <div class="flex flex-col gap-y-1">
         @foreach ($processedRecentlyPlayedEntities as $processedRecentlyPlayedEntity)


### PR DESCRIPTION
Applies title-case capitalization to every heading-role text element in the main content area. Also changes `<h4>` tags to `<h2>` to remediate an a11y/SEO problem with skip-level headings.

**Before**
![Screenshot 2024-02-01 at 5 31 53 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/cdaf8903-7f2b-4c85-a6a5-fdf1d553a457)


**After**
![Screenshot 2024-02-01 at 5 30 45 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/50239333-3519-4adf-9835-363848e0907e)
