### PR TITLE
feat(manage): allow users to upload game icon images

### DIFF
--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -337,6 +337,9 @@ class GameResource extends Resource
                             ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/gif'])
                             ->maxSize(1024)
                             ->rules('dimensions:width=96,height=96')
+                            ->validationMessages([
+                                'dimensions' => 'The game icon must be 96x96 pixels.'
+                            ])
                             ->preserveFilenames(),
                     ])
                     ->collapsible()

--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -322,6 +322,25 @@ class GameResource extends Resource
                             ->default('day')
                             ->reactive(),
                     ]),
+
+                Forms\Components\Section::make('Media')
+                    ->icon('heroicon-o-photo')
+                    ->description("Provide the game icon, screenshots, and box art.")
+                    ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
+                    ->schema([
+                        Forms\Components\FileUpload::make('ImageIcon')
+                            ->label('Game Icon')
+                            ->disk('local')
+                            ->directory('temp')
+                            ->visibility('private')
+                            ->image()
+                            ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/gif'])
+                            ->maxSize(1024)
+                            ->rules('dimensions:width=96,height=96')
+                            ->preserveFilenames(),
+                    ])
+                    ->collapsible()
+                    ->persistCollapsed(),
             ]);
     }
 

--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -338,7 +338,7 @@ class GameResource extends Resource
                             ->maxSize(1024)
                             ->rules('dimensions:width=96,height=96')
                             ->validationMessages([
-                                'dimensions' => 'The game icon must be 96x96 pixels.'
+                                'dimensions' => 'The game icon must be 96x96 pixels.',
                             ])
                             ->preserveFilenames(),
                     ])

--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -340,7 +340,8 @@ class GameResource extends Resource
                             ->preserveFilenames(),
                     ])
                     ->collapsible()
-                    ->persistCollapsed(),
+                    ->persistCollapsed()
+                    ->visible(fn () => $user->can('update', $form->model)),
             ]);
     }
 

--- a/app/Filament/Resources/GameResource/Actions/ProcessUploadedImageAction.php
+++ b/app/Filament/Resources/GameResource/Actions/ProcessUploadedImageAction.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\GameResource\Actions;
+
+use App\Platform\Enums\ImageType;
+use Illuminate\Support\Facades\Storage;
+
+class ProcessUploadedImageAction
+{
+    public function execute(string $tempImagePath): string
+    {
+        $file = Storage::disk('local')->get($tempImagePath);
+        $base64 = base64_encode($file);
+        $mimeType = Storage::disk('local')->mimeType($tempImagePath);
+        $dataUrl = "data:{$mimeType};base64,{$base64}";
+
+        $imagePath = UploadGameImage(createFileArrayFromDataUrl($dataUrl), ImageType::GameIcon);
+
+        $this->cleanUpTempFiles();
+
+        return $imagePath;
+    }
+
+    private function cleanUpTempFiles(): void
+    {
+        // We don't want to accidentally clear out a temp file someone else
+        // may be working on.
+        $threeHoursAgo = now()->subHours(6)->timestamp;
+
+        $tempFiles = Storage::disk('local')->files('temp');
+
+        foreach ($tempFiles as $tempFile) {
+            if (Storage::disk('local')->lastModified($tempFile) < $threeHoursAgo) {
+                Storage::disk('local')->delete($tempFile);
+            }
+        }
+    }
+}

--- a/app/Filament/Resources/GameResource/Pages/Edit.php
+++ b/app/Filament/Resources/GameResource/Pages/Edit.php
@@ -6,6 +6,7 @@ namespace App\Filament\Resources\GameResource\Pages;
 
 use App\Filament\Concerns\HasFieldLevelAuthorization;
 use App\Filament\Resources\GameResource;
+use App\Filament\Resources\GameResource\Actions\ProcessUploadedImageAction;
 use Filament\Resources\Pages\EditRecord;
 
 class Edit extends EditRecord
@@ -17,6 +18,10 @@ class Edit extends EditRecord
     protected function mutateFormDataBeforeSave(array $data): array
     {
         $this->authorizeFields($this->record, $data);
+
+        if (isset($data['ImageIcon'])) {
+            $data['ImageIcon'] = (new ProcessUploadedImageAction())->execute($data['ImageIcon']);
+        }
 
         return $data;
     }

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -78,6 +78,7 @@ class Game extends BaseModel implements HasComments, HasMedia
         'released_at',
         'released_at_granularity',
         'GuideURL',
+        'ImageIcon',
     ];
 
     protected $casts = [


### PR DESCRIPTION
This PR makes a change to allow developers to upload new game icon images via the management app's game edit page.

Other media types will be supported in the future, but this felt like a good chunk to knock out first just to establish a pattern that can be applied to those other fields.


https://github.com/user-attachments/assets/825fc594-a88a-4527-a55d-97cd77637dbc

