### PR TITLE
refactor(Ticket): rename reporter/resolver user columns and add foreign keys

### DIFF
--- a/app/Helpers/database/ticket.php
+++ b/app/Helpers/database/ticket.php
@@ -117,7 +117,7 @@ function _createTicket(User $user, int $achID, int $reportType, ?int $hardcore, 
     $userId = $user->ID;
     $username = $user->User;
 
-    $query = "INSERT INTO Ticket (AchievementID, ReportedByUserID, ReportType, Hardcore, ReportNotes, ReportedAt, ResolvedAt, ResolvedByUserID )
+    $query = "INSERT INTO Ticket (AchievementID, reporter_id, ReportType, Hardcore, ReportNotes, ReportedAt, ResolvedAt, resolver_id )
               VALUES($achID, $userId, $reportType, $hardcoreValue, \"$noteSanitized\", NOW(), NULL, NULL )";
 
     $db = getMysqliConnection();
@@ -179,7 +179,7 @@ $bugReportDetails";
 function getExistingTicketID(User $user, int $achievementID): int
 {
     $userID = $user->ID;
-    $query = "SELECT ID FROM Ticket WHERE ReportedByUserID=$userID AND AchievementID=$achievementID"
+    $query = "SELECT ID FROM Ticket WHERE reporter_id=$userID AND AchievementID=$achievementID"
            . " AND ReportState NOT IN (" . TicketState::Closed . "," . TicketState::Resolved . ")";
     $dbResult = s_mysql_query($query);
     if ($dbResult) {
@@ -283,8 +283,8 @@ function getAllTickets(
               LEFT JOIN Achievements AS ach ON ach.ID = tick.AchievementID
               LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-              LEFT JOIN UserAccounts AS ua ON ua.ID = tick.ReportedByUserID
-              LEFT JOIN UserAccounts AS ua2 ON ua2.ID = tick.ResolvedByUserID
+              LEFT JOIN UserAccounts AS ua ON ua.ID = tick.reporter_id
+              LEFT JOIN UserAccounts AS ua2 ON ua2.ID = tick.resolver_id
               $devJoin
               WHERE $innerCond $achFlagCond $stateCond $modeCond $reportTypeCond $hashCond $emulatorCond $devActiveCond $notAuthorCond $notReporterCond $progressionCond
               ORDER BY tick.ID DESC
@@ -302,8 +302,8 @@ function getTicket(int $ticketID): ?array
               LEFT JOIN Achievements AS ach ON ach.ID = tick.AchievementID
               LEFT JOIN GameData AS gd ON gd.ID = ach.GameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID
-              LEFT JOIN UserAccounts AS ua ON ua.ID = tick.ReportedByUserID
-              LEFT JOIN UserAccounts AS ua2 ON ua2.ID = tick.ResolvedByUserID
+              LEFT JOIN UserAccounts AS ua ON ua.ID = tick.reporter_id
+              LEFT JOIN UserAccounts AS ua2 ON ua2.ID = tick.resolver_id
               WHERE tick.ID = $ticketID
               ";
 
@@ -319,9 +319,9 @@ function updateTicket(string $user, int $ticketID, int $ticketVal, ?string $reas
 
     $resolvedFields = "";
     if ($ticketVal == TicketState::Resolved || $ticketVal == TicketState::Closed) {
-        $resolvedFields = ", ResolvedAt=NOW(), ResolvedByUserID=$userID ";
+        $resolvedFields = ", ResolvedAt=NOW(), resolver_id=$userID ";
     } elseif ($ticketData['ReportState'] == TicketState::Resolved || $ticketData['ReportState'] == TicketState::Closed) {
-        $resolvedFields = ", ResolvedAt=NULL, ResolvedByUserID=NULL ";
+        $resolvedFields = ", ResolvedAt=NULL, resolver_id=NULL ";
     }
 
     $query = "UPDATE Ticket
@@ -411,7 +411,7 @@ function countRequestTicketsByUser(?User $user = null): int
 
     return Cache::remember($cacheKey, Carbon::now()->addHours(20), function () use ($user) {
         return Ticket::where('ReportState', TicketState::Request)
-            ->where('ReportedByUserID', $user->ID)
+            ->where('reporter_id', $user->ID)
             ->count();
     });
 }
@@ -525,14 +525,14 @@ function countOpenTickets(
     $reporterJoin = "";
     $notReporterCond = getNotReporterCondition($ticketFilters);
     if ($notReporterCond != "") {
-        $reporterJoin = "LEFT JOIN UserAccounts AS ua ON ua.ID = tick.ReportedByUserID";
+        $reporterJoin = "LEFT JOIN UserAccounts AS ua ON ua.ID = tick.reporter_id";
     }
 
     // Not Author condition
     $resolverJoin = "";
     $notAuthorCond = getNotAuthorCondition($ticketFilters);
     if ($notAuthorCond != "" || $notReporterCond != "") {
-        $resolverJoin = "LEFT JOIN UserAccounts AS ua2 ON ua2.ID = tick.ResolvedByUserID AND tick.ReportState IN (" . TicketState::Closed . "," . TicketState::Resolved . ")";
+        $resolverJoin = "LEFT JOIN UserAccounts AS ua2 ON ua2.ID = tick.resolver_id AND tick.ReportState IN (" . TicketState::Closed . "," . TicketState::Resolved . ")";
     }
 
     // Author condition
@@ -545,7 +545,7 @@ function countOpenTickets(
     // Reporter condition
     $reporterCond = "";
     if ($reportedByUser != null) {
-        $reporterJoin = "LEFT JOIN UserAccounts AS ua ON ua.ID = tick.ReportedByUserID";
+        $reporterJoin = "LEFT JOIN UserAccounts AS ua ON ua.ID = tick.reporter_id";
         $reporterCond = " AND ua.User = :reportedByUsername";
         $bindings['reportedByUsername'] = $reportedByUser;
     }
@@ -555,7 +555,7 @@ function countOpenTickets(
     if ($resolvedByUser != null) {
         $resolverCond = " AND ua2.User = :resolvedByUsername";
         $bindings['resolvedByUsername'] = $resolvedByUser;
-        $resolverJoin = "LEFT JOIN UserAccounts AS ua2 ON ua2.ID = tick.ResolvedByUserID AND tick.ReportState IN (" . TicketState::Closed . "," . TicketState::Resolved . ")";
+        $resolverJoin = "LEFT JOIN UserAccounts AS ua2 ON ua2.ID = tick.resolver_id AND tick.ReportState IN (" . TicketState::Closed . "," . TicketState::Resolved . ")";
     }
 
     // Progression condition
@@ -929,11 +929,11 @@ function getUserWhoCreatedMostTickets(string $user): ?array
 
     $query = "SELECT ua.User as TicketCreator, COUNT(*) as TicketCount
               FROM Ticket AS t
-              LEFT JOIN UserAccounts as ua ON ua.ID = t.ReportedByUserID
+              LEFT JOIN UserAccounts as ua ON ua.ID = t.reporter_id
               LEFT JOIN Achievements as a ON a.ID = t.AchievementID
               WHERE a.Author = '$user'
               AND t.ReportState != " . TicketState::Closed . "
-              GROUP BY t.ReportedByUserID
+              GROUP BY t.reporter_id
               ORDER BY TicketCount DESC
               LIMIT 1";
 
@@ -957,8 +957,8 @@ function getNumberOfTicketsClosedForOthers(string $user): array
               SUM(CASE WHEN t.ReportState = " . TicketState::Closed . " THEN 1 ELSE 0 END) AS ClosedCount,
               SUM(CASE WHEN t.ReportState = " . TicketState::Resolved . " THEN 1 ELSE 0 END) AS ResolvedCount
               FROM Ticket AS t
-              LEFT JOIN UserAccounts as ua ON ua.ID = t.ReportedByUserID
-              LEFT JOIN UserAccounts as ua2 ON ua2.ID = t.ResolvedByUserID
+              LEFT JOIN UserAccounts as ua ON ua.ID = t.reporter_id
+              LEFT JOIN UserAccounts as ua2 ON ua2.ID = t.resolver_id
               LEFT JOIN Achievements as a ON a.ID = t.AchievementID
               WHERE t.ReportState IN (" . TicketState::Closed . "," . TicketState::Resolved . ")
               AND ua.User NOT LIKE '$user'
@@ -990,8 +990,8 @@ function getNumberOfTicketsClosed(string $user): array
               SUM(CASE WHEN t.ReportState = " . TicketState::Closed . " THEN 1 ELSE 0 END) AS ClosedCount,
               SUM(CASE WHEN t.ReportState = " . TicketState::Resolved . " THEN 1 ELSE 0 END) AS ResolvedCount
               FROM Ticket AS t
-              LEFT JOIN UserAccounts as ua ON ua.ID = t.ReportedByUserID
-              LEFT JOIN UserAccounts as ua2 ON ua2.ID = t.ResolvedByUserID
+              LEFT JOIN UserAccounts as ua ON ua.ID = t.reporter_id
+              LEFT JOIN UserAccounts as ua2 ON ua2.ID = t.resolver_id
               LEFT JOIN Achievements as a ON a.ID = t.AchievementID
               WHERE t.ReportState IN (" . TicketState::Closed . "," . TicketState::Resolved . ")
               AND ua.User NOT LIKE '$user'

--- a/app/Helpers/database/user.php
+++ b/app/Helpers/database/user.php
@@ -280,7 +280,7 @@ function GetDeveloperStatsFull(int $count, int $offset = 0, int $sortBy = 0, int
     } elseif ($sortBy == 4) { // TicketsResolvedForOthers DESC
         $query = "SELECT ua.ID, SUM(!ISNULL(ach.ID)) as total
                   FROM UserAccounts as ua
-                  LEFT JOIN Ticket tick ON tick.ResolvedByUserID = ua.ID AND tick.ReportState = 2 AND tick.ResolvedByUserID != tick.ReportedByUserID
+                  LEFT JOIN Ticket tick ON tick.resolver_id = ua.ID AND tick.ReportState = 2 AND tick.resolver_id != tick.reporter_id
                   LEFT JOIN Achievements as ach ON ach.ID = tick.AchievementID AND ach.flags = 3 AND ach.Author != ua.User
                   WHERE $stateCond
                   GROUP BY ua.ID
@@ -338,9 +338,9 @@ function GetDeveloperStatsFull(int $count, int $offset = 0, int $sortBy = 0, int
     // merge in tickets resolved for others
     $query = "SELECT ua.ID, COUNT(*) as total
               FROM Ticket AS tick
-              INNER JOIN UserAccounts as ua ON ua.ID = tick.ResolvedByUserID
+              INNER JOIN UserAccounts as ua ON ua.ID = tick.resolver_id
               INNER JOIN Achievements as ach ON ach.ID = tick.AchievementID
-              WHERE tick.ResolvedByUserID != tick.ReportedByUserID
+              WHERE tick.resolver_id != tick.reporter_id
               AND ach.Author != ua.User
               AND ach.Flags = 3
               AND tick.ReportState = 2

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -19,12 +19,10 @@ class Ticket extends BaseModel
 
     // TODO rename Ticket table to tickets
     // TODO rename ID column to id
-    // TODO rename ReportedByUserID column to reporter_id
     // TODO rename ReportType column to type
     // TODO rename ReportNotes column to body
     // TODO rename ReportedAt column to created_at
     // TODO rename ResolvedAt column to resolved_at
-    // TODO rename ResolvedByUserID column to resolver_id
     // TODO rename ReportState column to state
     // TODO rename Updated column to updated_at
     // TODO drop AchievementID, use ticketable morph instead
@@ -73,6 +71,22 @@ class Ticket extends BaseModel
     public function achievement(): BelongsTo
     {
         return $this->belongsTo(Achievement::class, 'AchievementID');
+    }
+
+    /**
+     * @return BelongsTo<User, Ticket>
+     */
+    public function reporter(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reporter_id', 'ID');
+    }
+
+    /**
+     * @return BelongsTo<User, Ticket>
+     */
+    public function resolver(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'resolver_id', 'ID');
     }
 
     // == scopes

--- a/app/Platform/Concerns/ActsAsDeveloper.php
+++ b/app/Platform/Concerns/ActsAsDeveloper.php
@@ -7,6 +7,7 @@ namespace App\Platform\Concerns;
 use App\Models\Achievement;
 use App\Models\Leaderboard;
 use App\Models\MemoryNote;
+use App\Models\Ticket;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 trait ActsAsDeveloper
@@ -41,6 +42,14 @@ trait ActsAsDeveloper
     public function authoredLeaderboards(): HasMany
     {
         return $this->hasMany(Leaderboard::class, 'Author', 'User');
+    }
+
+    /**
+     * @return HasMany<Ticket>
+     */
+    public function resolvedTickets(): HasMany
+    {
+        return $this->hasMany(Ticket::class, 'resolver_id', 'ID');
     }
 
     // == scopes

--- a/app/Platform/Concerns/ActsAsPlayer.php
+++ b/app/Platform/Concerns/ActsAsPlayer.php
@@ -44,7 +44,7 @@ trait ActsAsPlayer
 
     public function hasPlayed(Game $game): bool
     {
-        return $this->playerGame($game)->exists();
+        return $this->playerGames()->where('game_id', $game->id)->exists();
     }
 
     public function playerGame(Game $game): ?PlayerGame

--- a/database/migrations/community/2024_03_16_000001_update_ticket_table.php
+++ b/database/migrations/community/2024_03_16_000001_update_ticket_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('Ticket', function (Blueprint $table) {
+            $table->renameColumn('ReportedByUserID', 'reporter_id');
+        });
+        Schema::table('Ticket', function (Blueprint $table) {
+            $table->renameColumn('ResolvedByUserID', 'resolver_id');
+        });
+
+        Schema::table('Ticket', function (Blueprint $table) {
+            $table->foreign('reporter_id')->references('ID')->on('UserAccounts')->onDelete('set null');
+            $table->foreign('resolver_id')->references('ID')->on('UserAccounts')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('Ticket', function (Blueprint $table) {
+            $table->dropForeign(['reporter_id']);
+            $table->dropForeign(['resolver_id']);
+        });
+
+        Schema::table('Ticket', function (Blueprint $table) {
+            $table->renameColumn('reporter_id', 'ReportedByUserID');
+        });
+        Schema::table('Ticket', function (Blueprint $table) {
+            $table->renameColumn('resolver_id', 'ResolvedByUserID');
+        });
+    }
+};

--- a/tests/Feature/Api/V1/TicketDataTest.php
+++ b/tests/Feature/Api/V1/TicketDataTest.php
@@ -29,7 +29,7 @@ class TicketDataTest extends TestCase
         /** @var Achievement $achievement */
         $achievement = Achievement::factory()->published()->create(['GameID' => $game->ID]);
         /** @var Ticket $ticket */
-        $ticket = Ticket::factory()->create(['AchievementID' => $achievement->ID, 'ReportedByUserID' => $this->user->ID]);
+        $ticket = Ticket::factory()->create(['AchievementID' => $achievement->ID, 'reporter_id' => $this->user->ID]);
 
         $this->get($this->apiUrl('GetTicketData', ['i' => $ticket->ID]))
             ->assertSuccessful()
@@ -68,7 +68,7 @@ class TicketDataTest extends TestCase
         /** @var Achievement $achievement */
         $achievement = Achievement::factory()->published()->create(['GameID' => $game->ID]);
         /** @var Ticket $ticket */
-        $ticket = Ticket::factory()->create(['AchievementID' => $achievement->ID, 'ReportedByUserID' => $this->user->ID]);
+        $ticket = Ticket::factory()->create(['AchievementID' => $achievement->ID, 'reporter_id' => $this->user->ID]);
         /** @var User $user2 */
         $user2 = User::factory()->create();
         /** @var Game $game2 */
@@ -77,7 +77,7 @@ class TicketDataTest extends TestCase
         $achievement2 = Achievement::factory()->published()->create(['GameID' => $game2->ID]);
         /** @var Ticket $ticket2 */
         $ticket2 = Ticket::factory()->create(['AchievementID' => $achievement2->ID,
-            'ReportedByUserID' => $user2->ID, 'Hardcore' => 0, 'ReportType' => TicketType::TriggeredAtWrongTime]);
+            'reporter_id' => $user2->ID, 'Hardcore' => 0, 'ReportType' => TicketType::TriggeredAtWrongTime]);
         /** @var User $user3 */
         $user3 = User::factory()->create();
         /** @var Game $game3 */
@@ -85,8 +85,8 @@ class TicketDataTest extends TestCase
         /** @var Achievement $achievement3 */
         $achievement3 = Achievement::factory()->published()->create(['GameID' => $game3->ID]);
         Ticket::factory()->create(['AchievementID' => $achievement3->ID,
-            'ReportedByUserID' => $user2->ID, 'ReportState' => TicketState::Resolved,
-            'ResolvedByUserID' => $user3->ID, 'ResolvedAt' => Carbon::now()]);
+            'reporter_id' => $user2->ID, 'ReportState' => TicketState::Resolved,
+            'resolver_id' => $user3->ID, 'ResolvedAt' => Carbon::now()]);
 
         $this->get($this->apiUrl('GetTicketData'))
             ->assertSuccessful()
@@ -159,13 +159,13 @@ class TicketDataTest extends TestCase
         $achievements3 = Achievement::factory()->published()->count(6)->create(['GameID' => $game3->ID]);
 
         for ($i = 0; $i < 1; $i++) {
-            Ticket::factory()->create(['AchievementID' => $achievements->get($i)->ID, 'ReportedByUserId' => $this->user->ID]);
+            Ticket::factory()->create(['AchievementID' => $achievements->get($i)->ID, 'reporter_id' => $this->user->ID]);
         }
         for ($i = 0; $i < 5; $i++) {
-            Ticket::factory()->create(['AchievementID' => $achievements2->get($i)->ID, 'ReportedByUserId' => $this->user->ID]);
+            Ticket::factory()->create(['AchievementID' => $achievements2->get($i)->ID, 'reporter_id' => $this->user->ID]);
         }
         for ($i = 0; $i < 3; $i++) {
-            Ticket::factory()->create(['AchievementID' => $achievements3->get($i)->ID, 'ReportedByUserId' => $this->user->ID]);
+            Ticket::factory()->create(['AchievementID' => $achievements3->get($i)->ID, 'reporter_id' => $this->user->ID]);
         }
 
         $this->get($this->apiUrl('GetTicketData', ['f' => 1]))
@@ -207,7 +207,7 @@ class TicketDataTest extends TestCase
         /** @var Achievement $achievement */
         $achievement = Achievement::factory()->published()->create(['GameID' => $game->ID, 'Author' => $this->user->User]);
         /** @var Ticket $ticket */
-        $ticket = Ticket::factory()->create(['AchievementID' => $achievement->ID, 'ReportedByUserID' => $this->user->ID]);
+        $ticket = Ticket::factory()->create(['AchievementID' => $achievement->ID, 'reporter_id' => $this->user->ID]);
         /** @var User $user2 */
         $user2 = User::factory()->create();
         /** @var Game $game2 */
@@ -216,7 +216,7 @@ class TicketDataTest extends TestCase
         $achievement2 = Achievement::factory()->published()->create(['GameID' => $game2->ID, 'Author' => $this->user->User]);
         /** @var Ticket $ticket2 */
         $ticket2 = Ticket::factory()->create(['AchievementID' => $achievement2->ID,
-            'ReportedByUserID' => $user2->ID, 'Hardcore' => 0, 'ReportType' => TicketType::TriggeredAtWrongTime]);
+            'reporter_id' => $user2->ID, 'Hardcore' => 0, 'ReportType' => TicketType::TriggeredAtWrongTime]);
         /** @var User $user3 */
         $user3 = User::factory()->create();
         /** @var Game $game3 */
@@ -224,8 +224,8 @@ class TicketDataTest extends TestCase
         /** @var Achievement $achievement3 */
         $achievement3 = Achievement::factory()->published()->create(['GameID' => $game3->ID, 'Author' => $this->user->User]);
         Ticket::factory()->create(['AchievementID' => $achievement3->ID,
-            'ReportedByUserID' => $user2->ID, 'ReportState' => TicketState::Resolved,
-            'ResolvedByUserID' => $user3->ID, 'ResolvedAt' => Carbon::now()]);
+            'reporter_id' => $user2->ID, 'ReportState' => TicketState::Resolved,
+            'resolver_id' => $user3->ID, 'ResolvedAt' => Carbon::now()]);
 
         $this->get($this->apiUrl('GetTicketData', ['u' => $this->user->User]))
             ->assertSuccessful()
@@ -253,10 +253,10 @@ class TicketDataTest extends TestCase
         $achievement2 = $achievements->get(3);
 
         /** @var Ticket $ticket */
-        $ticket = Ticket::factory()->create(['AchievementID' => $achievement1->ID, 'ReportedByUserID' => $this->user->ID]);
+        $ticket = Ticket::factory()->create(['AchievementID' => $achievement1->ID, 'reporter_id' => $this->user->ID]);
         /** @var Ticket $ticket2 */
         $ticket2 = Ticket::factory()->create(['AchievementID' => $achievement2->ID,
-            'ReportedByUserID' => $this->user->ID, 'Hardcore' => 0, 'ReportType' => TicketType::TriggeredAtWrongTime]);
+            'reporter_id' => $this->user->ID, 'Hardcore' => 0, 'ReportType' => TicketType::TriggeredAtWrongTime]);
 
         $this->get($this->apiUrl('GetTicketData', ['g' => $game->ID, 'd' => 1]))
             ->assertSuccessful()
