### PR TITLE
fix(game): sort leaderboards by displayorder

### DIFF
--- a/resources/views/components/game/leaderboards-listing/index.blade.php
+++ b/resources/views/components/game/leaderboards-listing/index.blade.php
@@ -9,7 +9,7 @@
         <x-game.leaderboards-listing.empty-state :game="$game" />
     @else
         <x-game.leaderboards-listing.leaderboards-list
-            :gameLeaderboards="$game->visibleLeaderboards"
+            :gameLeaderboards="$game->visibleLeaderboards->sortBy('DisplayOrder')"
         />
     @endif
 </div>


### PR DESCRIPTION
Resolves a regression on game pages. Leaderboards are not currently sorted by `DisplayOrder`. Easily visible on game 1446.

**Before**
![Screenshot 2024-05-09 at 5 54 19 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/04818ea3-0060-42c8-893f-8e55b4e6aa11)

**After**
![Screenshot 2024-05-09 at 5 54 59 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/2b028f33-d1e5-48ca-9340-834eff3f01c2)
