### PR TITLE
include command line arguments in exception

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -56,7 +56,7 @@ class Handler extends ExceptionHandler
         $context = parent::buildExceptionContext($e);
 
         $request = request();
-        if ($request) {
+        if ($request && !app()->runningInConsole()) {
             $context['url'] = $request->url();
 
             // never log raw passwords
@@ -85,6 +85,12 @@ class Handler extends ExceptionHandler
 
             // capture any remaining parameters
             $context['params'] = http_build_query($params);
+        } elseif ($request) {
+            // running in console - dump command line parameters
+            $argv = $request->server('argv', null);
+            if ($argv) {
+                $context['argv'] = json_encode($argv);
+            }
         }
 
         return $context;


### PR DESCRIPTION
dump command line parameters when exception occurs running command from console.

i.e.
```
{
  "exception": "[object] (ErrorException(code: 0): Attempt to read property \"id\" on bool at /var/www/html/app/Platform/Commands/UpdateDeveloperContributionYield.php:40)
[stacktrace]
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(255): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 /var/www/html/app/Platform/Commands/UpdateDeveloperContributionYield.php(40): Illuminate\\Foundation\\Bootstrap\\HandleExceptions->Illuminate\\Foundation\\Bootstrap\\{closure}()
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\\Platform\\Commands\\UpdateDeveloperContributionYield->handle()
#3 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/Util.php(41): Illuminate\\Container\\BoundMethod::Illuminate\\Container\\{closure}()
#4 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\\Container\\Util::unwrapIfClosure()
#5 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\\Container\\BoundMethod::callBoundMethod()
#6 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/Container.php(662): Illuminate\\Container\\BoundMethod::call()
#7 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Command.php(211): Illuminate\\Container\\Container->call()
#8 /var/www/html/vendor/symfony/console/Command/Command.php(326): Illuminate\\Console\\Command->execute()
#9 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Command.php(180): Symfony\\Component\\Console\\Command\\Command->run()
#10 /var/www/html/vendor/symfony/console/Application.php(1096): Illuminate\\Console\\Command->run()
#11 /var/www/html/vendor/symfony/console/Application.php(324): Symfony\\Component\\Console\\Application->doRunCommand()
#12 /var/www/html/vendor/symfony/console/Application.php(175): Symfony\\Component\\Console\\Application->doRun()
#13 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(201): Symfony\\Component\\Console\\Application->run()
#14 /var/www/html/artisan(35): Illuminate\\Foundation\\Console\\Kernel->handle()
#15 {main}
",
  "argv": "[\"artisan\",\"ra:platform:developer:update-contribution-yield\",\"Test\"]"
}
```

This example shows an exception in the command when run from the command line using "sail artisan ...". I couldn't actually get an exception in the Action to log, but I'm hopeful this will help with some of the exceptions we're actually seeing in the log as they seem to be going through the same code path and incorrectly reporting themselves as coming from the home page:
```
...
#17 /home/forge/retroachievements.org/releases/2024-08-22T131209-6.12.0-7136bf9c/vendor/symfony/console/Application.php(324): Symfony\\Component\\Console\\Application->doRunCommand()
#18 /home/forge/retroachievements.org/releases/2024-08-22T131209-6.12.0-7136bf9c/vendor/symfony/console/Application.php(175): Symfony\\Component\\Console\\Application->doRun()
#19 /home/forge/retroachievements.org/releases/2024-08-22T131209-6.12.0-7136bf9c/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(201): Symfony\\Component\\Console\\Application->run()
#20 /home/forge/retroachievements.org/releases/2024-08-22T131209-6.12.0-7136bf9c/artisan(35): Illuminate\\Foundation\\Console\\Kernel->handle()
#21 {main}
",
  "url": "https://retroachievements.org",
  "params": ""
}
```