### PR TITLE
prevent exception trying to render recent mastery for deleted user

### DIFF
--- a/app/Platform/Services/GameTopAchieversService.php
+++ b/app/Platform/Services/GameTopAchieversService.php
@@ -6,6 +6,7 @@ namespace App\Platform\Services;
 
 use App\Models\Game;
 use App\Models\PlayerGame;
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -108,7 +109,10 @@ class GameTopAchieversService
         $cacheKey = "game:{$this->gameId}:top-achievers";
         $retval = Cache::get($cacheKey);
         if ($retval !== null) {
-            return $retval;
+            $numTrashed = User::onlyTrashed()->whereIn('ID', array_column($retval[1], 'user_id'))->count();
+            if ($numTrashed === 0) {
+                return $retval;
+            }
         }
 
         $numMasteries = $this->numMasteries();

--- a/resources/views/components/game/top-achievers/latest-masters.blade.php
+++ b/resources/views/components/game/top-achievers/latest-masters.blade.php
@@ -29,6 +29,9 @@ $rank = $numMasters;
                 @foreach ($latestMasters as $mastery)
                     @php
                         $masteryUser = User::find($mastery['user_id']);
+                        if (!$masteryUser) {
+                            continue;
+                        }
                         $masteryDate = Carbon::createFromTimestamp($mastery['last_unlock_hardcore_at']);
                     @endphp
 


### PR DESCRIPTION
Fixes
```
Attempt to read property "id" on null (View: /home/forge/retroachievements.org/releases/2024-08-22T131209-6.12.0-7136bf9c/resources/views/components/game/top-achievers/mastery-row.blade.php) 
```
error that occurs when viewing a game where the recent masteries contained a deleted user.

The query to fetch the recent masteries ignored deleted users, but the results are cached to improve page load times. If the cached results reference a deleted user, the exception occurs.

The proper solution is to expire the cached lists for any games the deleted user has mastered, but a more immediate solution is necessary to deal with the bad data already in the cache. I've chosen to check for deleted users before returning the cached data. It's still faster than not having the cache.