### PR TITLE
feat(user): give beaten games stat an href

### DIFF
--- a/app/Community/Components/UserProfileMeta.php
+++ b/app/Community/Components/UserProfileMeta.php
@@ -210,18 +210,23 @@ class UserProfileMeta extends Component
 
         $recentPointsEarned = $this->calculateRecentPointsEarned($user, $preferredMode);
 
-        // Retail games beaten
-        $retailGamesBeaten = (int) PlayerStat::where('user_id', $user->ID) // keep in mind, this is hardcore only.
+        // Total games beaten
+        $totalGamesBeaten = (int) PlayerStat::where('user_id', $user->ID)
+            ->where('system_id', null)
+            ->sum('value');
+        $retailGamesBeaten = (int) PlayerStat::where('user_id', $user->ID)
             ->where('system_id', null)
             ->whereIn('type', [
                 PlayerStatType::GamesBeatenHardcoreRetail,
                 PlayerStatType::GamesBeatenHardcoreUnlicensed,
             ])
             ->sum('value');
-        $retailGamesBeatenStat = [
-            'label' => 'Retail games beaten',
-            'value' => localized_number($retailGamesBeaten),
-            'isMuted' => !$retailGamesBeaten,
+        $totalGamesBeatenStat = [
+            'label' => 'Total games beaten',
+            'hrefLabel' => "(" . localized_number($retailGamesBeaten) . " retail)",
+            'value' => localized_number($totalGamesBeaten),
+            'isHrefLabelBeforeLabel' => false,
+            'isMuted' => !$totalGamesBeaten,
             'href' => $retailGamesBeaten ? route('ranking.beaten-games', ['filter[user]' => $user->username]) : null,
         ];
 
@@ -272,8 +277,8 @@ class UserProfileMeta extends Component
                 'averagePointsPerWeekStat',
                 'pointsLast30DaysStat',
                 'pointsLast7DaysStat',
-                'retailGamesBeatenStat',
                 'startedGamesBeatenPercentageStat',
+                'totalGamesBeatenStat',
             ),
             $this->buildHardcorePlayerStats($user, $userMassData, $hardcoreRankMeta),
             $this->buildSoftcorePlayerStats($user, $userMassData, $softcoreRankMeta),

--- a/app/Community/Components/UserProfileMeta.php
+++ b/app/Community/Components/UserProfileMeta.php
@@ -222,7 +222,7 @@ class UserProfileMeta extends Component
             'label' => 'Retail games beaten',
             'value' => localized_number($retailGamesBeaten),
             'isMuted' => !$retailGamesBeaten,
-            'href' => route('ranking.beaten-games', ['filter[user]' => $user->username]),
+            'href' => $retailGamesBeaten ? route('ranking.beaten-games', ['filter[user]' => $user->username]) : null,
         ];
 
         // Started games beaten

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -496,6 +496,18 @@ class User extends Authenticatable implements CommunityMember, Developer, HasCom
     // == scopes
 
     /**
+     * To make the transition to customizable usernames a little easier
+     * once `display_name` is populated in the database.
+     *
+     * @param Builder<User> $query
+     * @return Builder<User>
+     */
+    public function scopeByDisplayName(Builder $query, string $username): Builder
+    {
+        return $query->where('User', $username);
+    }
+
+    /**
      * @param Builder<User> $query
      * @return Builder<User>
      */

--- a/resources/views/components/beaten-games-leaderboard/leaderboard-card-row.blade.php
+++ b/resources/views/components/beaten-games-leaderboard/leaderboard-card-row.blade.php
@@ -1,12 +1,7 @@
 @props([
     'isHighlighted' => false,
-    'myUsername' => null,
     'paginatedRow' => null,
 ])
-
-<?php
-$isHighlighted = $isHighlighted || ($paginatedRow->User === $myUsername);
-?>
 
 <div class="rounded bg-embed p-2 {{ $isHighlighted ? 'my-2' : '' }}" @if ($isHighlighted) style="outline: thin solid;" @endif>
     <div class="flex items-center justify-between">

--- a/resources/views/components/beaten-games-leaderboard/leaderboard-table-row.blade.php
+++ b/resources/views/components/beaten-games-leaderboard/leaderboard-table-row.blade.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Carbon;
 @props([
     'isHighlighted' => null,
     'paginatedRow' => null,
-    'myUsername' => null,
 ])
 
 <?php

--- a/resources/views/components/beaten-games-leaderboard/leaderboard-table-row.blade.php
+++ b/resources/views/components/beaten-games-leaderboard/leaderboard-table-row.blade.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Carbon;
 
 @props([
     'isHighlighted' => null,
+    'myUsername' => '',
     'paginatedRow' => null,
 ])
 

