### PR TITLE
refactor(game): use native Folio routing and render hooks for activity and compare pages

### DIFF
--- a/app/Platform/Controllers/PlayerGameController.php
+++ b/app/Platform/Controllers/PlayerGameController.php
@@ -97,14 +97,4 @@ class PlayerGameController extends Controller
          * TODO: detach
          */
     }
-
-    public function activity(User $user, Game $game): View
-    {
-        $this->authorize('viewSessionHistory', [PlayerGame::class, $user]);
-
-        return view('pages.user.[user].game.[game].activity', [
-            'user' => $user,
-            'game' => $game,
-        ]);
-    }
 }

--- a/app/Platform/RouteServiceProvider.php
+++ b/app/Platform/RouteServiceProvider.php
@@ -8,7 +8,6 @@ use App\Community\Controllers\TicketController;
 use App\Models\GameHash;
 use App\Platform\Controllers\AchievementController;
 use App\Platform\Controllers\BeatenGamesLeaderboardController;
-use App\Platform\Controllers\CompareUnlocksController;
 use App\Platform\Controllers\DeveloperFeedController;
 use App\Platform\Controllers\DeveloperSetsController;
 use App\Platform\Controllers\GameDevInterestController;
@@ -102,8 +101,6 @@ class RouteServiceProvider extends ServiceProvider
             // Route::resource('user.achievements', PlayerAchievementController::class)->only('index')->names(['index' => 'user.achievement.index']);
             // Route::resource('user.games', PlayerGameController::class)->only('index')->names(['index' => 'user.game.index']);
             // Route::resource('user.game', PlayerGameController::class)->only('show');
-            Route::get('user/{user}/game/{game}/activity', [PlayerGameController::class, 'activity'])->name('user.game.activity');
-            Route::get('user/{user}/game/{game}/compare', CompareUnlocksController::class)->name('game.compare-unlocks');
 
             // Route::resource('user.badges', PlayerBadgeController::class)->only('index')->names(['index' => 'user.badge.index']);
             // Route::resource('user.badge', PlayerBadgeController::class)->only('show');
@@ -115,9 +112,6 @@ class RouteServiceProvider extends ServiceProvider
                 'middleware' => ['auth'], // TODO: 'verified'
             ], function () {
                 Route::resource('game-hash', GameHashController::class)->parameters(['game-hash' => 'gameHash'])->only(['update', 'destroy']);
-
-                // Route::get('user/{user}/game/{game}/compare', [PlayerGameController::class, 'compare'])
-                //     ->name('user.game.compare');
             });
         });
     }

--- a/app/Platform/Services/PlayerGameActivityPageService.php
+++ b/app/Platform/Services/PlayerGameActivityPageService.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Services;
+
+use App\Models\Game;
+use App\Models\User;
+
+class PlayerGameActivityPageService
+{
+    public function __construct(
+        protected PlayerGameActivityService $playerGameActivityService,
+        protected UserAgentService $userAgentService,
+    ) {
+    }
+
+    public function buildViewData(User $user, Game $game): array
+    {
+        $this->playerGameActivityService->initialize($user, $game);
+        $summary = $this->playerGameActivityService->summarize();
+
+        $estimated = ($summary['generatedSessionAdjustment'] !== 0) ? " (estimated)" : "";
+
+        $unlockSessionCount = $summary['achievementSessionCount'];
+        $sessionInfo = "$unlockSessionCount session";
+        if ($unlockSessionCount != 1) {
+            $sessionInfo .= 's';
+
+            if ($unlockSessionCount > 1) {
+                $elapsedAchievementDays = ceil($summary['totalUnlockTime'] / (24 * 60 * 60));
+                if ($elapsedAchievementDays > 2) {
+                    $sessionInfo .= " over $elapsedAchievementDays days";
+                } else {
+                    $sessionInfo .= " over " . ceil($summary['totalUnlockTime'] / (60 * 60)) . " hours";
+                }
+            }
+        }
+
+        $gameAchievementCount = $game->achievements_published ?? 0;
+        $userProgress = ($gameAchievementCount > 0) ? sprintf("/%d (%01.2f%%)",
+            $gameAchievementCount, $this->playerGameActivityService->achievementsUnlocked * 100 / $gameAchievementCount) : "n/a";
+
+        return [
+            'activity' => $this->playerGameActivityService,
+            'estimated' => $estimated,
+            'sessionInfo' => $sessionInfo,
+            'summary' => $summary,
+            'userAgentService' => $this->userAgentService,
+            'userProgress' => $userProgress,
+        ];
+    }
+}

