### PR TITLE
fix(completion-progress): show tooltips on dynamic icons

### DIFF
--- a/resources/views/livewire/game/user-achievements-grid.blade.php
+++ b/resources/views/livewire/game/user-achievements-grid.blade.php
@@ -47,7 +47,7 @@ $loadContent = function() {
                         $achievement,
                         label: false,
                         iconSize: 48,
-                        iconClass: "badgeimglarge {$achievement['BadgeClassNames']}",
+                        iconClass: "z-10 badgeimglarge {$achievement['BadgeClassNames']}",
                         loading: 'eager',
                     )
                 !!}
@@ -58,7 +58,7 @@ $loadContent = function() {
     <div
         x-ref="skeleton"
         class="z-[1] w-full h-full transition-opacity duration-500"
-        :class="{ 'opacity-0': !isLoading }"
+        :class="{ 'opacity-0 pointer-events-none': !isLoading }"
     >
         <x-game-list-item.user-achievements-grid.skeleton
             :$achievementCount
@@ -68,7 +68,7 @@ $loadContent = function() {
 
 @script
 <script>
-    Alpine.data('userAchievementsGrid', () => {
+Alpine.data('userAchievementsGrid', () => {
         return {
             isLoading: $wire.entangle('isLoading'),
             gameAchievementsWithProgress: $wire.entangle('gameAchievementsWithProgress'),

--- a/resources/views/livewire/game/user-achievements-grid.blade.php
+++ b/resources/views/livewire/game/user-achievements-grid.blade.php
@@ -68,7 +68,7 @@ $loadContent = function() {
 
 @script
 <script>
-Alpine.data('userAchievementsGrid', () => {
+    Alpine.data('userAchievementsGrid', () => {
         return {
             isLoading: $wire.entangle('isLoading'),
             gameAchievementsWithProgress: $wire.entangle('gameAchievementsWithProgress'),

--- a/resources/views/livewire/game/user-achievements-grid.blade.php
+++ b/resources/views/livewire/game/user-achievements-grid.blade.php
@@ -47,7 +47,7 @@ $loadContent = function() {
                         $achievement,
                         label: false,
                         iconSize: 48,
-                        iconClass: "z-10 badgeimglarge {$achievement['BadgeClassNames']}",
+                        iconClass: "badgeimglarge {$achievement['BadgeClassNames']}",
                         loading: 'eager',
                     )
                 !!}


### PR DESCRIPTION
Resolves an issue where achievement card tooltips don't appear when hovering over dynamic achievement icons on the completion progress page.