### PR TITLE
fix(game): show 'Supported Game Files' link even while unauthenticated

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -104,7 +104,7 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
 
         Fortify::loginView(function () {
-            if (!session()->has('intended_url')) {
+            if (!session()->has('url.intended')) {
                 session()->put('url.intended', url()->previous());
             }
 

--- a/resources/views/components/game/link-buttons/index.blade.php
+++ b/resources/views/components/game/link-buttons/index.blade.php
@@ -26,7 +26,7 @@ if ($gameForumTopicId) {
 $canCreateForumTopic = !$doesForumTopicExist && $me && $me->Permissions >= Permissions::Developer;
 
 $canSeeForumLink = in_array('forum-topic', $allowedLinks);
-$canSeeSupportedGameFiles = in_array('game-files', $allowedLinks) && $me && $me->Permissions >= Permissions::Registered;
+$canSeeSupportedGameFiles = in_array('game-files', $allowedLinks);
 $canSeeCodeNotes = in_array('code-notes', $allowedLinks) && $me && $me->Permissions >= Permissions::Registered;
 $canSeeGuide = in_array('guide', $allowedLinks) && $gameGuideUrl;
 $canSeeOpenTickets = in_array('tickets', $allowedLinks) && $me && $me->Permissions >= Permissions::Registered;

--- a/resources/views/pages-legacy/linkedhashes.blade.php
+++ b/resources/views/pages-legacy/linkedhashes.blade.php
@@ -3,7 +3,8 @@
 use App\Enums\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
-    abort(401);
+    session(['url.intended' => url()->full()]);
+    return redirect()->route('login');
 }
 
 $gameID = (int) request()->query('g');

--- a/resources/views/pages-legacy/linkedhashes.blade.php
+++ b/resources/views/pages-legacy/linkedhashes.blade.php
@@ -4,6 +4,7 @@ use App\Enums\Permissions;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Registered)) {
     session(['url.intended' => url()->full()]);
+
     return redirect()->route('login');
 }
 


### PR DESCRIPTION
I have seen questions about this page and how to find it in at least 3 different Reddit threads. It seems users are hitting the site on mobile while not logged in and can't find the link. We should instead show the link, require login upon clicking it, then after login redirect the user back to the page.

This PR also fixes a bug in _FortifyServiceProvider.php_ which is causing callback/intended URLs in the session to not work correctly. It appears `Fortify::loginView`'s callback function is looking for a session property called `intended_url`, and if not present, overrides it. I believe it should actually be looking for `url.intended`.

**Before**
![Screenshot 2024-02-05 at 5 18 44 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/7865ecaa-41cb-42b9-9876-65cd79ea222a)


**After**
![Screenshot 2024-02-05 at 5 18 31 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/60dfe5eb-86d0-4332-b543-2ef0aaa55b75)
