### PR TITLE
fix(SubmitLeaderboardEntry): attach timestamp to ResumePlayerSession

### DIFF
--- a/app/Helpers/database/leaderboard.php
+++ b/app/Helpers/database/leaderboard.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Platform\Actions\ResumePlayerSession;
 use App\Platform\Enums\ValueFormat;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 
 // TODO migrate to action
 function SubmitLeaderboardEntry(
@@ -50,6 +51,7 @@ function SubmitLeaderboardEntry(
         $user,
         $leaderboard->game,
         ($gameHash && !$gameHash->isMultiDiscGameHash()) ? $gameHash : null,
+        timestamp: Carbon::now(),
     );
 
     $existingLeaderboardEntry = LeaderboardEntry::withTrashed()


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/2590.

**Root Cause**
In https://github.com/RetroAchievements/RAWeb/pull/2537, we started recording game hashes on user activity. A new `ResumePlayerSession` event is executed on leaderboard submit. This event is inadvertently sent without a timestamp, and the timestamp is set to default to null in `ResumePlayerSession`. As a result, the `last_played_at` on the user's `player_games` row for the game is erased.