### PR TITLE
refactor: rename BelongsToMany<User> model relations

### DIFF
--- a/app/Actions/ClearAccountDataAction.php
+++ b/app/Actions/ClearAccountDataAction.php
@@ -29,8 +29,8 @@ class ClearAccountDataAction
         // TODO $user->activities()->delete();
         // TODO $user->emailConfirmations()->delete();
         DB::statement('DELETE FROM EmailConfirmations WHERE User = :username', ['username' => $user->User]);
-        $user->relationships()->detach();
-        $user->inverseRelationships()->detach();
+        $user->relatedUsers()->detach();
+        $user->inverseRelatedUsers()->detach();
         // TODO $user->ratings()->delete();
         DB::statement('DELETE FROM Rating WHERE User = :username', ['username' => $user->User]);
         $user->gameListEntries()->delete();

--- a/app/Community/Components/UserActivityFeed.php
+++ b/app/Community/Components/UserActivityFeed.php
@@ -46,7 +46,7 @@ class UserActivityFeed extends Grid
         return [
             AllowedFilter::callback('users', function (Builder $query, $value) {
                 if (request()->user() && $value === 'following') {
-                    $followingIds = request()->user()->following()->get(['id'])->pluck('id');
+                    $followingIds = request()->user()->followedUsers()->get(['id'])->pluck('id');
                     $followingIds[] = request()->user()->ID;
                     $query->whereIn('user_id', $followingIds);
                 }

--- a/app/Community/Concerns/ActsAsCommunityMember.php
+++ b/app/Community/Concerns/ActsAsCommunityMember.php
@@ -50,7 +50,7 @@ trait ActsAsCommunityMember
     /**
      * @return BelongsToMany<User>
      */
-    public function relationships(): BelongsToMany
+    public function relatedUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'user_id', 'related_user_id');
     }
@@ -58,7 +58,7 @@ trait ActsAsCommunityMember
     /**
      * @return BelongsToMany<User>
      */
-    public function inverseRelationships(): BelongsToMany
+    public function inverseRelatedUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, (new UserRelation())->getTable(), 'related_user_id', 'user_id');
     }
@@ -66,17 +66,17 @@ trait ActsAsCommunityMember
     /**
      * @return BelongsToMany<User>
      */
-    public function following(): BelongsToMany
+    public function followedUsers(): BelongsToMany
     {
-        return $this->relationships()->where('Friendship', '=', UserRelationship::Following);
+        return $this->relatedUsers()->where('Friendship', '=', UserRelationship::Following);
     }
 
     /**
      * @return BelongsToMany<User>
      */
-    public function followers(): BelongsToMany
+    public function followerUsers(): BelongsToMany
     {
-        return $this->inverseRelationships()->where('Friendship', '=', UserRelationship::Following);
+        return $this->inverseRelatedUsers()->where('Friendship', '=', UserRelationship::Following);
     }
 
     public function isFollowing(string $username): bool

--- a/app/Models/Achievement.php
+++ b/app/Models/Achievement.php
@@ -317,7 +317,7 @@ class Achievement extends BaseModel implements HasComments
     /**
      * @return BelongsToMany<User>
      */
-    public function players(): BelongsToMany
+    public function playerUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'player_achievements', 'achievement_id', 'user_id')
             ->using(PlayerAchievement::class);

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -304,7 +304,7 @@ class Game extends BaseModel implements HasComments, HasMedia
     /**
      * @return BelongsToMany<User>
      */
-    public function players(): BelongsToMany
+    public function playerUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'player_games')
             ->using(PlayerGame::class);

--- a/resources/views/components/game/compare-progress.blade.php
+++ b/resources/views/components/game/compare-progress.blade.php
@@ -9,7 +9,7 @@ use App\Models\User;
 ])
 
 <?php
-$followedUserIds = $user->following()->select(['UserAccounts.ID', 'UserAccounts.User'])->pluck('ID');
+$followedUserIds = $user->followedUsers()->select(['UserAccounts.ID', 'UserAccounts.User'])->pluck('ID');
 
 $followedUserCompletion = null;
 if (!empty($followedUserIds)) {


### PR DESCRIPTION
Renames all `BelongsToMany<User>` model relations to more clearly designate actual `User` models are being selected:

* `relationships` -> `relatedUsers`
* `inverseRelationships` -> `inverseRelatedUsers`
* `following` -> `followedUsers`
* `followers` -> `followerUsers`
* `players` -> `playerUsers`