### PR TITLE
feat(manage): add memory notes management to game resources

### DIFF
--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -8,6 +8,7 @@ use App\Filament\Extensions\Resources\Resource;
 use App\Filament\Resources\GameResource\Pages;
 use App\Filament\Resources\GameResource\RelationManagers\AchievementsRelationManager;
 use App\Filament\Resources\GameResource\RelationManagers\GameHashesRelationManager;
+use App\Filament\Resources\GameResource\RelationManagers\MemoryNotesRelationManager;
 use App\Filament\Rules\ExistsInForumTopics;
 use App\Filament\Rules\IsAllowedGuideUrl;
 use App\Models\Game;
@@ -424,6 +425,7 @@ class GameResource extends Resource
         return [
             AchievementsRelationManager::class,
             GameHashesRelationManager::class,
+            MemoryNotesRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/GameResource/RelationManagers/MemoryNotesRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/MemoryNotesRelationManager.php
@@ -149,7 +149,7 @@ class MemoryNotesRelationManager extends RelationManager
                         }),
                 ]),
             ])
-            ->paginated([200])
+            ->paginated([50, 100])
             ->extremePaginationLinks()
             ->recordAction(null);
     }

--- a/app/Filament/Resources/GameResource/RelationManagers/MemoryNotesRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/MemoryNotesRelationManager.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\GameResource\RelationManagers;
+
+use App\Models\MemoryNote;
+use App\Models\User;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Support\Enums\FontFamily;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class MemoryNotesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'memoryNotes';
+
+    protected static ?string $title = 'Code Notes';
+
+    public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        return $user->can('manage', MemoryNote::class);
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        $gameId = $this->ownerRecord->id;
+
+        $associatedUsers = User::whereHas('authoredCodeNotes', function (Builder $query) use ($gameId) {
+            $query->where('game_id', $gameId);
+        })->get();
+
+        return $table
+            ->recordTitleAttribute('address')
+            ->searchPlaceholder('Search (Body)')
+            ->modifyQueryUsing(fn (Builder $query) => $query->where('body', '!=', ''))
+            ->columns([
+                Tables\Columns\TextColumn::make('address_hex')
+                    ->label('Address')
+                    ->fontFamily(FontFamily::Mono)
+                    ->color('info'), // Add some visual distinction between the address and the body.
+
+                Tables\Columns\TextColumn::make('body')
+                    ->label('Body')
+                    ->fontFamily(FontFamily::Mono)
+                    ->wrap()
+                    ->html()
+                    ->formatStateUsing(fn (string $state): string => nl2br(e($state)))
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('user.display_name')
+                    ->label('Author'),
+
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Date Updated')
+                    ->dateTime()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('user_id')
+                    ->label('Author')
+                    ->options($associatedUsers->pluck('display_name', 'ID'))
+                    ->searchable(),
+            ])
+            ->headerActions([
+
+            ])
+            ->actions([
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make()
+                        ->form([
+                            Forms\Components\Textarea::make('body')
+                                ->label('Body')
+                                ->autosize()
+                                ->required(),
+                            ])
+                        ->modalHeading(function (MemoryNote $memoryNote): string {
+                            return "Edit Note at {$memoryNote->address_hex}";
+                        })
+                        ->modalDescription(function (MemoryNote $memoryNote): ?string {
+                            /** @var User $user */
+                            $user = auth()->user();
+
+                            if ($user->is($memoryNote->user)) {
+                                return null;
+                            }
+
+                            return "WARNING: By making changes to this note, you will become the author of the note.";
+                        })
+                        ->modalSubmitActionLabel(function (MemoryNote $memoryNote): string {
+                            /** @var User $user */
+                            $user = auth()->user();
+
+                            if ($user->is($memoryNote->user)) {
+                                return "Save changes";
+                            }
+
+                            return "Save changes and become note's author";
+                        })
+                        ->mutateFormDataUsing(function (array $data): array {
+                            /** @var User $user */
+                            $user = auth()->user();
+
+                            // The code note will always be "owned" by whoever last edited it.
+                            $data['user_id'] = $user->id;
+
+                            return $data;
+                        }),
+
+                    Tables\Actions\Action::make('delete')
+                        ->label('Delete')
+                        ->icon('heroicon-s-trash')
+                        ->color('danger')
+                        ->requiresConfirmation()
+                        ->modalHeading(function (MemoryNote $memoryNote): string {
+                            return "Delete Note at {$memoryNote->address_hex}";
+                        })
+                        ->modalDescription('Are you sure you want to delete this note? It will be irreversibly lost.')
+                        ->action(function (MemoryNote $memoryNote): void {
+                            /** @var User $user */
+                            $user = auth()->user();
+
+                            if (!$user->can('delete', $memoryNote)) {
+                                return;
+                            }
+
+                            $memoryNote->user_id = $user->id;
+                            $memoryNote->forceFill(['body' => '']);
+                            $memoryNote->save();
+                        })
+                        ->visible(function (MemoryNote $memoryNote): bool {
+                            /** @var User $user */
+                            $user = auth()->user();
+
+                            return $user->can('delete', $memoryNote);
+                        }),
+                ]),
+            ])
+            ->paginated([200])
+            ->extremePaginationLinks()
+            ->recordAction(null);
+    }
+}

