### PR TITLE
fix(tooltip): raise z-index value

### DIFF
--- a/resources/js/alpine/tooltipComponent/utils/renderTooltip.ts
+++ b/resources/js/alpine/tooltipComponent/utils/renderTooltip.ts
@@ -23,7 +23,7 @@ export function renderTooltip(
   html: string,
   givenX?: number,
   givenY?: number,
-  options?: Partial<{ isBorderless: boolean }>,
+  options?: Partial<{ isBorderless: boolean }>
 ) {
   if (store.tooltipEl !== null) {
     store.tooltipEl.remove();
@@ -48,7 +48,7 @@ export function renderTooltip(
     'rounded',
     'pointer-events-none',
     'overflow-hidden',
-    'z-10',
+    'z-20'
   );
 
   if (!options?.isBorderless) {


### PR DESCRIPTION
This PR resolves an issue on game lists where tooltips can appear underneath table sticky headers. To repro, go to a hub and group it by console.

**Before**
![Screenshot 2024-03-02 at 8 33 42 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/c9b69a91-a5db-4887-a770-78f0f09158bd)


**After**
![Screenshot 2024-03-02 at 8 33 28 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/abe293c6-30ac-45e6-93b4-54d83a1a8068)
