### PR TITLE
fix: remediate layout issues with forums/messages reply ui

### DIFF
--- a/resources/views/components/base/button/submit.blade.php
+++ b/resources/views/components/base/button/submit.blade.php
@@ -4,7 +4,6 @@
     ]) }}
     :disabled="!isValid || isSending"
 >
-    {{ svg('fas-' . ($icon ?? 'paper-plane'), 'icon') }}
     <span x-show="isSending" x-cloak>{{ __('Sending...') }}</span>
     <span x-show="!isSending">{{ (string) $slot ?: __('Submit') }}</span>
 </button>

--- a/resources/views/components/base/form-actions.blade.php
+++ b/resources/views/components/base/form-actions.blade.php
@@ -10,7 +10,7 @@
         {{ $submitLabel }}
     </x-base.button.submit>
 
-    @if($hasRequiredFields)
+    @if ($hasRequiredFields)
         <div class="{{ $largeSubmit ? 'mt-2' : 'ml-3' }} whitespace-nowrap">
             * {{ __('Required') }}
         </div>

--- a/resources/views/components/base/form-field.blade.php
+++ b/resources/views/components/base/form-field.blade.php
@@ -4,6 +4,7 @@
     'id' => null,
     'inline' => false,
     'inputType' => null,
+    'isLabelVisible' => true,
     'label' => null,
     'name' => null,
     'required' => false,
@@ -14,13 +15,13 @@ $id = $id ?: 'input_' . Str::random();
 ?>
 
 <div class="{{ $inline ? 'lg:flex' : '' }}">
-    @if($inputType !== 'hidden' && $inputType !== 'checkbox')
-        <label for="{{ $id }}" class="block {{ $inline ? 'lg:w-36 lg:pr-3 lg:text-right lg:pt-1' : 'mb-1' }} {{ $name && $errors && $errors->has($name) ? 'text-danger' : '' }}">
+    @if ($inputType !== 'hidden' && $inputType !== 'checkbox')
+        <label for="{{ $id }}" class="block {{ $inline ? 'lg:w-36 lg:pr-3 lg:text-right lg:pt-1' : 'mb-1' }} {{ $name && $errors && $errors->has($name) ? 'text-danger' : '' }} {{ $isLabelVisible ? '' : 'sr-only' }}">
             {{ $label ?: __('validation.attributes.' . strtolower($name)) }} {{ $required && !$requiredSilent ? '*' : '' }}
         </label>
     @endif
     <div class="grow">
-        @if($icon)
+        @if ($icon)
             <div class="flex flex-row">
                 <div class="form-control-prepend flex items-center" aria-hidden="true">
                     {{ $icon ? svg('fas-' . $icon, 'icon') : '' }}
@@ -30,13 +31,13 @@ $id = $id ?: 'input_' . Str::random();
         @else
             {{ $slot }}
         @endif
-        @if($help)
+        @if ($help)
             <p class="help-block text-muted" id="help-{{ $id }}">
                 {!! $help  !!}
             </p>
         @endif
-        @if($name)
-            @error($name)
+        @if ($name)
+            @error ($name)
             <p class="help-block text-danger" id="error-{{ $id }}">
                 <x-fas-exclamation-triangle /> {{ $errors->first($name) }}
             </p>

--- a/resources/views/components/base/form/input.blade.php
+++ b/resources/views/components/base/form/input.blade.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
     'icon' => false,
     'id' => null,
     'inline' => false,
+    'isLabelVisible' => true,
     'label' => null,
     'maxlength' => 255,
     'model' => null,
@@ -37,6 +38,7 @@ $id = $id ?: 'input_' . Str::random();
     :id="$id"
     :inline="$inline"
     :inputType="$type"
+    :isLabelVisible="$isLabelVisible"
     :label="$label"
     :model="$model"
     :name="$name"

--- a/resources/views/components/base/form/input/checkbox.blade.php
+++ b/resources/views/components/base/form/input/checkbox.blade.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
     'help' => null,
     'id' => null,
     'inline' => false,
+    'isLabelVisible' => true,
     'label' => null,
     'model' => null,
     'name' => null,
@@ -29,6 +30,7 @@ $id = $id ?: 'input_' . Str::random();
     :help="$help"
     :id="$id"
     :inline="$inline"
+    :isLabelVisible="$isLabelVisible"
     inputType="checkbox"
     :model="$model"
     :name="$name"

