### PR TITLE
allow SECS_AS_MINS formatting for leaderboards

### DIFF
--- a/app/Platform/Enums/ValueFormat.php
+++ b/app/Platform/Enums/ValueFormat.php
@@ -21,6 +21,9 @@ abstract class ValueFormat
     // hhhmm
     public const TimeMinutes = 'MINUTES';
 
+    // hhhmm calculated by taking value / 60
+    public const TimeSecondsAsMinutes = 'SECS_AS_MINS';
+
     // number followed by three zeroes
     public const ValueThousands = 'THOUSANDS';
 
@@ -45,6 +48,9 @@ abstract class ValueFormat
     // n.nnn calculated by taking number / 1000
     public const Fixed3 = 'FIXED3';
 
+    // NOTE: RichPresence supports additional types for floats, but leaderboards can't
+    //       store floats.
+
     public static function cases(): array
     {
         return [
@@ -53,11 +59,12 @@ abstract class ValueFormat
             self::TimeCentiseconds,
             self::TimeSeconds,
             self::TimeMinutes,
-            self::ValueThousands,
-            self::ValueHundreds,
-            self::ValueTens,
+            self::TimeSecondsAsMinutes,
             self::Value,
             self::ValueUnsigned,
+            self::ValueTens,
+            self::ValueHundreds,
+            self::ValueThousands,
             self::Fixed1,
             self::Fixed2,
             self::Fixed3,
@@ -77,14 +84,15 @@ abstract class ValueFormat
             self::TimeCentiseconds => 'Time (Centiseconds)',
             self::TimeSeconds => 'Time (Seconds)',
             self::TimeMinutes => 'Time (Minutes)',
-            self::ValueThousands => 'Value (Thousands)',
-            self::ValueHundreds => 'Value (Hundreds)',
-            self::ValueTens => 'Value (Tens)',
+            self::TimeSecondsAsMinutes => 'Time (Seconds as Minutes)',
             self::Value => 'Value',
-            self::ValueUnsigned => 'Value (unsigned)',
-            self::Fixed1 => 'Fixed1',
-            self::Fixed2 => 'Fixed2',
-            self::Fixed3 => 'Fixed3',
+            self::ValueUnsigned => 'Value (Unsigned)',
+            self::ValueTens => 'Value (Tens)',
+            self::ValueHundreds => 'Value (Hundreds)',
+            self::ValueThousands => 'Value (Thousands)',
+            self::Fixed1 => 'Value (Fixed1)',
+            self::Fixed2 => 'Value (Fixed2)',
+            self::Fixed3 => 'Value (Fixed3)',
             default => 'Unknown',
         };
     }
@@ -104,6 +112,7 @@ abstract class ValueFormat
             self::TimeCentiseconds => sprintf("%s.%02d", ValueFormat::formatSeconds((int) ($value / 100)), $value % 100),
             self::TimeSeconds => ValueFormat::formatSeconds($value),
             self::TimeMinutes => sprintf("%01dh%02d", (int) $value / 60, $value % 60),
+            self::TimeSecondsAsMinutes => sprintf("%01dh%02d", (int) $value / 60 / 60, ($value / 60) % 60),
             self::ValueThousands => localized_number($value * 1000),
             self::ValueHundreds => localized_number($value * 100),
             self::ValueTens => localized_number($value * 10),

--- a/tests/Unit/ValueFormatTest.php
+++ b/tests/Unit/ValueFormatTest.php
@@ -22,7 +22,7 @@ final class ValueFormatTest extends TestCase
 
     public function testFormatUnsignedValue(): void
     {
-        $this->assertEquals("Value (unsigned)", ValueFormat::toString(ValueFormat::ValueUnsigned));
+        $this->assertEquals("Value (Unsigned)", ValueFormat::toString(ValueFormat::ValueUnsigned));
 
         $this->assertEquals("12,345", ValueFormat::format(12345, ValueFormat::ValueUnsigned));
         $this->assertEquals("4,294,954,951", ValueFormat::format(-12345, ValueFormat::ValueUnsigned));
@@ -83,6 +83,16 @@ final class ValueFormatTest extends TestCase
         $this->assertEquals("0h01", ValueFormat::format(1, ValueFormat::TimeMinutes));
     }
 
+    public function testFormatSecondsAsMinutes(): void
+    {
+        $this->assertEquals("Time (Seconds as Minutes)", ValueFormat::toString(ValueFormat::TimeSecondsAsMinutes));
+
+        $this->assertEquals("3h25", ValueFormat::format(12345, ValueFormat::TimeSecondsAsMinutes));
+        $this->assertEquals("0h05", ValueFormat::format(345, ValueFormat::TimeSecondsAsMinutes));
+        $this->assertEquals("0h00", ValueFormat::format(0, ValueFormat::TimeSecondsAsMinutes));
+        $this->assertEquals("0h00", ValueFormat::format(1, ValueFormat::TimeSecondsAsMinutes));
+    }
+
     public function testFormatThousands(): void
     {
         $this->assertEquals("Value (Thousands)", ValueFormat::toString(ValueFormat::ValueThousands));
@@ -121,7 +131,7 @@ final class ValueFormatTest extends TestCase
 
     public function testFormatFixed1(): void
     {
-        $this->assertEquals("Fixed1", ValueFormat::toString(ValueFormat::Fixed1));
+        $this->assertEquals("Value (Fixed1)", ValueFormat::toString(ValueFormat::Fixed1));
 
         $this->assertEquals("1,234.5", ValueFormat::format(12345, ValueFormat::Fixed1));
         $this->assertEquals("-1,234.5", ValueFormat::format(-12345, ValueFormat::Fixed1));
@@ -133,7 +143,7 @@ final class ValueFormatTest extends TestCase
 
     public function testFormatFixed2(): void
     {
-        $this->assertEquals("Fixed2", ValueFormat::toString(ValueFormat::Fixed2));
+        $this->assertEquals("Value (Fixed2)", ValueFormat::toString(ValueFormat::Fixed2));
 
         $this->assertEquals("123.45", ValueFormat::format(12345, ValueFormat::Fixed2));
         $this->assertEquals("-123.45", ValueFormat::format(-12345, ValueFormat::Fixed2));
@@ -145,7 +155,7 @@ final class ValueFormatTest extends TestCase
 
     public function testFormatFixed3(): void
     {
-        $this->assertEquals("Fixed3", ValueFormat::toString(ValueFormat::Fixed3));
+        $this->assertEquals("Value (Fixed3)", ValueFormat::toString(ValueFormat::Fixed3));
 
         $this->assertEquals("12.345", ValueFormat::format(12345, ValueFormat::Fixed3));
         $this->assertEquals("-12.345", ValueFormat::format(-12345, ValueFormat::Fixed3));


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195377993416714/1228338799138967554

also changes the order to prioritize unshifted values over shifted ones and prefixes the fixed sizes with "Value"
![image](https://github.com/RetroAchievements/RAWeb/assets/32680403/0ba48d32-d779-4fdf-a914-2af4772dcfa1)
