### PR TITLE
fix(user): link to the correct user completion progress page

### DIFF
--- a/resources/views/pages-legacy/userInfo.blade.php
+++ b/resources/views/pages-legacy/userInfo.blade.php
@@ -156,7 +156,7 @@ if (getActiveClaimCount($userPageModel, true, true) > 0) {
             :recentlyPlayedEntities="$userMassData['RecentlyPlayed'] ?? []"
             :recentAchievementEntities="$userMassData['RecentAchievements'] ?? []"
             :recentAwardedEntities="$userMassData['Awarded'] ?? []"
-            :targetUsername="$user ?? ''"
+            :targetUsername="$userPage ?? ''"
             :userAwards="$userAwards"
         />
     <?php


### PR DESCRIPTION
This PR fixes a minor bug on the user profile.

The new Completion Progress links on the "Last 5 Games Played" rows do not link to the correct user. They always link to yourself.

For example, go to http://localhost:64000/user/Scott and click on one of the links - it will link to your own Completion Progress page.

Now, the links will go to the right place.