### PR TITLE
chore(CodeNotes): implement schema TODOs and add foreign key to game_id

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -323,13 +323,13 @@ class Game extends BaseModel implements HasComments, HasMedia
     }
 
     /**
-     * TODO will need to be modified if GameID is migrated to game_hash_set_id
+     * TODO will need to be modified if game_id is migrated to game_hash_set_id
      *
      * @return HasMany<MemoryNote>
      */
     public function memoryNotes(): HasMany
     {
-        return $this->hasMany(MemoryNote::class, 'GameID');
+        return $this->hasMany(MemoryNote::class, 'game_id');
     }
 
     /**

--- a/app/Models/MemoryNote.php
+++ b/app/Models/MemoryNote.php
@@ -7,61 +7,28 @@ namespace App\Models;
 use App\Support\Database\Eloquent\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Carbon;
 
 class MemoryNote extends BaseModel
 {
     use SoftDeletes;
 
-    // TODO rename CodeNotes table to memory_notes
-    // TODO rename Address column to address, remove getAddressAttribute()
-    // TODO rename Note column to body, remove getBodyAttribute()
-    // TODO rename Created column to created_at, remove getCreatedAtAttribute()
-    // TODO rename Updated column to updated_at, remove getUpdatedAtAttribute()
-    // TODO drop GameID, migrate to game_hash_set_id
-    protected $table = 'CodeNotes';
-
-    public const CREATED_AT = 'Created';
-    public const UPDATED_AT = 'Updated';
+    // TODO drop game_id, migrate to game_hash_set_id
+    protected $table = 'memory_notes';
 
     protected $fillable = [
         'user_id',
-        'GameID',
-        'Address',
-        'Note',
+        'game_id',
+        'address',
+        'body',
     ];
 
     protected $visible = [
-        'GameID',
-        'Address',
-        'Note',
+        'game_id',
+        'address',
+        'body',
     ];
 
     // == accessors
-
-    // TODO remove after Address renamed to address
-    public function getAddressAttribute(): int
-    {
-        return $this->attributes['Address'];
-    }
-
-    // TODO remove after Note renamed to body
-    public function getBodyAttribute(): ?string
-    {
-        return $this->attributes['Note'];
-    }
-
-    // TODO remove after Created renamed to created_at
-    public function getCreatedAtAttribute(): ?Carbon
-    {
-        return $this->attributes['Created'] ? Carbon::parse($this->attributes['Created']) : null;
-    }
-
-    // TODO remove after Updated renamed to updated_at
-    public function getUpdatedAtAttribute(): ?Carbon
-    {
-        return $this->attributes['Updated'] ? Carbon::parse($this->attributes['Updated']) : null;
-    }
 
     // == mutators
 
@@ -74,7 +41,7 @@ class MemoryNote extends BaseModel
      */
     public function game(): BelongsTo
     {
-        return $this->belongsTo(Game::class, 'GameID', 'ID');
+        return $this->belongsTo(Game::class, 'game_id', 'ID');
     }
 
     /**

--- a/app/Platform/Commands/SyncMemoryNotes.php
+++ b/app/Platform/Commands/SyncMemoryNotes.php
@@ -48,7 +48,7 @@ class SyncMemoryNotes extends Command
         /*
          * Address might be 0 even though it's 0 - fix that
          */
-        $transformed['address'] = $origin->Address ?? 0;
+        $transformed['address'] = $origin->address ?? 0;
 
         $transformed['game_hash_set_id'] = $gameHashSetId;
 

--- a/app/Platform/Services/TriggerDecoderService.php
+++ b/app/Platform/Services/TriggerDecoderService.php
@@ -340,11 +340,11 @@ class TriggerDecoderService
             }
         }
 
-        $codeNotes = MemoryNote::where('GameID', $gameId)
-            ->whereIn('Address', $memoryReferences)
+        $codeNotes = MemoryNote::where('game_id', $gameId)
+            ->whereIn('address', $memoryReferences)
             ->get()
             ->mapWithKeys(function ($row, $key) {
-                return [$row['Address'] => $row['Note']];
+                return [$row['address'] => $row['body']];
             })
             ->toArray();
 

