### PR TITLE
fix(ForumTopic): on delete, remove any associated game ForumTopicID values

### DIFF
--- a/public/request/forum-topic/delete.php
+++ b/public/request/forum-topic/delete.php
@@ -2,6 +2,7 @@
 
 use App\Enums\Permissions;
 use App\Models\ForumTopic;
+use App\Models\Game;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 
@@ -13,8 +14,18 @@ $input = Validator::validate(Arr::wrap(request()->post()), [
     'topic' => 'required|integer|exists:ForumTopic,ID',
 ]);
 
+$forumTopicId = $input['topic'];
+
 /** @var ForumTopic $topic */
-$topic = ForumTopic::find($input['topic']);
-$topic->delete();
+$foundTopic = ForumTopic::find($forumTopicId);
+if ($foundTopic) {
+    $foundTopic->delete();
+
+    $foundAssociatedGame = Game::firstWhere('ForumTopicID', $forumTopicId);
+    if ($foundAssociatedGame) {
+        $foundAssociatedGame->ForumTopicID = null;
+        $foundAssociatedGame->save();
+    }
+}
 
 return back()->with('success', __('legacy.success.delete'));


### PR DESCRIPTION
Normally, I'd reach for a foreign key with `onDelete("set null")`, but that might not be the correct approach given this comment on the `Game` model:

```php
// TODO drop ForumTopicID, migrate to forumable morph
```

At a minimum, we should be preserving integrity of the game records on topic delete.