### PR TITLE
feat(manage): add 'View Comments' button to game hash management table

### DIFF
--- a/app/Filament/Resources/GameResource/RelationManagers/GameHashesRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/GameHashesRelationManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\GameResource\RelationManagers;
 
 use App\Community\Enums\ArticleType;
+use App\Models\Comment;
 use App\Models\Game;
 use App\Models\GameHash;
 use App\Models\User;
@@ -61,7 +62,13 @@ class GameHashesRelationManager extends RelationManager
 
             ])
             ->headerActions([
-
+                Tables\Actions\Action::make('view-comments')
+                    ->label('View comments (' . Comment::where('ArticleType', ArticleType::GameHash)
+                        ->where('ArticleID', $this->ownerRecord->id)
+                        ->notAutomated()
+                        ->count() . ')'
+                    )
+                    ->url(route('game.hashes.comments', ['game' => $this->ownerRecord->id])),
             ])
             ->actions([
                 Tables\Actions\EditAction::make()

--- a/app/Filament/Resources/GameResource/RelationManagers/GameHashesRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/GameHashesRelationManager.php
@@ -37,6 +37,11 @@ class GameHashesRelationManager extends RelationManager
 
     public function table(Table $table): Table
     {
+        $nonAutomatedCommentsCount = Comment::where('ArticleType', ArticleType::GameHash)
+            ->where('ArticleID', $this->ownerRecord->id)
+            ->notAutomated()
+            ->count();
+
         return $table
             ->recordTitleAttribute('name')
             ->columns([
@@ -63,11 +68,8 @@ class GameHashesRelationManager extends RelationManager
             ])
             ->headerActions([
                 Tables\Actions\Action::make('view-comments')
-                    ->label('View comments (' . Comment::where('ArticleType', ArticleType::GameHash)
-                        ->where('ArticleID', $this->ownerRecord->id)
-                        ->notAutomated()
-                        ->count() . ')'
-                    )
+                    ->color($nonAutomatedCommentsCount > 0 ? 'info' : 'gray')
+                    ->label("View Comments ({$nonAutomatedCommentsCount})")
                     ->url(route('game.hashes.comments', ['game' => $this->ownerRecord->id])),
             ])
             ->actions([

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Support\Database\Eloquent\BaseModel;
 use Database\Factories\CommentFactory;
 use Exception;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -34,6 +35,8 @@ class Comment extends BaseModel
 
     public const CREATED_AT = 'Submitted';
     public const UPDATED_AT = 'Edited';
+
+    public const SYSTEM_USER_ID = 14188;
 
     protected $fillable = [
         'Payload',
@@ -104,5 +107,16 @@ class Comment extends BaseModel
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id', 'ID')->withDefault(['username' => 'Deleted User']);
+    }
+
+    // == scopes
+
+    /**
+     * @param Builder<Achievement> $query
+     * @return Builder<Achievement>
+     */
+    public function scopeNotAutomated(Builder $query): Builder
+    {
+        return $query->where('user_id', '!=', self::SYSTEM_USER_ID);
     }
 }

--- a/app/Models/System.php
+++ b/app/Models/System.php
@@ -210,7 +210,7 @@ class System extends BaseModel implements HasMedia
     // TODO remove after rename
     public function getNameAttribute(): string
     {
-        return $this->attributes['Name'];
+        return $this->attributes['Name'] ?? '';
     }
 
     // == mutators


### PR DESCRIPTION
Very simple change to add a "View Comments" button to the game hash management table:

![Screenshot 2024-09-02 at 8 49 03 AM](https://github.com/user-attachments/assets/f1c9b6d0-61ba-4f42-aa11-c220628e08d7)

If there is at least one non-system comment, the button color changes. Automated system comments are not included in the count.

The button leads the user to the dedicated comments page for the game's hashes.

I originally explored trying to get these comments inline in the table somehow, but Filament is very unhappy with trying to do this. This seems like the next best option.

Next steps:
* Phase out the `/game/[game]/hashes/manage` route so this stuff can live entirely in Filament.