### PR TITLE
 refactor(search): make search results follow input when scrolling

### DIFF
--- a/public/js/all.js
+++ b/public/js/all.js
@@ -74,31 +74,6 @@ function useCard(type, id, context = null, html = '') {
 jQuery(document).ready(function onReady($) {
   $('.msgPayload').hide();
 
-  $('.searchboxinput').each(function () {
-    // eslint-disable-next-line no-underscore-dangle
-    $(this).autocomplete({
-      source: function (request, response) {
-        $.post('/request/search.php', request)
-          .done(function (data) {
-            response(data);
-          });
-      },
-      minLength: 2,
-      select: function (_, ui) {
-        window.location = ui.item.mylink;
-        return false;
-      }
-    }).data('autocomplete')._renderItem = function (ul, item) {
-      const li = $('<li>');
-      const a = $('<a>', {
-        text: item.label,
-        href: item.mylink,
-      });
-
-      return li.data('item.autocomplete', item).append(a).appendTo(ul);
-    };
-  });
-
   var $seachBoxCompareUser = $('.searchboxgamecompareuser');
   $seachBoxCompareUser.autocomplete({
     source: function (request, response) {

--- a/resources/css/search.css
+++ b/resources/css/search.css
@@ -34,6 +34,22 @@
   padding-left: 10px;
 }
 
+#search-listbox>li {
+  padding: 3px 6px;
+  font-family: Segoe UI, Arial, sans-serif;
+}
+
+#search-listbox>li:hover {
+  padding: 1px 4px;
+}
+
+#search-listbox>li.listbox-item--hover {
+  background: rgb(253 230 138);
+  border: 2px solid rgb(161 98 7);
+  border-radius: 0.5rem;
+  padding: 1px 4px;
+}
+
 @media only screen and (max-width: 374px) {
   .searchbox-top .searchboxinput:focus,
   .searchbox-top .searchboxinput:not(:placeholder-shown) {

--- a/resources/js/alpine/index.ts
+++ b/resources/js/alpine/index.ts
@@ -3,3 +3,4 @@ export * from './modalComponent';
 export * from './newsCarouselComponent';
 export * from './toggleAchievementRowsComponent';
 export * from './tooltipComponent';
+export * from './navbarSearchComponent';

--- a/resources/js/alpine/navbarSearchComponent/index.ts
+++ b/resources/js/alpine/navbarSearchComponent/index.ts
@@ -1,0 +1,1 @@
+export * from './navbarSearchComponent';

--- a/resources/js/alpine/navbarSearchComponent/navbarSearchComponent.ts
+++ b/resources/js/alpine/navbarSearchComponent/navbarSearchComponent.ts
@@ -1,0 +1,129 @@
+import { fetcher } from '@/utils';
+
+type SearchResult = {
+  label: string,
+  mylink: string,
+}
+
+type NavbarSearchComponentType = {
+  showSearchResults:boolean,
+  searchText:string,
+  results: SearchResult[],
+  selectedIndex:number,
+  activeDecendentId: string,
+  handleClickSearchResult: (label: string) => void,
+  handleKeyDown: (e:KeyboardEvent) => void,
+  handleKeyUp: (e:KeyboardEvent, el:HTMLInputElement) => void,
+}
+
+export function navbarSearchComponent(): NavbarSearchComponentType {
+  return {
+    showSearchResults: false,
+    searchText: '',
+    results: [],
+    selectedIndex: -1,
+
+    get activeDecendentId() {
+      if (this.selectedIndex !== -1) {
+        return this.results[this.selectedIndex - 2].mylink.slice(1).replace('/', '-');
+      }
+      return '';
+    },
+
+    handleClickSearchResult(label: string) {
+      const input = document.querySelector<HTMLInputElement>('.searchboxinput');
+      this.searchText = label;
+      if (input) {
+        input.value = label;
+        this.showSearchResults = false;
+        input.scrollLeft = input.scrollWidth * -1;
+      }
+    },
+
+    handleKeyDown(e:KeyboardEvent) {
+      if (e.key === 'ArrowUp' || e.key === 'Enter') {
+        e.preventDefault();
+      }
+    },
+
+    async handleKeyUp(e:KeyboardEvent, el: HTMLInputElement) {
+      if (e.key === 'ArrowLeft'
+          || e.key === 'ArrowRight'
+          || e.key === 'Shift'
+          || e.key === 'Control'
+          || e.key === 'Alt'
+          || e.key === 'Meta'
+      ) return;
+
+      const {
+        value
+      } = el;
+
+      if (value.length < 2) {
+        this.showSearchResults = false;
+        this.selectedIndex = -1;
+        return;
+      }
+      const SearchBoxTopDropdown = document.querySelector('#search-listbox');
+      const SearchBoxTopDropdownOptions = SearchBoxTopDropdown?.childNodes;
+      if (SearchBoxTopDropdownOptions === undefined) return;
+
+      switch (e.key) {
+        case 'ArrowUp':
+          if (this.showSearchResults) {
+            if (this.selectedIndex === -1 || this.selectedIndex === 2) {
+              this.selectedIndex = SearchBoxTopDropdownOptions.length - 2;
+            } else {
+              this.selectedIndex--;
+            }
+          }
+
+          return;
+        case 'ArrowDown':
+          if (this.showSearchResults) {
+            if (this.selectedIndex === -1 || this.selectedIndex === SearchBoxTopDropdownOptions.length - 2) {
+              this.selectedIndex = 2;
+            } else {
+              this.selectedIndex++;
+            }
+          } else {
+            this.showSearchResults = true;
+          }
+          return;
+        case 'Enter':
+          if (this.showSearchResults) {
+            this.showSearchResults = false;
+
+            if (this.selectedIndex !== -1) {
+              this.searchText = this.results[this.selectedIndex - 2].label;
+              window.location.href = this.results[this.selectedIndex - 2].mylink;
+            }
+          } else {
+            document.querySelector<HTMLFormElement>('.searchbox-top')?.requestSubmit();
+          }
+          return;
+        case 'Escape':
+          if (this.showSearchResults) {
+            this.showSearchResults = false;
+          } else {
+            this.searchText = '';
+          }
+          return;
+        default:
+      }
+
+      this.selectedIndex = -1;
+
+      const formData = new FormData();
+      formData.append('term', this.searchText);
+
+      const response = await fetcher<SearchResult[]>('/request/search.php', {
+        method: 'POST',
+        body: `term=${this.searchText}`,
+      });
+
+      this.results = response;
+      this.showSearchResults = this.results.length > 0;
+    }
+  };
+}

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -12,6 +12,7 @@ import {
   newsCarouselComponent,
   toggleAchievementRowsComponent,
   tooltipComponent,
+  navbarSearchComponent,
 } from './alpine';
 import {
   autoExpandTextInput,
@@ -59,6 +60,7 @@ window.modalComponent = modalComponent;
 window.newsCarouselComponent = newsCarouselComponent;
 window.toggleAchievementRowsComponent = toggleAchievementRowsComponent;
 window.tooltipComponent = tooltipComponent;
+window.navbarSearchComponent = navbarSearchComponent;
 
 // Alpine.js Directives
 Alpine.directive('linkify', linkifyDirective);

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -6,6 +6,7 @@ import type {
   newsCarouselComponent as NewsCarouselComponent,
   toggleAchievementRowsComponent as ToggleAchievementRowsComponent,
   tooltipComponent as TooltipComponent,
+  navbarSearchComponent as NavbarSearchComponent,
 } from '@/alpine';
 import type { fetcher as Fetcher } from '@/utils/fetcher';
 import type { getStringByteCount as GetStringByteCount } from '@/utils/getStringByteCount';
@@ -38,6 +39,7 @@ declare global {
   var loadPostPreview: typeof LoadPostPreview;
   var modalComponent: typeof ModalComponent;
   var newsCarouselComponent: typeof NewsCarouselComponent;
+  var navbarSearchComponent: typeof NavbarSearchComponent;
   var setCookie: typeof SetCookie;
   var showStatusFailure: (message: string) => void;
   var showStatusSuccess: (message: string) => void;

--- a/resources/views/components/menu/search.blade.php
+++ b/resources/views/components/menu/search.blade.php
@@ -14,7 +14,81 @@ if ($_SERVER['SCRIPT_NAME'] === '/searchresults.php') {
     $searchQuery = attributeEscape(request()->query('s'));
 }
 ?>
-<form class="flex searchbox-top" action="/searchresults.php">
-    <input name="s" type="text" class="flex-1 searchboxinput" value="{!! $searchQuery !!}" placeholder="{{ __('Search') }}">
-    <button class="nav-link" title="Search"><x-fas-search /></button>
-</form>
+<div
+     x-data="navbarSearchComponent"
+     class="searchbox-container"
+     @click.outside="showSearchResults = false">
+    <form class="flex searchbox-top" action="/searchresults.php">
+        <input
+               name="s"
+               type="text"
+               role="combobox"
+               class="flex-1 cursor-pointer searchboxinput"
+               placeholder=" {{ __('Search') }}"
+               x-model="searchText"
+               @keyup="handleKeyUp($event, $el)"
+               @keydown="handleKeyDown"
+               @blur="showSearchResults = false"
+               aria-autocomplete="list"
+               aria-controls="search-listbox"
+               :aria-expanded="showSearchResults"
+               :aria-activedescendant="activeDecendentId">
+        <button class="nav-link" title="Search">
+            <x-fas-search />
+        </button>
+    </form>
+    <ul
+        id="search-listbox"
+        role="listbox"
+        aria-label="Search"
+        class="p-0.5 w-fit absolute top-0 left-0 rounded-lg bg-yellow-100"
+        x-show="showSearchResults">
+        <template x-for="(result, i) in results">
+            <li
+                :id="result.mylink.slice(1).replace('/','-')"
+                role="option"
+                tabindex="-1"
+                class="text-sm cursor-pointer 
+                hover:rounded-lg 
+                hover:bg-amber-200
+                hover:border-2 
+                hover:border-yellow-700"
+                :class="selectedIndex - 2 === i ? 'listbox-item--hover' : ''"
+                :aria-selected="selectedIndex - 2 === i"
+                @click="handleClickSearchResult(result.label)"
+                @mouseDown="$event.preventDefault()">
+                <a
+                   class="text-black hover:text-black flex"
+                   :href="result.mylink"
+                   x-text="result.label"></a>
+            </li>
+        </template>
+    </ul>
+</div>
+<script>
+// For FloatingUI
+document.addEventListener('DOMContentLoaded', () => {
+    const SearchBoxTop = document.querySelector('.searchbox-top');
+    const SearchBoxTopDropdown = document.querySelector('#search-listbox');
+
+    const {
+        computePosition,
+        autoUpdate
+    } = window.FloatingUIDOM
+
+    autoUpdate(SearchBoxTop, SearchBoxTopDropdown, () => {
+        computePosition(SearchBoxTop, SearchBoxTopDropdown, {
+            placement: 'bottom-start'
+        }).then(({
+            x,
+            y
+        }) => {
+            Object.assign(SearchBoxTopDropdown.style, {
+                left: `${x}px`,
+                top: `${y}px`,
+            });
+        });
+    });
+
+});
+</script>

--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -43,6 +43,9 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.23/jquery-ui.min.js"></script>
 
+    <script src="https://cdn.jsdelivr.net/npm/@floating-ui/core@1.6.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.6.1"></script>
+
     @if (app()->environment('local'))
         <script src="/js/all.js?v={{ random_int(0, mt_getrandmax()) }}"></script>
     @else


### PR DESCRIPTION
I rewrote the main website search bar using Alpine and Floating UI. This fixes an issue where if the user scrolled down while the search results were open the search results would not follow the search input.

I followed the WAI-ARIA compliance guidelines:  
[https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/)

I didn't style the focus or hover state because I thought it might look weird if it was the only element styled to spec when tabbing through. (2px focus ring with 2px space between ring and combobox)

I did add some custom CSS outside of Tailwind for the dropdown item selected state. The combobox spec said to replace borders with padding instead of making them transparent. Tailwind uses rem for padding and px for borders and I needed to use px for both.

![RA-Search](https://github.com/RetroAchievements/RAWeb/assets/54478555/7c26db27-29bf-49b0-a31f-086a4dd4d024)

Fixes #1723