### PR TITLE
fix: delete player_stats records on account deletion

### DIFF
--- a/app/Actions/ClearAccountDataAction.php
+++ b/app/Actions/ClearAccountDataAction.php
@@ -35,6 +35,7 @@ class ClearAccountDataAction
         DB::statement('DELETE FROM Rating WHERE User = :username', ['username' => $user->User]);
         $user->gameListEntries()->delete();
         $user->playerBadges()->delete();
+        $user->playerStats()->delete();
         $user->leaderboardEntries()->delete();
         $user->subscriptions()->delete();
 

--- a/app/Models/ForumTopicComment.php
+++ b/app/Models/ForumTopicComment.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Support\Database\Eloquent\BaseModel;
+use Database\Factories\ForumTopicCommentFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Scout\Searchable;
 
 class ForumTopicComment extends BaseModel
 {
+    use HasFactory;
     use Searchable;
     use SoftDeletes;
 
@@ -41,6 +44,11 @@ class ForumTopicComment extends BaseModel
     protected $casts = [
         'ManuallyVerified' => 'boolean',
     ];
+
+    protected static function newFactory(): ForumTopicCommentFactory
+    {
+        return ForumTopicCommentFactory::new();
+    }
 
     // == search
 

--- a/app/Models/PlayerStat.php
+++ b/app/Models/PlayerStat.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Support\Database\Eloquent\BaseModel;
+use Database\Factories\PlayerStatFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PlayerStat extends BaseModel
 {
+    use HasFactory;
+
     protected $table = 'player_stats';
 
     protected $fillable = [
@@ -27,6 +31,11 @@ class PlayerStat extends BaseModel
         'stat_updated_at' => 'datetime',
         'value' => 'integer',
     ];
+
+    protected static function newFactory(): PlayerStatFactory
+    {
+        return PlayerStatFactory::new();
+    }
 
     // == accessors
 

--- a/app/Platform/Concerns/ActsAsPlayer.php
+++ b/app/Platform/Concerns/ActsAsPlayer.php
@@ -12,6 +12,7 @@ use App\Models\PlayerAchievement;
 use App\Models\PlayerBadge;
 use App\Models\PlayerGame;
 use App\Models\PlayerSession;
+use App\Models\PlayerStat;
 use App\Models\Ticket;
 use App\Models\User;
 use Carbon\Carbon;
@@ -116,6 +117,14 @@ trait ActsAsPlayer
     }
 
     /**
+     * @return HasMany<PlayerGame>
+     */
+    public function playerGames(): HasMany
+    {
+        return $this->hasMany(PlayerGame::class, 'user_id');
+    }
+
+    /**
      * @return HasMany<PlayerSession>
      */
     public function playerSessions(): HasMany
@@ -124,11 +133,11 @@ trait ActsAsPlayer
     }
 
     /**
-     * @return HasMany<PlayerGame>
+     * @return HasMany<PlayerStat>
      */
-    public function playerGames(): HasMany
+    public function playerStats(): HasMany
     {
-        return $this->hasMany(PlayerGame::class, 'user_id');
+        return $this->hasMany(PlayerStat::class, 'user_id');
     }
 
     /**

--- a/database/factories/PlayerStatFactory.php
+++ b/database/factories/PlayerStatFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\PlayerStat;
+use App\Models\User;
+use App\Platform\Enums\PlayerStatType;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PlayerStat>
+ */
+class PlayerStatFactory extends Factory
+{
+    protected $model = PlayerStat::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $user = User::inRandomOrder()->first();
+
+        return [
+            'user_id' => $user->id,
+            'type' => PlayerStatType::GamesBeatenHardcoreRetail,
+            'value' => rand(1, 100),
+        ];
+    }
+}

--- a/tests/Feature/Platform/Action/ClearAccountDataTest.php
+++ b/tests/Feature/Platform/Action/ClearAccountDataTest.php
@@ -14,6 +14,7 @@ use App\Models\LeaderboardEntry;
 use App\Models\MessageThread;
 use App\Models\MessageThreadParticipant;
 use App\Models\PlayerBadge;
+use App\Models\PlayerStat;
 use App\Models\Subscription;
 use App\Models\System;
 use App\Models\User;
@@ -92,12 +93,15 @@ class ClearAccountDataTest extends TestCase
             'user_id' => $user2->id,
         ]);
 
+        $playerStat = PlayerStat::factory()->create(['user_id' => $user2->id]);
+
         $this->assertEquals(1, UserRelation::where('user_id', $user2->id)->count());
         $this->assertEquals(1, UserRelation::where('related_user_id', $user2->id)->count());
         $this->assertEquals(1, UserGameListEntry::where('user_id', $user2->id)->count());
         $this->assertEquals(1, Subscription::where('user_id', $user2->id)->count());
         $this->assertEquals(1, MessageThreadParticipant::where('user_id', $user2->id)->count());
         $this->assertEquals(1, PlayerBadge::where('user_id', $user2->id)->count());
+        $this->assertEquals(1, PlayerStat::where('user_id', $user2->id)->count());
 
         $action = new ClearAccountDataAction();
         $action->execute($user2);
@@ -109,6 +113,7 @@ class ClearAccountDataTest extends TestCase
         $this->assertEquals(0, MessageThreadParticipant::where('user_id', $user2->id)->count());
         $this->assertEquals(0, PlayerBadge::where('user_id', $user2->id)->count());
         $this->assertEquals(0, LeaderboardEntry::where('user_id', $user2->id)->count());
+        $this->assertEquals(0, PlayerStat::where('user_id', $user2->id)->count());
 
         $user2->refresh();
         $this->assertEquals('', $user2->EmailAddress);


### PR DESCRIPTION
`player_stats` currently has orphaned records from deleted users. These appear as empty slots on the Beaten Games Leaderboard. One such instance is directly observable at this URL:

https://retroachievements.org/ranking/beaten-games?page%5Bnumber%5D=1&filter%5Bsystem%5D=39&filter%5Bkind%5D=retail

This PR adds a line to `ClearAccountDataAccount` to delete player stats records. We should also run the following query:

```sql
DELETE ps
FROM player_stats ps
INNER JOIN UserAccounts ua ON ps.user_id = ua.ID
WHERE ua.Deleted IS NOT NULL;
```