### PR TITLE
fix: don't change all cache keys due to laravel 11 upgrade

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -106,6 +106,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_cache_'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_cache_') . ':',
 
 ];


### PR DESCRIPTION
[Laravel 11 renames all of our Redis cache keys](https://laravel.com/docs/11.x/upgrade#cache).

In other words, without this fix, every user will be logged out on the next prod deploy. This fix re-adds the ":" character so the cache keys wont change.