### PR TITLE
fix: remediate z-index issue with progress indicators

### DIFF
--- a/resources/views/components/game/game-list.blade.php
+++ b/resources/views/components/game/game-list.blade.php
@@ -64,7 +64,7 @@ $numGames = count($games);
         <div class="overflow-x-auto lg:overflow-x-visible">
             <table class='table-highlight mb-4'>
                 <thead>
-                    <tr class="do-not-highlight lg:sticky lg:top-[42px] z-[1] bg-box">
+                    <tr class="do-not-highlight lg:sticky lg:top-[42px] z-[11] bg-box">
                         @foreach ($columns as $column)
                             @php
                                 $styles = [];


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1206007100308856942.

**Before**
![Screenshot 2024-02-11 at 10 40 56 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/d889bd31-8629-475b-ba55-669249be785b)


**After**
![Screenshot 2024-02-11 at 10 40 23 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/59959ec3-6879-419f-95af-11064fd87fd4)