--- a/app/Policies/MemoryNotePolicy.php
+++ b/app/Policies/MemoryNotePolicy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
-use App\Models\GameHash;
+use App\Models\MemoryNote;
 use App\Models\Role;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
@@ -25,7 +25,7 @@ class MemoryNotePolicy
         return true;
     }
 
-    public function view(User $user, GameHash $gameHash): bool
+    public function view(User $user, MemoryNote $memoryNote): bool
     {
         return true;
     }
@@ -37,24 +37,24 @@ class MemoryNotePolicy
         ]);
     }
 
-    public function update(User $user, GameHash $gameHash): bool
+    public function update(User $user, MemoryNote $memoryNote): bool
     {
         return $user->hasAnyRole([
             Role::DEVELOPER,
         ]);
     }
 
-    public function delete(User $user, GameHash $gameHash): bool
+    public function delete(User $user, MemoryNote $memoryNote): bool
     {
         return false;
     }
 
-    public function restore(User $user, GameHash $gameHash): bool
+    public function restore(User $user, MemoryNote $memoryNote): bool
     {
         return false;
     }
 
-    public function forceDelete(User $user, GameHash $gameHash): bool
+    public function forceDelete(User $user, MemoryNote $memoryNote): bool
     {
         return false;
     }

--- a/database/migrations/platform/2024_07_03_000000_update_codenotes_table.php
+++ b/database/migrations/platform/2024_07_03_000000_update_codenotes_table.php
@@ -11,11 +11,20 @@ return new class() extends Migration {
     {
         Schema::rename('CodeNotes', 'memory_notes');
 
+        // SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.
         Schema::table('memory_notes', function (Blueprint $table) {
             $table->renameColumn('Address', 'address');
+        });
+        Schema::table('memory_notes', function (Blueprint $table) {
             $table->renameColumn('Note', 'body');
+        });
+        Schema::table('memory_notes', function (Blueprint $table) {
             $table->renameColumn('Created', 'created_at');
+        });
+        Schema::table('memory_notes', function (Blueprint $table) {
             $table->renameColumn('Updated', 'updated_at');
+        });
+        Schema::table('memory_notes', function (Blueprint $table) {
             $table->renameColumn('GameID', 'game_id');
         });
 

--- a/database/migrations/platform/2024_07_03_000000_update_codenotes_table.php
+++ b/database/migrations/platform/2024_07_03_000000_update_codenotes_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::rename('CodeNotes', 'memory_notes');
+
+        Schema::table('memory_notes', function (Blueprint $table) {
+            $table->renameColumn('Address', 'address');
+            $table->renameColumn('Note', 'body');
+            $table->renameColumn('Created', 'created_at');
+            $table->renameColumn('Updated', 'updated_at');
+            $table->renameColumn('GameID', 'game_id');
+        });
+
+        Schema::table('memory_notes', function (Blueprint $table) {
+            $table->unsignedBigInteger('game_id')->change();
+
+            $table->foreign('game_id')->references('ID')->on('GameData')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('memory_notes', function (Blueprint $table) {
+            $table->dropForeign(['game_id']);
+
+            $table->renameColumn('game_id', 'GameID');
+            $table->renameColumn('address', 'Address');
+            $table->renameColumn('body', 'Note');
+            $table->renameColumn('created_at', 'Created');
+            $table->renameColumn('updated_at', 'Updated');
+        });
+
+        Schema::rename('memory_notes', 'CodeNotes');
+    }
+};


### PR DESCRIPTION
**Before running the migration, execute this SQL:**
```sql
DELETE FROM CodeNotes
WHERE GameID NOT IN (SELECT ID FROM GameData)
```

---

This PR is prep work for the ultimate migration of code notes management into Filament. Gets nearly all of the model's TODOs out of the way and adds a foreign key to `game_id`. Even though we ultimately plan on dropping the column, as long as it's there, it should be bound to GameData.ID to ensure data integrity.