### PR TITLE
fix(user): remediate padding issues on progression status container

### DIFF
--- a/resources/views/components/user/progression-status/legend.blade.php
+++ b/resources/views/components/user/progression-status/legend.blade.php
@@ -5,7 +5,7 @@
     'totalMasteredCount' => 0,
 ])
 
-<div class="{{ ($totalCompletedCount || $totalBeatenSoftcoreCount) ? 'grid grid-cols-2' : 'flex' }} sm:flex gap-x-4 [&>div]:flex [&>div]:items-center [&>div]:gap-x-1">
+<div class="{{ ($totalCompletedCount || $totalBeatenSoftcoreCount) ? 'grid grid-cols-2' : 'flex' }} gap-x-4 [&>div]:flex [&>div]:items-center [&>div]:gap-x-1 sm:flex sm:gap-x-3 md:gap-x-4">
     <div class="order-1">
         <p class="text-zinc-500 font-bold text-xs">Unfinished</p>
     </div>

--- a/resources/views/components/user/progression-status/root.blade.php
+++ b/resources/views/components/user/progression-status/root.blade.php
@@ -17,7 +17,7 @@ if ($widthMode !== 'equal' && $widthMode !== 'dynamic') {
             :totalMasteredCount="$totalMasteredCount"
         />
 
-        <label class="flex items-center gap-x-1 select-none cursor-pointer text-xs transition md:active:scale-95">
+        <label class="flex items-center gap-x-1 select-none cursor-pointer text-xs transition sm:-mt-[2px] md:active:scale-95">
             <input
                 type="checkbox"
                 autocomplete="off"

--- a/resources/views/pages-legacy/userInfo.blade.php
+++ b/resources/views/pages-legacy/userInfo.blade.php
@@ -138,7 +138,7 @@ if (getActiveClaimCount($userPage, true, true) > 0) {
     if ($canShowProgressionStatusComponent) {
         echo "<hr class='border-neutral-700 black:border-embed-highlight light:border-embed-highlight my-4' />";
 
-        echo "<div class='mt-1 mb-8 bg-embed p-5 rounded sm:p-2 lg:p-3 xl:p-5'>";
+        echo "<div class='mt-1 mb-8 bg-embed p-5 rounded sm:p-2.5 md:p-5 lg:p-3 xl:p-5'>";
         ?>
         <x-user-progression-status
             :userCompletionProgress="$userCompletedGamesList"

--- a/resources/views/pages-legacy/userInfo.blade.php
+++ b/resources/views/pages-legacy/userInfo.blade.php
@@ -138,7 +138,7 @@ if (getActiveClaimCount($userPage, true, true) > 0) {
     if ($canShowProgressionStatusComponent) {
         echo "<hr class='border-neutral-700 black:border-embed-highlight light:border-embed-highlight my-4' />";
 
-        echo "<div class='mt-1 mb-8 bg-embed p-5 rounded'>";
+        echo "<div class='mt-1 mb-8 bg-embed p-5 rounded sm:p-2 lg:p-3 xl:p-5'>";
         ?>
         <x-user-progression-status
             :userCompletionProgress="$userCompletedGamesList"


### PR DESCRIPTION
This PR resolves some padding issues at the LG breakpoint in the Progression Status component container. It also slightly shifts the "Dynamic widths" checkbox up by 2px to be better aligned with the legend on SM+ breakpoints.

**Before**
![Screenshot 2024-03-02 at 8 40 08 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/3cf7d4e6-f932-4712-8419-cc15b6a3c3d5)


**After**
![Screenshot 2024-03-02 at 8 40 17 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/b1c2abec-dbd5-41ad-bc57-64c20edf5136)