@@ -325,12 +325,12 @@ class TicketDataTest extends TestCase
         /** @var Achievement $achievement */
         $achievement = Achievement::factory()->published()->create(['GameID' => $game->ID, 'Author' => $this->user->User]);
         /** @var Ticket $ticket */
-        $ticket = Ticket::factory()->create(['AchievementID' => $achievement->ID, 'ReportedByUserID' => $this->user->ID]);
+        $ticket = Ticket::factory()->create(['AchievementID' => $achievement->ID, 'reporter_id' => $this->user->ID]);
         /** @var User $user2 */
         $user2 = User::factory()->create();
         /** @var Ticket $ticket2 */
         $ticket2 = Ticket::factory()->create(['AchievementID' => $achievement->ID,
-            'ReportedByUserID' => $user2->ID, 'Hardcore' => 0, 'ReportType' => TicketType::TriggeredAtWrongTime]);
+            'reporter_id' => $user2->ID, 'Hardcore' => 0, 'ReportType' => TicketType::TriggeredAtWrongTime]);
 
         $this->get($this->apiUrl('GetTicketData', ['a' => $achievement->ID]))
             ->assertSuccessful()


### PR DESCRIPTION
**BEFORE RUNNING THIS MIGRATION, YOU MUST EXECUTE:**
```sql
-- Command One (this resolves around ~13 rows with integrity issues)
UPDATE Ticket
LEFT JOIN UserAccounts ON Ticket.ReportedByUserID = UserAccounts.ID
SET Ticket.ReportedByUserID = NULL
WHERE UserAccounts.ID IS NULL;

-- Command Two (this probably won't do anything)
UPDATE Ticket
LEFT JOIN UserAccounts ON Ticket.ResolvedByUserID = UserAccounts.ID
SET Ticket.ResolvedByUserID = NULL
WHERE UserAccounts.ID IS NULL;
```

This PR renames two columns on the `Ticket` table:
* `ReportedByUserID` -> `reporter_id`
* `ResolvedByUserID` -> `resolver_id`

Additionally, foreign key relationships are added between these columns to `UserAccounts.ID`.

`User` and `Ticket` models are updated so Eloquent ORM is aware of the relationships. I shuffled some existing code around in `ActsAsPlayer` just to properly organize/alphabetize things.