### PR TITLE
fix(forum): don't show post edit date unless it's different from create date

### DIFF
--- a/resources/views/components/forum/post-comment-meta.blade.php
+++ b/resources/views/components/forum/post-comment-meta.blade.php
@@ -11,7 +11,11 @@ use Illuminate\Support\Carbon;
 
 <?php
 $postCreatedTimestamp = $forumTopicComment->DateCreated;
-$postEditedTimestamp = $forumTopicComment->DateModified;
+$postEditedTimestamp =
+    ($forumTopicComment->DateModified
+    && $forumTopicComment->DateModified != $forumTopicComment->DateCreated)
+        ? $forumTopicComment->DateModified
+        : null;
 
 /** @var ?User $user */
 $user = auth()->user();


### PR DESCRIPTION
In `submitTopicComment()`, we're now always setting `DateModified` due to the Eloquent ORM version. I believe logically this is correct, but the UI now needs to ensure that `DateModified` is different from `DateCreated`.