### PR TITLE
fix(controlpanel): render web api keys properly

### DIFF
--- a/resources/views/pages-legacy/controlpanel.blade.php
+++ b/resources/views/pages-legacy/controlpanel.blade.php
@@ -259,8 +259,8 @@ function confirmEmailChange(event) {
             echo "<td class='align-top'>Web API Key</td>";
             echo "<td>";
             ?>
-            <button x-init="{}" @click="copyToClipboard('$apiKey')" class="btn flex items-center gap-x-2 mb-2" title="Copy your web API key to the clipboard" aria-label="Copy your web API key to the clipboard">
-                <span class="font-mono">$apiKey</span>
+            <button x-init="{}" @click="copyToClipboard('{{ $apiKey }}')" class="btn flex items-center gap-x-2 mb-2" title="Copy your web API key to the clipboard" aria-label="Copy your web API key to the clipboard">
+                <span class="font-mono">{{ $apiKey }}</span>
                 <x-fas-copy />
             </button>
             <div class="mb-2">


### PR DESCRIPTION
Resolves an issue where web API keys are no longer rendering on controlpanel.php. "$apiKey" is currently rendering on prod.

This is happening because the variable isn't wrapped in handlebars `{{ }}`.