### PR TITLE
refactor(Comment): rename UserID to user_id, add foreign key

### DIFF
--- a/app/Helpers/database/search.php
+++ b/app/Helpers/database/search.php
@@ -139,7 +139,7 @@ function performSearch(
 
     if ($articleTypes !== []) {
         $counts[] = "SELECT COUNT(*) AS Count FROM Comment AS c
-            LEFT JOIN UserAccounts AS cua ON cua.ID=c.UserID
+            LEFT JOIN UserAccounts AS cua ON cua.ID=c.user_id
             LEFT JOIN UserAccounts AS ua ON ua.ID=c.ArticleID AND c.articletype=" . ArticleType::User . "
             WHERE c.Payload LIKE '%$searchQuery%'
             AND cua.User != 'Server' AND c.articletype IN (" . implode(',', $articleTypes) . ")
@@ -173,7 +173,7 @@ function performSearch(
                 ELSE CONCAT( '...', MID( c.Payload, GREATEST( LOCATE('$searchQuery', c.Payload)-25, 1), 60 ), '...' )
             END AS Title
             FROM Comment AS c
-            LEFT JOIN UserAccounts AS cua ON cua.ID=c.UserID
+            LEFT JOIN UserAccounts AS cua ON cua.ID=c.user_id
             LEFT JOIN UserAccounts AS ua ON ua.ID=c.ArticleID AND c.articletype in (" . ArticleType::User . "," . ArticleType::UserModeration . ")
             WHERE c.Payload LIKE '%$searchQuery%'
             AND cua.User != 'Server' AND c.articletype IN (" . implode(',', $articleTypes) . ")

--- a/app/Helpers/database/subscription.php
+++ b/app/Helpers/database/subscription.php
@@ -237,7 +237,7 @@ function getSubscribersOfArticle(
     $qry = "
         SELECT DISTINCT _ua.*
         FROM Comment AS _c
-        INNER JOIN UserAccounts as _ua ON _ua.ID = _c.UserID
+        INNER JOIN UserAccounts as _ua ON _ua.ID = _c.user_id
         WHERE _c.ArticleType = $articleType
               AND _c.ArticleID = $articleID
               $websitePrefsFilter
@@ -284,11 +284,11 @@ function isUserSubscribedToArticleComments(int $articleType, int $articleID, int
             SELECT DISTINCT ua.*
             FROM
                 Comment AS c
-                LEFT JOIN UserAccounts AS ua ON ua.ID = c.UserID
+                LEFT JOIN UserAccounts AS ua ON ua.ID = c.user_id
             WHERE
                 c.ArticleType = $articleType
                 AND c.ArticleID = $articleID
-                AND c.UserID = $userID
+                AND c.user_id = $userID
         "
     );
 }

--- a/app/Helpers/database/user-activity.php
+++ b/app/Helpers/database/user-activity.php
@@ -24,7 +24,7 @@ function RemoveComment(int $commentID, int $userID, int $permissions): bool
     // if not UserWall's owner nor admin, check if it's the author
     // TODO use policies to explicitly determine ability to delete a comment instead of piggy-backing query specificity
     if ($articleID != $userID && $permissions < Permissions::Moderator) {
-        $query .= " AND UserID = $userID";
+        $query .= " AND user_id = $userID";
     }
 
     $db = getMysqliConnection();
@@ -43,7 +43,7 @@ function getIsCommentDoublePost(int $userID, array|int $articleID, string $comme
 {
     $query = "SELECT Comment.Payload, Comment.ArticleID
         FROM Comment
-        WHERE UserID = :userId
+        WHERE user_id = :userId
         ORDER BY Comment.Submitted DESC
         LIMIT 1";
 
@@ -92,7 +92,7 @@ function addArticleComment(
         $articleIDs = $articleID;
         $arrayCount = count($articleID);
         $count = 0;
-        $query = "INSERT INTO Comment (ArticleType, ArticleID, UserID, Payload) VALUES";
+        $query = "INSERT INTO Comment (ArticleType, ArticleID, user_id, Payload) VALUES";
         foreach ($articleID as $id) {
             $bindings['commentPayload' . $count] = $commentPayload;
             $query .= "( $articleType, $id, $userID, :commentPayload$count )";
@@ -101,7 +101,7 @@ function addArticleComment(
             }
         }
     } else {
-        $query = "INSERT INTO Comment (ArticleType, ArticleID, UserID, Payload) VALUES( $articleType, $articleID, $userID, :commentPayload)";
+        $query = "INSERT INTO Comment (ArticleType, ArticleID, user_id, Payload) VALUES( $articleType, $articleID, $userID, :commentPayload)";
         $bindings = ['commentPayload' => $commentPayload];
         $articleIDs = [$articleID];
     }
@@ -111,7 +111,7 @@ function addArticleComment(
     // Inform Subscribers of this comment:
     foreach ($articleIDs as $id) {
         $query = "SELECT MAX(ID) AS CommentID FROM Comment
-                  WHERE ArticleType=$articleType AND ArticleID=$id AND UserID=$userID";
+                  WHERE ArticleType=$articleType AND ArticleID=$id AND user_id=$userID";
         $commentID = legacyDbFetch($query)['CommentID'];
 
         informAllSubscribersAboutActivity($articleType, $id, $user, $commentID, $onBehalfOfUser);
@@ -206,11 +206,11 @@ function getArticleComments(
     $numArticleComments = 0;
     $order = $recent ? ' DESC' : '';
 
-    $query = "SELECT SQL_CALC_FOUND_ROWS ua.User, ua.RAPoints, ua.banned_at, c.ID, c.UserID,
+    $query = "SELECT SQL_CALC_FOUND_ROWS ua.User, ua.RAPoints, ua.banned_at, c.ID, c.user_id,
                      c.Payload AS CommentPayload,
                      UNIX_TIMESTAMP(c.Submitted) AS Submitted, c.Edited
               FROM Comment AS c
-              LEFT JOIN UserAccounts AS ua ON ua.ID = c.UserID
+              LEFT JOIN UserAccounts AS ua ON ua.ID = c.user_id
               WHERE c.ArticleType=$articleTypeID AND c.ArticleID=$articleID
               ORDER BY c.Submitted$order, c.ID$order
               LIMIT $offset, $count";

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -19,7 +19,6 @@ class Comment extends BaseModel
 
     // TODO rename Comment table to comments
     // TODO rename ID column id
-    // TODO rename UserID column to user_id
     // TODO drop ArticleType, migrate to commentable_type (morph map)
     // TODO drop ArticleID, migrate to commentable_id
     // TODO rename Payload to body or payload
@@ -95,6 +94,6 @@ class Comment extends BaseModel
      */
     public function user(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'UserID')->withDefault(['username' => 'Deleted User']);
+        return $this->belongsTo(User::class, 'user_id', 'ID')->withDefault(['username' => 'Deleted User']);
     }
 }

--- a/database/migrations/community/2024_03_16_000001_update_comment_table.php
+++ b/database/migrations/community/2024_03_16_000001_update_comment_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('Comment', function (Blueprint $table) {
+            $table->renameColumn('UserID', 'user_id');
+        });
+
+        Schema::table('Comment', function (Blueprint $table) {
+            $table->foreign('user_id')->references('ID')->on('UserAccounts')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('Comment', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+        });
+
+        Schema::table('Comment', function (Blueprint $table) {
+            $table->renameColumn('user_id', 'UserID');
+        });
+    }
+};


### PR DESCRIPTION
**BEFORE EXECUTING THE MIGRATION, YOU MUST RUN:**
```sql
DELETE FROM Comment WHERE NOT EXISTS (
  SELECT 1 FROM UserAccounts WHERE ID = Comment.UserID
);
```

---

This PR renames `UserID` to `user_id` in the `Comment` table. Additionally, `UserID` was missing a FK relationship to the `UserAccounts` table. The migration introduced in this branch adds this relationship.