### PR TITLE
chore(database): add game_hash_id to player_achievements and leaderboard_entries

### DIFF
--- a/database/migrations/platform/2024_06_25_000000_update_player_hash_references.php
+++ b/database/migrations/platform/2024_06_25_000000_update_player_hash_references.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('player_achievements', function (Blueprint $table) {
+            $table->unsignedBigInteger('game_hash_id')->nullable()->after('trigger_id');
+            $table->foreign('game_hash_id')->references('id')->on('game_hashes')->onDelete('set null');
+        });
+
+        Schema::table('leaderboard_entries', function (Blueprint $table) {
+            $table->unsignedBigInteger('game_hash_id')->nullable()->after('trigger_id');
+            $table->foreign('game_hash_id')->references('id')->on('game_hashes')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('leaderboard_entries', function (Blueprint $table) {
+            $table->dropForeign(['game_hash_id']);
+            $table->dropColumn('game_hash_id');
+        });
+
+        Schema::table('player_achievements', function (Blueprint $table) {
+            $table->dropForeign(['game_hash_id']);
+            $table->dropColumn('game_hash_id');
+        });
+    }
+};


### PR DESCRIPTION
`rc_client` is already sending the currently-used hash for the `awardachievement` and `submitlbentry` routines. However, the server isn't storing it anywhere.

While `game_hash_id` exists on `player_games` and `player_sessions`, this is actually a reference to the most recently-used hash by the player. It is a close approximation, but not an exact measurement, of the hash the player used to unlock X achievement or submit Y leaderboard entry.

For trustworthy analytics, we need more precise tracking of these values at the achievement and leaderboard entry level. This PR adds a migration to insert these columns into those two tables.

**WARNING: The migration takes approximately 40 minutes to complete.** Given this duration, it makes sense to separate the migration from the PR that includes any logic changes to record the values. They'll need to be deployed separately.

While the migration is running, MariaDB leaves both tables open for reads and writes. This should not cause any disruption on prod.