### PR TITLE
fix(email-verification): unset email_verified_at when changing email address

### DIFF
--- a/public/request/user/update-email.php
+++ b/public/request/user/update-email.php
@@ -16,7 +16,7 @@ $input = Validator::validate(Arr::wrap(request()->post()), [
 
 $email = $input['email'];
 
-DB::statement("UPDATE UserAccounts SET EmailAddress='$email', Permissions=" . Permissions::Unregistered . ", email_verified_at = NULL, Updated=NOW() WHERE User='$username'")
+DB::statement("UPDATE UserAccounts SET EmailAddress='$email', Permissions=" . Permissions::Unregistered . ", email_verified_at = NULL, Updated=NOW() WHERE User='$username'");
 
 sendValidationEmail($username, $email);
 

--- a/public/request/user/update-email.php
+++ b/public/request/user/update-email.php
@@ -3,6 +3,7 @@
 use App\Community\Enums\ArticleType;
 use App\Site\Enums\Permissions;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 
 if (!authenticateFromCookie($username, $permissions, $userDetail)) {
@@ -15,13 +16,7 @@ $input = Validator::validate(Arr::wrap(request()->post()), [
 
 $email = $input['email'];
 
-$dbResult = s_mysql_query(
-    "UPDATE UserAccounts SET EmailAddress='$email', Permissions=" . Permissions::Unregistered . ", Updated=NOW() WHERE User='$username'"
-);
-
-if (!$dbResult) {
-    return back()->withErrors(__('legacy.error.error'));
-}
+DB::statement("UPDATE UserAccounts SET EmailAddress='$email', Permissions=" . Permissions::Unregistered . ", email_verified_at = NULL, Updated=NOW() WHERE User='$username'")
 
 sendValidationEmail($username, $email);
 


### PR DESCRIPTION
Followup for https://github.com/RetroAchievements/RAWeb/pull/2189#issuecomment-1919708289:

```sql
-- Reset any timestamps that were not unset after email changes (none on production so far since v6 release, just to be sure)

UPDATE
    UserAccounts u
SET
    u.email_verified_at = NULL
WHERE
    u.Permissions < 1
    AND u.email_verified_at IS NOT NULL;


-- Pull email_verified_at from server comments, affecting ~345k user entries

UPDATE
    UserAccounts u
SET
    u.email_verified_at = (
        SELECT
            MAX(c.Submitted) -- take latest verification comment
        FROM
            `Comment` c
        WHERE
            c.ArticleID = u.ID
            AND c.ArticleType = 9 # User moderation
            AND c.UserID = 14188 # Server user
            AND c.Payload = 'Server set account type to Registered'
        GROUP BY
            c.ArticleID
    )
WHERE
    u.Permissions > 0
    AND u.email_verified_at IS NULL;


-- Update remaining email_verified_at timestamps to creation date as a best guess, affecting ? user entries

UPDATE
    UserAccounts u
SET
    u.email_verified_at = u.Created
WHERE
    u.Permissions > 0
    AND u.email_verified_at IS NULL;
```