### PR TITLE
fix(game): don't add an extra bucket to achievement distribution

### DIFF
--- a/app/Helpers/render/game.php
+++ b/app/Helpers/render/game.php
@@ -305,7 +305,7 @@ function generateEmptyBucketsWithBounds(int $numAchievements): array
 
     // If bucketing is enabled, we'll dynamically generate 19 buckets. The final 20th
     // bucket will contain all users who have completed/mastered the game.
-    $bucketCount = $isDynamicBucketingEnabled ? $GENERATED_RANGED_BUCKETS_COUNT : $numAchievements;
+    $bucketCount = $isDynamicBucketingEnabled ? $GENERATED_RANGED_BUCKETS_COUNT : $numAchievements - 1;
 
     // Bucket size is determined based on the total number of achievements in the set.
     // If bucketing is enabled, we aim for roughly 20 buckets (hence dividing by $bucketCount).


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/2396.

Currently, an extra column is being added to the Achievement Distribution chart if bucketing is not enabled for the game.

Screenshots below are from game 3609.

**Before**
![Screenshot 2024-05-02 at 6 42 14 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/063346c1-9f56-4232-b35e-698f8e9ded81)


**After**
![Screenshot 2024-05-02 at 6 42 05 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/fea9ba2b-be35-4b45-abe0-8a352c007516)
