### PR TITLE
fix(GameListService): sort category game titles primarily by category and then by title

### DIFF
--- a/app/Platform/Services/GameListService.php
+++ b/app/Platform/Services/GameListService.php
@@ -111,7 +111,7 @@ class GameListService
              * that titles with "~" are grouped together and sorted alphabetically based
              * on their designated categories and then by their actual game title.
              *
-             * The "zzz" prefix is added to the SortTitle of games with "~" to ensure these
+             * The "~" prefix is retained in the SortTitle of games with "~" to ensure these
              * games are sorted at the end of the list, maintaining a clear separation from
              * non-prefixed titles. This approach allows game titles to be grouped and sorted
              * in a specific order:
@@ -128,7 +128,7 @@ class GameListService
                     $withinTildes = substr($game['SortTitle'], 1, $endOfFirstTilde - 1);
                     $afterTildes = trim(substr($game['SortTitle'], $endOfFirstTilde + 1));
 
-                    $game['SortTitle'] = 'zzz' . $withinTildes . ' ' . $afterTildes;
+                    $game['SortTitle'] = '~' . $withinTildes . ' ' . $afterTildes;
                 }
             }
 

--- a/app/Platform/Services/GameListService.php
+++ b/app/Platform/Services/GameListService.php
@@ -103,13 +103,33 @@ class GameListService
             $game['RetroRatio'] = $gameModel->points_total ? $gameModel->TotalTruePoints / $gameModel->points_total : 0.0;
 
             $game['ConsoleName'] = $this->consoles[$gameModel->ConsoleID]->Name;
-            $game['SortTitle'] = mb_strtolower($game['Title']);
-            if (substr($game['SortTitle'], 0, 1) == '~') {
-                $tilde = strrpos($game['SortTitle'], '~');
-                $game['SortTitle'] = trim(substr($game['SortTitle'], $tilde + 1) . ' ' . substr($game['SortTitle'], 0, $tilde + 1));
 
-                // Keep these games at the bottom of the list (under the "untagged" game titles).
-                $game['SortTitle'] = '~' . $game['SortTitle'];
+            /**
+             * Ensure games on the list are sorted properly.
+             * For titles starting with "~", the sort order is determined by the content
+             * within the "~" markers followed by the content after the "~". This ensures
+             * that titles with "~" are grouped together and sorted alphabetically based
+             * on their designated categories and then by their actual game title.
+             * 
+             * The "zzz" prefix is added to the SortTitle of games with "~" to ensure these
+             * games are sorted at the end of the list, maintaining a clear separation from
+             * non-prefixed titles. This approach allows game titles to be grouped and sorted
+             * in a specific order:
+             * 
+             * 1. Non-prefixed titles are sorted alphabetically at the beginning of the list.
+             * 2. Titles prefixed with "~" are grouped at the end, sorted first by the category
+             *    specified within the "~" markers, and then alphabetically by the title following
+             *    the "~".
+             */
+            $game['SortTitle'] = mb_strtolower($game['Title']);
+            if ($game['SortTitle'][0] === '~') {
+                $endOfFirstTilde = strpos($game['SortTitle'], '~', 1);
+                if ($endOfFirstTilde !== false) {
+                    $withinTildes = substr($game['SortTitle'], 1, $endOfFirstTilde - 1);
+                    $afterTildes = trim(substr($game['SortTitle'], $endOfFirstTilde + 1));
+                    
+                    $game['SortTitle'] = 'zzz' . $withinTildes . ' ' . $afterTildes;
+                }
             }
 
             $this->games[] = $game;

--- a/app/Platform/Services/GameListService.php
+++ b/app/Platform/Services/GameListService.php
@@ -110,12 +110,12 @@ class GameListService
              * within the "~" markers followed by the content after the "~". This ensures
              * that titles with "~" are grouped together and sorted alphabetically based
              * on their designated categories and then by their actual game title.
-             * 
+             *
              * The "zzz" prefix is added to the SortTitle of games with "~" to ensure these
              * games are sorted at the end of the list, maintaining a clear separation from
              * non-prefixed titles. This approach allows game titles to be grouped and sorted
              * in a specific order:
-             * 
+             *
              * 1. Non-prefixed titles are sorted alphabetically at the beginning of the list.
              * 2. Titles prefixed with "~" are grouped at the end, sorted first by the category
              *    specified within the "~" markers, and then alphabetically by the title following
@@ -127,7 +127,7 @@ class GameListService
                 if ($endOfFirstTilde !== false) {
                     $withinTildes = substr($game['SortTitle'], 1, $endOfFirstTilde - 1);
                     $afterTildes = trim(substr($game['SortTitle'], $endOfFirstTilde + 1));
-                    
+
                     $game['SortTitle'] = 'zzz' . $withinTildes . ' ' . $afterTildes;
                 }
             }


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1203413537247076362.

**Before**
Games with categories on prod are currently sorted primarily by title, not category. Eg:

```
~AAA~ Game A
~BBB~ Game B
~AAA~ Game C
```

**After**
Now, category is given the priority.

```
~AAA~ Game A
~AAA~ Game C
~BBB~ Game B
```