### PR TITLE
show resolver when filtering on resolved tickets

### DIFF
--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -92,7 +92,7 @@ class Ticket extends BaseModel
      */
     public function reporter(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'reporter_id', 'ID');
+        return $this->belongsTo(User::class, 'reporter_id', 'ID')->withTrashed();
     }
 
     /**
@@ -100,7 +100,7 @@ class Ticket extends BaseModel
      */
     public function resolver(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'resolver_id', 'ID');
+        return $this->belongsTo(User::class, 'resolver_id', 'ID')->withTrashed();
     }
 
     // == scopes

--- a/app/Platform/Services/TicketListService.php
+++ b/app/Platform/Services/TicketListService.php
@@ -209,6 +209,6 @@ class TicketListService
             $tickets->offset(($this->pageNumber - 1) * $this->perPage)->take($this->perPage);
         }
 
-        return $tickets->with(['achievement', 'reporter']);
+        return $tickets->with(['achievement', 'reporter', 'resolver']);
     }
 }

--- a/resources/views/components/ticket/ticket-list.blade.php
+++ b/resources/views/components/ticket/ticket-list.blade.php
@@ -5,6 +5,7 @@
     'offset' => 0,
     'currentPage' => 0,
     'totalPages' => 0,
+    'showResolver' => false,
 ])
 
 @php
@@ -47,6 +48,9 @@ $gameCache = [];
                         <th>Developer</th>
                         <th>Reporter</th>
                         <th>Reported At</th>
+                        @if ($showResolver)
+                            <th>Resovled By</th>
+                        @endif
                     </tr>
                 </thead>
 
@@ -73,6 +77,9 @@ $gameCache = [];
                             <td>{!! userAvatar($ticket->achievement->author) !!}</td>
                             <td>{!! userAvatar($ticket->reporter) !!}</td>
                             <td class="smalldate">{{ getNiceDate($ticket->ReportedAt->unix()) }}</td>
+                            @if ($showResolver)
+                                <td>{!! userAvatar($ticket->resolver) !!}</td>
+                            @endif
                         </tr>
                     @endforeach
                 </tbody>

--- a/resources/views/components/ticket/ticket-list.blade.php
+++ b/resources/views/components/ticket/ticket-list.blade.php
@@ -49,7 +49,7 @@ $gameCache = [];
                         <th>Reporter</th>
                         <th>Reported At</th>
                         @if ($showResolver)
-                            <th>Resovled By</th>
+                            <th>Resolved By</th>
                         @endif
                     </tr>
                 </thead>

--- a/resources/views/pages/achievement/[achievement]/tickets.blade.php
+++ b/resources/views/pages/achievement/[achievement]/tickets.blade.php
@@ -35,5 +35,6 @@ name('achievement.tickets');
         :tickets="$tickets"
         :totalTickets="$totalTickets"
         :numFilteredTickets="$numFilteredTickets"
+        showResolver="{{ ($filterOptions['status'] !== 'unresolved') }}"
     />
 </x-app-layout>

--- a/resources/views/pages/game/[game]/tickets.blade.php
+++ b/resources/views/pages/game/[game]/tickets.blade.php
@@ -35,5 +35,6 @@ name('game.tickets');
         :tickets="$tickets"
         :totalTickets="$totalTickets"
         :numFilteredTickets="$numFilteredTickets"
+        showResolver="{{ ($filterOptions['status'] !== 'unresolved') }}"
     />
 </x-app-layout>

--- a/resources/views/pages/tickets/index.blade.php
+++ b/resources/views/pages/tickets/index.blade.php
@@ -40,5 +40,6 @@ $openTicketCount = Ticket::unresolved()->count();
         :numFilteredTickets="$numFilteredTickets"
         :currentPage="$currentPage"
         :totalPages="$totalPages"
+        showResolver="{{ ($filterOptions['status'] !== 'unresolved') }}"
     />
 </x-app-layout>

--- a/resources/views/pages/user/[user]/tickets.blade.php
+++ b/resources/views/pages/user/[user]/tickets.blade.php
@@ -40,5 +40,6 @@ name('developer.tickets');
         :numFilteredTickets="$numFilteredTickets"
         :currentPage="$currentPage"
         :totalPages="$totalPages"
+        showResolver="{{ ($filterOptions['status'] !== 'unresolved') }}"
     />
 </x-app-layout>


### PR DESCRIPTION
https://discord.com/channels/476211979464343552/1002693810037477377/1238989109029244988

The column was previously shown if the filter included resolved/closed tickets. I've restored that logic, but the column now appears after the reported by date instead of between it and the reporter.

Also fixes display of reporter/resolver for deleted users.