### PR TITLE
fix(game-compare): remediate link button size issue on LG and lower

### DIFF
--- a/resources/views/components/game/link-buttons/game-link-button.blade.php
+++ b/resources/views/components/game/link-buttons/game-link-button.blade.php
@@ -4,8 +4,8 @@
 ])
 
 <li>
-    <a class="btn py-2 pr-3 block transition-transform lg:active:scale-[97%]" href="{{ $href }}">
-        <span class="icon icon-md mx-1">{{ $icon }}</span>
-        {{ $slot }}
+    <a class="btn py-2 w-full px-3 inline-flex gap-x-2 transition-transform lg:active:scale-[97%]" href="{{ $href }}">
+        <span>{{ $icon }}</span>
+        <span>{{ $slot }}</span>
     </a>
 </li>

--- a/resources/views/pages/user/[user]/game/[game]/compare.blade.php
+++ b/resources/views/pages/user/[user]/game/[game]/compare.blade.php
@@ -74,7 +74,7 @@ $canModerate = ($user->Permissions >= Permissions::Moderator);
 
 @if ($canModerate)
     <x-hidden-controls>
-        <div style="width:20%">
+        <div class="grid md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
             <ul class="flex flex-col gap-2">
                 <x-game.link-buttons.game-link-button
                     icon="🔬"


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1229087996075315351.

Additionally, modifies some of the link button styles so the icon and text are now better aligned along the center of the button.

**Before**
<img width="504" alt="Screenshot 2024-04-14 at 1 30 53 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/47789bc3-7631-4a36-b8e3-abd1c94480c8">


**After**
<img width="496" alt="Screenshot 2024-04-14 at 1 30 43 PM" src="https://github.com/RetroAchievements/RAWeb/assets/3984985/24e27f9f-b6ae-4685-8abd-9c5dd430ad4e">
