### PR TITLE
feat(completion-progress): allow viewing Events progress

### DIFF
--- a/app/Platform/Controllers/PlayerCompletionProgressController.php
+++ b/app/Platform/Controllers/PlayerCompletionProgressController.php
@@ -6,6 +6,7 @@ namespace App\Platform\Controllers;
 
 use App\Enums\Permissions;
 use App\Http\Controller;
+use App\Models\System;
 use App\Models\User;
 use App\Platform\Services\PlayerProgressionService;
 use Illuminate\Contracts\View\View;
@@ -25,7 +26,7 @@ class PlayerCompletionProgressController extends Controller
         $targetUsername = $request->route()->parameters['user'];
         $validatedData = $request->validate([
             'page.number' => 'sometimes|integer|min:1',
-            'filter.system' => 'sometimes|integer|between:0,102|not_in:100,101',
+            'filter.system' => 'sometimes|integer|between:0,102|not_in:100',
             'filter.status' => 'sometimes|string|min:2|max:30',
             'sort' => 'sometimes|string|in:unlock_date,pct_won,-unlock_date,-pct_won,game_title,-game_title',
         ]);
@@ -65,6 +66,7 @@ class PlayerCompletionProgressController extends Controller
         $filteredAndJoinedGamesList = $this->playerProgressionService->filterAndJoinGames(
             $userGamesList,
             $userSiteAwards,
+            allowEvents: $targetSystemId === System::Events,
         );
         $primaryCountsMetrics = $this->playerProgressionService->buildPrimaryCountsMetrics($filteredAndJoinedGamesList);
 

--- a/app/Platform/Services/PlayerProgressionService.php
+++ b/app/Platform/Services/PlayerProgressionService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Platform\Services;
 
 use App\Community\Enums\AwardType;
+use App\Models\System;
 use App\Platform\Enums\UnlockMode;
 
 class PlayerProgressionService
@@ -46,7 +47,7 @@ class PlayerProgressionService
         return $metrics;
     }
 
