### PR TITLE
fix(manage): remediate a few game resource issues

### DIFF
--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -79,7 +79,8 @@ class GameResource extends Resource
                     ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
                     ->schema([
                         Infolists\Components\TextEntry::make('permalink')
-                            ->url(fn (Game $record): string => $record->getPermalinkAttribute()),
+                            ->url(fn (Game $record): string => $record->getPermalinkAttribute())
+                            ->extraAttributes(['class' => 'underline']),
 
                         Infolists\Components\TextEntry::make('id')
                             ->label('ID'),
@@ -88,16 +89,24 @@ class GameResource extends Resource
 
                         Infolists\Components\TextEntry::make('forumTopic.id')
                             ->label('Forum Topic ID')
-                            ->url(fn (?int $state) => url("viewtopic.php?t={$state}")),
+                            ->url(fn (?int $state) => url("viewtopic.php?t={$state}"))
+                            ->extraAttributes(['class' => 'underline']),
 
                         Infolists\Components\TextEntry::make('system')
                             ->formatStateUsing(fn (System $state) => "[{$state->id}] {$state->name}")
-                            ->url(function (System $state) {
+                            ->url(function (System $state): ?string {
                                 if (request()->user()->can('manage', System::class)) {
                                     return SystemResource::getUrl('view', ['record' => $state->id]);
                                 }
 
                                 return null;
+                            })
+                            ->extraAttributes(function (): array {
+                                if (request()->user()->can('manage', System::class)) {
+                                    return ['class' => 'underline'];
+                                }
+
+                                return [];
                             }),
                     ]),
 
@@ -113,7 +122,17 @@ class GameResource extends Resource
                         Infolists\Components\TextEntry::make('Genre'),
 
                         Infolists\Components\TextEntry::make('GuideURL')
-                            ->label('RAGuide URL'),
+                            ->label('RAGuide URL')
+                            ->placeholder('none')
+                            ->url(fn (Game $record): ?string => $record?->GuideURL)
+                            ->extraAttributes(function (Game $game): array {
+                                if ($game?->GuideURL) {
+                                    return ['class' => 'underline'];
+                                }
+
+                                return [];
+                            })
+                            ->limit(30),
                     ]),
 
                 Infolists\Components\Section::make('Earliest Release Date')
@@ -126,6 +145,7 @@ class GameResource extends Resource
                     ->schema([
                         Infolists\Components\TextEntry::make('released_at')
                             ->label('Earliest Release Date')
+                            ->placeholder('unknown')
                             ->formatStateUsing(function (Game $game): string {
                                 $releasedAt = $game->released_at;
                                 $releasedAtGranularity = $game->released_at_granularity;
@@ -148,10 +168,15 @@ class GameResource extends Resource
 
                         Infolists\Components\TextEntry::make('released_at_granularity')
                             ->label('Release Date Precision')
+                            ->placeholder('none')
                             ->formatStateUsing(fn (string $state): string => ucfirst($state)),
                     ]),
 
                 Infolists\Components\Section::make('Metrics')
+                    ->icon('heroicon-s-arrow-trending-up')
+                    ->description("
+                        Statistics regarding the game's players and achievements can be found here.
+                    ")
                     ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
                     ->schema([
                         Infolists\Components\Fieldset::make('Players')

--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -124,9 +124,9 @@ class GameResource extends Resource
                         Infolists\Components\TextEntry::make('GuideURL')
                             ->label('RAGuide URL')
                             ->placeholder('none')
-                            ->url(fn (Game $record): ?string => $record?->GuideURL)
+                            ->url(fn (Game $record): ?string => $record->GuideURL)
                             ->extraAttributes(function (Game $game): array {
-                                if ($game?->GuideURL) {
+                                if ($game->GuideURL) {
                                     return ['class' => 'underline'];
                                 }
 

--- a/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
@@ -15,6 +15,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -220,7 +221,11 @@ class AchievementsRelationManager extends RelationManager
             )
             ->paginated([50, 100, 'all'])
             ->defaultPaginationPageOption(50)
-            ->defaultSort('DisplayOrder')
+            ->defaultSort(function (Builder $query): Builder {
+                return $query
+                    ->orderBy('DisplayOrder')
+                    ->orderBy('DateCreated', 'asc');
+            })
             ->reorderRecordsTriggerAction(
                 fn (Action $action, bool $isReordering) => $action
                     ->button()


### PR DESCRIPTION
This PR fixes a critical bug I've discovered in the management app's game resource related to achievement reordering, as well as a few very minor issues. Due to the nature of this bug, I've added the `priority/high` label to this PR, as I don't believe we can release without this being fixed.

Currently, the achievements list table is not respecting the proper sort order. It is sorting by `DisplayOrder`, so if multiple achievements have the same `DisplayOrder` value of 0, they will all be in the wrong order. This is easily observable with game 2721 (http://localhost:64000/manage/games/2721):

**Player-facing achievements list:**
![Screenshot 2024-07-21 at 5 28 07 PM](https://github.com/user-attachments/assets/1a35f5f9-73a5-49fb-9a2f-0f73ceed4936)


**Management-facing achievements list:**
![Screenshot 2024-07-21 at 5 28 01 PM](https://github.com/user-attachments/assets/353e7ed6-6d81-4269-b422-8cfc3dcfdb6b)

Other than fixing this, I've made a few small quality-of-life improvements with the game resource:
* URLs are now underlined.
* Most fields with the exception of those that still have some connection to a hub now have empty-state placeholder text if their values are null.
* I added an icon and description to the Metrics section.

![Screenshot 2024-07-21 at 5 30 00 PM](https://github.com/user-attachments/assets/aa6754da-833a-486c-b31f-3943f0c15748)
