### PR TITLE
feat: don't show rich presence strings from muted users

### DIFF
--- a/app/Community/Services/ActivePlayersService.php
+++ b/app/Community/Services/ActivePlayersService.php
@@ -31,6 +31,7 @@ class ActivePlayersService
         $filteredActivePlayers = $allActivePlayers;
         $filteredActivePlayers = $this->useDevelopmentGameTitle($filteredActivePlayers);
         $filteredActivePlayers = $this->useTargetGameIds($filteredActivePlayers, $targetGameIds);
+        $filteredActivePlayers = $this->useSuppressedMutedUserPresences($filteredActivePlayers);
 
         $trendingGames = isset($targetGameIds) ? [] : $this->computeTrendingGames($filteredActivePlayers);
 
@@ -140,6 +141,19 @@ class ActivePlayersService
 
         return $activePlayers->filter(function ($activePlayer) use ($targetGameIds) {
             return in_array($activePlayer['GameID'], $targetGameIds);
+        });
+    }
+
+    private function useSuppressedMutedUserPresences(mixed $activePlayers): mixed
+    {
+        return $activePlayers->map(function ($activePlayer) {
+            $isMuted = isset($activePlayer['MutedUntil']) && Carbon::parse($activePlayer['MutedUntil'])->isFuture();
+
+            if ($isMuted) {
+                $activePlayer['RichPresenceMsg'] = 'Playing ' . $activePlayer['GameTitle'];
+            }
+
+            return $activePlayer;
         });
     }
 }

--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -300,7 +300,7 @@ function getGameRecentPlayers(int $gameID, int $maximum_results = 10): array
         ->join('UserAccounts', 'UserAccounts.ID', '=', 'player_sessions.user_id')
         ->where('UserAccounts.Permissions', '>=', Permissions::Unregistered)
         ->orderBy('rich_presence_updated_at', 'DESC')
-        ->select(['player_sessions.user_id', 'User', 'player_sessions.rich_presence', 'player_sessions.rich_presence_updated_at']);
+        ->select(['player_sessions.user_id', 'User', 'muted_until', 'player_sessions.rich_presence', 'player_sessions.rich_presence_updated_at']);
 
     if ($maximum_results) {
         $sessions = $sessions->limit($maximum_results);
@@ -312,6 +312,7 @@ function getGameRecentPlayers(int $gameID, int $maximum_results = 10): array
             'User' => $session->User,
             'Date' => $session->rich_presence_updated_at->__toString(),
             'Activity' => $session->rich_presence,
+            'MutedUntil' => $session->muted_until,
             'NumAwarded' => 0,
             'NumAwardedHardcore' => 0,
             'NumAchievements' => 0,

--- a/app/Helpers/database/user-activity.php
+++ b/app/Helpers/database/user-activity.php
@@ -257,7 +257,7 @@ function getLatestRichPresenceUpdates(): array
     $timestampStatement = timestampAddMinutesStatement(-$recentMinutes);
 
     $query = "SELECT ua.User, $ifRAPoints as RAPoints, $ifRASoftcorePoints as RASoftcorePoints,
-                     ua.RichPresenceMsg, gd.ID AS GameID, gd.Title AS GameTitle, gd.ImageIcon AS GameIcon, c.Name AS ConsoleName
+                     ua.muted_until AS MutedUntil, ua.RichPresenceMsg, gd.ID AS GameID, gd.Title AS GameTitle, gd.ImageIcon AS GameIcon, c.Name AS ConsoleName
               FROM UserAccounts AS ua
               LEFT JOIN GameData AS gd ON gd.ID = ua.LastGameID
               LEFT JOIN Console AS c ON c.ID = gd.ConsoleID

--- a/resources/views/components/game/recent-game-players.blade.php
+++ b/resources/views/components/game/recent-game-players.blade.php
@@ -20,6 +20,7 @@ foreach ($recentPlayerData as $recentPlayer) {
         'User' => $recentPlayer['User'],
         'Date' => $date,
         'IsBroken' => $isBroken,
+        'IsMuted' => isset($recentPlayer['MutedUntil']) && Carbon::parse($recentPlayer['MutedUntil'])->isFuture(),
         'Activity' => $recentPlayer['Activity'],
         'NumAwarded' => (int) $recentPlayer['NumAwarded'],
         'NumAwardedHardcore' => (int) $recentPlayer['NumAwardedHardcore'],
@@ -99,6 +100,8 @@ foreach ($recentPlayerData as $recentPlayer) {
                             <span>⚠️</span>
                             <span>Playing {{ $gameTitle }}</span>
                         </div>
+                    @elseif ($recentPlayer['IsMuted'])
+                        Playing {{ $gameTitle }}
                     @else
                         {{ $recentPlayer['Activity'] }}
                     @endif

--- a/resources/views/components/user/profile-meta.blade.php
+++ b/resources/views/components/user/profile-meta.blade.php
@@ -48,7 +48,7 @@ if ($me) {
 @endif
 
 @if (!empty($userMassData['LastGame']))
-    <x-user.profile.last-seen-in :userMassData="$userMassData" />
+    <x-user.profile.last-seen-in :userMassData="$userMassData" :user="$user" />
 @endif
 
 <div

--- a/resources/views/components/user/profile/last-seen-in.blade.php
+++ b/resources/views/components/user/profile/last-seen-in.blade.php
@@ -7,10 +7,11 @@ use Illuminate\Support\Carbon;
 
 @props([
     'userMassData' => [],
+    'user' => null, // User
 ])
 
 <?php
-$mostRecentSession = PlayerSession::where('user_id', $userMassData['ID'])
+$mostRecentSession = PlayerSession::where('user_id', $user->id)
     ->with('game')
     ->orderBy('created_at', 'desc')
     ->first();
@@ -23,7 +24,7 @@ if (!$mostRecentSession) {
 
 $mostRecentRichPresenceMessage = (
     $mostRecentSession?->rich_presence
-    ?? $userMassData['RichPresenceMsg']
+    ?? $user->RichPresenceMsg
     ?? null
 );
 
@@ -54,7 +55,8 @@ $parsedDate = Carbon::parse($mostRecentSession?->rich_presence_updated_at);
             />
 
             @if (
-                $mostRecentRichPresenceMessage
+                !$user->is_muted
+                && $mostRecentRichPresenceMessage
                 && $mostRecentRichPresenceMessage !== 'Unknown'
                 && $mostRecentRichPresenceMessage !== 'Playing ' . $sessionGame->Title
             )


### PR DESCRIPTION
This PR makes an adjustment to rich presence strings for muted users. While their strings will continue to be stored in the DB, they are now displayed to end users as "Playing {Game Title}".

This impacts the active players component on the home page and the dev feed, as well as the players list on game pages. Additionally, the RP string is removed from the "last seen in" component on the user profile.