### PR TITLE
refactor(ForumTopic): rename AuthorID to author_id, add foreign key

### DIFF
--- a/app/Helpers/database/forum.php
+++ b/app/Helpers/database/forum.php
@@ -58,7 +58,7 @@ function getForumTopics(int $forumID, int $offset, int $count, int $permissions,
         $maxCountOut = (int) $data['COUNT(*)'];
     }
 
-    $query = "  SELECT f.Title AS ForumTitle, ft.ID AS ForumTopicID, ft.Title AS TopicTitle, LEFT( ftc2.Payload, 54 ) AS TopicPreview, ft.Author, ft.AuthorID, ft.DateCreated AS ForumTopicPostedDate, ftc.ID AS LatestCommentID, ftc.Author AS LatestCommentAuthor, ftc.AuthorID AS LatestCommentAuthorID, ftc.DateCreated AS LatestCommentPostedDate, (COUNT(ftc2.ID)-1) AS NumTopicReplies
+    $query = "  SELECT f.Title AS ForumTitle, ft.ID AS ForumTopicID, ft.Title AS TopicTitle, LEFT( ftc2.Payload, 54 ) AS TopicPreview, ft.Author, ft.author_id AS AuthorID, ft.DateCreated AS ForumTopicPostedDate, ftc.ID AS LatestCommentID, ftc.Author AS LatestCommentAuthor, ftc.AuthorID AS LatestCommentAuthorID, ftc.DateCreated AS LatestCommentPostedDate, (COUNT(ftc2.ID)-1) AS NumTopicReplies
                 FROM ForumTopic AS ft
                 LEFT JOIN ForumTopicComment AS ftc ON ftc.ID = ft.LatestCommentID
                 LEFT JOIN Forum AS f ON f.ID = ft.ForumID
