### PR TITLE
fix(metrics): update player RetroPoints metrics on achievement unlocks

### DIFF
--- a/app/Platform/Actions/UpdateGameMetrics.php
+++ b/app/Platform/Actions/UpdateGameMetrics.php
@@ -94,8 +94,8 @@ class UpdateGameMetrics
         $tmp = $playersTotalChange;
         $tmp = $playersHardcoreChange;
 
-        if ($achievementSetVersionChanged) {
-            Log::info('Achievement set version changed for ' . $game->id . '. Queueing all outdated player games.');
+        if ($achievementSetVersionChanged || $pointsWeightedChange !== 0) {
+            Log::info("Hash or stats change detected for game [" . $game->id . "]. Queueing all outdated player games.");
             dispatch(new UpdateGamePlayerGamesJob($game->id))
                 ->onQueue('game-player-games');
         }

--- a/app/Platform/Actions/UpdateGamePlayerGames.php
+++ b/app/Platform/Actions/UpdateGamePlayerGames.php
@@ -26,10 +26,6 @@ class UpdateGamePlayerGames
         // Note: this might dispatch multiple thousands of jobs depending on a game's players count
         // add all affected player games to the update queue in batches
         $game->playerGames()
-            ->where(function ($query) use ($game) {
-                $query->whereNot('achievement_set_version_hash', '=', $game->achievement_set_version_hash)
-                    ->orWhereNull('achievement_set_version_hash');
-            })
             ->chunkById(1000, function (Collection $chunk, $page) use ($game) {
                 // map and dispatch this chunk as a batch of jobs
                 Bus::batch(

--- a/tests/Feature/Api/V1/GameInfoAndUserProgressTest.php
+++ b/tests/Feature/Api/V1/GameInfoAndUserProgressTest.php
@@ -8,6 +8,7 @@ use App\Models\Achievement;
 use App\Models\Game;
 use App\Models\System;
 use App\Models\User;
+use App\Platform\Enums\AchievementType;
 use App\Platform\Enums\UnlockMode;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -218,7 +219,7 @@ class GameInfoAndUserProgressTest extends TestCase
             'Released' => 'Jan 1989',
         ]);
         /** @var Achievement $achievement1 */
-        $achievement1 = Achievement::factory()->published()->create(['GameID' => $game->ID, 'BadgeName' => '12345', 'DisplayOrder' => 1]);
+        $achievement1 = Achievement::factory()->published()->create(['GameID' => $game->ID, 'BadgeName' => '12345', 'DisplayOrder' => 1, 'type' => AchievementType::Progression]);
         /** @var Achievement $achievement2 */
         $achievement2 = Achievement::factory()->published()->create(['GameID' => $game->ID, 'BadgeName' => '23456', 'DisplayOrder' => 3]);
         /** @var Achievement $achievement3 */


### PR DESCRIPTION
This PR resolves a longstanding issue with our denormalized data. Currently, once a user masters a set, unless the set's achievement set version hash changes, their RetroPoints earned on the game will be permanently frozen.

This is directly observable at: https://retroachievements.org/user/Kosmicd12
Kosmic's RetroPoints value is a staggering 1,376,121.
However, the true value sum of his two mastered sets is somewhere in the neighborhood of 700,000 RetroPoints.

**Root Cause**
Player A has mastered a set.
Player B starts playing the set and unlocks an achievement.
Currently, Player A's `player_games` metrics (and the denormalized metrics in their `UserAccounts` row) is not being updated.
This is being caused by a conditional in the `UpdateGameMetrics` action that isn't checking for if the total weighted points value of a set has changed.