### PR TITLE
feat(ticket): add `assignee_id` field

### DIFF
--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -22,8 +22,8 @@ class Ticket extends BaseModel
 
     // TODO rename Ticket table to tickets
     // TODO rename ID column to id
-    // TODO rename ReportType column to type
-    // TODO rename ReportNotes column to body
+    // TODO rename ReportType column to type, remove getTypeAttribute()
+    // TODO rename ReportNotes column to body, remove getBodyAttribute()
     // TODO rename ReportedAt column to created_at
     // TODO rename ResolvedAt column to resolved_at
     // TODO rename ReportState column to state, remove getStateAttribute()
@@ -36,6 +36,15 @@ class Ticket extends BaseModel
 
     public const CREATED_AT = 'ReportedAt';
     public const UPDATED_AT = 'Updated';
+
+    protected $fillable = [
+        'AchievementID',
+        'assignee_id',
+        'Hardcore',
+        'reporter_id',
+        'ReportNotes',
+        'ReportType',
+    ];
 
     protected $casts = [
         'ResolvedAt' => 'datetime',
@@ -64,6 +73,18 @@ class Ticket extends BaseModel
 
     // == accessors
 
+    // TODO remove after renaming "ReportNotes" to "body"
+    public function getBodyAttribute(): string
+    {
+        return $this->attributes['ReportNotes'];
+    }
+
+    // TODO remove after renaming "ID" to "id"
+    public function getIdAttribute(): int
+    {
+        return $this->attributes['ID'];
+    }
+
     public function getIsOpenAttribute(): bool
     {
         return TicketState::isOpen($this->state);
@@ -73,6 +94,12 @@ class Ticket extends BaseModel
     public function getStateAttribute(): int
     {
         return $this->attributes['ReportState'];
+    }
+
+    // TODO remove after renaming "ReportType" to "type"
+    public function getTypeAttribute(): int
+    {
+        return $this->attributes['ReportType'];
     }
 
     // == mutators
@@ -93,6 +120,14 @@ class Ticket extends BaseModel
     public function reporter(): BelongsTo
     {
         return $this->belongsTo(User::class, 'reporter_id', 'ID')->withTrashed();
+    }
+
+    /**
+     * @return BelongsTo<User, Ticket>
+     */
+    public function assignee(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assignee_id', 'ID')->withTrashed();
     }
 
     /**

--- a/database/migrations/platform/2024_05_19_000000_update_tickets_table.php
+++ b/database/migrations/platform/2024_05_19_000000_update_tickets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('Ticket', function (Blueprint $table) {
+            $table->unsignedBigInteger('assignee_id')->nullable()->after('reporter_id');
+            $table->foreign('assignee_id')->references('ID')->on('UserAccounts')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('Ticket', function (Blueprint $table) {
+            $table->dropForeign(['assignee_id']);
+        });
+
+        Schema::table('Ticket', function (Blueprint $table) {
+            $table->dropColumn('assignee_id');
+        });
+    }
+};


### PR DESCRIPTION
Adds a nullable `assignee_id` field to the `Ticket` table. This is a foreign key to `UserAccounts.ID`. The field is not currently used.

Right now, tickets are implicitly assigned to the achievement author. It is [desirable](https://discord.com/channels/476211979464343552/1241906810689028137/1241918238120607895) for an explicit assignee to instead be associated to a ticket.

This PR does some mild refactoring work as well in _Helpers/database/ticket.php_.

The next steps will be:
* Default the `assignee_id` value to the achievement author for newly-opened tickets.
* Write & execute a SQL query to backfill `assignee_id` values for currently-open tickets.
* Set `assignee_id` to null when a ticket is resolved or closed.
* Have `assignee_id` drive a user's open ticket count.
* Show the assignee in the ticket UI.
* Support ticket reassignment.