### PR TITLE
feat(api): add fortify login route to retrieve api key

### DIFF
--- a/app/Api/Controllers/WebApiController.php
+++ b/app/Api/Controllers/WebApiController.php
@@ -37,7 +37,7 @@ class WebApiController extends Controller
         ], 501);
     }
 
-    public function requestWebApiKey(Request $request): JsonResponse
+    public function login(Request $request): JsonResponse
     {
         $request->validate([
             'username' => 'required|string',

--- a/app/Api/Controllers/WebApiController.php
+++ b/app/Api/Controllers/WebApiController.php
@@ -7,6 +7,8 @@ namespace App\Api\Controllers;
 use App\Http\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Fortify;
 
 class WebApiController extends Controller
 {
@@ -33,5 +35,26 @@ class WebApiController extends Controller
             // 'method' => $method,
             'data' => $request->input(),
         ], 501);
+    }
+
+    public function requestWebApiKey(Request $request): JsonResponse
+    {
+        $request->validate([
+            'username' => 'required|string',
+            'password' => 'required|string',
+        ]);
+
+        $credentials = [
+            Fortify::username() => $request->input('username'),
+            'password' => $request->input('password'),
+        ];
+
+        if (Auth::attempt($credentials)) {
+            $user = Auth::user();
+
+            return response()->json(['webApiKey' => $user->api_token]);
+        }
+
+        return response()->json(['error' => 'Something went wrong'], 400);
     }
 }

--- a/app/Api/RouteServiceProvider.php
+++ b/app/Api/RouteServiceProvider.php
@@ -67,7 +67,7 @@ class RouteServiceProvider extends ServiceProvider
                     });
 
                     Route::middleware(['throttle:login'])->group(function () {
-                        Route::post('request-web-api-key', [WebApiController::class, 'requestWebApiKey']);
+                        Route::post('login', [WebApiController::class, 'login']);
                     });
                 });
 

--- a/app/Api/RouteServiceProvider.php
+++ b/app/Api/RouteServiceProvider.php
@@ -65,6 +65,10 @@ class RouteServiceProvider extends ServiceProvider
                     Route::middleware(['auth:passport'])->group(function () {
                         Route::get('users', [WebApiController::class, 'users']);
                     });
+
+                    Route::middleware(['throttle:login'])->group(function () {
+                        Route::post('request-web-api-key', [WebApiController::class, 'requestWebApiKey']);
+                    });
                 });
 
                 /*

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -106,7 +106,7 @@ class User extends Authenticatable implements CommunityMember, Developer, HasCom
     // TODO rename LastLogin column to last_activity_at
     // TODO rename appToken column to connect_token or to passport
     // TODO rename appTokenExpiry column to connect_token_expires_at or to passport
-    // TODO rename APIKey column to api_token or to passport
+    // TODO rename APIKey column to api_token or to passport, remove getApiTokenAttribute()
     // TODO rename APIUses column to api_calls or to passport
     // TODO rename RAPoints column to points
     // TODO rename TrueRAPoints column to points_weighted
@@ -389,6 +389,12 @@ class User extends Authenticatable implements CommunityMember, Developer, HasCom
     public function getIdAttribute(): ?int
     {
         return $this->attributes['ID'] ?? null;
+    }
+
+    // TODO remove after rename
+    public function getApiTokenAttribute(): string
+    {
+        return $this->attributes['APIKey'];
     }
 
     // TODO remove after rename


### PR DESCRIPTION
The PR adds a new V2 web API route:

```
POST https://localhost:64000/api/v2/login
```
```
# Request Payload
{
  "username": "MyUsername"
  "password": "MyPassword"
}
```
```
# Response Payload
{
  "webApiKey": "XXXXXXXXXXXXXXXXXXXXXXXXXX"
}
```

This route will conceivably allow emulation front-ends to exchange user credentials for a user's web API key, ideally to ween them off the Connect API (for which they're currently exchanging credentials for a connect token).

**Security Considerations:**
* Error messages are intentionally obtuse.
* The route uses Fortify, not `authenticateFromPassword()`.
* The route uses the same rate limiter as the site's login page.