### PR TITLE
fix(history): use the correct hardcore and softcore chart colors

### DIFF
--- a/public/history.php
+++ b/public/history.php
@@ -82,7 +82,7 @@ RenderContentStart("$userPage's Legacy");
       legend: { position: 'none' },
       chartArea: { 'width': '86%', 'height': '70%' },
       height: 250,
-      colors: ['#186DEE','#8c8c8c'],
+      colors: ['#cc9900','#737373'],
     };
 
     var dataBestDays = new google.visualization.DataTable();


### PR DESCRIPTION
This PR adjusts the History page line chart colors to be consistent with chart colors used for Recent Progress on the user profile.

**Before**
![Screenshot 2024-02-02 at 5 06 40 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/9cec1f9d-2050-4ebc-92b6-94246887b575)

**After**
![Screenshot 2024-02-02 at 5 05 55 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/1aecd295-9b5f-40fa-81e2-9df8a697f039)
