### PR TITLE
fix: dispatch UpdatePlayerStatsJob on ResetPlayerProgress execution

### DIFF
--- a/app/Platform/Actions/ResetPlayerProgress.php
+++ b/app/Platform/Actions/ResetPlayerProgress.php
@@ -11,6 +11,7 @@ use App\Platform\Events\PlayerBadgeLost;
 use App\Platform\Jobs\UpdateDeveloperContributionYieldJob;
 use App\Platform\Jobs\UpdateGameMetricsJob;
 use App\Platform\Jobs\UpdatePlayerGameMetricsJob;
+use App\Platform\Jobs\UpdatePlayerStatsJob;
 
 class ResetPlayerProgress
 {
@@ -101,6 +102,8 @@ class ResetPlayerProgress
                 dispatch(new UpdateGameMetricsJob($affectedGameID));
             }
         }
+
+        dispatch(new UpdatePlayerStatsJob($user->id));
 
         $user->save();
     }


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1204092628182900807.

It's currently possible to reset progress on a game and fall into a circumstance where `PlayerStat` records for the user ID are not updated.

After this is merged and deployed, a full resync on `PlayerStat` records should be run via:
```
sail artisan ra:platform:player:update-stats
```