### PR TITLE
fix: hard delete leaderboard entries on leaderboard reset

### DIFF
--- a/app/Helpers/database/leaderboard.php
+++ b/app/Helpers/database/leaderboard.php
@@ -618,7 +618,8 @@ function duplicateLeaderboard(int $gameID, int $leaderboardID, int $duplicateNum
 function requestResetLB(int $lbID): bool
 {
     $entries = LeaderboardEntry::where('leaderboard_id', $lbID);
-    $entriesDeleted = $entries->delete();
+    // TODO utilize soft deletes
+    $entriesDeleted = $entries->forceDelete();
 
     // When `delete()` returns false, it indicates an error has occurred.
     return $entriesDeleted !== false;


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1244081094983159961.

Related: https://github.com/RetroAchievements/RAWeb/issues/2471