### PR TITLE
fix(game): add an existence check to game forum topic links

### DIFF
--- a/resources/views/components/game/link-buttons/index.blade.php
+++ b/resources/views/components/game/link-buttons/index.blade.php
@@ -47,7 +47,7 @@ $ticketManagerUrl = url('/ticketmanager.php') . '?' . http_build_query($ticketMa
 
 <ul class="flex @if ($variant === 'stacked') flex-col @endif gap-2">
     @if (in_array('forum-topic', $allowedLinks))
-        @if ($game->ForumTopicID)
+        @if ($game->ForumTopicID && ForumTopic::find($game->ForumTopicID)?->exists())
             <x-game.link-buttons.game-link-button
                 icon="💬"
                 href="{{ '/viewtopic.php?t=' . $game->ForumTopicID }}"


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/310195377993416714/1228722777230671952.

It seems `GameData.ForumTopicID` has integrity issues with the actual `ForumTopic` table due to a lack of a foreign key.

We should run this in prod to fix the integrity issues. This will set all `ForumTopicID` values to NULL if the forum topic was hard deleted from the database at some point in the past:
```sql
UPDATE GameData g
LEFT JOIN ForumTopic f ON g.ForumTopicID = f.ID
SET g.ForumTopicID = NULL
WHERE f.ID IS NULL AND g.ForumTopicID IS NOT NULL;
```