### PR TITLE
feat(api): return RASoftcorePoints in API_GetAchievementUnlocks

### DIFF
--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -138,7 +138,7 @@ function getAchievementUnlocksData(
     return PlayerAchievement::where('achievement_id', $achievementId)
         ->join('UserAccounts', 'UserAccounts.ID', '=', 'user_id')
         ->orderByRaw('COALESCE(unlocked_hardcore_at, unlocked_at) DESC')
-        ->select(['UserAccounts.User', 'UserAccounts.RAPoints', 'unlocked_at', 'unlocked_hardcore_at'])
+        ->select(['UserAccounts.User', 'UserAccounts.RAPoints', 'UserAccounts.RASoftcorePoints', 'unlocked_at', 'unlocked_hardcore_at'])
         ->offset($offset)
         ->limit($limit)
         ->get()
@@ -146,6 +146,7 @@ function getAchievementUnlocksData(
             return [
                 'User' => $row->User,
                 'RAPoints' => $row->RAPoints,
+                'RASoftcorePoints' => $row->RASoftcorePoints,
                 'DateAwarded' => $row->unlocked_hardcore_at ?? $row->unlocked_at,
                 'HardcoreMode' => $row->unlocked_hardcore_at ? 1 : 0,
             ];
@@ -187,7 +188,7 @@ function getRecentUnlocksPlayersData(
     }
 
     // Get recent winners, and their most recent activity:
-    $query = "SELECT u.User, u.RAPoints, " . unixTimestampStatement('pa.unlocked_at', 'DateAwarded') . "
+    $query = "SELECT u.User, u.RAPoints, u.RASoftcorePoints, " . unixTimestampStatement('pa.unlocked_at', 'DateAwarded') . "
               FROM player_achievements AS pa
               LEFT JOIN UserAccounts AS u ON u.ID = pa.user_id
               WHERE pa.achievement_id = $achID $extraWhere
@@ -196,6 +197,7 @@ function getRecentUnlocksPlayersData(
 
     foreach (legacyDbFetchAll($query) as $db_entry) {
         $db_entry['RAPoints'] = (int) $db_entry['RAPoints'];
+        $db_entry['RASoftcorePoints'] = (int) $db_entry['RASoftcorePoints'];
         $db_entry['DateAwarded'] = (int) $db_entry['DateAwarded'];
         $retVal['RecentWinner'][] = $db_entry;
     }

--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -188,7 +188,7 @@ function getRecentUnlocksPlayersData(
     }
 
     // Get recent winners, and their most recent activity:
-    $query = "SELECT u.User, u.RAPoints, u.RASoftcorePoints, " . unixTimestampStatement('pa.unlocked_at', 'DateAwarded') . "
+    $query = "SELECT u.User, u.RAPoints, " . unixTimestampStatement('pa.unlocked_at', 'DateAwarded') . "
               FROM player_achievements AS pa
               LEFT JOIN UserAccounts AS u ON u.ID = pa.user_id
               WHERE pa.achievement_id = $achID $extraWhere
@@ -197,7 +197,6 @@ function getRecentUnlocksPlayersData(
 
     foreach (legacyDbFetchAll($query) as $db_entry) {
         $db_entry['RAPoints'] = (int) $db_entry['RAPoints'];
-        $db_entry['RASoftcorePoints'] = (int) $db_entry['RASoftcorePoints'];
         $db_entry['DateAwarded'] = (int) $db_entry['DateAwarded'];
         $retVal['RecentWinner'][] = $db_entry;
     }

--- a/public/API/API_GetAchievementOfTheWeek.php
+++ b/public/API/API_GetAchievementOfTheWeek.php
@@ -34,6 +34,7 @@ use Illuminate\Support\Carbon;
  *  array      Unlocks                  requested unlock information
  *   string     User                    user who unlocked the achievement
  *   int        RAPoints                number of points the user has
+ *   int        RASoftcorePoints        number of softcore points the user has
  *   datetime   DateAwarded             when the achievement was unlocked
  *   int        HardcoreMode            1 if unlocked in hardcore, otherwise 0
  */

--- a/public/API/API_GetAchievementUnlocks.php
+++ b/public/API/API_GetAchievementUnlocks.php
@@ -28,6 +28,7 @@
  *  array      Unlocks                  requested unlock information
  *   string     User                    user who unlocked the achievement
  *   string     RAPoints                number of points the user has
+ *   string     RASoftcorePoints        number of softcore points the user has
  *   datetime   DateAwarded             when the achievement was unlocked
  *   string     HardcoreMode            "1" if unlocked in hardcore, otherwise "0"
  */

--- a/tests/Feature/Api/V1/AchievementOfTheWeekTest.php
+++ b/tests/Feature/Api/V1/AchievementOfTheWeekTest.php
@@ -65,16 +65,19 @@ class AchievementOfTheWeekTest extends TestCase
                     [
                         'User' => $user3->User,
                         'RAPoints' => $user3->RAPoints,
+                        'RASoftcorePoints' => $user3->RASoftcorePoints,
                         'HardcoreMode' => 1,
                     ],
                     [
                         'User' => $this->user->User,
                         'RAPoints' => $this->user->RAPoints,
+                        'RASoftcorePoints' => $user->RASoftcorePoints,
                         'HardcoreMode' => 0,
                     ],
                     [
                         'User' => $user2->User,
                         'RAPoints' => $user2->RAPoints,
+                        'RASoftcorePoints' => $user2->RASoftcorePoints,
                         'HardcoreMode' => 0,
                     ],
                 ],

--- a/tests/Feature/Api/V1/AchievementOfTheWeekTest.php
+++ b/tests/Feature/Api/V1/AchievementOfTheWeekTest.php
@@ -71,7 +71,7 @@ class AchievementOfTheWeekTest extends TestCase
                     [
                         'User' => $this->user->User,
                         'RAPoints' => $this->user->RAPoints,
-                        'RASoftcorePoints' => $user->RASoftcorePoints,
+                        'RASoftcorePoints' $this->user->RASoftcorePoints,
                         'HardcoreMode' => 0,
                     ],
                     [

--- a/tests/Feature/Api/V1/AchievementOfTheWeekTest.php
+++ b/tests/Feature/Api/V1/AchievementOfTheWeekTest.php
@@ -71,7 +71,7 @@ class AchievementOfTheWeekTest extends TestCase
                     [
                         'User' => $this->user->User,
                         'RAPoints' => $this->user->RAPoints,
-                        'RASoftcorePoints' $this->user->RASoftcorePoints,
+                        'RASoftcorePoints' => $this->user->RASoftcorePoints,
                         'HardcoreMode' => 0,
                     ],
                     [

--- a/tests/Feature/Api/V1Test.php
+++ b/tests/Feature/Api/V1Test.php
@@ -307,6 +307,7 @@ class V1Test extends TestCase
                     [
                         'User' => $this->user->User,
                         'RAPoints' => $this->user->RAPoints,
+                        'RASoftcorePoints' => $this->user->RASoftcorePoints,
                         'HardcoreMode' => 0,
                     ],
                 ],

--- a/tests/Feature/Connect/AchievementWonDataTest.php
+++ b/tests/Feature/Connect/AchievementWonDataTest.php
@@ -78,11 +78,11 @@ class AchievementWonDataTest extends TestCase
                     'GameID' => $game->ID,
                     'TotalPlayers' => 16,
                     'RecentWinner' => [
-                        ['User' => $users[19]->User, 'RAPoints' => $users[19]->RAPoints, 'DateAwarded' => $unlocks[19]],
-                        ['User' => $users[18]->User, 'RAPoints' => $users[18]->RAPoints, 'DateAwarded' => $unlocks[18]],
-                        ['User' => $users[16]->User, 'RAPoints' => $users[16]->RAPoints, 'DateAwarded' => $unlocks[16]],
-                        ['User' => $users[15]->User, 'RAPoints' => $users[15]->RAPoints, 'DateAwarded' => $unlocks[15]],
-                        ['User' => $users[14]->User, 'RAPoints' => $users[14]->RAPoints, 'DateAwarded' => $unlocks[14]],
+                        ['User' => $users[19]->User, 'RAPoints' => $users[19]->RAPoints, 'RASoftcorePoints' => $users[19]->RASoftcorePoints, 'DateAwarded' => $unlocks[19]],
+                        ['User' => $users[18]->User, 'RAPoints' => $users[18]->RAPoints, 'RASoftcorePoints' => $users[18]->RASoftcorePoints, 'DateAwarded' => $unlocks[18]],
+                        ['User' => $users[16]->User, 'RAPoints' => $users[16]->RAPoints, 'RASoftcorePoints' => $users[16]->RASoftcorePoints, 'DateAwarded' => $unlocks[16]],
+                        ['User' => $users[15]->User, 'RAPoints' => $users[15]->RAPoints, 'RASoftcorePoints' => $users[15]->RASoftcorePoints, 'DateAwarded' => $unlocks[15]],
+                        ['User' => $users[14]->User, 'RAPoints' => $users[14]->RAPoints, 'RASoftcorePoints' => $users[14]->RASoftcorePoints, 'DateAwarded' => $unlocks[14]],
                     ],
                 ],
             ]);
@@ -100,8 +100,8 @@ class AchievementWonDataTest extends TestCase
                     'GameID' => $game->ID,
                     'TotalPlayers' => 16,
                     'RecentWinner' => [
-                        ['User' => $users[3]->User, 'RAPoints' => $users[3]->RAPoints, 'DateAwarded' => $unlocks[3]],
-                        ['User' => $users[2]->User, 'RAPoints' => $users[2]->RAPoints, 'DateAwarded' => $unlocks[2]],
+                        ['User' => $users[3]->User, 'RAPoints' => $users[3]->RAPoints, 'RASoftcorePoints' => $users[3]->RASoftcorePoints, 'DateAwarded' => $unlocks[3]],
+                        ['User' => $users[2]->User, 'RAPoints' => $users[2]->RAPoints, 'RASoftcorePoints' => $users[2]->RASoftcorePoints, 'DateAwarded' => $unlocks[2]],
                     ],
                 ],
             ]);
