### PR TITLE
feat(manage): have table rows navigate to edit pages instead of view

### DIFF
--- a/app/Filament/Resources/AchievementResource.php
+++ b/app/Filament/Resources/AchievementResource.php
@@ -214,6 +214,9 @@ class AchievementResource extends Resource
 
     public static function table(Table $table): Table
     {
+        /** @var User $user */
+        $user = Auth::user();
+
         return $table
             ->columns([
                 Tables\Columns\ImageColumn::make('badge_url')
@@ -362,6 +365,11 @@ class AchievementResource extends Resource
                         ->icon('fas-clock-rotate-left'),
                 ]),
             ])
+            ->recordUrl(
+                fn (Achievement $record) => $user->can('update', $record)
+                    ? AchievementResource::getUrl('edit', ['record' => $record])
+                    : AchievementResource::getUrl('view', ['record' => $record])
+            )
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     // Tables\Actions\DeleteBulkAction::make(),

--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -333,6 +333,9 @@ class GameResource extends Resource
 
     public static function table(Table $table): Table
     {
+        /** @var User $user */
+        $user = Auth::user();
+
         return $table
             ->columns([
                 Tables\Columns\ImageColumn::make('badge_url')
@@ -445,6 +448,11 @@ class GameResource extends Resource
                         ->icon('fas-clock-rotate-left'),
                 ]),
             ])
+            ->recordUrl(
+                fn (Game $record) => $user->can('update', $record)
+                    ? GameResource::getUrl('edit', ['record' => $record])
+                    : GameResource::getUrl('view', ['record' => $record])
+            )
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     // Tables\Actions\DeleteBulkAction::make(),

--- a/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\GameResource\RelationManagers;
 
+use App\Filament\Resources\AchievementResource;
 use App\Models\Achievement;
 use App\Models\Game;
 use App\Models\User;
@@ -20,6 +21,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class AchievementsRelationManager extends RelationManager
@@ -29,7 +31,7 @@ class AchievementsRelationManager extends RelationManager
     public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
     {
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
 
         if ($ownerRecord instanceof Game) {
             return $user->can('manage', $ownerRecord);
@@ -51,7 +53,7 @@ class AchievementsRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
 
         return $table
             ->recordTitleAttribute('title')
@@ -223,13 +225,13 @@ class AchievementsRelationManager extends RelationManager
             ])
             ->recordUrl(function (Achievement $record): string {
                 /** @var User $user */
-                $user = auth()->user();
+                $user = Auth::user();
 
                 if ($user->can('update', $record)) {
-                    return route('filament.admin.resources.achievements.edit', ['record' => $record]);
+                    return AchievementResource::getUrl('edit', ['record' => $record]);
                 }
 
-                return route('filament.admin.resources.achievements.view', ['record' => $record]);
+                return AchievementResource::getUrl('view', ['record' => $record]);
             })
             ->paginated([50, 100, 150])
             ->defaultPaginationPageOption(50)
@@ -254,7 +256,7 @@ class AchievementsRelationManager extends RelationManager
         parent::reorderTable($order);
 
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
         /** @var Game $game */
         $game = $this->getOwnerRecord();
 
@@ -272,7 +274,7 @@ class AchievementsRelationManager extends RelationManager
         if (!$recentReorderingActivity) {
             activity()
                 ->useLog('default')
-                ->causedBy(auth()->user())
+                ->causedBy($user)
                 ->performedOn($game)
                 ->event('reorderedAchievements')
                 ->log('Reordered Achievements');
@@ -287,7 +289,7 @@ class AchievementsRelationManager extends RelationManager
     private function canReorderAchievements(): bool
     {
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
 
         /** @var Game $game */
         $game = $this->getOwnerRecord();

--- a/app/Filament/Resources/LeaderboardResource.php
+++ b/app/Filament/Resources/LeaderboardResource.php
@@ -23,6 +23,7 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 
 class LeaderboardResource extends Resource
 {
@@ -155,6 +156,9 @@ class LeaderboardResource extends Resource
 
     public static function table(Table $table): Table
     {
+        /** @var User $user */
+        $user = Auth::user();
+
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('ID')
@@ -247,6 +251,12 @@ class LeaderboardResource extends Resource
             ->actions([
                 Tables\Actions\ActionGroup::make([
                     Tables\Actions\ActionGroup::make([
+                        Tables\Actions\ViewAction::make(),
+                        Tables\Actions\EditAction::make(),
+                    ])
+                        ->dropdown(false),
+
+                    Tables\Actions\ActionGroup::make([
                         ResetAllLeaderboardEntriesAction::make('delete_all_entries'),
                         DeleteLeaderboardAction::make('delete_leaderboard'),
                     ])
@@ -257,6 +267,11 @@ class LeaderboardResource extends Resource
                         ->icon('fas-clock-rotate-left'),
                 ]),
             ])
+            ->recordUrl(
+                fn (Leaderboard $record) => $user->can('update', $record)
+                    ? LeaderboardResource::getUrl('edit', ['record' => $record])
+                    : LeaderboardResource::getUrl('view', ['record' => $record])
+            )
             ->bulkActions([
 
             ]);


### PR DESCRIPTION
Reduces a click.

Now when clicking on a table row while viewing game, achievement, or leaderboard resources, if the user has permissions to edit the row, they'll be navigated to the edit page on click instead of view.