--- a/resources/views/components/beaten-games-leaderboard/leaderboard-table.blade.php
+++ b/resources/views/components/beaten-games-leaderboard/leaderboard-table.blade.php
@@ -1,23 +1,19 @@
 @props([
     'isUserOnCurrentPage' => false,
-    'myRankingData' => null, // always null if unauthenticated or no rank
-    'myUsername' => null,
     'paginator' => null,
+    'targetUserRankingData' => null, // always null if unauthenticated, no user filter, or no rank
 ])
 
 <div class="sm:hidden flex flex-col gap-y-1">
     @foreach ($paginator as $paginatedRow)
-        <x-beaten-games-leaderboard.leaderboard-card-row
-            :myUsername="$myUsername"
-            :paginatedRow="$paginatedRow"
-        />
+        <x-beaten-games-leaderboard.leaderboard-card-row :paginatedRow="$paginatedRow" />
     @endforeach
 
-    @if ($myRankingData && $myRankingData['userRank'] && !$isUserOnCurrentPage)
+    @if ($targetUserRankingData && $targetUserRankingData['userRank'] && !$isUserOnCurrentPage)
         <x-beaten-games-leaderboard.leaderboard-card-row
             :isHighlighted="true"
-            :paginatedRow="$myRankingData['userRankingData']"
-            :rank="$myRankingData['userRank']"
+            :paginatedRow="$targetUserRankingData['userRankingData']"
+            :rank="$targetUserRankingData['userRank']"
         />
     @endif
 </div>
@@ -35,19 +31,16 @@
 
     <tbody>
         @foreach ($paginator as $paginatedRow)
-            <x-beaten-games-leaderboard.leaderboard-table-row
-                :myUsername="$myUsername"
-                :paginatedRow="$paginatedRow"
-            />
+            <x-beaten-games-leaderboard.leaderboard-table-row :paginatedRow="$paginatedRow" />
         @endforeach
 
-        @if ($myRankingData && $myRankingData['userRank'] && !$isUserOnCurrentPage)
+        @if ($targetUserRankingData && $targetUserRankingData['userRank'] && !$isUserOnCurrentPage)
             <tr class="do-not-highlight"><td colspan="5">&nbsp;</td></tr>
 
             <x-beaten-games-leaderboard.leaderboard-table-row
                 :isHighlighted="true"
-                :paginatedRow="$myRankingData['userRankingData']"
-                :rank="$myRankingData['userRank']"
+                :paginatedRow="$targetUserRankingData['userRankingData']"
+                :rank="$targetUserRankingData['userRank']"
             />
         @endif
     </tbody>

--- a/resources/views/components/user/profile/arranged-stat-items.blade.php
+++ b/resources/views/components/user/profile/arranged-stat-items.blade.php
@@ -13,6 +13,7 @@
                 <x-user.profile.stat-element
                     :href="$stat['href'] ?? null"
                     :hrefLabel="$stat['hrefLabel'] ?? null"
+                    :isHrefLabelBeforeLabel="$stat['isHrefLabelBeforeLabel'] ?? true"
                     :isMuted="$stat['isMuted'] ?? false"
                     :label="$stat['label']"
                     :shouldEnableBolding="isset($stat['shouldEnableBolding']) ? $stat['shouldEnableBolding'] : true"
@@ -29,6 +30,7 @@
                 <x-user.profile.stat-element
                     :href="$stat['href'] ?? null"
                     :hrefLabel="$stat['hrefLabel'] ?? null"
+                    :isHrefLabelBeforeLabel="$stat['isHrefLabelBeforeLabel'] ?? true"
                     :isMuted="$stat['isMuted'] ?? false"
                     :label="$stat['label']"
                     :shouldEnableBolding="isset($stat['shouldEnableBolding']) ? $stat['shouldEnableBolding'] : true"

--- a/resources/views/components/user/profile/player-stats.blade.php
+++ b/resources/views/components/user/profile/player-stats.blade.php
@@ -51,7 +51,7 @@ $secondaryMode = $softcorePoints > $hardcorePoints ? 'hardcore' : 'softcore';
         <x-user.profile.arranged-stat-items
             :stats="[
                 $playerStats['hardcoreAchievementsUnlockedStat'],   $playerStats['retroRatioStat'],
-                $playerStats['retailGamesBeatenStat'],              $playerStats['startedGamesBeatenPercentageStat'],   
+                $playerStats['totalGamesBeatenStat'],               $playerStats['startedGamesBeatenPercentageStat'],   
             ]"
         />
     @elseif ($primaryMode === 'softcore')
@@ -78,7 +78,7 @@ $secondaryMode = $softcorePoints > $hardcorePoints ? 'hardcore' : 'softcore';
         @if ($hasMixedProgress)
             <x-user.profile.arranged-stat-items
                 :stats="[
