### PR TITLE
fix double server in ticket comment url

### DIFF
--- a/app/Helpers/util/mail.php
+++ b/app/Helpers/util/mail.php
@@ -287,7 +287,10 @@ function sendActivityEmail(
         return false;
     }
 
-    $link = "<a href='" . config('app.url') . "/$urlTarget'>here</a>";
+    if (!str_starts_with($urlTarget, "http")) {
+        $urlTarget = config('app.url') . "/$urlTarget";
+    }
+    $link = "<a href='$urlTarget'>here</a>";
 
     switch ($articleType) {
         case ArticleType::Game:


### PR DESCRIPTION
https://discord.com/channels/476211979464343552/1026595325038833725/1238961731741552790

Fixes duplicate https://retroachievements.org in links in emails for ticket comments 