### PR TITLE
fix(developerstats): remediate issue where the pagination offset can go negative

### DIFF
--- a/resources/views/pages-legacy/developerstats.blade.php
+++ b/resources/views/pages-legacy/developerstats.blade.php
@@ -16,16 +16,15 @@ $totalDevCount = getDeveloperStatsTotalCount($devFilter);
 $totalPages = ceil($totalDevCount / $maxItemsPerPage);
 $currentPage = ($offset / $maxItemsPerPage) + 1;
 
-$previousPageHref = null;
-$nextPageHref = null;
-if ($currentPage > 1) {
-    $previousOffset = $offset - $filteredDevCount;
-    $previousPageHref = url('developerstats.php?t=' . $type . '&f=' . $devFilter . '&o=' . $previousOffset);
-}
-if ($currentPage < $totalPages) {
-    $nextOffset = $offset + $filteredDevCount;
-    $nextPageHref = url('developerstats.php?t=' . $type . '&f=' . $devFilter . '&o=' . $nextOffset);
-}
+$previousOffset = max(0, $offset - $maxItemsPerPage);
+$nextOffset = $offset + $maxItemsPerPage;
+
+$previousPageHref = ($currentPage > 1)
+    ? url('developerstats.php?t=' . $type . '&f=' . $devFilter . '&o=' . $previousOffset)
+    : null;
+$nextPageHref = ($currentPage < $totalPages)
+    ? url('developerstats.php?t=' . $type . '&f=' . $devFilter . '&o=' . $nextOffset)
+    : null;
 ?>
 
 <x-app-layout pageTitle="Developer Stats">


### PR DESCRIPTION
Resolves:
```
SQLSTATE: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '-4, 25' at line 6 (Connection: mysql, SQL: SELECT ua.ID, SUM(!ISNULL(sc.ID)) AS ActiveClaims
                  FROM UserAccounts ua
                  LEFT JOIN SetClaim sc ON sc.user_id=ua.ID AND sc.Status IN (0,3)
                  WHERE ua.ContribCount > 0 AND ua.ContribYield > 0  AND ua.Permissions = 2
                  GROUP BY ua.ID
                  ORDER BY ActiveClaims DESC, ua.User LIMIT -4, 25) (View: /home/forge/retroachievements.org/releases/2024-06-24T203904-6.7.1-b1a49d25/resources/views/pages-legacy/developerstats.blade.php) {"exception":"[object] (Illuminate\\View\\ViewException(code: 0): SQLSTATE: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '-4, 25' at line 6 (Connection: mysql, SQL: SELECT ua.ID, SUM(!ISNULL(sc.ID)) AS ActiveClaims
                  FROM UserAccounts ua
                  LEFT JOIN SetClaim sc ON sc.user_id=ua.ID AND sc.Status IN (0,3)
                  WHERE ua.ContribCount > 0 AND ua.ContribYield > 0  AND ua.Permissions = 2
                  GROUP BY ua.ID
                  ORDER BY ActiveClaims DESC, ua.User LIMIT -4, 25) (View: /home/forge/retroachievements.org/releases/2024-06-24T203904-6.7.1-b1a49d25/resources/views/pages-legacy/developerstats.blade.php) at /home/forge/retroachievements.org/releases/2024-06-24T203904-6.7.1-b1a49d25/vendor/laravel/framework/src/Illuminate/Database/Connection.php:829)
```