### PR TITLE
feat(user): add links from recently played to Completion Progress page

### DIFF
--- a/resources/views/components/game-list-item/index.blade.php
+++ b/resources/views/components/game-list-item/index.blade.php
@@ -68,10 +68,16 @@ $doesGameHaveAchievements = !!$game['MaxPossible'];
 
         <div class="mt-1 sm:mt-0">
             <div class="flex gap-x-2 items-center sm:gap-x-4 sm:divide-x divide-neutral-700 ml-[68px] sm:ml-0">
-                <div class="hidden sm:flex gap-x-1 items-center rounded bg-zinc-950 light:bg-zinc-300 py-0.5 px-2">
+                @php
+                    $consoleTag = $variant === 'user-recently-played' ? 'a' : 'div';
+                @endphp
+                <{{ $consoleTag }}
+                    @if ($variant === 'user-recently-played') href="{{ route('user.completion-progress', ['user' => $targetUsername, 'filter[system]' => $consoleId]) }}" @endif
+                    class="hidden sm:flex gap-x-1 items-center rounded bg-zinc-950 light:bg-zinc-300 py-0.5 px-2"
+                >
                     <img src="{{ $gameSystemIconSrc }}" width="18" height="18" alt="{{ $consoleName }} console icon">
                     <p>{{ $consoleShortName }}</p>
-                </div>
+                </{{ $consoleTag }}>
 
                 <x-game-list-item.progress-bar
                     :softcoreCompletionPercentage="$totalCompletionPercentage"

--- a/resources/views/components/user/recently-played/index.blade.php
+++ b/resources/views/components/user/recently-played/index.blade.php
@@ -17,7 +17,7 @@
         @foreach ($processedRecentlyPlayedEntities as $processedRecentlyPlayedEntity)
             <x-game-list-item
                 :game="$processedRecentlyPlayedEntity"
-                :targetUserName="$targetUsername"
+                :targetUsername="$targetUsername"
                 :isExpandable="true"
                 :isDefaultExpanded="$loop->index === 0 && !empty($processedRecentlyPlayedEntity['AchievementAvatars'])"
                 variant="user-recently-played"


### PR DESCRIPTION
This PR makes a slight change to the "Last 5 Games Played" component on user profiles.

The system chips in each row now link to the user's Completion Progress page for that system.


https://github.com/user-attachments/assets/ac8716c2-05dd-469b-a18f-e4e40e8227a4

