### PR TITLE
fix: overflow-x when the table is so huge

### DIFF
--- a/resources/views/pages-legacy/gamecompare.blade.php
+++ b/resources/views/pages-legacy/gamecompare.blade.php
@@ -119,6 +119,7 @@ sanitize_outputs(
 
         $iconSize = 48;
 
+        echo "<div class='overflow-auto'>";
         echo "<table class='table-highlight'><tbody>";
 
         echo "<tr class='do-not-highlight'>";
@@ -272,7 +273,7 @@ sanitize_outputs(
             echo "</tr>";
         }
 
-        echo "</tbody></table>";
+        echo "</tbody></table></div>";
 
         echo "<br><br>";
         ?>


### PR DESCRIPTION
This PR going to solve or put a little fix into https://github.com/RetroAchievements/RAWeb/issues/1451

Now it's seen:

![image](https://github.com/RetroAchievements/RAWeb/assets/20032391/7ad6d7e8-e25d-4ec0-b42c-6d3daf3003af)

With the fix:

![image](https://github.com/RetroAchievements/RAWeb/assets/20032391/64685efd-58e6-4185-9085-6c8dfe8f19ff)

The overflow fixed the content to the box. And solve possible problems in others displays.