--- a/app/Helpers/database/code-note.php
+++ b/app/Helpers/database/code-note.php
@@ -49,21 +49,17 @@ function submitCodeNote2(string $username, int $gameID, int $address, string $no
     /** @var ?User $user */
     $user = User::firstWhere('User', $username);
 
-    if (!$user) {
-        return false;
-    }
-
-    // TODO refactor to ability
-    $permissions = (int) $user->getAttribute('Permissions');
-
-    // Prevent <= registered users from creating code notes.
-    if ($permissions <= Permissions::Registered) {
+    if (!$user?->can('create', MemoryNote::class)) {
         return false;
     }
 
     $addressHex = '0x' . str_pad(dechex($address), 6, '0', STR_PAD_LEFT);
     $currentNotes = getCodeNotesData($gameID);
     $i = array_search($addressHex, array_column($currentNotes, 'Address'));
+
+    // TODO use Eloquent ORM to determine if the operation is an update, and
+    // if so, use MemoryNotePolicy::update() instead of a legacy Permissions check.
+    $permissions = (int) $user->getAttribute('Permissions');
 
     if (
         $i !== false

--- a/app/Models/MemoryNote.php
+++ b/app/Models/MemoryNote.php
@@ -7,10 +7,16 @@ namespace App\Models;
 use App\Support\Database\Eloquent\BaseModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class MemoryNote extends BaseModel
 {
     use SoftDeletes;
+
+    use LogsActivity {
+        LogsActivity::activities as auditLog;
+    }
 
     // TODO drop game_id, migrate to game_hash_set_id
     protected $table = 'memory_notes';
@@ -28,7 +34,24 @@ class MemoryNote extends BaseModel
         'body',
     ];
 
+    // == logging
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly([
+                'user_id',
+            ])
+            ->dontSubmitEmptyLogs();
+    }
+
     // == accessors
+
+    public function getAddressHexAttribute(): string
+    {
+        // 16399 -> "0x00400f"
+        return '0x' . str_pad(dechex($this->address), 6, '0', STR_PAD_LEFT);
+    }
 
     // == mutators
 
@@ -49,7 +72,7 @@ class MemoryNote extends BaseModel
      */
     public function user(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class, 'user_id', 'ID');
     }
 
     // == scopes

--- a/app/Models/MemoryNote.php
+++ b/app/Models/MemoryNote.php
@@ -42,6 +42,7 @@ class MemoryNote extends BaseModel
             ->logOnly([
                 'user_id',
             ])
+            ->logOnlyDirty()
             ->dontSubmitEmptyLogs();
     }
 

