### PR TITLE
Add hash information to game history

### DIFF
--- a/app/Platform/Services/PlayerGameActivityService.php
+++ b/app/Platform/Services/PlayerGameActivityService.php
@@ -17,7 +17,7 @@ class PlayerGameActivityService
 
     public function initialize(User $user, Game $game): void
     {
-        $playerSessions = $user->playerSessions()->where('game_id', $game->id)->get();
+        $playerSessions = $user->playerSessions()->with('gameHash')->where('game_id', $game->id)->get();
 
         foreach ($playerSessions as $playerSession) {
             $session = [

--- a/resources/views/components/user/game-activity.blade.php
+++ b/resources/views/components/user/game-activity.blade.php
@@ -32,6 +32,18 @@ use App\Platform\Enums\AchievementFlag;
                         @if ($session['type'] === PlayerGameActivitySessionType::Player)
                             <td>
                                 <span class='text-muted'>Started Playing</span>
+                                @if ($session['playerSession'] && $session['playerSession']['gameHash'])
+                                    @php $hash = $session['playerSession']['gameHash']; @endphp
+                                    <span class="smalltext" title="{{ $hash['md5'] }}">
+                                        {{ $hash['name'] }}
+                                        @if ($hash->isMultiDiscGameHash())
+                                            <span title="Hashes associated to multi-disc game only reflect the first disc loaded">*</span>
+                                        @endif
+                                    </span>
+                                    @if ($session['userAgent'])
+                                        <span class="text-muted"> | </span>
+                                    @endif
+                                @endif
                                 @if ($session['userAgent'])
                                     <span class="smalltext" title="{{ $session['userAgent'] }}">
                                     @php $userAgent = $userAgentService->decode($session['userAgent']) @endphp
@@ -45,18 +57,6 @@ use App\Platform\Enums\AchievementFlag;
                                     @if (!empty($userAgent['os']))
                                         ({{ $userAgent['os'] }})
                                     @endif
-                                    </span>
-                                @endif
-                                @if ($session['playerSession'] && $session['playerSession']['gameHash'])
-                                    @if ($session['userAgent'])
-                                        <span class="text-muted"> | </span>
-                                    @endif
-                                    @php $hash = $session['playerSession']['gameHash']; @endphp
-                                    <span class="smalltext" title="{{ $hash['name'] }}">
-                                        {{ $hash['md5'] }}
-                                        @if ($hash->isMultiDiscGameHash())
-                                            <span title="Hashes associated to multi-disc game only reflect the first disc loaded">*</span>
-                                        @endif
                                     </span>
                                 @endif
                             </td>

--- a/resources/views/components/user/game-activity.blade.php
+++ b/resources/views/components/user/game-activity.blade.php
@@ -47,6 +47,18 @@ use App\Platform\Enums\AchievementFlag;
                                     @endif
                                     </span>
                                 @endif
+                                @if ($session['playerSession'] && $session['playerSession']['gameHash'])
+                                    @if ($session['userAgent'])
+                                        <span class="text-muted"> | </span>
+                                    @endif
+                                    @php $hash = $session['playerSession']['gameHash']; @endphp
+                                    <span class="smalltext" title="{{ $hash['name'] }}">
+                                        {{ $hash['md5'] }}
+                                        @if ($hash->isMultiDiscGameHash())
+                                            <span title="Hashes associated to multi-disc game only reflect the first disc loaded">*</span>
+                                        @endif
+                                    </span>
+                                @endif
                             </td>
                         @elseif ($session['type'] === PlayerGameActivitySessionType::Generated)
                             <td class='text-muted' title='These events occurred outside of any captured play sessions'>Generated Session</td>

--- a/resources/views/pages/achievement/[achievement]/tickets/create.blade.php
+++ b/resources/views/pages/achievement/[achievement]/tickets/create.blade.php
@@ -33,11 +33,13 @@ render(function (View $view, Achievement $achievement) {
 
     if ($selectedEmulator === null) {
         $userAgent = null;
+        $selectedHash = null;
 
         $unlock = $user->playerAchievements()->where('achievement_id', $achievement->id)->first();
         if ($unlock !== null) {
             $playerSession = $user->playerSessions()->firstWhere('player_sessions.id', $unlock->player_session_id);
             $userAgent = $playerSession?->user_agent;
+            $selectedHash = $playerSession?->gameHash?->md5;
         }
 
         if ($userAgent === null) {
@@ -48,6 +50,7 @@ render(function (View $view, Achievement $achievement) {
                 ->orderBy('updated_at', 'DESC')
                 ->first();
             $userAgent = $playerSession?->user_agent;
+            $selectedHash = $playerSession?->gameHash?->md5;
         }
 
         if ($userAgent !== null) {


### PR DESCRIPTION
On tickets page and moderation page. Description of hash appears in tooltip.
![image](https://github.com/user-attachments/assets/bfbf31f2-4e31-4326-a6a2-65ae7ddd1483)

If the description includes any of the keywords associated with multi-disc games, an asterisk is added with a tooltip indicating that only the first disc loaded is captured for a multi-disc game session.
![image](https://github.com/user-attachments/assets/74578f92-957e-4b0e-b84e-5e9605f000fc)

Also attempts to pre-select a hash when creating a ticket based on session data, similar to how emulator/version information is pre-filled.
![image](https://github.com/user-attachments/assets/061887e3-e7ac-4850-9267-270b1ad833c3)