@@ -119,10 +119,10 @@ class AchievementWonDataTest extends TestCase
                     'GameID' => $game->ID,
                     'TotalPlayers' => 16,
                     'RecentWinner' => [
-                        ['User' => $users[10]->User, 'RAPoints' => $users[10]->RAPoints, 'DateAwarded' => $unlocks[10]],
-                        ['User' => $users[7]->User, 'RAPoints' => $users[7]->RAPoints, 'DateAwarded' => $unlocks[7]],
-                        ['User' => $users[4]->User, 'RAPoints' => $users[4]->RAPoints, 'DateAwarded' => $unlocks[4]],
-                        ['User' => $users[1]->User, 'RAPoints' => $users[1]->RAPoints, 'DateAwarded' => $unlocks[1]],
+                        ['User' => $users[10]->User, 'RAPoints' => $users[10]->RAPoints, 'RASoftcorePoints' => $users[10]->RASoftcorePoints, 'DateAwarded' => $unlocks[10]],
+                        ['User' => $users[7]->User, 'RAPoints' => $users[7]->RAPoints, 'RASoftcorePoints' => $users[7]->RASoftcorePoints, 'DateAwarded' => $unlocks[7]],
+                        ['User' => $users[4]->User, 'RAPoints' => $users[4]->RAPoints, 'RASoftcorePoints' => $users[4]->RASoftcorePoints, 'DateAwarded' => $unlocks[4]],
+                        ['User' => $users[1]->User, 'RAPoints' => $users[1]->RAPoints, 'RASoftcorePoints' => $users[1]->RASoftcorePoints, 'DateAwarded' => $unlocks[1]],
                     ],
                 ],
             ]);
