### PR TITLE
refactor(MemoryNote): rename AuthorID to user_id, add foreign key

### DIFF
--- a/app/Helpers/database/code-note.php
+++ b/app/Helpers/database/code-note.php
@@ -10,7 +10,7 @@ function getCodeNotesData(int $gameID): array
 
     $query = "SELECT ua.User, cn.Address, cn.Note
               FROM CodeNotes AS cn
-              LEFT JOIN UserAccounts AS ua ON ua.ID = cn.AuthorID
+              LEFT JOIN UserAccounts AS ua ON ua.ID = cn.user_id
               WHERE cn.GameID = '$gameID'
               ORDER BY cn.Address ";
 
@@ -32,7 +32,7 @@ function getCodeNotes(int $gameID, ?array &$codeNotesOut): bool
 {
     $query = "SELECT ua.User, cn.Address, cn.Note
               FROM CodeNotes AS cn
-              LEFT JOIN UserAccounts AS ua ON ua.ID = cn.AuthorID
+              LEFT JOIN UserAccounts AS ua ON ua.ID = cn.user_id
               WHERE cn.GameID = $gameID
               ORDER BY cn.Address ";
 
@@ -90,7 +90,7 @@ function submitCodeNote2(string $username, int $gameID, int $address, string $no
             'Address' => $address,
         ],
         [
-            'AuthorID' => $user->ID,
+            'user_id' => $user->ID,
             'Note' => $note,
         ]
     );
@@ -109,12 +109,12 @@ function getCodeNoteCounts(string $username): array
 
     $retVal = [];
     $query = "SELECT gd.Title as GameTitle, gd.ImageIcon as GameIcon, c.Name as ConsoleName, cn.GameID as GameID, COUNT(cn.GameID) as TotalNotes,
-              SUM(CASE WHEN cn.AuthorID = $userId THEN 1 ELSE 0 END) AS NoteCount
+              SUM(CASE WHEN cn.user_id = $userId THEN 1 ELSE 0 END) AS NoteCount
               FROM CodeNotes AS cn
               LEFT JOIN GameData AS gd ON gd.ID = cn.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
               WHERE LENGTH(Note) > 0
-              AND gd.ID IN (SELECT GameID from CodeNotes WHERE AuthorID = $userId GROUP BY GameID)
+              AND gd.ID IN (SELECT GameID from CodeNotes WHERE user_id = $userId GROUP BY GameID)
               AND gd.Title IS NOT NULL
               GROUP BY GameID, GameTitle
               HAVING NoteCount > 0

--- a/app/Models/MemoryNote.php
+++ b/app/Models/MemoryNote.php
@@ -14,7 +14,6 @@ class MemoryNote extends BaseModel
 
     // TODO rename CodeNotes table to memory_notes
     // TODO rename Address column to address
-    // TODO rename AuthorID column to user_id
     // TODO rename Note column to body
     // TODO rename Created column to created_at
     // TODO rename Updated column to updated_at
@@ -25,7 +24,7 @@ class MemoryNote extends BaseModel
     public const UPDATED_AT = 'Updated';
 
     protected $fillable = [
-        'AuthorID',
+        'user_id',
         'GameID',
         'Address',
         'Note',

--- a/app/Platform/Concerns/ActsAsDeveloper.php
+++ b/app/Platform/Concerns/ActsAsDeveloper.php
@@ -32,7 +32,7 @@ trait ActsAsDeveloper
      */
     public function authoredCodeNotes(): HasMany
     {
-        return $this->hasMany(MemoryNote::class, 'AuthorID', 'ID')->where('Note', '!=', '');
+        return $this->hasMany(MemoryNote::class, 'user_id', 'ID')->where('Note', '!=', '');
     }
 
     /**

--- a/database/migrations/platform/2024_03_16_000000_update_codenotes_table.php
+++ b/database/migrations/platform/2024_03_16_000000_update_codenotes_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('CodeNotes', function (Blueprint $table) {
+            $table->renameColumn('AuthorID', 'user_id');
+        });
+
+        Schema::table('CodeNotes', function (Blueprint $table) {
+            $table->foreign('user_id')->references('ID')->on('UserAccounts')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('CodeNotes', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+        });
+
+        Schema::table('CodeNotes', function (Blueprint $table) {
+            $table->renameColumn('user_id', 'AuthorID');
+        });
+    }
+};

--- a/resources/views/components/game/claim-info.blade.php
+++ b/resources/views/components/game/claim-info.blade.php
@@ -81,7 +81,7 @@ if ($userPermissions >= Permissions::Moderator) {
             }
 
             $note = MemoryNote::where('GameID', $gameId)
-                ->join('UserAccounts', 'UserAccounts.ID', '=', 'AuthorID')
+                ->join('UserAccounts', 'UserAccounts.ID', '=', 'user_id')
                 ->where('UserAccounts.User', '=', $claim['User'])
                 ->select(DB::raw('MAX(CodeNotes.Updated) AS last_updated'))
                 ->first();


### PR DESCRIPTION
Sorry, I'm going to have a few of these 😅

This PR renames `AuthorID` to `user_id` in the `CodeNotes` table. Additionally, `AuthorID` was missing a FK relationship to the `UserAccounts` table. The migration introduced in this branch adds this relationship.