### PR TITLE
fix(leaderboard): favor updated_at over created_at

### DIFF
--- a/app/Helpers/database/leaderboard.php
+++ b/app/Helpers/database/leaderboard.php
@@ -390,7 +390,7 @@ function GetLeaderboardData(
         }
 
         // Now get entries:
-        $query = "SELECT ua.User, le.score AS Score, le.created_at AS DateSubmitted,
+        $query = "SELECT ua.User, le.score AS Score, le.updated_at AS DateSubmitted,
                   CASE WHEN lbd.LowerIsBetter = 0
                   THEN RANK() OVER(ORDER BY Score DESC)
                   ELSE RANK() OVER(ORDER BY Score ASC) END AS UserRank,
@@ -434,7 +434,7 @@ function GetLeaderboardData(
             if ($userFound == false && !$nearby) {
                 // Go find user's score in this table, if it exists!
                 $query = "SELECT User, Score, DateSubmitted, UserRank, UserIndex FROM
-                         (SELECT ua.User, le.score AS Score, le.created_at AS DateSubmitted,
+                         (SELECT ua.User, le.score AS Score, le.updated_at AS DateSubmitted,
                           CASE WHEN lbd.LowerIsBetter = 0
                           THEN RANK() OVER(ORDER BY Score DESC)
                           ELSE RANK() OVER(ORDER BY Score ASC) END AS UserRank,
@@ -482,10 +482,10 @@ function getLeaderboardUserPosition(int $lbID, string $user, ?int &$lbPosition):
     sanitize_sql_inputs($user);
 
     $query = "SELECT UserIndex FROM
-                         (SELECT ua.User, le.score, le.created_at,
+                         (SELECT ua.User, le.score, le.updated_at,
                           CASE WHEN lbd.LowerIsBetter = 0
-                          THEN ROW_NUMBER() OVER(ORDER BY le.score DESC, le.created_at ASC)
-                          ELSE ROW_NUMBER() OVER(ORDER BY le.score ASC, le.created_at ASC) END AS UserIndex
+                          THEN ROW_NUMBER() OVER(ORDER BY le.score DESC, le.updated_at ASC)
+                          ELSE ROW_NUMBER() OVER(ORDER BY le.score ASC, le.updated_at ASC) END AS UserIndex
                           FROM leaderboard_entries AS le
                           LEFT JOIN UserAccounts AS ua ON ua.ID = le.user_id
                           LEFT JOIN LeaderboardDef AS lbd ON lbd.ID = le.leaderboard_id


### PR DESCRIPTION
Resolves this display/ranking issue: https://discord.com/channels/476211979464343552/1026595325038833725/1238308585931538503

`created_at` shouldn't be null for these records, but `updated_at` should probably be the source of truth for submission/ranking placement.