### PR TITLE
fix(globalRanking): prevent server error from possible null value

### DIFF
--- a/resources/views/pages-legacy/globalRanking.blade.php
+++ b/resources/views/pages-legacy/globalRanking.blade.php
@@ -269,7 +269,7 @@ $unlockMode = match ($sort % 10) {
             if ($type == 0) {
                 echo "<td class='text-right'><a href='historyexamine.php?d=$dateUnix&u=" . $dataPoint['User'] . "'>" . localized_number($dataPoint['AchievementCount']) . "</a></td>";
             } else {
-                echo "<td class='text-right'>" . localized_number($dataPoint['AchievementCount']) . "</td>";
+                echo "<td class='text-right'>" . localized_number($dataPoint['AchievementCount'] ?? 0) . "</td>";
             }
 
             if ($unlockMode == UnlockMode::Hardcore) {


### PR DESCRIPTION
Resolves the following error which is frequently appearing in the logs:

> localized_number(): Argument #1 ($number) must be of type int|float, null given, called in /home/forge/retroachievements.org/storage/framework/views/bb998d942beed7ef95ff6df7116dc309.php on line 271 (View: /home/forge/retroachievements.org/releases/2024-06-30T112700-6.7.1-76e5a495/resources/views/pages-legacy/globalRanking.blade.php) {"userId":117089,"exception":"[object] (Illuminate\\View\\ViewException(code: 0): localized_number(): Argument #1 ($number) must be of type int|float, null given, called in /home/forge/retroachievements.org/storage/framework/views/bb998d942beed7ef95ff6df7116dc309.php on line 271 (View: /home/forge/retroachievements.org/releases/2024-06-30T112700-6.7.1-76e5a495/resources/views/pages-legacy/globalRanking.blade.php) at /home/forge/retroachievements.org/releases/2024-06-30T112700-6.7.1-76e5a495/app/Helpers/formatters.php:29)