### PR TITLE
perf: add .animate-spin just-in-time

### DIFF
--- a/public/controlpanel.php
+++ b/public/controlpanel.php
@@ -48,6 +48,7 @@ function ShowLoadingIcon(iconRootId) {
     var iconRoot = document.getElementById(iconRootId);
     iconRoot.querySelector('.loadingicon-done').classList.add('hidden');
     iconRoot.querySelector('.loadingicon-spinner').classList.remove('hidden');
+    iconRoot.querySelector('.loadingicon-spinner').classList.add('animate-spin');
     iconRoot.classList.remove('opacity-0');
 }
 
@@ -55,6 +56,7 @@ function ShowDoneIcon(iconRootId) {
     var iconRoot = document.getElementById(iconRootId);
     iconRoot.querySelector('.loadingicon-done').classList.remove('hidden');
     iconRoot.querySelector('.loadingicon-spinner').classList.add('hidden');
+    iconRoot.querySelector('.loadingicon-spinner').classList.remove('animate-spin');
     setTimeout(() => iconRoot.classList.add('opacity-0'), 750);
 }
 
@@ -234,7 +236,7 @@ function confirmEmailChange(event) {
                 </tbody>
             </table>
             <span id="loadingicon-1" class="transition-all duration-300 opacity-0 float-right pt-2" aria-hidden="true">
-                <?= Blade::render('<x-fas-spinner class="animate-spin loadingicon-spinner h-5 w-5" />') ?>
+                <?= Blade::render('<x-fas-spinner class="loadingicon-spinner h-5 w-5" />') ?>
                 <?= Blade::render('<x-fas-check class="loadingicon-done text-green-500 h-5 w-5" />') ?>
             </span>
         </div>
@@ -266,7 +268,7 @@ function confirmEmailChange(event) {
                 </tr>
             </table>
             <span id="loadingicon-2" class="transition-all duration-300 opacity-0 float-right pt-2" aria-hidden="true">
-                <?= Blade::render('<x-fas-spinner class="animate-spin loadingicon-spinner h-5 w-5" />') ?>
+                <?= Blade::render('<x-fas-spinner class="loadingicon-spinner h-5 w-5" />') ?>
                 <?= Blade::render('<x-fas-check class="loadingicon-done text-green-500 h-5 w-5" />') ?>
             </span>
         </div>
@@ -418,7 +420,7 @@ function confirmEmailChange(event) {
                         <td>
                             <button class='btn btn-danger' type='button' onclick="ResetProgressForSelection()">Reset Progress for Selection</button>
                             <span id="loadingiconreset" class="transition-all duration-300 opacity-0 float-right" aria-hidden="true">
-                                <?= Blade::render('<x-fas-spinner class="animate-spin loadingicon-spinner h-5 w-5" />') ?>
+                                <?= Blade::render('<x-fas-spinner class="loadingicon-spinner h-5 w-5" />') ?>
                                 <?= Blade::render('<x-fas-check class="loadingicon-done text-green-500 h-5 w-5" />') ?>
                             </span>
                         </td>
@@ -581,7 +583,7 @@ function confirmEmailChange(event) {
             <div style="margin-bottom: 10px">
                 <input type="file" name="file" id="uploadimagefile" onchange="return UploadNewAvatar();">
                 <span id="loadingiconavatar" class="transition-all duration-300 opacity-0 float-right pt-1" aria-hidden="true">
-                    <?= Blade::render('<x-fas-spinner class="animate-spin loadingicon-spinner h-5 w-5" />') ?>
+                    <?= Blade::render('<x-fas-spinner class="loadingicon-spinner h-5 w-5" />') ?>
                     <?= Blade::render('<x-fas-check class="loadingicon-done text-green-500 h-5 w-5" />') ?>
                 </span>
             </div>

--- a/public/createtopic.php
+++ b/public/createtopic.php
@@ -64,7 +64,7 @@ RenderContentStart("Create topic: $thisForumTitle");
     <?php
     echo "</td></tr>";
 
-    $loadingIcon = Blade::render('<x-fas-spinner id="preview-loading-icon" class="animate-spin opacity-0 transition-all duration-200" aria-hidden="true" />');
+    $loadingIcon = Blade::render('<x-fas-spinner id="preview-loading-icon" class="opacity-0 transition-all duration-200" aria-hidden="true" />');
 
     echo <<<HTML
         <tr>

--- a/public/editpost.php
+++ b/public/editpost.php
@@ -80,7 +80,7 @@ RenderContentStart("Edit post");
     HTML;
     echo "</td></tr>";
 
-    $loadingIcon = Blade::render('<x-fas-spinner id="preview-loading-icon" class="animate-spin opacity-0 transition-all duration-200 mt-1" aria-hidden="true" />');
+    $loadingIcon = Blade::render('<x-fas-spinner id="preview-loading-icon" class="opacity-0 transition-all duration-200 mt-1" aria-hidden="true" />');
 
     echo <<<HTML
         <tr>

--- a/public/submitnews.php
+++ b/public/submitnews.php
@@ -80,7 +80,7 @@ RenderContentStart("Manage News");
                         <img src="<?= $newsImage ?>" width="470" alt="News header image preview">
                     </div>
                     <input type="file" name="file" id="uploadimagefile" onchange="return UploadImage();">
-                    <?= Blade::render('<x-fas-spinner id="loadingicon" class="animate-spin opacity-0 transition-all duration-200" aria-hidden="true" />') ?>
+                    <?= Blade::render('<x-fas-spinner id="loadingicon" class="opacity-0 transition-all duration-200" aria-hidden="true" />') ?>
                 </td>
             </tr>
             <tr>
@@ -112,9 +112,11 @@ function UploadImage() {
     reader.onload = function () {
         var loadingIcon = document.getElementById('loadingicon');
         loadingIcon.classList.remove('opacity-0');
+        loadingIcon.classList.add('animate-spin');
         $.post('/request/news/update-image.php', { image: reader.result },
             function (data) {
                 loadingIcon.classList.add('opacity-0');
+                loadingIcon.classList.remove('animate-spin');
 
                 var image = data.filename;
                 $('#image').val(image);

--- a/public/viewtopic.php
+++ b/public/viewtopic.php
@@ -243,7 +243,7 @@ RenderContentStart($pageTitle);
                 x-on:input='autoExpandTextInput(\$el); isValid = window.getStringByteCount(\$event.target.value) <= 60000;'
             >$defaultMessage</textarea>
         HTML;
-        $loadingIcon = Blade::render('<x-fas-spinner id="preview-loading-icon" class="animate-spin opacity-0 transition-all duration-200" aria-hidden="true" />');
+        $loadingIcon = Blade::render('<x-fas-spinner id="preview-loading-icon" class="opacity-0 transition-all duration-200" aria-hidden="true" />');
 
         echo <<<HTML
             <div class="flex justify-between mb-2">

--- a/resources/js/utils/loadPostPreview.ts
+++ b/resources/js/utils/loadPostPreview.ts
@@ -56,6 +56,12 @@ const setLoadingIconVisibility = (elementId: string, options: { isVisible: boole
   const loadingImageEl = document.getElementById('preview-loading-icon') as HTMLImageElement | null;
 
   if (loadingImageEl) {
-    loadingImageEl.style.opacity = options.isVisible ? '100' : '0';
+    if (options.isVisible) {
+      loadingImageEl.style.opacity = '100';
+      loadingImageEl.classList.add('animate-spin');
+    } else {
+      loadingImageEl.style.opacity = '0';
+      loadingImageEl.classList.remove('animate-spin');
+    }
   }
 };

--- a/resources/views/components/input/shortcode-textarea.blade.php
+++ b/resources/views/components/input/shortcode-textarea.blade.php
@@ -40,7 +40,7 @@ $buttonEnabled = $enabled ? ":disabled='!isValid'" : "disabled";
         <span class="textarea-counter" data-textarea-id="commentTextarea">0 / 60000</span>
 
         <div>
-            <x-fas-spinner id="preview-loading-icon" class="animate-spin opacity-0 transition-all duration-200" aria-hidden="true" />
+            <x-fas-spinner id="preview-loading-icon" class="opacity-0 transition-all duration-200" aria-hidden="true" />
             <button id="preview-button" type="button" class="btn" onclick="window.loadPostPreview()" {!! $buttonEnabled !!}>Preview</button>
             <button id="postBtn" class="btn" onclick="this.form.submit(); disableRepost();" {!! $buttonEnabled !!}>Submit</button>
         </div>


### PR DESCRIPTION
Force `.animate-spin` to only appear when loading spinner SVGs are actually visible.