### PR TITLE
feat: add webhook for unwelcome concepts inbox

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -32,6 +32,7 @@ return [
                 'url' => env('DISCORD_WEBHOOK_DEVCOMPLIANCE'),
                 'is_forum' => true,
                 'mention_role' => env('DISCORD_ROLE_DEVCOMPLIANCE'),
+                'unwelcome_concept_url' => env('DISCORD_WEBHOOK_DEVCOMPLIANCE_UNWELCOME_CONCEPT'),
             ],
             'DevQuest' => [
                 'url' => env('DISCORD_WEBHOOK_DEVQUEST'),


### PR DESCRIPTION
https://discord.com/channels/476211979464343552/1002688331827658774/1257349523081265307

Already added the webhook env var to prod's .env.

Additionally, this PR fixes a bug which is causing a few errors in our logs. Message thread titles cannot be over 100 characters long, otherwise the webhook POST errors out.