### PR TITLE
fix(achievement): show badge on tooltips even when `$icon` is false

### DIFF
--- a/app/Helpers/render/achievement.php
+++ b/app/Helpers/render/achievement.php
@@ -46,15 +46,17 @@ function achievementAvatar(
         $tooltip = $tooltip !== false ? $achievement : false;
     }
 
+    $iconUrl = $icon !== false && ($icon || !$label) ? $icon : null;
+
     return avatar(
         resource: 'achievement',
         id: $id,
         label: $label !== false && ($label || !$icon) ? $label : null,
         link: route('achievement.show', $id),
         tooltip: is_array($tooltip)
-            ? renderAchievementCard($tooltip, iconUrl: $icon)
+            ? renderAchievementCard($tooltip, iconUrl: $iconUrl)
             : $tooltip,
-        iconUrl: $icon !== false && ($icon || !$label) ? $icon : null,
+        iconUrl: $iconUrl,
         iconSize: $iconSize,
         iconClass: $iconClass,
         context: $context,


### PR DESCRIPTION
This PR resolves an issue observable on /achievementList.php. If you hover over one of the achievement titles, you'll see a tooltip with a broken badge.

This is being caused by a logic error in render/achievement.php.

**Before**
<img width="431" alt="Screenshot 2024-04-13 at 8 05 30 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/6825d4eb-32e7-4df1-abca-4f43cfa0c380">


**After**
<img width="465" alt="Screenshot 2024-04-13 at 8 05 21 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/a5bbc86a-e558-405f-a06f-fd257d325c2b">
