### PR TITLE
feat(api): Get User Friend List

### DIFF
--- a/app/Community/Concerns/ActsAsCommunityMember.php
+++ b/app/Community/Concerns/ActsAsCommunityMember.php
@@ -81,6 +81,21 @@ trait ActsAsCommunityMember
         return $this->inverseRelatedUsers()->where('Friendship', '=', UserRelationship::Following);
     }
 
+    /**
+     * @return BelongsToMany<User>
+     */
+    public function friends(): BelongsToMany
+    {
+        return $this->relatedUsers()
+            ->where('Friendship', UserRelationship::Following)
+            ->whereIn('related_user_id', function ($query) {
+                $query->select('user_id')
+                    ->from((new UserRelation())->getTable())
+                    ->where('Friendship', UserRelationship::Following)
+                    ->where('related_user_id', $this->id);
+            });
+    }
+
     public function getRelationship(User $user): int
     {
         $relatedUser = $this->relatedUsers()->where('related_user_id', $user->id)->first();

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -153,17 +153,9 @@ class UserPolicy
         return $user->unranked_at === null;
     }
 
-    public function viewFriends(User $user, User $model): bool
+    public function viewFriends(User $user, User $targetUser): bool
     {
-        if (!$user->is($model)) {
-            return false;
-        }
-
-        /*
-         * TODO: check privacy settings
-         */
-
-        return true;
+        return $user->is($targetUser) || $user->isFriendsWith($targetUser);
     }
 
     public function updateProfileSettings(User $user, User $model): bool

--- a/public/API/API_GetUserFriendList.php
+++ b/public/API/API_GetUserFriendList.php
@@ -2,7 +2,6 @@
 
 /*
  *  API_GetUserFriendList - returns a list of Friends, with basic data, for a user
- *    u : username
  *    o : offset - number of entries to skip (default: 0)
  *    c : count - number of entries to return (default: 100, max: 500)
  *  int         Count                       number of friend records returned in the response
@@ -25,23 +24,13 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 
 $input = Validator::validate(Arr::wrap(request()->query()), [
-    'u' => ['required', 'min:2', 'max:20', new CtypeAlnum()],
     'o' => ['sometimes', 'integer', 'min:0', 'nullable'],
     'c' => ['sometimes', 'integer', 'min:1', 'max:500', 'nullable'],
 ]);
 
 $offset = $input['o'] ?? 0;
 $count = $input['c'] ?? 100;
-
-$user = User::firstWhere('User', request()->query('u'));
-if (!$user) {
-    return response()->json([], 404);
-}
-
-$policy = new UserPolicy();
-if (!$policy->viewFriends(Auth::user(), $user)) {
-    return response()->json([], 401);
-}
+$user = Auth::user();
 
 $totalFriends = $user->friends()
     ->where('Permissions', '>=', Permissions::Unregistered)

--- a/public/API/API_GetUserFriendList.php
+++ b/public/API/API_GetUserFriendList.php
@@ -1,21 +1,19 @@
 <?php
 
 /*
- *  API_GetUserFriendList - returns a list of Games, with basic data, that a user has saved on their WantToPlayList
+ *  API_GetUserFriendList - returns a list of Friends, with basic data, for a user
  *    u : username
  *    o : offset - number of entries to skip (default: 0)
  *    c : count - number of entries to return (default: 100, max: 500)
- *  int         Count                       number of want to play game records returned in the response
- *  int         Total                       number of want to play game records the user actually has overall
+ *  int         Count                       number of friend records returned in the response
+ *  int         Total                       number of friend records the user actually has overall
  *  array       Results
  *   object      [value]
- *    int        ID                         unique identifier of the game
- *    string     Title                      name of the game
- *    int        ConsoleID                  unique identifier of the console associated to the game
- *    string     ConsoleName                name of the console associated to the game
- *    string     ImageIcon                  site-relative path to the game's icon image
- *    int        PointsTotal                total points able to be earned
- *    int        AchievementsPublished      total number of achievements to be unlocked
+ *    string     Friend                     username of the friend
+ *    int        Points                     number of hardcore points the friend has earned
+ *    int        PointsSoftcore             number of softcore points the friend has earned
+ *    string     LastSeen                   rich presence message for the friend
+ *    int        ID                         unique id of the friend
  */
 
 use App\Enums\Permissions;

