### PR TITLE
refactor(Subscription): rename columns and adjust primary/foreign keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Validated to run on Windows, macOS, and Linux with any of the setup options belo
 
 See [Laravel Sail documentation](https://laravel.com/docs/sail).
 
-### **[XAMPP](https://www.apachefriends.org/download.html)** (indows, Linux, macOS)
+### **[XAMPP](https://www.apachefriends.org/download.html)** (Windows, Linux, macOS)
 
 Install the XAMPP version packaged with PHP 8.2 to run an Apache web server, MySQL/MariaDB, and PHP on your system.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Validated to run on Windows, macOS, and Linux with any of the setup options belo
 
 See [Laravel Sail documentation](https://laravel.com/docs/sail).
 
-### **[XAMPP](https://www.apachefriends.org/download.html)** (Windows, Linux, macOS)
+### **[XAMPP](https://www.apachefriends.org/download.html)** (indows, Linux, macOS)
 
 Install the XAMPP version packaged with PHP 8.2 to run an Apache web server, MySQL/MariaDB, and PHP on your system.
 

--- a/app/Actions/ClearAccountDataAction.php
+++ b/app/Actions/ClearAccountDataAction.php
@@ -38,8 +38,7 @@ class ClearAccountDataAction
         DB::statement('DELETE FROM SetRequest WHERE User = :username', ['username' => $user->User]);
         // TODO $user->badges()->delete();
         DB::statement('DELETE FROM SiteAwards WHERE User = :username', ['username' => $user->User]);
-        // TODO $user->subscriptions()->delete();
-        DB::statement('DELETE FROM Subscription WHERE UserID = :userId', ['userId' => $user->ID]);
+        $user->subscriptions()->delete();
 
         // use action to delete each participation so threads with no remaing active participants get cleaned up
         $deleteMessageThreadAction = new DeleteMessageThreadAction();

--- a/app/Community/Concerns/ActsAsCommunityMember.php
+++ b/app/Community/Concerns/ActsAsCommunityMember.php
@@ -7,6 +7,7 @@ namespace App\Community\Concerns;
 use App\Community\Enums\UserRelationship;
 use App\Models\ForumTopicComment;
 use App\Models\MessageThreadParticipant;
+use App\Models\Subscription;
 use App\Models\User;
 use App\Models\UserActivity;
 use App\Models\UserComment;
@@ -123,5 +124,13 @@ trait ActsAsCommunityMember
     public function forumPosts(): HasMany
     {
         return $this->hasMany(ForumTopicComment::class, 'AuthorID', 'ID');
+    }
+
+    /**
+     * @return HasMany<Subscription>
+     */
+    public function subscriptions(): HasMany
+    {
+        return $this->hasMany(Subscription::class, 'user_id', 'ID');
     }
 }

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -5,12 +5,36 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Support\Database\Eloquent\BaseModel;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Subscription extends BaseModel
 {
-    // TODO rename Subscription to subscriptions
-    protected $table = 'Subscription';
+    protected $table = 'subscriptions';
 
-    public const CREATED_AT = 'Created';
-    public const UPDATED_AT = 'Updated';
+    protected $fillable = [
+        'subject_type',
+        'subject_id',
+        'user_id',
+        'state',
+    ];
+
+    protected $casts = [
+        'state' => 'boolean',
+    ];
+
+    // == accessors
+
+    // == mutators
+
+    // == relations
+
+    /**
+     * @return BelongsTo<User, Subscription>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id', 'ID');
+    }
+
+    // == scopes
 }

--- a/database/migrations/2012_10_03_133633_create_base_tables.php
+++ b/database/migrations/2012_10_03_133633_create_base_tables.php
@@ -633,6 +633,7 @@ return new class() extends Migration {
 
         if (!Schema::hasTable('Subscription')) {
             Schema::create('Subscription', function (Blueprint $table) {
+                $table->bigIncrements('id');
                 $table->enum('SubjectType', [
                     'ForumTopic',
                     'UserWall',
@@ -645,7 +646,7 @@ return new class() extends Migration {
                 $table->unsignedInteger('UserID');
                 $table->unsignedTinyInteger('State')->comment('Whether UserID is subscribed (1) or unsubscribed (0)');
 
-                $table->primary(['SubjectType', 'SubjectID', 'UserID']);
+                $table->unique(['SubjectType', 'SubjectID', 'UserID']);
             });
         }
 

--- a/database/migrations/platform/2024_03_17_000000_update_subscription_table.php
+++ b/database/migrations/platform/2024_03_17_000000_update_subscription_table.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        // [1] Create `id` column as the new primary key.
+        // SQLite doesn't let us change a primary key after the initial migration.
+        /** @see 2012_10_03_133633_create_base_tables.php */
+        Schema::table('Subscription', function (Blueprint $table) {
+            if (DB::connection()->getDriverName() !== 'sqlite') {
+                $table->dropPrimary(['SubjectType', 'SubjectID', 'UserID']);
+            }
+        });
+        Schema::table('Subscription', function (Blueprint $table) {
+            if (DB::connection()->getDriverName() !== 'sqlite') {
+                $table->bigIncrements('id')->first();
+            }
+        });
+
+        // [2] Rename columns to align with Laravel conventions.
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->renameColumn('SubjectType', 'subject_type');
+        });
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->renameColumn('SubjectID', 'subject_id');
+        });
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->renameColumn('UserID', 'user_id');
+        });
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->renameColumn('State', 'state');
+        });
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->renameColumn('Created', 'created_at');
+        });
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->renameColumn('Updated', 'updated_at');
+        });
+
+        // [3] Change the datatype of `user_id` to match `UserAccounts.ID`.
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->change();
+        });
+
+        // [4] Enforce a unique constraint on type, subject_id, and user_id combos.
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->unique(['type', 'subject_id', 'user_id']);
+        });
+
+        // [5] Add a foreign key to UserAccounts.
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->foreign('user_id')->references('ID')->on('UserAccounts')->onDelete('cascade');
+        });
+
+        // [6] Rename the table from `Subscription` to `subscriptions`.
+        Schema::rename('Subscription', 'subscriptions');
+    }
+
+    public function down(): void
+    {
+        // [6] Rename the table from `Subscription` to `subscriptions`.
+        Schema::rename('subscriptions', 'Subscription');
+
+        // [5] Add a foreign key to UserAccounts.
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+        });
+
+        // [4] Enforce a unique constraint on type, subject_id, and user_id combos.
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->dropUnique(['type', 'subject_id', 'user_id']);
+        });
+
+        // [3] Change the datatype of `user_id` to match `UserAccounts.ID`.
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->unsignedInteger('user_id')->change();
+        });
+
+        // [2] Rename columns to align with Laravel conventions.
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->renameColumn('subject_type', 'SubjectType');
+            $table->renameColumn('subject_id', 'SubjectID');
+            $table->renameColumn('user_id', 'UserID');
+            $table->renameColumn('state', 'State');
+            $table->renameColumn('created_at', 'Created');
+            $table->renameColumn('updated_at', 'Updated');
+        });
+
+        // [1] Create `id` column as the new primary key.
+        Schema::table('Subscription', function (Blueprint $table) {
+            $table->dropColumn('id');
+
+            $table->primary(['SubjectType', 'SubjectID', 'UserID']);
+        });
+    }
+};

