### PR TITLE
fix(mail): differentiate between 'mastered' and 'completed' on set revision emails

### DIFF
--- a/app/Helpers/database/site-award.php
+++ b/app/Helpers/database/site-award.php
@@ -48,18 +48,6 @@ function AddSiteAward(
         ->first();
 }
 
-function getUsersWithAward(int $awardType, int $data, ?int $dataExtra = null): array
-{
-    $query = "SELECT u.User, u.EmailAddress FROM SiteAwards saw
-              LEFT JOIN UserAccounts u ON u.User=saw.User
-              WHERE saw.AwardType=$awardType AND saw.AwardData=$data";
-    if ($dataExtra != null) {
-        $query .= " AND saw.AwardDataExtra=$dataExtra";
-    }
-
-    return legacyDbFetchAll($query)->toArray();
-}
-
 function removeDuplicateGameAwards(array &$dbResult, array $gamesToDedupe, int $awardType): void
 {
     foreach ($gamesToDedupe as $game) {

--- a/app/Helpers/util/mail.php
+++ b/app/Helpers/util/mail.php
@@ -423,15 +423,21 @@ function sendSetRequestEmail(string $user, string $email, int $gameID, string $g
 }
 
 /**
- * Sends an email to all users who have mastered a set when a revision set claim has been marked as complete.
+ * Sends an email to all users who have mastered or completed a set when a revision set claim has been marked as complete.
  */
-function sendSetRevisionEmail(string $user, string $email, int $gameID, string $gameTitle): bool
-{
+function sendSetRevisionEmail(
+    string $user,
+    string $email,
+    bool $isHardcore,
+    int $gameId,
+    string $gameTitle,
+): bool {
     $emailTitle = "Revision Completed for " . $gameTitle;
-    $link = "<a href='" . config('app.url') . "/game/$gameID'>$gameTitle</a>";
+    $link = "<a href='" . config('app.url') . "/game/$gameId'>$gameTitle</a>";
+    $awardLabel = $isHardcore ? 'mastered' : 'completed';
 
     $msg = "Hello $user,<br>" .
-        "A set that you have previously mastered has been revised. Check out the changes to $link.<br><br>" .
+        "A set that you have previously $awardLabel has been revised. Check out the changes to $link.<br><br>" .
         "Thanks!<br>" .
         "-- Your friends at RetroAchievements.org<br>";
 

--- a/public/request/set-claim/complete-claim.php
+++ b/public/request/set-claim/complete-claim.php
@@ -1,9 +1,9 @@
 <?php
 
 use App\Community\Enums\ArticleType;
-use App\Community\Enums\AwardType;
 use App\Community\Enums\ClaimSetType;
 use App\Enums\Permissions;
+use App\Models\PlayerBadge;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 
@@ -25,8 +25,16 @@ if (!empty($claimData) && completeClaim($user, $gameID)) { // Check that the cla
     if ($claimData[0]['SetType'] == ClaimSetType::Revision) {
         // Send email to users who had previously mastered the set
         $gameTitle = getGameData($gameID)['Title'];
-        foreach (getUsersWithAward(AwardType::Mastery, $gameID) as $masteryUser) {
-            sendSetRevisionEmail($masteryUser['User'], $masteryUser['EmailAddress'], $gameID, $gameTitle);
+
+        $userAwards = PlayerBadge::with('user')->where('AwardData', $gameID);
+        foreach ($userAwards as $userAward) {
+            sendSetRevisionEmail(
+                $userAward->user->User,
+                $userAward->user->EmailAddress,
+                $userAward->AwardDataExtra === 1,
+                $gameID,
+                $gameTitle,
+            );
         }
     } else {
         // Send email to set requestors


### PR DESCRIPTION
Currently, set revision emails say the user has mastered the set, even if they only "completed" it in softcore mode.

This PR eliminates the `getUsersWithAward()` helper and designates in the email if the user only completed the revised set.