### PR TITLE
fix(Shortcode): remediate issue with new twitch clip url pattern

### DIFF
--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -468,7 +468,7 @@ final class Shortcode
 
         // https://clips.twitch.tv/AmorphousCautiousLegPanicVis
         $text = preg_replace(
-            '~(?:https?://)?clips.twitch.tv/([a-z0-9]+)~i',
+            '~(?:https?://)?clips.twitch.tv/([a-zA-Z0-9-_]+)~i',
             $this->embedVideo('//clips.twitch.tv/embed?clip=$1&parent=' . $parent . '&autoplay=false'),
             $text
         );


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1213223210942734448.

To repro, try using this embed URL:
```
https://clips.twitch.tv/NastyConcernedBeanWholeWheat-J9z5FEl1gMo5EUYW
```

Twitch clips can now have a `-[hash]` suffix, which is not supported by `autoEmbedTwitch()`'s current URL pattern. This PR slightly adjusts the pattern so these URLs are now supported.

**Before**
![Screenshot 2024-03-02 at 9 03 06 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/ebc2fdfa-6a77-445c-a8fb-76daf9bba05d)


**After**
![Screenshot 2024-03-02 at 9 02 57 AM](https://github.com/RetroAchievements/RAWeb/assets/3984985/1b587f72-85d2-4c0e-9fc1-3f9a5325725c)

