### PR TITLE
fix(system-games): show filters meta surface for unsupported console ids

### DIFF
--- a/app/Platform/Controllers/SystemController.php
+++ b/app/Platform/Controllers/SystemController.php
@@ -171,6 +171,7 @@ class SystemController extends Controller
             'filterOptions' => $filterOptions,
             'gameListConsoles' => $this->gameListService->consoles,
             'games' => $this->gameListService->games,
+            'shouldAlwaysShowMetaSurface' => !isValidConsoleId($system->id) || $system->id === System::Events,
             'sortOrder' => $sortOrder,
             'system' => $system,
             'totalUnfilteredCount' => $totalUnfilteredCount,

--- a/resources/views/components/game/game-list.blade.php
+++ b/resources/views/components/game/game-list.blade.php
@@ -9,6 +9,7 @@
     'games' => [],
     'noGamesMessage' => 'No games.',
     'sortOrder' => 'title',
+    'shouldAlwaysShowMetaSurface' => false,
     'shouldShowCount' => false,
     'totalUnfilteredCount' => null, // ?int
 ])
@@ -17,7 +18,12 @@
 $groupByConsole = isset($filterOptions['console']) && $filterOptions['console'];
 $areFiltersPristine = count(request()->query()) === 0;
 $numGames = count($games);
-$areGamesMaybePresent = !$areFiltersPristine || $numGames > 0;
+
+$areGamesMaybePresent = (
+    !$areFiltersPristine
+    || $numGames > 0
+    || $shouldAlwaysShowMetaSurface
+);
 ?>
 
 <div>

--- a/resources/views/pages/system/[system]/games.blade.php
+++ b/resources/views/pages/system/[system]/games.blade.php
@@ -15,6 +15,7 @@ name('system.game.index');
     'filterOptions' => [],
     'gameListConsoles' => [],
     'games' => [],
+    'shouldAlwaysShowMetaSurface' => true,
     'sortOrder' => 'title',
     'system', // System
     'totalUnfilteredCount' => null, // ?int
@@ -64,6 +65,7 @@ if ($areFiltersPristine) {
             :filterOptions="$filterOptions"
             :games="$games"
             :sortOrder="$sortOrder"
+            :shouldAlwaysShowMetaSurface="$shouldAlwaysShowMetaSurface"
             :shouldShowCount="true"
             :totalUnfilteredCount="$totalUnfilteredCount"
         />


### PR DESCRIPTION
Resolves an issue where viewing the system games list for an unsupported system no longer allows the user to filter into games without achievements.

**Before**
![Screenshot 2024-02-29 at 5 01 05 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/918f2935-3460-422d-950b-5ea6ea2ec8e0)


**After**
![Screenshot 2024-02-29 at 5 00 57 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/4dcff3ab-5805-4ef6-8335-3fbb744ef55b)