--- a/database/migrations/platform/2024_03_17_000000_update_subscription_table.php
+++ b/database/migrations/platform/2024_03_17_000000_update_subscription_table.php
@@ -51,7 +51,7 @@ return new class() extends Migration {
 
         // [4] Enforce a unique constraint on type, subject_id, and user_id combos.
         Schema::table('Subscription', function (Blueprint $table) {
-            $table->unique(['type', 'subject_id', 'user_id']);
+            $table->unique(['subject_type', 'subject_id', 'user_id']);
         });
 
         // [5] Add a foreign key to UserAccounts.
@@ -75,7 +75,7 @@ return new class() extends Migration {
 
         // [4] Enforce a unique constraint on type, subject_id, and user_id combos.
         Schema::table('Subscription', function (Blueprint $table) {
-            $table->dropUnique(['type', 'subject_id', 'user_id']);
+            $table->dropUnique(['subject_type', 'subject_id', 'user_id']);
         });
 
         // [3] Change the datatype of `user_id` to match `UserAccounts.ID`.


### PR DESCRIPTION
This PR updates the `Subscription` table to get it more closely aligned with Laravel best practices.

A migration has been added which performs the following:
* Drop the combined `[SubjectType, SubjectID, UserID]` primary key.
* Add a `id` column as the new primary key.
* Rename all columns:
  * `SubjectType` -> `subject_type`
  * `SubjectID` -> `subject_id`
  * `UserID` -> `user_id`
  * `State` -> `state`
  * `Created` -> `created_at`
  * `Updated` -> `updated_at`
* Change `user_id` to an unsigned big integer.
* Add a unique constraint to `[subject_type, subject_id, user_id]`.
* Add a foreign key from `user_id` to `UserAccounts.ID`.
* Rename `Subscription` to `subscriptions`.

Additionally, the `Subscription` and `User` Eloquent models have been updated.