--- a/resources/views/components/game/compare-progress.blade.php
+++ b/resources/views/components/game/compare-progress.blade.php
@@ -105,7 +105,7 @@ function selectSearchBoxUser() {
 
                         <a
                             class="min-w-[100px] flex flex-col"
-                            href="{!! route('game.compare-unlocks', ['game' => $game, 'user' => $friend->User]) !!}"
+                            href="{!! route('game.compare-unlocks', ['game' => $game, 'user' => $friend]) !!}"
                         >
                             <x-game-progress-bar
                                 containerClassNames="py-2.5"

--- a/resources/views/pages/user/[user]/game/[game]/compare.blade.php
+++ b/resources/views/pages/user/[user]/game/[game]/compare.blade.php
@@ -1,53 +1,20 @@
 <?php
 
-use function Laravel\Folio\{middleware, name};
+use App\Models\Game;
+use App\Models\User;
+use App\Platform\Services\CompareUnlocksPageService;
+use Illuminate\View\View;
+
+use function Laravel\Folio\{middleware, name, render};
 
 middleware(['auth', 'can:view,game', 'can:view,user']);
 name('game.compare-unlocks');
 
+render(function (View $view, User $user, Game $game, CompareUnlocksPageService $pageService) {
+    return $view->with($pageService->buildViewData(request(), $user, $game));
+});
+
 ?>
-
-@props([
-    'user' => null,
-    'otherUser' => null,
-    'game' => null,
-    'achievements' => [],
-    'sortOrder' => 'display',
-])
-
-@php
-use App\Enums\Permissions;
-
-$availableSorts = [
-    'selfUnlocks' => 'My Unlock Times',
-    'otherUnlocks' => 'Their Unlock Times',
-    'display' => 'Display Order',
-    'title' => 'Achievement Title',
-];
-
-$userUnlockCount = 0;
-$otherUserUnlockCount = 0;
-$userUnlockHardcoreCount = 0;
-$otherUserUnlockHardcoreCount = 0;
-$numAchievements = count($achievements);
-
-
-foreach ($achievements as $achievement) {
-    if (array_key_exists('userTimestamp', $achievement)) {
-        $userUnlockCount++;
-        if ($achievement['userHardcore'] ?? false) {
-            $userUnlockHardcoreCount++;
-        }
-    }
-
-    if (array_key_exists('otherUserTimestamp', $achievement)) {
-        $otherUserUnlockCount++;
-        if ($achievement['otherUserHardcore'] ?? false) {
-            $otherUserUnlockHardcoreCount++;
-        }
-    }
-}
-@endphp
 
 <x-app-layout
     pageTitle="Compare Unlocks - {{ $game->Title }}"
@@ -96,7 +63,12 @@ foreach ($achievements as $achievement) {
         </x-slot>
 
         <x-meta-panel
-            :availableSorts="$availableSorts"
+            :availableSorts="[
+                'selfUnlocks' => 'My Unlock Times',
+                'otherUnlocks' => 'Their Unlock Times',
+                'display' => 'Display Order',
+                'title' => 'Achievement Title',
+            ]"
             :selectedSortOrder="$sortOrder"
         />
 


### PR DESCRIPTION
This PR:
* Migrates `PlayerGameController::activity()` to `PlayerGameActivityPageService`.
* Transitions `CompareUnlocksController` to `CompareUnlocksPageService`.
* Removes references to both from `RouteServiceProvider`.
* Adds Folio `render()` hooks to both pages.

No functional changes.