--- a/app/Platform/Concerns/ActsAsDeveloper.php
+++ b/app/Platform/Concerns/ActsAsDeveloper.php
@@ -53,7 +53,7 @@ trait ActsAsDeveloper
      */
     public function authoredCodeNotes(): HasMany
     {
-        return $this->hasMany(MemoryNote::class, 'user_id', 'ID')->where('Note', '!=', '');
+        return $this->hasMany(MemoryNote::class, 'user_id', 'ID')->where('body', '!=', '');
     }
 
     /**

--- a/app/Policies/MemoryNotePolicy.php
+++ b/app/Policies/MemoryNotePolicy.php
@@ -16,7 +16,9 @@ class MemoryNotePolicy
     public function manage(User $user): bool
     {
         return $user->hasAnyRole([
-            Role::GAME_HASH_MANAGER,
+            Role::DEVELOPER_JUNIOR,
+            Role::DEVELOPER_STAFF,
+            Role::DEVELOPER,
         ]);
     }
 
@@ -33,20 +35,36 @@ class MemoryNotePolicy
     public function create(User $user): bool
     {
         return $user->hasAnyRole([
+            Role::DEVELOPER_JUNIOR,
+            Role::DEVELOPER_STAFF,
             Role::DEVELOPER,
         ]);
     }
 
     public function update(User $user, MemoryNote $memoryNote): bool
     {
+        // If the user has a DEVELOPER_JUNIOR role, they need to have authored the note to edit it.
+        if ($user->hasRole(Role::DEVELOPER_JUNIOR) && $user->is($memoryNote->user)) {
+            return true;
+        }
+
         return $user->hasAnyRole([
+            Role::DEVELOPER_STAFF,
             Role::DEVELOPER,
         ]);
     }
 
     public function delete(User $user, MemoryNote $memoryNote): bool
     {
-        return false;
+        // If the user has a DEVELOPER_JUNIOR role, they need to have authored the note to delete it.
+        if ($user->hasRole(Role::DEVELOPER_JUNIOR) && $user->is($memoryNote->user)) {
+            return true;
+        }
+
+        return $user->hasAnyRole([
+            Role::DEVELOPER_STAFF,
+            Role::DEVELOPER,
+        ]);
     }
 
     public function restore(User $user, MemoryNote $memoryNote): bool


### PR DESCRIPTION
This PR adds another relation manager to the management app's game resource. Now, developers can manage code notes from the game resource's page, similar to achievements and hashes. The intention is to fully mirror the code note management behavior in the player-facing app, and in a subsequent release have the functionality live exclusively in the management app.

There are a few minor behavior differences:
* Only 200 code notes are loaded per page. This solves the Dragon Quest VIII problem where that game's code notes page will not load locally.
* Users can now search for code notes via the `body` attribute.
* Optionally, users can view a column for the `updated_at` value.
* Users can filter by note author.

![Screenshot 2024-07-21 at 4 36 40 PM](https://github.com/user-attachments/assets/89851eed-a9d8-4dc8-880c-3d2aa7f81e68)

![Screenshot 2024-07-21 at 4 36 45 PM](https://github.com/user-attachments/assets/fd015042-2d67-41bf-a0f6-92eae5c9e8ad)

![Screenshot 2024-07-21 at 4 36 52 PM](https://github.com/user-attachments/assets/4fde4bd7-4764-4fe4-adf8-99b66dd0056d)

![Screenshot 2024-07-21 at 4 36 59 PM](https://github.com/user-attachments/assets/cc2ca1cc-edef-49a6-9fdd-a12127d5b1e7)

![Screenshot 2024-07-21 at 4 37 07 PM](https://github.com/user-attachments/assets/3ca4640d-2ab0-40f9-ab7c-a19106619d5c)

![Screenshot 2024-07-21 at 4 37 11 PM](https://github.com/user-attachments/assets/c712fbb7-c763-4a2e-898d-63045ae91a19)