### PR TITLE
fix(SystemController): allow viewing 'Events' games

### DIFF
--- a/app/Platform/Controllers/SystemController.php
+++ b/app/Platform/Controllers/SystemController.php
@@ -111,7 +111,7 @@ class SystemController extends Controller
         $totalUnfilteredCount = count($gameIds);
 
         $this->gameListService->initializeUserProgress($loggedInUser, $gameIds);
-        $this->gameListService->initializeGameList($gameIds);
+        $this->gameListService->initializeGameList($gameIds, $system->id === System::Events);
 
         $this->gameListService->filterGameList(function ($game) use ($filterOptions) {
             return $this->usePopulatedFilter($game, $filterOptions['populated']);

--- a/app/Platform/Services/GameListService.php
+++ b/app/Platform/Services/GameListService.php
@@ -40,7 +40,7 @@ class GameListService
         $this->initializeUserAwards($user, $gameIds);
     }
 
-    public function initializeGameList(array $gameIds): void
+    public function initializeGameList(array $gameIds, bool $allowNonGameSystems = false): void
     {
         if ($this->withTicketCounts) {
             $gameTicketsList = Ticket::whereIn('ReportState', [TicketState::Open, TicketState::Request])
@@ -62,19 +62,22 @@ class GameListService
             $gameTicketsList = [];
         }
 
-        $gameModels = Game::whereIn('ID', $gameIds)
-            ->whereNotIn('ConsoleID', System::getNonGameSystems())
+        $gameModelsQuery = Game::whereIn('ID', $gameIds)
             ->orderBy('Title')
             ->select([
                 'ID', 'Title', 'ImageIcon', 'ConsoleID', 'players_total',
                 'achievements_published', 'points_total', 'TotalTruePoints',
             ]);
 
-        if ($this->withLeaderboardCounts) {
-            $gameModels = $gameModels->withCount('leaderboards');
+        if (!$allowNonGameSystems) {
+            $gameModelsQuery->whereNotIn('ConsoleID', System::getNonGameSystems());
         }
 
-        $gameModels = $gameModels->get();
+        if ($this->withLeaderboardCounts) {
+            $gameModelsQuery->withCount('leaderboards');
+        }
+
+        $gameModels = $gameModelsQuery->get();
 
         $this->consoles = System::whereIn('ID', $gameModels->pluck('ConsoleID')->unique())
             ->orderBy('Name')


### PR DESCRIPTION
Resolves an issue where visiting the `/system/101/games` route returns no results.

**Before**
![Screenshot 2024-03-15 at 5 54 13 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/cb870c3c-0688-4b57-907b-0f41fd2fc155)


**After**
![Screenshot 2024-03-15 at 5 54 16 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/60031094-2f4d-4749-b5b2-9cffb5e260cd)
