### PR TITLE
feat(user): attach/detach user roles on Permissions update

### DIFF
--- a/app/Helpers/database/user-permission.php
+++ b/app/Helpers/database/user-permission.php
@@ -117,6 +117,7 @@ function setAccountForumPostAuth(User $sourceUser, int $sourcePermissions, User 
 
         // Also ban the spammy user!
         SetAccountPermissionsJSON($sourceUser->User, $sourcePermissions, $targetUser->User, Permissions::Spam);
+        $targetUser->roles()->detach();
 
         return true;
     }

--- a/public/request/user/update.php
+++ b/public/request/user/update.php
@@ -3,6 +3,7 @@
 use App\Community\Enums\ArticleType;
 use App\Community\Enums\UserAction;
 use App\Enums\Permissions;
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
@@ -28,13 +29,36 @@ $foundTargetUser = User::firstWhere('User', $targetUsername);
 if ($propertyType === UserAction::UpdatePermissions) {
     $response = SetAccountPermissionsJSON($foundSourceUser->User, $permissions, $targetUsername, $value);
 
-    // auto-apply forums permissions
-    if (
-        $response['Success']
-        && $value >= Permissions::JuniorDeveloper
-        && !$foundTargetUser->ManuallyVerified
-    ) {
-        setAccountForumPostAuth($foundSourceUser, $permissions, $foundTargetUser, authorize: true);
+    if ($response['Success']) {
+        // Auto-apply forums permissions.
+        if ($value >= Permissions::JuniorDeveloper && !$foundTargetUser->ManuallyVerified) {
+            setAccountForumPostAuth($foundSourceUser, $permissions, $foundTargetUser, authorize: true);
+        }
+
+        // Adjust attached roles.
+        if ($value <= Permissions::Unregistered) {
+            $foundTargetUser->roles()->detach();
+        }
+        if ($value === Permissions::Registered) {
+            $foundTargetUser->removeRole(Role::DEVELOPER_JUNIOR);
+            $foundTargetUser->removeRole(Role::DEVELOPER);
+            $foundTargetUser->removeRole(Role::MODERATOR);
+        }
+        if ($value === Permissions::JuniorDeveloper) {
+            $foundTargetUser->removeRole(Role::DEVELOPER);
+            $foundTargetUser->removeRole(Role::MODERATOR);
+
+            $foundTargetUser->assignRole(Role::DEVELOPER_JUNIOR);
+        }
+        if ($value === Permissions::Developer) {
+            $foundTargetUser->removeRole(Role::DEVELOPER_JUNIOR);
+            $foundTargetUser->removeRole(Role::MODERATOR);
+
+            $foundTargetUser->assignRole(Role::DEVELOPER);
+        }
+        if ($value === Permissions::Moderator) {
+            $foundTargetUser->assignRole(Role::MODERATOR);
+        }
     }
 
     return back()->with('success', __('legacy.success.ok'));


### PR DESCRIPTION
This PR makes an update to the legacy .php endpoint responsible for updating a user's `Permissions` value. Now when the value is set, the user's attached roles are updated accordingly. This is basically a form of double-writes so we can ultimately move towards dropping the `Permissions` field from the table.

Eventually this endpoint will go away altogether, with this sort of user management stuff happening in the Filament management app. 

We'll need to execute some SQL queries to get the `auth_model_roles` table current:

```sql
-- attach all junior developer roles
INSERT INTO auth_model_roles (role_id, model_type, model_id)
SELECT 7, 'user', ID
FROM UserAccounts
WHERE Permissions = 2;

-- attach all developer roles
INSERT INTO auth_model_roles (role_id, model_type, model_id)
SELECT 6, 'user', ID
FROM UserAccounts
WHERE Permissions = 3;
```