### PR TITLE
fix(comments): count textarea chars correctly

### DIFF
--- a/resources/views/components/comment/input-row.blade.php
+++ b/resources/views/components/comment/input-row.blade.php
@@ -36,14 +36,14 @@ if ($user) {
                         name="body"
                         maxlength="2000"
                         placeholder="Enter a comment here..."
-                        id="comment_textarea_$commentId"
-                        x-on:input="autoExpandTextInput(\$el); isValid = window.getStringByteCount(\$event.target.value) <= 2000;"
+                        id="comment_textarea_{{ $commentId }}"
+                        x-on:input="autoExpandTextInput($el); isValid = window.getStringByteCount($event.target.value) <= 2000;"
                     ></textarea>
                     <button class="btn h-9 ml-2" :disabled="!isValid" aria-label="Post comment" title="Post comment">
                         Submit
                     </button>
                 </div>
-                <div class="textarea-counter" data-textarea-id="comment_textarea_$commentId"></div>
+                <div class="textarea-counter" data-textarea-id="comment_textarea_{{ $commentId }}"></div>
                 <div class="text-danger hidden"></div>
             </form>
         </td>


### PR DESCRIPTION
This PR resolves two bugs in the comments textarea element:
* The textarea ID is not unique (`$commentId` is not currently being parsed)
* Alpine.js is throwing an error on initialization

Both bugs combined cause the character counter to never tick up beyond 0.

**Before**
![Screenshot 2024-06-11 at 5 13 55 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/6066bb0b-b71e-439a-87ac-cab7ca03d508)

**After**
![Screenshot 2024-06-11 at 5 14 13 PM](https://github.com/RetroAchievements/RAWeb/assets/3984985/ad23f4b8-01ce-420e-bb84-917dda82c333)
