### PR TITLE
feat(code-notes): pop a warning if attempting navigation while in edit mode

### DIFF
--- a/app/Helpers/render/code-note.php
+++ b/app/Helpers/render/code-note.php
@@ -32,7 +32,7 @@ function RenderCodeNotes(array $codeNotes, ?string $editingUser = null, ?int $ed
             || ($editingPermissions === Permissions::JuniorDeveloper && $nextCodeNote['User'] === $editingUser)
         );
 
-        echo "<tr id='row-$rowIndex'>";
+        echo "<tr id='row-$rowIndex' class='note-row'>";
 
         $addr = $nextCodeNote['Address'];
         $addrInt = hexdec($addr);

--- a/resources/views/pages-legacy/codenotes.blade.php
+++ b/resources/views/pages-legacy/codenotes.blade.php
@@ -15,6 +15,18 @@ $codeNoteCount = count(array_filter($codeNotes, function ($x) { return $x['Note'
 ?>
 <x-app-layout pageTitle="Code Notes - {{ $gameData['Title']}}">
 <script>
+window.addEventListener('beforeunload', function (event) {
+    // If any textareas are non-hidden, dirtiness is implied.
+    const visibleTextareas = Array.from(document.querySelectorAll('textarea:not(.hidden)'));
+
+    if (visibleTextareas.length) {
+        const confirmationMessage = 'There are rows still in edit mode. Any unsaved changes will be lost if you navigate away.';
+        (event || window.event).returnValue = confirmationMessage;
+        
+        return confirmationMessage;
+    }
+});
+
 /**
  * Toggle the editing state of a code note row and
  * show/hide the elements necessary to perform an edit.


### PR DESCRIPTION
This PR adds a minor quality of life improvement to editing code notes while on the web.

If the user attempts to reload the browser, navigate away, or cancel editing while a row is in edit mode and dirty/changed, a confirm will appear informing them they could accidentally discard any changes.

Note: `confirmationMessage` will not appear in all browsers due to security reasons. Chrome, for example, forces a default message to appear.