### PR TITLE
fix(achievementInfo): prevent escaping the page title

### DIFF
--- a/resources/views/pages-legacy/achievementInfo.blade.php
+++ b/resources/views/pages-legacy/achievementInfo.blade.php
@@ -125,7 +125,7 @@ $numArticleComments = getRecentArticleComments(ArticleType::Achievement, $achiev
 getCodeNotes($gameID, $codeNotes);
 ?>
 <x-app-layout
-    pageTitle="{{ $achievementTitleRaw }} in {{ $gameTitleRaw }} ({{ $consoleName }})"
+    pageTitle="{!! $achievementTitleRaw !!} in {!! $gameTitleRaw !!} ({{ $consoleName }})"
     :pageDescription="generateAchievementMetaDescription($achievementDescriptionRaw, $achType, $gameTitleRaw, $consoleName, $achPoints, $numWinners)"
     :pageImage="media_asset('/Badge/' . $badgeName . '.png')"
     pageType="retroachievements:achievement"


### PR DESCRIPTION
Resolves a regression from the Folio changes where achievement title tag content may not be rendered correctly.

**Before**
![Screenshot 2024-03-02 at 8 56 07 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/6576aa3c-c3f3-4016-b745-b5d8b3e25d1e)


**After**
![Screenshot 2024-03-02 at 8 56 02 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/f548006e-e58d-41b5-9cce-a2a089b2227f)