--- a/public/API/API_GetUserFriendList.php
+++ b/public/API/API_GetUserFriendList.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ *  API_GetUserFriendList - returns a list of Games, with basic data, that a user has saved on their WantToPlayList
+ *    u : username
+ *    o : offset - number of entries to skip (default: 0)
+ *    c : count - number of entries to return (default: 100, max: 500)
+ *  int         Count                       number of want to play game records returned in the response
+ *  int         Total                       number of want to play game records the user actually has overall
+ *  array       Results
+ *   object      [value]
+ *    int        ID                         unique identifier of the game
+ *    string     Title                      name of the game
+ *    int        ConsoleID                  unique identifier of the console associated to the game
+ *    string     ConsoleName                name of the console associated to the game
+ *    string     ImageIcon                  site-relative path to the game's icon image
+ *    int        PointsTotal                total points able to be earned
+ *    int        AchievementsPublished      total number of achievements to be unlocked
+ */
+
+use App\Enums\Permissions;
+use App\Models\User;
+use App\Policies\UserPolicy;
+use App\Support\Rules\CtypeAlnum;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+
+$input = Validator::validate(Arr::wrap(request()->query()), [
+    'u' => ['required', 'min:2', 'max:20', new CtypeAlnum()],
+    'o' => ['sometimes', 'integer', 'min:0', 'nullable'],
+    'c' => ['sometimes', 'integer', 'min:1', 'max:500', 'nullable'],
+]);
+
+$offset = $input['o'] ?? 0;
+$count = $input['c'] ?? 100;
+
+$user = User::firstWhere('User', request()->query('u'));
+if (!$user) {
+    return response()->json([], 404);
+}
+
+$policy = new UserPolicy();
+if (!$policy->viewFriends(Auth::user(), $user)) {
+    return response()->json([], 401);
+}
+
+$totalFriends = $user->friends()
+    ->where('Permissions', '>=', Permissions::Unregistered)
+    ->whereNull('Deleted')
+    ->count();
+
+$friendList = $user->friends()
+    ->where('Permissions', '>=', Permissions::Unregistered)
+    ->whereNull('Deleted')
+    ->orderBy('LastActivityID', 'DESC')
+    ->skip($offset)
+    ->take($count)
+    ->get()
+    ->map(function ($friend) {
+        return [
+            'Friend' => $friend->User,
+            'Points' => $friend->points,
+            'PointsSoftcore' => $friend->points_softcore,
+            'LastSeen' => empty($friend->RichPresenceMsg) ? 'Unknown' : strip_tags($friend->RichPresenceMsg),
+            'ID' => $friend->id,
+        ];
+    });
+
+return response()->json([
+    'Count' => count($friendList),
+    'Total' => $totalFriends,
+    'Results' => $friendList,
+]);

