### PR TITLE
fix(user): always show 'more...' for Recent Progress if user has any points

### DIFF
--- a/public/userInfo.php
+++ b/public/userInfo.php
@@ -340,10 +340,12 @@ RenderContentStart($userPage);
 
     echo Blade::render('
         <x-user.recent-progress
+            :hasAnyPoints="$hasAnyPoints"
             :username="$username"
             :userScoreData="$userScoreData"
         />
     ', [
+        'hasAnyPoints' => $userMassData['TotalPoints'] > 0 || $userMassData['TotalSoftcorePoints'] > 0,
         'username' => $userPage,
         'userScoreData' => $userScoreData,
     ]);

--- a/resources/views/community/components/user/recent-progress.blade.php
+++ b/resources/views/community/components/user/recent-progress.blade.php
@@ -1,4 +1,5 @@
 @props([
+    'hasAnyPoints' => false,
     'username' => '',
     'userScoreData' => [],
 ])
@@ -83,6 +84,9 @@ use Illuminate\Support\Carbon;
         </script>
 
         <div id="chart_recentprogress" class="mb-5 min-h-[200px]"></div>
+    @endif
+
+    @if ($hasAnyPoints)
         <div class="text-right">
             <a href="/history.php?u={{ $username }}">more...</a>
         </div>


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1203067172470005870.

If the user has any points, the "more..." link will always appear and direct to the user's history page.

![Screenshot 2024-02-02 at 5 04 48 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/0ecf8fa3-09a6-4c10-ab91-2e81bed85cf3)