--- a/resources/views/components/base/form/search.blade.php
+++ b/resources/views/components/base/form/search.blade.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
     'icon' => false,
     'id' => null,
     'inline' => false,
+    'isLabelVisible' => true,
     'label' => null,
     'loading' => false,
     'maxlength' => 255,
@@ -34,6 +35,7 @@ $id = $id ?: 'input_' . Str::random();
     :icon="$icon"
     :id="$id"
     :inline="$inline"
+    :isLabelVisible="$isLabelVisible"
     :label="$label"
     :model="$model"
     :name="$name"

--- a/resources/views/components/base/form/select.blade.php
+++ b/resources/views/components/base/form/select.blade.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
     'icon' => false,
     'id' => null,
     'inline' => false,
+    'isLabelVisible' => true,
     'label' => null,
     'options' => collect(),
     'model' => null,
@@ -37,6 +38,7 @@ $id = $id ?: 'input_' . Str::random();
     :help="$help ?? null"
     :id="$id"
     :inline="$inline"
+    :isLabelVisible="$isLabelVisible"
     :label="$label"
     :model="$model"
     :name="$name"

--- a/resources/views/components/base/form/textarea.blade.php
+++ b/resources/views/components/base/form/textarea.blade.php
@@ -30,6 +30,8 @@ if ($model && !$model instanceof Model) {
     throw new Exception('"model" is not an Eloquent model');
 }
 
+$hasProvidedId = $id !== null;
+
 $id = $id ?: 'input_' . Str::random();
 ?>
 
@@ -94,7 +96,7 @@ $id = $id ?: 'input_' . Str::random();
 
                     <button
                         type="button"
-                        class="btn btn-link"
+                        class="btn"
                         onclick="window.loadPostPreview('{{ $id }}', 'post-preview-{{ $id }}')"
                         :disabled="!isValid || isSending"
                     >
@@ -108,4 +110,8 @@ $id = $id ?: 'input_' . Str::random();
             @endif
         </div>
     </div>
+
+    @if ($richText && !$hasProvidedId)
+        <div id="post-preview-{{ $id }}"></div>
+    @endif
 </x-base.form-field>