@@ -90,7 +90,7 @@ function getForumTopics(int $forumID, int $offset, int $count, int $permissions,
 
 function getUnauthorisedForumLinks(): ?array
 {
-    $query = "  SELECT f.Title AS ForumTitle, ft.ID AS ForumTopicID, ft.Title AS TopicTitle, LEFT( ftc2.Payload, 60 ) AS TopicPreview, ft.Author, ft.AuthorID, ft.DateCreated AS ForumTopicPostedDate, ftc.ID AS LatestCommentID, ftc.Author AS LatestCommentAuthor, ftc.AuthorID AS LatestCommentAuthorID, ftc.DateCreated AS LatestCommentPostedDate, (COUNT(ftc2.ID)-1) AS NumTopicReplies
+    $query = "  SELECT f.Title AS ForumTitle, ft.ID AS ForumTopicID, ft.Title AS TopicTitle, LEFT( ftc2.Payload, 60 ) AS TopicPreview, ft.Author, ft.author_id AS AuthorID, ft.DateCreated AS ForumTopicPostedDate, ftc.ID AS LatestCommentID, ftc.Author AS LatestCommentAuthor, ftc.AuthorID AS LatestCommentAuthorID, ftc.DateCreated AS LatestCommentPostedDate, (COUNT(ftc2.ID)-1) AS NumTopicReplies
                 FROM ForumTopic AS ft
                 LEFT JOIN ForumTopicComment AS ftc ON ftc.ForumTopicID = ft.ID
                 LEFT JOIN Forum AS f ON f.ID = ft.ForumID
@@ -118,7 +118,7 @@ function getUnauthorisedForumLinks(): ?array
 
 function getTopicDetails(int $topicID, ?array &$topicDataOut = []): bool
 {
-    $query = "  SELECT ft.ID, ft.Author, ft.AuthorID, fc.ID AS CategoryID, fc.Name AS Category, fc.ID as CategoryID, f.ID AS ForumID, f.Title AS Forum, ft.Title AS TopicTitle, ft.RequiredPermissions
+    $query = "  SELECT ft.ID, ft.Author, ft.author_id AS AuthorID, fc.ID AS CategoryID, fc.Name AS Category, fc.ID as CategoryID, f.ID AS ForumID, f.Title AS Forum, ft.Title AS TopicTitle, ft.RequiredPermissions
                 FROM ForumTopic AS ft
                 LEFT JOIN Forum AS f ON f.ID = ft.ForumID
                 LEFT JOIN ForumCategory AS fc ON fc.ID = f.CategoryID
@@ -137,7 +137,7 @@ function getTopicDetails(int $topicID, ?array &$topicDataOut = []): bool
 
 function getSingleTopicComment(int $forumPostID, ?array &$dataOut): bool
 {
-    $query = "    SELECT ID, ForumTopicID, Payload, Author, AuthorID, DateCreated, DateModified
+    $query = "    SELECT ID, ForumTopicID, Payload, Author, author_id AS AuthorID, DateCreated, DateModified
                 FROM ForumTopicComment
                 WHERE ID=$forumPostID";
 
@@ -173,7 +173,7 @@ function submitNewTopic(
 
     // $authFlags = getUserForumPostAuth( $user );
 
-    $query = "INSERT INTO ForumTopic (ForumID, Title, Author, AuthorID, DateCreated, LatestCommentID, RequiredPermissions) VALUES ( $forumID, '$topicTitle', '$user', $userID, NOW(), 0, 0 )";
+    $query = "INSERT INTO ForumTopic (ForumID, Title, Author, author_id, DateCreated, LatestCommentID, RequiredPermissions) VALUES ( $forumID, '$topicTitle', '$user', $userID, NOW(), 0, 0 )";
 
     $db = getMysqliConnection();
     if (!mysqli_query($db, $query)) {

--- a/app/Models/ForumTopic.php
+++ b/app/Models/ForumTopic.php
@@ -24,7 +24,6 @@ class ForumTopic extends BaseModel
     // TODO rename ID column to id
     // TODO rename ForumID to forum_id
     // TODO rename Title to title
-    // TODO rename AuthorID to author_id
     // TODO rename DateCreated to created_at
     // TODO rename Updated to updated_at
     // TODO refactor RequiredPermissions to use RBAC
@@ -96,7 +95,7 @@ class ForumTopic extends BaseModel
      */
     public function user(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'AuthorID');
+        return $this->belongsTo(User::class, 'author_id', 'ID');
     }
 
     /**

--- a/database/factories/ForumTopicFactory.php
+++ b/database/factories/ForumTopicFactory.php
@@ -24,7 +24,7 @@ class ForumTopicFactory extends Factory
 
         return [
             'Title' => ucwords(fake()->words(2, true)),
-            'AuthorID' => $user->ID,
+            'author_id' => $user->ID,
         ];
     }
 }

--- a/database/migrations/community/2024_03_22_000000_update_forum_topic_table.php
+++ b/database/migrations/community/2024_03_22_000000_update_forum_topic_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('ForumTopic', function (Blueprint $table) {
+            $table->renameColumn('AuthorID', 'author_id');
+        });
+
+        Schema::table('ForumTopic', function (Blueprint $table) {
+            $table->unsignedBigInteger('author_id')->nullable()->change();
+        });
+
+        Schema::table('ForumTopic', function (Blueprint $table) {
+            $table->foreign('author_id')->references('ID')->on('UserAccounts')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ForumTopic', function (Blueprint $table) {
+            $table->dropForeign(['author_id']);
+        });
+
+        Schema::table('ForumTopic', function (Blueprint $table) {
+            $table->renameColumn('author_id', 'AuthorID');
+        });
+    }
+};


### PR DESCRIPTION
**Before the migration:**

```sql
UPDATE ForumTopic
SET AuthorID = NULL
WHERE AuthorID NOT IN (
  SELECT ID FROM UserAccounts
);
```

In my local DB, this updates 0 records, but this should resolve any integrity issues.

---

This PR renames `AuthorID` to `author_id` on the `ForumTopic` table. Additionally, `AuthorID` was missing a FK relationship to the `UserAccounts` table. The migration introduced in this branch adds this relationship.