### PR TITLE
update link for manual unlock instructions

### DIFF
--- a/resources/views/pages-legacy/reportissue.blade.php
+++ b/resources/views/pages-legacy/reportissue.blade.php
@@ -215,7 +215,7 @@ function reportIssueComponent() {
                     <div x-cloak>
                         <p x-show="descriptionIsNetworkProblem">
                             Please do not use this tool for network issues.
-                            See <a href='https://docs.retroachievements.org/FAQ/#how-can-i-get-credit-for-an-achievement-i-earned-but-wasnt-awarded'>here</a>
+                            See <a href='https://docs.retroachievements.org/FAQ/#in-short-how-to-request-a-manual-unlock'>here</a>
                             for instructions on how to request a manual unlock.
                         </p>
                         <p x-show="descriptionIsUnhelpful">


### PR DESCRIPTION
Fixes a broken link when the user types "manual unlock" into the Report Issue page.

https://discord.com/channels/476211979464343552/1002694942826704936/1209145643990523936