-                    $playerStats['pointsLast7DaysStat'],        $playerStats['retailGamesBeatenStat'],
+                    $playerStats['pointsLast7DaysStat'],        $playerStats['totalGamesBeatenStat'],
                     $playerStats['pointsLast30DaysStat'],       $playerStats['averageCompletionStat'],
                     $playerStats['averagePointsPerWeekStat'],
                 ]"

--- a/resources/views/components/user/profile/player-stats.blade.php
+++ b/resources/views/components/user/profile/player-stats.blade.php
@@ -51,7 +51,7 @@ $secondaryMode = $softcorePoints > $hardcorePoints ? 'hardcore' : 'softcore';
         <x-user.profile.arranged-stat-items
             :stats="[
                 $playerStats['hardcoreAchievementsUnlockedStat'],   $playerStats['retroRatioStat'],
-                $playerStats['totalGamesBeatenStat'],               $playerStats['startedGamesBeatenPercentageStat'],   
+                $playerStats['retailGamesBeatenStat'],              $playerStats['startedGamesBeatenPercentageStat'],   
             ]"
         />
     @elseif ($primaryMode === 'softcore')
@@ -78,7 +78,7 @@ $secondaryMode = $softcorePoints > $hardcorePoints ? 'hardcore' : 'softcore';
         @if ($hasMixedProgress)
             <x-user.profile.arranged-stat-items
                 :stats="[
-                    $playerStats['pointsLast7DaysStat'],        $playerStats['totalGamesBeatenStat'],
+                    $playerStats['pointsLast7DaysStat'],        $playerStats['retailGamesBeatenStat'],
                     $playerStats['pointsLast30DaysStat'],       $playerStats['averageCompletionStat'],
                     $playerStats['averagePointsPerWeekStat'],
                 ]"

--- a/resources/views/components/user/profile/stat-element.blade.php
+++ b/resources/views/components/user/profile/stat-element.blade.php
@@ -1,6 +1,7 @@
 @props([
     'href' => null, // ?string
     'hrefLabel' => null, // ?string
+    'isHrefLabelBeforeLabel' => true,
     'isMuted' => false,
     'label' => 'Label',
     'shouldEnableBolding' => true,
@@ -15,12 +16,17 @@
 
     <p class="z-[2] bg-embed pl-2 {{ $isMuted ? 'text-muted italic' : '' }} {{ $shouldEnableBolding && !$isMuted ? 'font-bold' : '' }}">
         @if ($href)
+            {{-- Allows for only fragments to be linked --}}
+            @if (!$isHrefLabelBeforeLabel && $hrefLabel && $value)
+                <span>{{ $value }}</span>
+            @endif
+
             <a href="{{ $href }}">
                 {{ $hrefLabel ?? $value }}
             </a>
 
-            {{-- Allows for only fragments to be linked (see: site rank stats) --}}
-            @if ($hrefLabel && $value)
+            {{-- Allows for only fragments to be linked --}}
+            @if ($isHrefLabelBeforeLabel && $hrefLabel && $value)
                 <span>{{ $value }}</span>
             @endif
         @elseif (!$hrefLabel && isset($value))

--- a/resources/views/pages/ranking/beaten-games.blade.php
+++ b/resources/views/pages/ranking/beaten-games.blade.php
@@ -16,10 +16,9 @@ name('ranking.beaten-games');
     'gameKindFilterOptions' => [],
     'isUserOnCurrentPage' => false,
     'leaderboardKind' => 'retail',
-    'myRankingData' => null,
-    'myUsername' => null,
     'paginator' => null,
     'selectedConsoleId' => null,
+    'targetUserRankingData' => null,
     'userPageNumber' => null,
 ])
 
@@ -45,9 +44,8 @@ name('ranking.beaten-games');
         <div class="mb-4">
             <x-beaten-games-leaderboard.leaderboard-table
                 :isUserOnCurrentPage="$isUserOnCurrentPage"
-                :myRankingData="$myRankingData"
-                :myUsername="$myUsername"
                 :paginator="$paginator"
+                :targetUserRankingData="$targetUserRankingData"
             />
         </div>
 


### PR DESCRIPTION
This PR aims to more closely align the new beaten games stat on user profiles to the existing beaten games leaderboard feature on the site:

* The beaten games leaderboard now accepts a `filter[user]` query param, which redirects the user to the correct page for the target user.
* If the target user can't be found or has no ranking, there is a redirect to the first page of the leaderboard.
* The "Total games beaten" stat now has an `href`, which leverages this new `filter[user]` query param to deep link into the beaten games leaderboard from the statistic itself. The link takes the user to the number of retail beaten games.

![Screenshot 2024-02-05 at 4 03 15 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/30e98a0a-621c-4d30-b102-add8c9622e5f)