--- a/tests/Feature/Api/V1/UserFriendListTest.php
+++ b/tests/Feature/Api/V1/UserFriendListTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Community\Enums\UserRelationship;
+use App\Models\User;
+use App\Models\UserRelation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class UserFriendListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var User $user */
+        $user = User::factory()->create(['User' => 'myUser']);
+        $this->user = $user;
+    }
+
+    protected function apiUrl(string $method, array $params = []): string
+    {
+        $params = array_merge(['y' => $this->user->APIKey], $params);
+
+        return sprintf('API/API_%s.php?%s', $method, http_build_query($params));
+    }
+
+    public function testItValidates(): void
+    {
+        $this->get($this->apiUrl('GetUserFriendList', ['u' => '1']))
+            ->assertJsonValidationErrors([
+                'u',
+            ]);
+    }
+
+    public function testGetUserWantToPlayListUnknownUser(): void
+    {
+        $this->get($this->apiUrl('GetUserFriendList', ['u' => 'nonExistant']))
+            ->assertNotFound()
+            ->assertJson([]);
+    }
+
+    public function testGetUserWantToPlayList(): void
+    {
+        Carbon::setTestNow(Carbon::now());
+
+        /** @var User $followedUser */
+        $followedUser = User::factory()->create(['User' => 'followedUser']);
+        UserRelation::create([
+            'user_id' => $this->user->id,
+            'related_user_id' => $followedUser->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+
+        /** @var User $followingUser */
+        $followingUser = User::factory()->create(['User' => 'followingUser']);
+        UserRelation::create([
+            'user_id' => $followingUser->id,
+            'related_user_id' => $this->user->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+
+        /** @var User $friend1 */
+        $friend1 = User::factory()->create(['User' => 'myFriend1', 'RichPresenceMsg' => 'Playing Friendship 1']);
+        UserRelation::create([
+            'user_id' => $this->user->id,
+            'related_user_id' => $friend1->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+        UserRelation::create([
+            'user_id' => $friend1->id,
+            'related_user_id' => $this->user->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+
+        /** @var User $friend2 */
+        $friend2 = User::factory()->create(['User' => 'myFriend2', 'RichPresenceMsg' => 'Playing Friendship 2']);
+        UserRelation::create([
+            'user_id' => $this->user->id,
+            'related_user_id' => $friend2->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+        UserRelation::create([
+            'user_id' => $friend2->id,
+            'related_user_id' => $this->user->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+
+        /** @var User $friend3 */
+        $friend3 = User::factory()->create(['User' => 'myFriend3', 'RichPresenceMsg' => 'Playing Friendship 3']);
+        UserRelation::create([
+            'user_id' => $this->user->id,
+            'related_user_id' => $friend3->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+        UserRelation::create([
+            'user_id' => $friend3->id,
+            'related_user_id' => $this->user->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+
+        /** @var User $friend4 */
+        $friend4 = User::factory()->create(['User' => 'myFriend4', 'RichPresenceMsg' => 'Playing Friendship 4']);
+        UserRelation::create([
+            'user_id' => $this->user->id,
+            'related_user_id' => $friend4->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+        UserRelation::create([
+            'user_id' => $friend4->id,
+            'related_user_id' => $this->user->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+
+        /** @var User $friend5 */
+        $friend5 = User::factory()->create(['User' => 'myFriend5']);
+        UserRelation::create([
+            'user_id' => $this->user->id,
+            'related_user_id' => $friend5->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+        UserRelation::create([
+            'user_id' => $friend5->id,
+            'related_user_id' => $this->user->id,
+            'Friendship' => UserRelationship::Following,
+        ]);
+
+        $this->get($this->apiUrl('GetUserFriendList', ['u' => $this->user->User]))
+            ->assertSuccessful()
+            ->assertJson([
+                'Count' => 5,
+                'Total' => 5,
+                'Results' => [
+                    [
+                        "Friend" => $friend1->User,
+                        "Points" => $friend1->Points,
+                        "PointsSoftcore" => $friend1->points_softcore,
+                        "LastSeen" => $friend1->RichPresenceMsg,
+                        "ID" => $friend1->ID,
+                    ],
+                    [
+                        "Friend" => $friend2->User,
+                        "Points" => $friend2->Points,
+                        "PointsSoftcore" => $friend2->points_softcore,
+                        "LastSeen" => $friend2->RichPresenceMsg,
+                        "ID" => $friend2->ID,
+                    ],
+                    [
+                        "Friend" => $friend3->User,
+                        "Points" => $friend3->Points,
+                        "PointsSoftcore" => $friend3->points_softcore,
+                        "LastSeen" => $friend3->RichPresenceMsg,
+                        "ID" => $friend3->ID,
+                    ],
+                    [
+                        "Friend" => $friend4->User,
+                        "Points" => $friend4->Points,
+                        "PointsSoftcore" => $friend4->points_softcore,
+                        "LastSeen" => $friend4->RichPresenceMsg,
+                        "ID" => $friend4->ID,
+                    ],
+                    [
+                        "Friend" => $friend5->User,
+                        "Points" => $friend5->Points,
+                        "PointsSoftcore" => $friend5->points_softcore,
+                        "LastSeen" => 'Unknown', // No Rich Presence
+                        "ID" => $friend5->ID,
+                    ],
+                ],
+            ]);
+
+            $this->get($this->apiUrl('GetUserFriendList', ['u' => $this->user->User, 'o' => 3]))
+                ->assertSuccessful()
+                ->assertJson([
+                    'Count' => 2,
+                    'Total' => 5,
+                    'Results' => [
+                        [
+                            "Friend" => $friend4->User,
+                            "Points" => $friend4->Points,
+                            "PointsSoftcore" => $friend4->points_softcore,
+                            "LastSeen" => $friend4->RichPresenceMsg,
+                            "ID" => $friend4->ID,
+                        ],
+                        [
+                            "Friend" => $friend5->User,
+                            "Points" => $friend5->Points,
+                            "PointsSoftcore" => $friend5->points_softcore,
+                            "LastSeen" => 'Unknown', // No Rich Presence
+                            "ID" => $friend5->ID,
+                        ],
+                    ],
+                ]);
+
+            $this->get($this->apiUrl('GetUserFriendList', ['u' => $this->user->User, 'c' => 2]))
+                ->assertSuccessful()
+                ->assertJson([
+                    'Count' => 2,
+                    'Total' => 5,
+                    'Results' => [
+                        [
+                            "Friend" => $friend1->User,
+                            "Points" => $friend1->Points,
+                            "PointsSoftcore" => $friend1->points_softcore,
+                            "LastSeen" => $friend1->RichPresenceMsg,
+                            "ID" => $friend1->ID,
+                        ],
+                        [
+                            "Friend" => $friend2->User,
+                            "Points" => $friend2->Points,
+                            "PointsSoftcore" => $friend2->points_softcore,
+                            "LastSeen" => $friend2->RichPresenceMsg,
+                            "ID" => $friend2->ID,
+                        ],
+                    ],
+                ]);
+
+            $this->get($this->apiUrl('GetUserFriendList', ['u' => $this->user->User, 'o' => 1, 'c' => 2]))
+                ->assertSuccessful()
+                ->assertJson([
+                    'Count' => 2,
+                    'Total' => 5,
+                    'Results' => [
+                        [
+                            "Friend" => $friend2->User,
+                            "Points" => $friend2->Points,
+                            "PointsSoftcore" => $friend2->points_softcore,
+                            "LastSeen" => $friend2->RichPresenceMsg,
+                            "ID" => $friend2->ID,
+                        ],
+                        [
+                            "Friend" => $friend3->User,
+                            "Points" => $friend3->Points,
+                            "PointsSoftcore" => $friend3->points_softcore,
+                            "LastSeen" => $friend3->RichPresenceMsg,
+                            "ID" => $friend3->ID,
+                        ],
+                    ],
+                ]);
+
+                $this->get($this->apiUrl('GetUserFriendList', ['u' => $followedUser->User]))
+                    ->assertUnauthorized()
+                    ->assertJson([]);
+
+                $this->get($this->apiUrl('GetUserFriendList', ['u' => $followingUser->User]))
+                    ->assertUnauthorized()
+                    ->assertJson([]);
+    }
+}

--- a/tests/Feature/Api/V1/UserFriendListTest.php
+++ b/tests/Feature/Api/V1/UserFriendListTest.php
@@ -33,40 +33,9 @@ class UserFriendListTest extends TestCase
         return sprintf('API/API_%s.php?%s', $method, http_build_query($params));
     }
 
-    public function testItValidates(): void
-    {
-        $this->get($this->apiUrl('GetUserFriendList', ['u' => '1']))
-            ->assertJsonValidationErrors([
-                'u',
-            ]);
-    }
-
-    public function testGetUserWantToPlayListUnknownUser(): void
-    {
-        $this->get($this->apiUrl('GetUserFriendList', ['u' => 'nonExistant']))
-            ->assertNotFound()
-            ->assertJson([]);
-    }
-
     public function testGetUserWantToPlayList(): void
     {
         Carbon::setTestNow(Carbon::now());
-
-        /** @var User $followedUser */
-        $followedUser = User::factory()->create(['User' => 'followedUser']);
-        UserRelation::create([
-            'user_id' => $this->user->id,
-            'related_user_id' => $followedUser->id,
-            'Friendship' => UserRelationship::Following,
-        ]);
-
-        /** @var User $followingUser */
-        $followingUser = User::factory()->create(['User' => 'followingUser']);
-        UserRelation::create([
-            'user_id' => $followingUser->id,
-            'related_user_id' => $this->user->id,
-            'Friendship' => UserRelationship::Following,
-        ]);
 
         /** @var User $friend1 */
         $friend1 = User::factory()->create(['User' => 'myFriend1', 'RichPresenceMsg' => 'Playing Friendship 1']);
@@ -133,7 +102,7 @@ class UserFriendListTest extends TestCase
             'Friendship' => UserRelationship::Following,
         ]);
 
-        $this->get($this->apiUrl('GetUserFriendList', ['u' => $this->user->User]))
+        $this->get($this->apiUrl('GetUserFriendList'))
             ->assertSuccessful()
             ->assertJson([
                 'Count' => 5,
@@ -177,7 +146,7 @@ class UserFriendListTest extends TestCase
                 ],
             ]);
 
-            $this->get($this->apiUrl('GetUserFriendList', ['u' => $this->user->User, 'o' => 3]))
+            $this->get($this->apiUrl('GetUserFriendList', ['o' => 3]))
                 ->assertSuccessful()
                 ->assertJson([
                     'Count' => 2,
@@ -200,7 +169,7 @@ class UserFriendListTest extends TestCase
                     ],
                 ]);
 
-            $this->get($this->apiUrl('GetUserFriendList', ['u' => $this->user->User, 'c' => 2]))
+            $this->get($this->apiUrl('GetUserFriendList', ['c' => 2]))
                 ->assertSuccessful()
                 ->assertJson([
                     'Count' => 2,
@@ -223,7 +192,7 @@ class UserFriendListTest extends TestCase
                     ],
                 ]);
 
-            $this->get($this->apiUrl('GetUserFriendList', ['u' => $this->user->User, 'o' => 1, 'c' => 2]))
+            $this->get($this->apiUrl('GetUserFriendList', ['o' => 1, 'c' => 2]))
                 ->assertSuccessful()
                 ->assertJson([
                     'Count' => 2,
@@ -245,13 +214,5 @@ class UserFriendListTest extends TestCase
                         ],
                     ],
                 ]);
-
-                $this->get($this->apiUrl('GetUserFriendList', ['u' => $followedUser->User]))
-                    ->assertUnauthorized()
-                    ->assertJson([]);
-
-                $this->get($this->apiUrl('GetUserFriendList', ['u' => $followingUser->User]))
-                    ->assertUnauthorized()
-                    ->assertJson([]);
     }
 }


### PR DESCRIPTION
This endpoint is for fetching a user's friend list. Friends will only be returned if users are mutually following each other.

With respect to viewing other users' lists, this works the same way that we set up API_GetWantToPlayList as well. A target user's friend list can be viewed if the calling user and target user are friends.

```
/*
 *  API_GetUserFriendList - returns a list of Friends, with basic data, for a user
 *    u : username
 *    o : offset - number of entries to skip (default: 0)
 *    c : count - number of entries to return (default: 100, max: 500)
 *  int         Count                       number of friend records returned in the response
 *  int         Total                       number of friend records the user actually has overall
 *  array       Results
 *   object      [value]
 *    string     Friend                     username of the friend
 *    int        Points                     number of hardcore points the friend has earned
 *    int        PointsSoftcore             number of softcore points the friend has earned
 *    string     LastSeen                   rich presence message for the friend
 *    int        ID                         unique id of the friend
 */

```