### PR TITLE
fix session classification for manual unlocks

### DIFF
--- a/app/Helpers/database/user-activity.php
+++ b/app/Helpers/database/user-activity.php
@@ -334,6 +334,7 @@ function getUserGameActivity(string $username, int $gameID): array
                 'Points' => $playerAchievement->Points,
                 'Type' => $playerAchievement->type,
                 'BadgeName' => $playerAchievement->BadgeName,
+                'UnlockedBy' => $playerAchievement->unlocker_id,
             ];
         };
 
@@ -350,7 +351,7 @@ function getUserGameActivity(string $username, int $gameID): array
 
                     return;
                 }
-                $possibleSession = $session;
+                $possibleSession = &$session;
             }
         }
 
@@ -366,8 +367,9 @@ function getUserGameActivity(string $username, int $gameID): array
 
             $index = array_search($sessions, $possibleSession);
             if ($index < count($sessions)) {
-                $possibleSession = $sessions[$index + 1];
-                if ($possibleSession['StartTime'] - $when < $maxSessionGap) {
+                $possibleSession = &$sessions[$index + 1];
+
+                if ($when > $possibleSession['StartTime'] && $when - $possibleSession['StartTime'] < $maxSessionGap) {
                     $possibleSession['Achievements'][] = $createSessionAchievement($playerAchievement, $when, $hardcore);
                     $possibleSession['StartTime'] = $when;
 
@@ -426,6 +428,17 @@ function getUserGameActivity(string $username, int $gameID): array
         $totalTime += $elapsed;
 
         if (!empty($session['Achievements'])) {
+            $onlyManualUnlocks = true;
+            foreach ($session['Achievements'] as &$achievement) {
+                if (!$achievement['UnlockedBy']) {
+                    $onlyManualUnlocks = false;
+                    break;
+                }
+            }
+            if ($onlyManualUnlocks) {
+                continue;
+            }
+
             if ($achievementsTime > 0) {
                 $achievementsTime += $intermediateTime;
                 $unlockSessionCount += $intermediateSessionCount;

--- a/resources/views/pages-legacy/usergameactivity.blade.php
+++ b/resources/views/pages-legacy/usergameactivity.blade.php
@@ -3,6 +3,7 @@
 // TODO migrate to PlayerGameController::activity() pages/user/game/activity.blade.php
 
 use App\Enums\Permissions;
+use App\Models\User;
 use App\Platform\Enums\AchievementFlag;
 
 if (!authenticateFromCookie($user, $permissions, $userDetails, Permissions::Moderator)) {
@@ -99,6 +100,12 @@ $userProgress = ($gameAchievementCount > 0) ? sprintf("/%d (%01.2f%%)",
 
             if ($achievement['UnlockedLater'] ?? false) {
                 echo " (unlocked again later)";
+            }
+
+            if ($achievement['UnlockedBy']) {
+                echo " (unlocked by ";
+                echo userAvatar(User::find($achievement['UnlockedBy']), label:true, icon:false);
+                echo ")";
             }
 
             echo "</td></tr>";


### PR DESCRIPTION
Fixes an issue where an achievement unlocked between two sessions doesn't appear in either session. Originally reported here https://discord.com/channels/476211979464343552/1207063525248344095/1210362941921038387 with a manually unlocked achievement.

Also updated the display to report when an achievement was manually unlocked.