### PR TITLE
fix: add missing orderBy to leaderboards-list-item

### DIFF
--- a/resources/views/components/game/leaderboards-listing/leaderboards-list-item.blade.php
+++ b/resources/views/components/game/leaderboards-listing/leaderboards-list-item.blade.php
@@ -20,6 +20,7 @@ use App\Platform\Enums\ValueFormat;
         @php
             $bestScore = $leaderboard->entries()
                 ->orderBy("score", $leaderboard->rank_asc ? 'ASC' : 'DESC')
+                ->orderBy('updated_at')
                 ->first();
         @endphp
         @if (!$bestScore)


### PR DESCRIPTION
Currently, ties are not sorting by earliest submission date in the new component. This PR resolves that issue.

Reproducible on `/game/1462`.

Actual leaderboard standings:
![Screenshot 2024-05-10 at 8 27 24 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/f73195cc-184a-4555-9a6d-8463c02eba46)


**Before**
![Screenshot 2024-05-10 at 8 27 05 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/6ba8230c-dceb-447f-a81d-b87f90b4b28e)


**After**
![Screenshot 2024-05-10 at 8 26 02 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/cb25e525-8236-4236-a9f5-7abefed3f741)
