### PR TITLE
refactor(Leaderboard): add author_id column and double writes

### DIFF
--- a/app/Models/Leaderboard.php
+++ b/app/Models/Leaderboard.php
@@ -31,7 +31,7 @@ class Leaderboard extends BaseModel
     // TODO rename Created column to created_at
     // TODO rename Updated column to updated_at
     // TODO drop Mem, migrate to triggerable morph
-    // TODO drop Author, migrate to triggerable morph author
+    // TODO drop Author and author_id, migrate to triggerable morph author
     protected $table = 'LeaderboardDef';
 
     protected $primaryKey = 'ID';

--- a/database/factories/LeaderboardFactory.php
+++ b/database/factories/LeaderboardFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use App\Models\Leaderboard;
-use App\Support\Database\Eloquent\Concerns\FakesUsername;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -13,8 +13,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class LeaderboardFactory extends Factory
 {
-    use FakesUsername;
-
     protected $model = Leaderboard::class;
 
     /**
@@ -22,12 +20,15 @@ class LeaderboardFactory extends Factory
      */
     public function definition(): array
     {
+        $author = User::inRandomOrder()->first();
+
         return [
             'GameID' => 0,
             'Title' => ucwords(fake()->words(2, true)),
             'Description' => fake()->sentence(),
             'Mem' => 'STA:0x000000=0::CAN:0x000001=2::SUB:0x000001=1::VAL:0x000002',
-            'Author' => $this->fakeUsername(),
+            'Author' => $author->User,
+            'author_id' => $author->id,
             'Format' => 'VALUE',
             'LowerIsBetter' => 0,
             'DisplayOrder' => rand(0, 500),

--- a/database/migrations/platform/2024_03_30_000000_update_leaderboarddef_table.php
+++ b/database/migrations/platform/2024_03_30_000000_update_leaderboarddef_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('LeaderboardDef', function (Blueprint $table) {
+            $table->unsignedBigInteger('author_id')->nullable()->after('Author');
+            $table->foreign('author_id')->references('ID')->on('UserAccounts')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('LeaderboardDef', function (Blueprint $table) {
+            $table->dropForeign(['author_id']);
+        });
+
+        Schema::table('LeaderboardDef', function (Blueprint $table) {
+            $table->dropColumn('author_id');
+        });
+    }
+};


### PR DESCRIPTION
**Before executing the migration, run:**
```sql
-- LeaderboardDef, clear orphaned Author values
UPDATE LeaderboardDef lb
SET Author = NULL
WHERE Author NOT IN (
  SELECT User FROM UserAccounts
);
```

**After executing the migration, run:**
```sql
-- LeaderboardDef, populate author_id values
UPDATE LeaderboardDef lb
JOIN UserAccounts ua on lb.Author = ua.User
SET lb.author_id = ua.ID;
```

---

This PR adds an `author_id` column to the `LeaderboardDef` table. This column has a foreign key to `UserAccounts.ID`. Additionally, `SubmitNewLeaderboard()` now writes to this new column.