### PR TITLE
perf(game): set box art dimensions ahead of time on the server

### DIFF
--- a/public/request/game/update-image.php
+++ b/public/request/game/update-image.php
@@ -5,6 +5,7 @@ use App\Community\Enums\ClaimSetType;
 use App\Platform\Enums\ImageType;
 use App\Site\Enums\Permissions;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
@@ -64,6 +65,10 @@ $label = match ($imageType) {
     ImageType::GameBoxArt => 'game box art',
     default => '?', // should never hit this because of the match above
 };
+
+if ($imageType === ImageType::GameBoxArt) {
+    Cache::forget('game:box-art-dimensions:' . $gameID);
+}
 
 addArticleComment('Server', ArticleType::GameModification, $gameID, "$user changed the $label");
 


### PR DESCRIPTION
This PR resolves a huge layout shift currently happening on game pages:


https://github.com/RetroAchievements/RAWeb/assets/3984985/4d1fd54e-c9a7-4312-a4cd-5ae2414c9bef

This is not a V6 regression; it has been happening for as long as I can remember.

**Root Cause**
Because box arts are dynamically sized images that sit above static content, they currently do not have defined `width` and `height` attributes. The browser by default assigns these values to 0, and a layout shift occurs when the browser finally loads the image. On fast connections this is imperceptible. On slow connections and mobile, the shift is quite obvious.

**Resolution**
These image dimensions can be set ahead of time by the server before loading the page by using PHP's builtin `getimagesize()`. Once the dimensions are determined, they can be cached long-term in Redis. The cache can be busted when new box art is uploaded for the game.