### PR TITLE
add dorequest?r=gameinfolist

### DIFF
--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -553,10 +553,8 @@ function getGamesListDataNamesOnly(int $consoleId, bool $officialFlag = false): 
         ->when($officialFlag === true, function ($query) {
             return $query->where('GameData.achievements_published', '>', 0);
         })
-        ->orderBy('Console.Name')
-        ->orderBy('GameData.Title')
         ->select('GameData.Title', 'GameData.ID')
-        ->pluck('GameData.Title', 'GameData.ID')
+        ->pluck('GameData.Title', 'GameData.ID') // return mapping of ID => Title
         ->toArray();
 }
 

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -222,6 +222,7 @@ switch ($requestType) {
         $response['CodeNotes'] = getCodeNotesData($gameID);
         $response['GameID'] = $gameID;
         break;
+
     case "gameid":
         $md5 = request()->input('m') ?? '';
         $response['GameID'] = getGameIDFromMD5($md5);
@@ -232,9 +233,18 @@ switch ($requestType) {
         $response['Response'] = getGamesListDataNamesOnly($consoleID);
         break;
 
-    case "officialgameslist":
+    case "officialgameslist": // TODO: is this used anymore? It's not used by the DLL.
         $consoleID = (int) request()->input('c', 0);
         $response['Response'] = getGamesListDataNamesOnly($consoleID, true);
+        break;
+
+    case "gameinfolist":
+        $gamesCSV = request()->input('g', '');
+        if (empty($gamesCSV)) {
+            return DoRequestError("You must specify which games to retrieve info for", 400);
+        }
+        $response['Response'] = Game::whereIn('ID', explode(',', $gamesCSV))
+            ->select('Title', 'ID', 'ImageIcon')->get()->toArray();
         break;
 
     case "hashlibrary":

--- a/tests/Feature/Connect/GamesListTest.php
+++ b/tests/Feature/Connect/GamesListTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Connect;
+
+use App\Models\Game;
+use App\Models\System;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GamesListTest extends TestCase
+{
+    use BootstrapsConnect;
+    use RefreshDatabase;
+
+    public function testGamesList(): void
+    {
+        /** @var System $system1 */
+        $system1 = System::factory()->create();
+        /** @var System $system2 */
+        $system2 = System::factory()->create();
+        /** @var System $system3 */
+        $system3 = System::factory()->create();
+
+        // games 1,2,3 have only published achievements
+        // games 4,5,6 have only unpublished achievements
+        // games 7,8,9 have no achievements
+        // game 10 has published and unpublished achievements
+        /** @var Game $game1 */
+        $game1 = Game::factory()->create(['ConsoleID' => $system1->ID, 'ImageIcon' => '/Images/000001.png', 'achievements_published' => 3]);
+        /** @var Game $game2 */
+        $game2 = Game::factory()->create(['ConsoleID' => $system2->ID, 'ImageIcon' => '/Images/000002.png', 'achievements_published' => 7]);
+        /** @var Game $game3 */
+        $game3 = Game::factory()->create(['ConsoleID' => $system3->ID, 'ImageIcon' => '/Images/000003.png', 'achievements_published' => 11]);
+        /** @var Game $game4 */
+        $game4 = Game::factory()->create(['ConsoleID' => $system2->ID, 'ImageIcon' => '/Images/000004.png', 'achievements_unpublished' => 5]);
+        /** @var Game $game5 */
+        $game5 = Game::factory()->create(['ConsoleID' => $system1->ID, 'ImageIcon' => '/Images/000005.png', 'achievements_unpublished' => 9]);
+        /** @var Game $game6 */
+        $game6 = Game::factory()->create(['ConsoleID' => $system3->ID, 'ImageIcon' => '/Images/000006.png', 'achievements_unpublished' => 1]);
+        /** @var Game $game7 */
+        $game7 = Game::factory()->create(['ConsoleID' => $system1->ID, 'ImageIcon' => '/Images/000007.png']);
+        /** @var Game $game8 */
+        $game8 = Game::factory()->create(['ConsoleID' => $system2->ID, 'ImageIcon' => '/Images/000008.png']);
+        /** @var Game $game9 */
+        $game9 = Game::factory()->create(['ConsoleID' => $system3->ID, 'ImageIcon' => '/Images/000009.png']);
+        /** @var Game $game10 */
+        $game10 = Game::factory()->create(['ConsoleID' => $system2->ID, 'ImageIcon' => '/Images/000010.png', 'achievements_published' => 2, 'achievements_unpublished' => 1]);
+
+        // all games for console 1
+        $this->get($this->apiUrl('gameslist', ['c' => $system1->id]))
+            ->assertExactJson([
+                'Success' => true,
+                'Response' => [
+                    '1' => $game1->Title,
+                    '5' => $game5->Title,
+                    '7' => $game7->Title,
+                ],
+            ]);
+
+        // all games for console 2
+        $this->get($this->apiUrl('gameslist', ['c' => $system2->id]))
+            ->assertExactJson([
+                'Success' => true,
+                'Response' => [
+                    '2' => $game2->Title,
+                    '4' => $game4->Title,
+                    '8' => $game8->Title,
+                    '10' => $game10->Title,
+                ],
+            ]);
+
+        // all games for console 3
+        $this->get($this->apiUrl('gameslist', ['c' => $system3->id]))
+            ->assertExactJson([
+                'Success' => true,
+                'Response' => [
+                    '3' => $game3->Title,
+                    '6' => $game6->Title,
+                    '9' => $game9->Title,
+                ],
+            ]);
+
+    // games with published achievements for console 1
+    $this->get($this->apiUrl('officialgameslist', ['c' => $system1->id]))
+        ->assertExactJson([
+            'Success' => true,
+            'Response' => [
+                '1' => $game1->Title,
+            ],
+        ]);
+
+    // games with published achievements for console 2
+    $this->get($this->apiUrl('officialgameslist', ['c' => $system2->id]))
+        ->assertExactJson([
+            'Success' => true,
+            'Response' => [
+                '2' => $game2->Title,
+                '10' => $game10->Title,
+            ],
+        ]);
+
+    // games with published achievements for console 3
+    $this->get($this->apiUrl('officialgameslist', ['c' => $system3->id]))
+        ->assertExactJson([
+            'Success' => true,
+            'Response' => [
+                '3' => $game3->Title,
+            ],
+        ]);
+
+    // game info
+    $this->get($this->apiUrl('gameinfolist', ['g' => implode(',', [$game2->id, $game4->id, $game7->id])]))
+        ->assertExactJson([
+            'Success' => true,
+            'Response' => [
+                [
+                    'ID' => $game2->ID,
+                    'Title' => $game2->Title,
+                    'ImageIcon' => $game2->ImageIcon,
+                ],
+                [
+                    'ID' => $game4->ID,
+                    'Title' => $game4->Title,
+                    'ImageIcon' => $game4->ImageIcon,
+                ],
+                [
+                    'ID' => $game7->ID,
+                    'Title' => $game7->Title,
+                    'ImageIcon' => $game7->ImageIcon,
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
Supports https://github.com/RetroAchievements/RAIntegration/pull/1080

To display the recently played games in the DLL overlay, we need the game title and image for all recently played games. Normally, we pull this from the cached patch data, but that expires after 30 days. For older records, we effectively fetch the patch data again. If we have to do this for a lot of games, the server sends back 429 Too Many Requests errors.

Instead of making N requests for patch data, this allows for a single request to be made for all of the needed game titles/icons, and avoids the overhead of also returning the achievement/leaderboard/rich presence data.