### PR TITLE
fix error logging dropped claim due to demoting user

### DIFF
--- a/app/Helpers/database/user-permission.php
+++ b/app/Helpers/database/user-permission.php
@@ -121,7 +121,7 @@ function SetAccountPermissionsJSON(
             $claim->save();
 
             $comment = "$actingUsername dropped $targetUsername's " . ClaimType::toString($claim->ClaimType) . " claim via demotion to $targetUserNewPermissionsString.";
-            addArticleComment('Server', ArticleType::SetClaim, $claim->GameID, $comment);
+            addArticleComment('Server', ArticleType::SetClaim, $claim->game_id, $comment);
         }
     }
 


### PR DESCRIPTION
Fixes
```
addArticleComment(): Argument #3 ($articleID) must be of type array|int, null given, called in /home/forge/retroachievements.org/releases/2024-04-11T181031-6.3.0-a94e4522/app/Helpers/database/user-permission.php on line 124 {"userId":75956,"exception":"[object] (TypeError(code: 0): addArticleComment(): Argument #3 ($articleID) must be of type array|int, null given, called in /home/forge/retroachievements.org/releases/2024-04-11T181031-6.3.0-a94e4522/app/Helpers/database/user-permission.php on line 124 at /home/forge/retroachievements.org/releases/2024-04-11T181031-6.3.0-a94e4522/app/Helpers/database/user-activity.php:61)
[stacktrace]
#0 /home/forge/retroachievements.org/releases/2024-04-11T181031-6.3.0-a94e4522/app/Helpers/database/user-permission.php(124): addArticleComment()
#1 /home/forge/retroachievements.org/releases/2024-04-11T181031-6.3.0-a94e4522/public/request/user/update.php(28): SetAccountPermissionsJSON()
```