### PR TITLE
fix(game-list): don't show empty state where there are no filterable games

### DIFF
--- a/resources/views/components/game/game-list.blade.php
+++ b/resources/views/components/game/game-list.blade.php
@@ -17,17 +17,20 @@
 $groupByConsole = isset($filterOptions['console']) && $filterOptions['console'];
 $areFiltersPristine = count(request()->query()) === 0;
 $numGames = count($games);
+$areGamesMaybePresent = !$areFiltersPristine || $numGames > 0;
 ?>
 
 <div>
-    <x-meta-panel
-        :availableCheckboxFilters="$availableCheckboxFilters"
-        :availableRadioFilters="$availableRadioFilters"
-        :availableSelectFilters="$availableSelectFilters"
-        :availableSorts="$availableSorts"
-        :filterOptions="$filterOptions"
-        :selectedSortOrder="$sortOrder"
-    />
+    @if ($areGamesMaybePresent)
+        <x-meta-panel
+            :availableCheckboxFilters="$availableCheckboxFilters"
+            :availableRadioFilters="$availableRadioFilters"
+            :availableSelectFilters="$availableSelectFilters"
+            :availableSorts="$availableSorts"
+            :filterOptions="$filterOptions"
+            :selectedSortOrder="$sortOrder"
+        />
+    @endif
 
     @if ($shouldShowCount)
         <p class="mb-4 text-xs">
@@ -134,7 +137,7 @@ $numGames = count($games);
         @endif
     @endforeach
 
-    @if (empty($games))
+    @if (empty($games) && $areGamesMaybePresent)
         <div class="mb-12">
             <x-empty-state>{{ $noGamesMessage }}</x-empty-state>
         </div>


### PR DESCRIPTION
Resolves an issue that's observable here:

https://retroachievements.org/game/3105

Games do not exist in this hub. The meta surface and empty state are redundant and should not be visible.

**Before**
![Screenshot 2024-02-17 at 11 59 49 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/ce93df82-d551-47b1-ac80-6b8053005a91)

**After**
![Screenshot 2024-02-17 at 11 59 59 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/53c2a2f5-cb9c-4756-82ac-d2fdbca2c2e0)
