### PR TITLE
chore(user): implement user ratings deletion todo

### DIFF
--- a/app/Actions/ClearAccountDataAction.php
+++ b/app/Actions/ClearAccountDataAction.php
@@ -32,8 +32,7 @@ class ClearAccountDataAction
         // TODO $user->followers()->delete();
         // TODO $user->following()->delete();
         DB::statement('DELETE FROM Friends WHERE User = :username OR Friend = :friendUsername', ['username' => $user->User, 'friendUsername' => $user->User]);
-        // TODO $user->ratings()->delete();
-        DB::statement('DELETE FROM Rating WHERE User = :username', ['username' => $user->User]);
+        $user->ratings()->delete();
         // TODO $user->achievementSetRequests()->delete();
         DB::statement('DELETE FROM SetRequest WHERE User = :username', ['username' => $user->User]);
         // TODO $user->badges()->delete();

--- a/app/Community/Concerns/ActsAsCommunityMember.php
+++ b/app/Community/Concerns/ActsAsCommunityMember.php
@@ -7,6 +7,7 @@ namespace App\Community\Concerns;
 use App\Community\Enums\UserRelationship;
 use App\Models\ForumTopicComment;
 use App\Models\MessageThreadParticipant;
+use App\Models\Rating;
 use App\Models\Subscription;
 use App\Models\User;
 use App\Models\UserActivity;
@@ -126,6 +127,14 @@ trait ActsAsCommunityMember
     public function forumPosts(): HasMany
     {
         return $this->hasMany(ForumTopicComment::class, 'AuthorID', 'ID');
+    }
+
+    /**
+     * @return HasMany<Rating>
+     */
+    public function ratings(): HasMany
+    {
+        return $this->hasMany(Rating::class, 'user_id', 'ID');
     }
 
     /**

--- a/app/Models/Rating.php
+++ b/app/Models/Rating.php
@@ -20,7 +20,7 @@ class Rating extends BaseModel
     public const UPDATED_AT = 'Updated';
 
     protected $fillable = [
-        'User',
+        'user_id',
         'RatingObjectType',
         'RatingID',
         'RatingValue',


### PR DESCRIPTION
Very minor housekeeping task as I work through the tables with user relations.

We can't write to these records anymore, but we do delete them on account deletion. This PR implements a TODO by associating `Rating` to the `User` model.

We should also populate the `user_id` records in stage & prod. They are currently unpopulated. I tested the following query on preview.

```sql
UPDATE Rating r
JOIN UserAccounts ua on r.User = ua.User
SET r.user_id = ua.ID;
```