--- a/resources/views/components/base/form/textarea.blade.php
+++ b/resources/views/components/base/form/textarea.blade.php
@@ -6,10 +6,12 @@ use Illuminate\Support\Str;
 
 @props([
     'disabled' => false,
+    'formActions' => null, // slot
     'fullWidth' => true,
     'help' => null,
     'id' => null,
     'inline' => false,
+    'isLabelVisible' => true,
     'label' => null,
     'maxlength' => 2000,
     'model' => null,
@@ -35,6 +37,7 @@ $id = $id ?: 'input_' . Str::random();
     :help="false"
     :id="$id"
     :inline="$inline"
+    :isLabelVisible="$isLabelVisible"
     :label="$label"
     :name="$name"
 >
@@ -70,7 +73,7 @@ $id = $id ?: 'input_' . Str::random();
         aria-describedby="{{ $name && $errors && $errors->has($name) ? 'error-' . $id : ($help ? 'help-' . $id : '') }}"
     >{{ $name ? old($name, $model?->getAttribute($name) ?? $value) : $value }}</textarea>
 
-    <div class="help-block text-muted md:flex justify-between items-start">
+    <div class="help-block text-muted flex justify-between items-center">
         <div>
             @if($maxlength)
                 <span class="textarea-counter" data-textarea-id="{{ $id }}">0 / {{ $maxlength }}</span>
@@ -79,18 +82,30 @@ $id = $id ?: 'input_' . Str::random();
                 <span class="ml-3">{{ $help }}</span>
             @endif
         </div>
-        <div>
-            @if($richText)
-                <x-fas-spinner id="preview-loading-icon" class="opacity-0 transition-all duration-200" aria-hidden="true" />
-                <button
-                    type="button"
-                    class="btn py-1 mt-1"
-                    onclick="window.loadPostPreview('{{ $id }}', 'post-preview-{{ $id }}')"
-                    :disabled="!isValid || isSending"
-                >{{ __('Preview') }}</button>
+
+        <div class="flex items-center gap-x-1">
+            <div>
+                @if ($richText)
+                    <x-fas-spinner
+                        id="preview-loading-icon"
+                        class="opacity-0 transition-all duration-200"
+                        aria-hidden="true"
+                    />
+
+                    <button
+                        type="button"
+                        class="btn btn-link"
+                        onclick="window.loadPostPreview('{{ $id }}', 'post-preview-{{ $id }}')"
+                        :disabled="!isValid || isSending"
+                    >
+                        {{ __('Preview') }}
+                    </button>
+                @endif
+            </div>
+
+            @if ($formActions)
+                {{ $formActions }}
             @endif
         </div>
     </div>
-
-    <div id="post-preview-{{ $id }}"></div>
 </x-base.form-field>

--- a/resources/views/components/base/form/user-select.blade.php
+++ b/resources/views/components/base/form/user-select.blade.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
     'help' => null,
     'id' => null,
     'inline' => false,
+    'isLabelVisible' => true,
     'label' => null,
     'model' => null,
     'name' => 'username',
@@ -77,6 +78,7 @@ $(function () {
     :help="$help"
     :id="$id"
     :inline="$inline"
+    :isLabelVisible="$isLabelVisible"
     :label="$label"
     :name="$name"
 >

--- a/resources/views/pages-legacy/createtopic.blade.php
+++ b/resources/views/pages-legacy/createtopic.blade.php
@@ -42,17 +42,22 @@ $thisCategoryName = htmlentities($forumData['CategoryName']);
                 <x-base.form.input label="{{ __res('author', 1) }}" value="{{ $user }}" inline readonly :fullWidth="false" />
                 <x-base.form.input name="title" inline />
                 <x-base.form.textarea
+                    id="input_compose"
                     maxlength="60000"
                     name="body"
                     rows="22"
-                    help="Don't share links to copyrighted ROMs."
                     placeholder="Don't share links to copyrighted ROMs."
                     inline
                     required-silent
                     richText
-                />
-                <x-base.form-actions submitLabel="Submit new topic" inline />
+                >
+                    <x-slot name="formActions">
+                        <x-base.form-actions />
+                    </x-slot>
+                </x-base.form.textarea>
             </div>
         </x-base.form>
+
+        <div id="post-preview-input_compose"></div>
     </x-section>
 </x-app-layout>

--- a/resources/views/pages-legacy/editpost.blade.php
+++ b/resources/views/pages-legacy/editpost.blade.php
@@ -59,19 +59,24 @@ $thisAuthor = $commentData['Author'];
                 <x-base.form.input label="{{ __res('author', 1) }}" readonly value="{{ $thisAuthor }}" inline :fullWidth="false" />
                 <x-base.form.input label="{{ __res('forum-topic', 1) }}" readonly value="{{ $thisTopicTitle }}" inline />
                 <x-base.form.textarea
+                    id="input_compose"
                     label="{{ __res('message', 1)}} "
                     value="{{ $commentData['Payload'] }}"
                     maxlength="60000"
                     name="body"
                     rows="22"
-                    help="Don't share links to copyrighted ROMs."
                     placeholder="Don't share links to copyrighted ROMs."
                     inline
                     required-silent
                     richText
-                />
-                <x-base.form-actions inline />
+                >
+                    <x-slot name="formActions">
+                        <x-base.form-actions />
+                    </x-slot>
+                </x-base.form.textarea>
             </div>
         </x-base.form>
+
+        <div id="post-preview-input_compose"></div>
     </x-section>
 </x-app-layout>

--- a/resources/views/pages-legacy/viewtopic.blade.php
+++ b/resources/views/pages-legacy/viewtopic.blade.php
@@ -197,36 +197,42 @@ $isSubscribed = isUserSubscribedToForumTopic($thisTopicID, $userID);
     ?>
     @if ($thisTopicID != 0 && $user?->hasVerifiedEmail())
         <x-section>
-            <div class="flex w-full bg-embed p-2 rounded-lg">
+            <div class="flex bg-embed p-2 rounded-lg -mx-2 w-[calc(100%+16px)] sm:mx-0 sm:w-full">
                 @guest
                     You must log in before you can join this conversation.
                 @endguest
 
                 @auth
-                    <div class="flex flex-col gap-1 justify-start items-center lg:border-r border-neutral-700 px-0.5 pb-2 lg:py-2 lg:w-44">
-                        <x-user.avatar :user="request()->user()" display="icon" iconSize="md" />
+                    <div class="hidden sm:flex flex-col gap-1 justify-start items-center lg:border-r border-neutral-700 px-0.5 pb-2 lg:py-2 lg:w-44">
+                        <x-user.avatar :user="request()->user()" display="icon" iconSize="md" class="rounded-sm" />
                         <x-user.avatar :user="request()->user()" />
                     </div>
                     <div class="grow lg:py-0 px-1 lg:px-6 pt-2 pb-4">
                         <x-base.form action="{{ url('request/forum-topic-comment/create.php') }}" validate>
-                            <div class="flex flex-col gap-y-3">
+                            <div class="flex flex-col">
                                 <x-base.form.input type="hidden" name="topic" value="{{ $thisTopicID }}" />
                                 <x-base.form.textarea
+                                    :isLabelVisible="false"
+                                    id="input_quickreply"
                                     label="{{ __('Reply') }}"
                                     maxlength="60000"
                                     name="body"
                                     rows="10"
                                     richText
                                     required-silent
-                                    help="Don't share links to copyrighted ROMs."
                                     placeholder="Don't share links to copyrighted ROMs."
-                                />
-                                <x-base.form-actions submitLabel="Submit reply" />
+                                >
+                                    <x-slot name="primaryButton">
+                                        <x-base.form-actions submitLabel="Submit" />
+                                    </x-slot>
+                                </x-base.form.textarea>
                             </div>
                         </x-base.form>
                     </div>
                 @endauth
             </div>
+
+            <div id="post-preview-input_quickreply"></div>
         </x-section>
     @endif
 </x-app-layout>

--- a/resources/views/pages-legacy/viewtopic.blade.php
+++ b/resources/views/pages-legacy/viewtopic.blade.php
@@ -222,7 +222,7 @@ $isSubscribed = isUserSubscribedToForumTopic($thisTopicID, $userID);
                                     required-silent
                                     placeholder="Don't share links to copyrighted ROMs."
                                 >
-                                    <x-slot name="primaryButton">
+                                    <x-slot name="formActions">
                                         <x-base.form-actions submitLabel="Submit" />
                                     </x-slot>
                                 </x-base.form.textarea>

--- a/resources/views/pages/message-thread/[messageThread].blade.php
+++ b/resources/views/pages/message-thread/[messageThread].blade.php
@@ -102,17 +102,24 @@ $pageDescription = "Conversation between " . implode(' and ', $participants);
                     <div class="flex flex-col gap-y-3">
                         <input type="hidden" name="thread_id" value="{{ $messageThread->id }}"/>
                         <x-base.form.textarea
+                            :isLabelVisible="false"
+                            id="input_compose"
                             name="body"
                             label="{{ __res('message', 1) }}"
                             placeholder="Enter your message here..."
                             requiredSilent
                             richText
-                        />
-                        <x-base.form-actions />
+                        >
+                            <x-slot name="formActions">
+                                <x-base.form-actions />
+                            </x-slot>
+                        </x-base.form.textarea>
                     </div>
                 </x-base.form>
             @endif
         </div>
+
+        <div id="post-preview-input_compose"></div>
     </x-section>
 
     <div class="w-full flex justify-end mt-2">

--- a/resources/views/pages/messages/create.blade.php
+++ b/resources/views/pages/messages/create.blade.php
@@ -30,15 +30,21 @@ $message = request()->input('message') ?? '';
                 <x-base.form.user-select name="recipient" value="{{ $toUser }}" requiredSilent inline />
                 <x-base.form.input name="title" label="{{ __('Subject') }}" requiredSilent inline />
                 <x-base.form.textarea
+                    id="input_compose"
                     name="body"
                     requiredSilent
                     inline
                     richText
                     maxlength="60000"
                     placeholder="Enter your message here..."
-                />
-                <x-base.form-actions inline />
+                >
+                    <x-slot name="formActions">
+                        <x-base.form-actions />
+                    </x-slot>
+                </x-base.form.textarea>
             </div>
         </x-base.form>
+
+        <div id="post-preview-input_compose"></div>
     </x-section>
 </x-app-layout>


### PR DESCRIPTION
Modifies the reply UI for forums & messages to resolve some layout issues, especially on mobile.

**Before**
![Screenshot 2024-03-15 at 5 35 30 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/e9e0e176-6df5-496d-9fd5-5d8b2be6db3f)

![Screenshot 2024-03-15 at 5 35 21 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/cb655dbb-2aeb-4288-bb6f-13fd6ecd8811)

**After**
![Screenshot 2024-03-15 at 5 34 13 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/879ba39f-3d67-400d-be3e-b9c65ed4e5c6)

![Screenshot 2024-03-15 at 5 34 25 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/76f0b7e9-8fb3-410d-b02c-29ca0389d630)
