### PR TITLE
feat(octane): enable Octane reloads in Docker

### DIFF
--- a/docker/8.2/supervisord.conf
+++ b/docker/8.2/supervisord.conf
@@ -14,8 +14,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:octane]
-# command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --watch --server=swoole --host=0.0.0.0 --port=8888
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --server=swoole --host=0.0.0.0 --port=8888
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan octane:start --watch --server=swoole --host=0.0.0.0 --port=8888
 user=sail
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout

--- a/resources/views/layouts/components/body-end.blade.php
+++ b/resources/views/layouts/components/body-end.blade.php
@@ -24,7 +24,11 @@
     </style>
 
     <div id="debug" role="button" x-init="{}" @click="handleClick($el)" class="text-2xs flex flex-col rounded-lg bg-black/20 p-1">
-        <b class="text-danger text-capitalize">{{ app()->environment() }} ({{ config('app.branch') }})</b>
+        <b class="text-danger text-capitalize">
+            {{ app()->environment() }}
+            {{ $_SERVER['LARAVEL_OCTANE'] ?? false ? '[Octane]' : '' }}
+            ({{ config('app.branch') }})
+        </b>
 
         <div>
             <b>


### PR DESCRIPTION
As a reminder: with our Laravel Sail setup, Octane runs at http://localhost:64008/ by default.

This adds a watcher to restart the Octane process after file changes.

An additional item is displayed in the bottom debug area:

![Screenshot 2024-02-09 at 19 05 44](https://github.com/RetroAchievements/RAWeb/assets/1280590/97ce8fff-cb7f-4195-8cb3-637311db2cf1)
