### PR TITLE
refactor(Friends): add double writes for user_id and related_user_id values

### DIFF
--- a/app/Actions/ClearAccountDataAction.php
+++ b/app/Actions/ClearAccountDataAction.php
@@ -29,9 +29,8 @@ class ClearAccountDataAction
         // TODO $user->activities()->delete();
         // TODO $user->emailConfirmations()->delete();
         DB::statement('DELETE FROM EmailConfirmations WHERE User = :username', ['username' => $user->User]);
-        // TODO $user->followers()->delete();
-        // TODO $user->following()->delete();
-        DB::statement('DELETE FROM Friends WHERE User = :username OR Friend = :friendUsername', ['username' => $user->User, 'friendUsername' => $user->User]);
+        $user->followers()->delete();
+        $user->following()->delete();
         // TODO $user->ratings()->delete();
         DB::statement('DELETE FROM Rating WHERE User = :username', ['username' => $user->User]);
         // TODO $user->achievementSetRequests()->delete();

--- a/app/Actions/ClearAccountDataAction.php
+++ b/app/Actions/ClearAccountDataAction.php
@@ -29,8 +29,8 @@ class ClearAccountDataAction
         // TODO $user->activities()->delete();
         // TODO $user->emailConfirmations()->delete();
         DB::statement('DELETE FROM EmailConfirmations WHERE User = :username', ['username' => $user->User]);
-        $user->followers()->delete();
-        $user->following()->delete();
+        $user->relationships()->delete();
+        $user->inverseRelationships()->delete();
         // TODO $user->ratings()->delete();
         DB::statement('DELETE FROM Rating WHERE User = :username', ['username' => $user->User]);
         // TODO $user->achievementSetRequests()->delete();

--- a/app/Community/Concerns/ActsAsCommunityMember.php
+++ b/app/Community/Concerns/ActsAsCommunityMember.php
@@ -43,6 +43,22 @@ trait ActsAsCommunityMember
     /**
      * @return BelongsToMany<User>
      */
+    public function relationships(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'user_id', 'related_user_id');
+    }
+
+    /**
+     * @return BelongsToMany<User>
+     */
+    public function inverseRelationships(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'related_user_id', 'user_id');
+    }
+
+    /**
+     * @return BelongsToMany<User>
+     */
     public function following(): BelongsToMany
     {
         return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'user_id', 'related_user_id')

--- a/app/Community/Concerns/ActsAsCommunityMember.php
+++ b/app/Community/Concerns/ActsAsCommunityMember.php
@@ -45,14 +45,7 @@ trait ActsAsCommunityMember
      */
     public function following(): BelongsToMany
     {
-        // return $this->belongsToMany(User::class, 'Friends', 'user_id', 'related_user_id');
-        return $this->belongsToMany(User::class,
-            'Friends', // related table
-            'User',    // foreign key in related table pointing to this model
-            'Friend',  // foreign key in related table pointing to target model
-            'User',    // local key in this model
-            'User')    // local key in target model
-            ->where('Friendship', '=', UserRelationship::Following);
+        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'user_id', 'related_user_id');
     }
 
     /**
@@ -60,8 +53,7 @@ trait ActsAsCommunityMember
      */
     public function followers(): BelongsToMany
     {
-        // untested - likely needs to be refactored to match following() implementation
-        return $this->belongsToMany(User::class, 'Friends', 'related_user_id', 'user_id');
+        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'related_user_id', 'user_id');
     }
 
     public function isFollowing(string $username): bool

--- a/app/Community/Concerns/ActsAsCommunityMember.php
+++ b/app/Community/Concerns/ActsAsCommunityMember.php
@@ -61,8 +61,7 @@ trait ActsAsCommunityMember
      */
     public function following(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'user_id', 'related_user_id')
-            ->where('Friendship', '=', UserRelationship::Following);
+        return $this->relationships()->where('Friendship', '=', UserRelationship::Following);
     }
 
     /**
@@ -70,8 +69,7 @@ trait ActsAsCommunityMember
      */
     public function followers(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'related_user_id', 'user_id')
-            ->where('Friendship', '=', UserRelationship::Following);
+        return $this->inverseRelationships()->where('Friendship', '=', UserRelationship::Following);
     }
 
     public function isFollowing(string $username): bool

