### PR TITLE
chore: add foreign key to GameData.ForumTopicID

### DIFF
--- a/database/migrations/community/2024_04_13_000000_update_gamedata_table.php
+++ b/database/migrations/community/2024_04_13_000000_update_gamedata_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('GameData', function (Blueprint $table) {
+            $table->unsignedBigInteger('ForumTopicID')->change();
+        });
+
+        Schema::table('GameData', function (Blueprint $table) {
+            $table->foreign('ForumTopicID')->references('ID')->on('ForumTopic')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('GameData', function (Blueprint $table) {
+            $table->dropForeign(['ForumTopicID']);
+        });
+
+        Schema::table('GameData', function (Blueprint $table) {
+            $table->integer('ForumTopicID')->change();
+        });
+    }
+};


### PR DESCRIPTION
**Before running the migration, execute:**
```sql
UPDATE GameData g
LEFT JOIN ForumTopic f ON g.ForumTopicID = f.ID
SET g.ForumTopicID = NULL
WHERE f.ID IS NULL AND g.ForumTopicID IS NOT NULL;
```

---

This PR adds a migration which changes `GameData.ForumTopicID`'s field type and gives it a foreign key to `ForumTopic.ID`.

