### PR TITLE
allow muted users to message team accounts

### DIFF
--- a/app/Community/Controllers/MessageController.php
+++ b/app/Community/Controllers/MessageController.php
@@ -40,7 +40,9 @@ class MessageController extends Controller
 
             foreach ($thread->users as $threadUser) {
                 if (!$threadUser->is($user) && !$user->can('sendToRecipient', [Message::class, $threadUser])) {
-                    return back()->withErrors(__('legacy.error.cannot_message_user'));
+                    return back()->withErrors($user->isMuted() ?
+                        __('legacy.error.muted_user') :
+                        __('legacy.error.cannot_message_user'));
                 }
             }
 
@@ -49,7 +51,9 @@ class MessageController extends Controller
             $recipient = User::firstWhere('User', $input['recipient']);
 
             if (!$user->can('sendToRecipient', [Message::class, $recipient])) {
-                return back()->withErrors(__('legacy.error.cannot_message_user'));
+                return back()->withErrors($user->isMuted() ?
+                    __('legacy.error.muted_user') :
+                    __('legacy.error.cannot_message_user'));
             }
 
             $thread = (new CreateMessageThreadAction())->execute($user, $recipient, $input['title'], $input['body']);

--- a/app/Community/Listeners/NotifyMessageThreadParticipants.php
+++ b/app/Community/Listeners/NotifyMessageThreadParticipants.php
@@ -76,7 +76,7 @@ class NotifyMessageThreadParticipants
         $inboxConfig = config('services.discord.inbox_webhook.' . $userTo->username);
         $webhookUrl = $inboxConfig['url'] ?? null;
 
-        if ($inboxConfig === null || $webhookUrl === null) {
+        if ($inboxConfig === null || empty($webhookUrl)) {
             return;
         }
 

--- a/app/Policies/MessagePolicy.php
+++ b/app/Policies/MessagePolicy.php
@@ -25,7 +25,7 @@ class MessagePolicy
 
     public function create(User $user): bool
     {
-        return $user->isNotMuted();
+        return true;
     }
 
     public function update(User $user, Message $message): bool
@@ -50,6 +50,10 @@ class MessagePolicy
 
     public function sendToRecipient(User $user, User $targetUser): bool
     {
+        if ($user->isMuted() && !$targetUser->hasRole(Role::TEAM_ACCOUNT)) {
+            return false;
+        }
+
         $canUserSendWhileBlocked = $user->hasAnyRole([
             Role::ADMINISTRATOR,
             Role::MODERATOR,

--- a/lang/en/legacy.php
+++ b/lang/en/legacy.php
@@ -14,6 +14,7 @@ return [
         'game_modify' => __("Problems encountered while performing modification. Does the target game already exist? If so, try a merge instead on the target game title."),
         'image_upload' => "Image could not be uploaded.",
         'invalid_news_content' => __("Problems encountered with news content. Ensure any given HTML is valid."),
+        'muted_user' => __("Muted users can only message team accounts."),
         'permissions' => __('Insufficient permissions.'),
         'recaptcha' => __("Invalid ReCaptcha."),
         'subscription_update' => __("Failed to update topic subscription."),


### PR DESCRIPTION
The "new message" button is currently hidden for muted users. This re-enables the "new message" button, but will generate an error if the user tries to send to a non-team account.

https://discord.com/channels/476211979464343552/1002689485005406249/1276533882983940219