@@ -185,8 +185,8 @@ class AchievementWonDataTest extends TestCase
                     'GameID' => $game->ID,
                     'TotalPlayers' => 16,
                     'RecentWinner' => [
-                        ['User' => $users[10]->User, 'RAPoints' => $users[10]->RAPoints, 'DateAwarded' => $unlocks[10]],
-                        ['User' => $users[4]->User, 'RAPoints' => $users[4]->RAPoints, 'DateAwarded' => $unlocks[4]],
+                        ['User' => $users[10]->User, 'RAPoints' => $users[10]->RAPoints, 'RASoftcorePoints' => $users[10]->RASoftcorePoints, 'DateAwarded' => $unlocks[10]],
+                        ['User' => $users[4]->User, 'RAPoints' => $users[4]->RAPoints, 'RASoftcorePoints' => $users[4]->RASoftcorePoints, 'DateAwarded' => $unlocks[4]],
                         // $users[1] is not their own friend, so won't be in the list
                     ],
                 ],

--- a/tests/Feature/Connect/AchievementWonDataTest.php
+++ b/tests/Feature/Connect/AchievementWonDataTest.php
@@ -78,11 +78,11 @@ class AchievementWonDataTest extends TestCase
                     'GameID' => $game->ID,
                     'TotalPlayers' => 16,
                     'RecentWinner' => [
-                        ['User' => $users[19]->User, 'RAPoints' => $users[19]->RAPoints, 'RASoftcorePoints' => $users[19]->RASoftcorePoints, 'DateAwarded' => $unlocks[19]],
-                        ['User' => $users[18]->User, 'RAPoints' => $users[18]->RAPoints, 'RASoftcorePoints' => $users[18]->RASoftcorePoints, 'DateAwarded' => $unlocks[18]],
-                        ['User' => $users[16]->User, 'RAPoints' => $users[16]->RAPoints, 'RASoftcorePoints' => $users[16]->RASoftcorePoints, 'DateAwarded' => $unlocks[16]],
-                        ['User' => $users[15]->User, 'RAPoints' => $users[15]->RAPoints, 'RASoftcorePoints' => $users[15]->RASoftcorePoints, 'DateAwarded' => $unlocks[15]],
-                        ['User' => $users[14]->User, 'RAPoints' => $users[14]->RAPoints, 'RASoftcorePoints' => $users[14]->RASoftcorePoints, 'DateAwarded' => $unlocks[14]],
+                        ['User' => $users[19]->User, 'RAPoints' => $users[19]->RAPoints, 'DateAwarded' => $unlocks[19]],
+                        ['User' => $users[18]->User, 'RAPoints' => $users[18]->RAPoints, 'DateAwarded' => $unlocks[18]],
+                        ['User' => $users[16]->User, 'RAPoints' => $users[16]->RAPoints, 'DateAwarded' => $unlocks[16]],
+                        ['User' => $users[15]->User, 'RAPoints' => $users[15]->RAPoints, 'DateAwarded' => $unlocks[15]],
+                        ['User' => $users[14]->User, 'RAPoints' => $users[14]->RAPoints, 'DateAwarded' => $unlocks[14]],
                     ],
                 ],
             ]);
