### PR TITLE
fix(manage-hash): show correct hash name on unlink confirm

### DIFF
--- a/resources/views/platform/components/manage-hashes/hash-entity.blade.php
+++ b/resources/views/platform/components/manage-hashes/hash-entity.blade.php
@@ -8,61 +8,6 @@
 use Illuminate\Support\Carbon;
 ?>
 
-<script>
-/**
- * @param {Event} event
- * @param {string} hash
- */
-function updateHashDetails(event, hash) {
-    event.preventDefault();
-
-    const gameId = {{ $gameId }};
-    const user = "{{ $myUsername }}";
-    const name = document.querySelector(`#HASH_${hash}_Name`).value.trim();
-    const labels = document.querySelector(`#HASH_${hash}_Labels`).value.trim();
-    const patchUrl = document.querySelector(`#HASH_${hash}_PatchURL`).value.trim();
-    const source = document.querySelector(`#HASH_${hash}_SourceURL`).value.trim();
-
-    showStatusMessage('Updating hash...');
-    $.ajax({
-        url: `/game-hash/${hash}`,
-        type: 'PUT',
-        data: {
-            name,
-            labels,
-            source,
-            patch_url: patchUrl
-        },
-        success: () => {
-            // Hard refresh the page rather than doing an optimistic UI update.
-            window.location.reload();
-        },
-    });
-}
-
-/**
- * @param {string} hash
- * @param {string} hashName
- */
-function unlinkHash(hash) {
-    const hashName = <?= json_encode($hashEntity->Name); ?>;
-
-    if (!confirm(`Are you sure you want to unlink hash ${hashName} (${hash}) from this game?`)) {
-        return;
-    }
-
-    showStatusMessage('Unlinking hash...');
-    $.ajax({
-        url: `/game-hash/${hash}`,
-        type: 'DELETE',
-        success: () => {
-            // Hard refresh the page rather than doing an optimistic UI update.
-            window.location.reload();
-        }
-    });
-}
-</script>
-
 <div class="border border-embed-highlight bg-embed rounded-lg overflow-hidden">
     <div class="flex w-full justify-between px-4 py-2 bg-stone-950 light:bg-stone-100 border-b border-embed-highlight items-center">
         <p class="font-bold">

--- a/resources/views/platform/components/manage-hashes/hashes-list.blade.php
+++ b/resources/views/platform/components/manage-hashes/hashes-list.blade.php
@@ -5,6 +5,60 @@
 ])
 
 @if (!$hashes->isEmpty())
+    <script>
+    /**
+     * @param {Event} event
+     * @param {string} hash
+     */
+    function updateHashDetails(event, hash) {
+        event.preventDefault();
+    
+        const gameId = {{ $gameId }};
+        const user = "{{ $myUsername }}";
+        const name = document.querySelector(`#HASH_${hash}_Name`).value.trim();
+        const labels = document.querySelector(`#HASH_${hash}_Labels`).value.trim();
+        const patchUrl = document.querySelector(`#HASH_${hash}_PatchURL`).value.trim();
+        const source = document.querySelector(`#HASH_${hash}_SourceURL`).value.trim();
+    
+        showStatusMessage('Updating hash...');
+        $.ajax({
+            url: `/game-hash/${hash}`,
+            type: 'PUT',
+            data: {
+                name,
+                labels,
+                source,
+                patch_url: patchUrl
+            },
+            success: () => {
+                // Hard refresh the page rather than doing an optimistic UI update.
+                window.location.reload();
+            },
+        });
+    }
+    
+    /**
+     * @param {string} hash
+     */
+    function unlinkHash(hash) {
+        const hashName = document.querySelector(`#HASH_${hash}_Name`).value.trim();
+
+        if (!confirm(`Are you sure you want to unlink hash ${hashName} (${hash}) from this game?`)) {
+            return;
+        }
+    
+        showStatusMessage('Unlinking hash...');
+        $.ajax({
+            url: `/game-hash/${hash}`,
+            type: 'DELETE',
+            success: () => {
+                // Hard refresh the page rather than doing an optimistic UI update.
+                window.location.reload();
+            }
+        });
+    }
+    </script>
+
     <div class="flex flex-col gap-y-4">
         @foreach ($hashes as $hashEntity)
             <x-manage-hashes.hash-entity


### PR DESCRIPTION
Fixes a bug on the Manage Hashes page where when the user attempts to unlink a hash, the hash name in the `confirm()` is wrong.

**Root Cause**
The JS function responsible for popping this confirm was being redefined, as it was a `<script>` tag being rendered in a loop.

I've lifted the `<script>` tag up one level in the tree and changed how `hashName` is defined in the JS code.