### PR TITLE
chore(GamesTableSeeder): don't seed gameHashSets

### DIFF
--- a/database/seeders/GamesTableSeeder.php
+++ b/database/seeders/GamesTableSeeder.php
@@ -7,7 +7,6 @@ namespace Database\Seeders;
 use App\Models\Achievement;
 use App\Models\Game;
 use App\Models\GameHash;
-use App\Models\GameHashSet;
 use App\Models\System;
 use App\Platform\Enums\AchievementFlag;
 use Illuminate\Database\Seeder;

--- a/database/seeders/GamesTableSeeder.php
+++ b/database/seeders/GamesTableSeeder.php
@@ -32,12 +32,10 @@ class GamesTableSeeder extends Seeder
          * add hashes to games
          */
         Game::all()->each(function (Game $game) {
-            $game->gameHashSets()->save(new GameHashSet([
-                'game_id' => $game->ID,
-            ]))->hashes()->save(new GameHash([
+            $game->hashes()->save(new GameHash([
                 'system_id' => $game->ConsoleID,
-                'hash' => Str::random(16),
-                'md5' => Str::random(16),
+                'hash' => Str::random(32),
+                'md5' => Str::random(32),
             ]));
         });
 


### PR DESCRIPTION
This PR resolves a failure in `GamesTableSeeder` which is occurring due to a foreign key constraint. The failure is caused by changes from https://github.com/RetroAchievements/RAWeb/pull/2283.

`game_hash_sets` and `game_hash_set_hashes` are both going to be removed. It is no longer necessary to attempt to seed `$gameHashSets()`.

The seeder now directly adds rows for `$game->hashes()` without going through `$gameHashSets()`.