--- a/app/Community/Concerns/ActsAsCommunityMember.php
+++ b/app/Community/Concerns/ActsAsCommunityMember.php
@@ -45,7 +45,8 @@ trait ActsAsCommunityMember
      */
     public function following(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'user_id', 'related_user_id');
+        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'user_id', 'related_user_id')
+            ->where('Friendship', '=', UserRelationship::Following);
     }
 
     /**
@@ -53,7 +54,8 @@ trait ActsAsCommunityMember
      */
     public function followers(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'related_user_id', 'user_id');
+        return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'related_user_id', 'user_id')
+            ->where('Friendship', '=', UserRelationship::Following);
     }
 
     public function isFollowing(string $username): bool

--- a/app/Models/UserRelation.php
+++ b/app/Models/UserRelation.php
@@ -17,6 +17,8 @@ class UserRelation extends BaseModel
     public const UPDATED_AT = 'Updated';
 
     protected $fillable = [
+        'user_id',
+        'related_user_id',
         'User',
         'Friend',
         'Friendship',

--- a/public/request/user/update-relationship.php
+++ b/public/request/user/update-relationship.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Community\Enums\UserRelationship;
+use App\Models\User;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
@@ -14,7 +15,14 @@ $input = Validator::validate(Arr::wrap(request()->post()), [
     'action' => ['required', 'integer', Rule::in(UserRelationship::cases())],
 ]);
 
-if (changeFriendStatus($user, $input['user'], (int) $input['action']) !== 'error') {
+$senderUser = auth()->user();
+$targetUser = User::firstWhere('User', $input['user']);
+
+if (!$targetUser) {
+    return back()->withErrors(__('legacy.error.error'));
+}
+
+if (changeFriendStatus($senderUser, $targetUser, (int) $input['action']) !== 'error') {
     return back()->with('success', __('legacy.success.ok'));
 }
 

--- a/tests/Feature/Connect/AchievementWonDataTest.php
+++ b/tests/Feature/Connect/AchievementWonDataTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Connect;
 
+use App\Community\Enums\UserRelationship;
 use App\Models\Achievement;
 use App\Models\Game;
 use App\Models\System;
 use App\Models\User;
+use App\Models\UserRelation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Tests\Feature\Platform\Concerns\TestsPlayerAchievements;
@@ -159,11 +161,22 @@ class AchievementWonDataTest extends TestCase
 
         // second achievement - friends only
         $this->assertEquals($this->user->ID, $users[1]->ID); /* logic assumes that first user is making API call */
-        // TODO: Use UserRelation model
-        legacyDbStatement("INSERT INTO Friends (User, Friend, Friendship) VALUES (:user, :friend, 1)",
-            ['user' => $this->user->User, 'friend' => $users[10]->User]);
-        legacyDbStatement("INSERT INTO Friends (User, Friend, Friendship) VALUES (:user, :friend, 1)",
-            ['user' => $this->user->User, 'friend' => $users[4]->User]);
+
+        UserRelation::create([
+            'User' => $this->user->User,
+            'user_id' => $this->user->id,
+            'Friend' => $users[10]->User,
+            'related_user_id' => $users[10]->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+        UserRelation::create([
+            'User' => $this->user->User,
+            'user_id' => $this->user->id,
+            'Friend' => $users[4]->User,
+            'related_user_id' => $users[4]->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+
         $this->get($this->apiUrl('achievementwondata', ['a' => $achievement2->ID, 'f' => 1]))
             ->assertExactJson([
                 'Success' => true,


### PR DESCRIPTION
This PR rewrites the `changeFriendStatus()` helper function to use Eloquent ORM. As part of this rewrite, the `user_id` and `related_user_id` values are now populated into the database.

Additionally, the User model's `following()` and `followers()` relationships have been updated to utilize these values.

The following SQL needs to be run **after merge/deployment** to delete orphaned records and to populate values for existing records:

```sql
-- Friends, delete orphaned User records
DELETE FROM Friends
WHERE User NOT IN (SELECT User FROM UserAccounts);

-- Friends, delete orphaned Friend records
DELETE FROM Friends
WHERE Friend NOT IN (SELECT User FROM UserAccounts);

-- Friends, populate user_id values
UPDATE Friends f
JOIN UserAccounts ua on f.User = ua.User
SET f.user_id = ua.ID;

-- Friends, populate related_user_id values
UPDATE Friends f
JOIN UserAccounts ua on f.Friend = ua.User
SET f.related_user_id = ua.ID;
```