-    public function filterAndJoinGames(array $gamesList, array $siteAwards): array
+    public function filterAndJoinGames(array $gamesList, array $siteAwards, bool $allowEvents = false): array
     {
         /**
          * We need to append the most prestigious award kind+date to the game entities,
@@ -100,8 +101,8 @@ class PlayerProgressionService
         foreach ($gamesList as &$game) {
             $canUseGame = (
                 isValidConsoleId($game['ConsoleID'])
-                && $game['ConsoleID'] != 101
-                && $game['NumAwarded'] != 0
+                && ($allowEvents ? true : $game['ConsoleID'] !== System::Events)
+                && $game['NumAwarded'] !== 0
             );
 
             if ($canUseGame) {
@@ -143,7 +144,11 @@ class PlayerProgressionService
                     $award = current($searchResults);
                 }
 
-                if ($award && isValidConsoleId($award['ConsoleID']) && $award['ConsoleID'] != 101) {
+                if (
+                    $award
+                    && isValidConsoleId($award['ConsoleID'])
+                    && ($allowEvents ? true : $award['ConsoleID'] !== System::Events)
+                ) {
                     $newGame = [
                         'GameID' => $gameId,
                         'ConsoleID' => $award['ConsoleID'],

--- a/resources/views/components/completion-progress-page/meta-panel/console-filter.blade.php
+++ b/resources/views/components/completion-progress-page/meta-panel/console-filter.blade.php
@@ -20,7 +20,7 @@ usort($availableConsoleIds, function ($a, $b) {
     <option @if (!$selectedConsoleId) selected @endif value="0">All systems</option>
 
     @foreach ($availableConsoleIds as $consoleId)
-        @if (isValidConsoleId($consoleId) && $consoleId != 101)
+        @if (isValidConsoleId($consoleId))
             @if ($selectedConsoleId == $consoleId)
                 <option selected>{{ config('systems')[$consoleId]['name'] }}</option>
             @else

--- a/resources/views/components/game-list-item/index.blade.php
+++ b/resources/views/components/game-list-item/index.blade.php
@@ -51,6 +51,7 @@ $doesGameHaveAchievements = !!$game['MaxPossible'];
 
             <x-game-list-item.primary-meta
                 :gameId="$gameId"
+                :consoleId="$consoleId"
                 :gameTitle="$game['Title']"
                 :numAwardedAchievements="$game['NumAwarded']"
                 :numPossibleAchievements="$game['MaxPossible']"

--- a/resources/views/components/game-list-item/primary-meta.blade.php
+++ b/resources/views/components/game-list-item/primary-meta.blade.php
@@ -1,11 +1,13 @@
 <?php
 
+use App\Models\System;
 use Illuminate\Support\Carbon;
 ?>
 
 @props([
     'firstWonDate' => '',
     'gameId' => 0,
+    'consoleId' => 0,
     'gameTitle' => '',
     'highestAwardDate' => null,
     'highestAwardKind' => null, // null | 'beaten-softcore' | 'beaten-hardcore' | 'completed' | 'mastered'
@@ -19,13 +21,15 @@ use Illuminate\Support\Carbon;
 ])
 
 <?php
+$isEvent = $consoleId === System::Events;
+
 $firstUnlockDate = Carbon::parse($firstWonDate);
 $mostRecentUnlockDate = Carbon::parse($mostRecentWonDate);
 
 $timeToSiteAwardLabelPartOne = '';
 $timeToSiteAwardLabelPartTwo = '';
 $mostRecentUnlockDateLabel = $mostRecentUnlockDate->format('F j Y');
-if ($highestAwardKind && $highestAwardDate) {
+if ($highestAwardKind && $highestAwardDate && !$isEvent) {
     $highestAwardedAt = Carbon::createFromTimestamp($highestAwardDate);
 
     $awardLabelMap = [
@@ -107,25 +111,27 @@ if ($highestAwardKind && $highestAwardDate) {
         </div>
     @endif
 
-    {{-- c.progress-pmeta__root > div --}}
-    <div @if ($variant === 'user-recently-played') class="flex !flex-col-reverse" @endif>
-        <p>
-            @if ($variant === 'user-recently-played')
-                <span>Last played</span>
-            @endif
-            {{ $mostRecentUnlockDateLabel }}
-        </p>
-
-        @if ($timeToSiteAwardLabelPartOne && $timeToSiteAwardLabelPartTwo)
+    @if (!$isEvent)
+        {{-- c.progress-pmeta__root > div --}}
+        <div @if ($variant === 'user-recently-played') class="flex !flex-col-reverse" @endif>
             <p>
-                <span class="hidden md:inline lg:hidden">•</span>
-                {{ $timeToSiteAwardLabelPartOne }}
-                
-                @if ($numPossibleAchievements > 0)
-                    in
-                    <span class="font-bold">{{ $timeToSiteAwardLabelPartTwo }}</span>
+                @if ($variant === 'user-recently-played')
+                    <span>Last played</span>
                 @endif
+                {{ $mostRecentUnlockDateLabel }}
             </p>
-        @endif
-    </div>
+
+            @if ($timeToSiteAwardLabelPartOne && $timeToSiteAwardLabelPartTwo)
+                <p>
+                    <span class="hidden md:inline lg:hidden">•</span>
+                    {{ $timeToSiteAwardLabelPartOne }}
+                    
+                    @if ($numPossibleAchievements > 0)
+                        in
+                        <span class="font-bold">{{ $timeToSiteAwardLabelPartTwo }}</span>
+                    @endif
+                </p>
+            @endif
+        </div>
+    @endif
 </div>

--- a/resources/views/pages/user/[user]/progress.blade.php
+++ b/resources/views/pages/user/[user]/progress.blade.php
@@ -22,6 +22,7 @@ if ($isMe) {
 
 $pageDescription = "View {$targetUsername}'s game completion stats and milestones on RetroAchievements. Track their played, unfinished, and mastered games from various systems.";
 @endphp
+
 <x-app-layout
     :pageTitle="$headingLabel"
     :pageDescription="$pageDescription"


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1206427760491237396.

It is now possible to view "Events" progress on the Completion Progress page:

![Screenshot 2024-02-17 at 11 50 00 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/c727e248-853e-4b52-a625-df0f74ef805d)

This also means it's possible to go to another user's Completion Progress page and view their Events progress as well.

Unless explicitly filtering by system ID 101, these remain excluded from every other viewable context offered by the page. This should help alleviate some pain that a few achievement developers are currently experiencing.