### PR TITLE
chore(achievementInfo): fix issue with IDE syntax highlighting

### DIFF
--- a/resources/views/pages-legacy/achievementInfo.blade.php
+++ b/resources/views/pages-legacy/achievementInfo.blade.php
@@ -187,7 +187,8 @@ getCodeNotes($gameID, $codeNotes);
      * @param {3 | 5} newFlag - see AchievementFlag.php
      */
     function updateAchievementFlag(newFlag) {
-        if (!confirm(`Are you sure you want to ${(newFlag === <?= AchievementFlag::OfficialCore ?> ? 'promote' : 'demote')} these achievements?`)) {
+        const actionLabel = newFlag === <?= AchievementFlag::OfficialCore ?> ? 'promote' : 'demote';
+        if (!confirm(`Are you sure you want to ${actionLabel} this achievement?`)) {
             return;
         }
         showStatusMessage('Updating...');
@@ -401,9 +402,12 @@ getCodeNotes($gameID, $codeNotes);
     }
 
     if (!empty($embedVidURL)) {
+        echo "<div class='mb-4'>";
         echo Shortcode::render($embedVidURL, ['imgur' => true]);
+        echo "</div>";
     }
 
+    echo "<div class='mb-4'>";
     RenderCommentsComponent(
         $user,
         $numArticleComments,
@@ -412,6 +416,7 @@ getCodeNotes($gameID, $codeNotes);
         ArticleType::Achievement,
         $permissions
     );
+    echo "</div>";
 
     echo "</div>"; // achievement
 


### PR DESCRIPTION
Remediates a small issue where syntax highlighting in _achievementInfo.blade.php_ is broken past a certain point in the code.

Also adds some margins to the page around embeds and the comments section.

**Before**
![Screenshot 2024-03-12 at 4 51 13 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/1ca2121f-6a8c-44cc-8204-53d2df18ee62)

**After**
![Screenshot 2024-03-12 at 4 51 07 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/143a79c9-7b29-4f13-ac43-71b3100ae0c6)