@@ -100,8 +100,8 @@ class AchievementWonDataTest extends TestCase
                     'GameID' => $game->ID,
                     'TotalPlayers' => 16,
                     'RecentWinner' => [
-                        ['User' => $users[3]->User, 'RAPoints' => $users[3]->RAPoints, 'RASoftcorePoints' => $users[3]->RASoftcorePoints, 'DateAwarded' => $unlocks[3]],
-                        ['User' => $users[2]->User, 'RAPoints' => $users[2]->RAPoints, 'RASoftcorePoints' => $users[2]->RASoftcorePoints, 'DateAwarded' => $unlocks[2]],
+                        ['User' => $users[3]->User, 'RAPoints' => $users[3]->RAPoints, 'DateAwarded' => $unlocks[3]],
+                        ['User' => $users[2]->User, 'RAPoints' => $users[2]->RAPoints, 'DateAwarded' => $unlocks[2]],
                     ],
                 ],
             ]);
@@ -119,10 +119,10 @@ class AchievementWonDataTest extends TestCase
                     'GameID' => $game->ID,
                     'TotalPlayers' => 16,
                     'RecentWinner' => [
-                        ['User' => $users[10]->User, 'RAPoints' => $users[10]->RAPoints, 'RASoftcorePoints' => $users[10]->RASoftcorePoints, 'DateAwarded' => $unlocks[10]],
-                        ['User' => $users[7]->User, 'RAPoints' => $users[7]->RAPoints, 'RASoftcorePoints' => $users[7]->RASoftcorePoints, 'DateAwarded' => $unlocks[7]],
-                        ['User' => $users[4]->User, 'RAPoints' => $users[4]->RAPoints, 'RASoftcorePoints' => $users[4]->RASoftcorePoints, 'DateAwarded' => $unlocks[4]],
-                        ['User' => $users[1]->User, 'RAPoints' => $users[1]->RAPoints, 'RASoftcorePoints' => $users[1]->RASoftcorePoints, 'DateAwarded' => $unlocks[1]],
+                        ['User' => $users[10]->User, 'RAPoints' => $users[10]->RAPoints, 'DateAwarded' => $unlocks[10]],
+                        ['User' => $users[7]->User, 'RAPoints' => $users[7]->RAPoints, 'DateAwarded' => $unlocks[7]],
+                        ['User' => $users[4]->User, 'RAPoints' => $users[4]->RAPoints, 'DateAwarded' => $unlocks[4]],
+                        ['User' => $users[1]->User, 'RAPoints' => $users[1]->RAPoints, 'DateAwarded' => $unlocks[1]],
                     ],
                 ],
             ]);
@@ -185,8 +185,8 @@ class AchievementWonDataTest extends TestCase
                     'GameID' => $game->ID,
                     'TotalPlayers' => 16,
                     'RecentWinner' => [
-                        ['User' => $users[10]->User, 'RAPoints' => $users[10]->RAPoints, 'RASoftcorePoints' => $users[10]->RASoftcorePoints, 'DateAwarded' => $unlocks[10]],
-                        ['User' => $users[4]->User, 'RAPoints' => $users[4]->RAPoints, 'RASoftcorePoints' => $users[4]->RASoftcorePoints, 'DateAwarded' => $unlocks[4]],
+                        ['User' => $users[10]->User, 'RAPoints' => $users[10]->RAPoints, 'DateAwarded' => $unlocks[10]],
+                        ['User' => $users[4]->User, 'RAPoints' => $users[4]->RAPoints, 'DateAwarded' => $unlocks[4]],
                         // $users[1] is not their own friend, so won't be in the list
                     ],
                 ],


### PR DESCRIPTION
This PR is to add Softcore Points in the return value for API_GetAchievementUnlocks. 

Model Before:
```
{
    "User": "DripZ07",
    "RAPoints": 0,
    "DateAwarded": "2024-03-15T19:49:20.000000Z",
    "HardcoreMode": 0
}
```
Model After:
```
{
    "User": "DripZ07",
    "RAPoints": 0,
    "RASoftcorePoints" 116,
    "DateAwarded": "2024-03-15T19:49:20.000000Z",
    "HardcoreMode": 0
}
```