### PR TITLE
fix(Shortcode): prevent potential crash from malformed link

### DIFF
--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -197,7 +197,7 @@ final class Shortcode
         $url = $shortcode->getParameter('url') ?: $shortcode->getContent();
 
         if (empty($url)) {
-            return '';
+            return '[broken link]';
         }
 
         // Ensure the correct protocol prefix (http/https) is being used.

--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -156,7 +156,7 @@ final class Shortcode
         $processor = (new Processor(new RegularParser(), $this->handlers))
             ->withEventContainer($events);
 
-        $html = $processor->process(nl2br($input, false), ['input' => $input]);
+        $html = $processor->process(nl2br($input, false));
 
         // linkify whatever's left
         if ($options['imgur'] ?? false) {

--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -156,7 +156,7 @@ final class Shortcode
         $processor = (new Processor(new RegularParser(), $this->handlers))
             ->withEventContainer($events);
 
-        $html = $processor->process(nl2br($input, false));
+        $html = $processor->process(nl2br($input, false), ['input' => $input]);
 
         // linkify whatever's left
         if ($options['imgur'] ?? false) {
@@ -195,6 +195,10 @@ final class Shortcode
     {
         // Determine the URL from the shortcode's 'url' parameter or content.
         $url = $shortcode->getParameter('url') ?: $shortcode->getContent();
+
+        if (empty($url)) {
+            return '';
+        }
 
         // Ensure the correct protocol prefix (http/https) is being used.
         $prefixedUrl = $this->protocolPrefix($url);


### PR DESCRIPTION
If `[link]` is malformed, return an empty string.

Unfortunately, we have no way to access the original `$input` to use that as a fallback. This is a stopgap fix to prevent the page from crashing outright.