### PR TITLE
fix(user): show user walls even while unauthenticated

### DIFF
--- a/resources/views/pages-legacy/userInfo.blade.php
+++ b/resources/views/pages-legacy/userInfo.blade.php
@@ -173,10 +173,13 @@ if (getActiveClaimCount($userPageModel, true, true) > 0) {
 
     echo "<h2 class='text-h4'>User Wall</h2>";
 
-    if ($userWallActive && request()->user()) {
+    if ($userWallActive) {
+        $currentUser = request()->user();
+        $userToPassToComments = ($currentUser && !$userPageModel->isBlocking($currentUser)) ? $user : null;
+
         // passing 'null' for $user disables the ability to add comments
         RenderCommentsComponent(
-            !$userPageModel->isBlocking(request()->user()) ? $user : null,
+            $userToPassToComments,
             $numArticleComments,
             $commentData,
             $userPageID,


### PR DESCRIPTION
Resolves a regression on user profiles where user wall comments do not appear if the current user is unauthenticated.

Screenshots from http://localhost:64000/user/WCopeland while not signed in.

**Before**
![Screenshot 2024-05-09 at 6 29 39 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/856f323e-1e80-49b5-9f97-73bfee40bd0a)


**After**
![Screenshot 2024-05-09 at 6 29 27 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/48b51b1e-4096-480a-bc99-1c253d82a763)
