### PR TITLE
fix(message): remove char limit on discord/email previews

### DIFF
--- a/app/Community/Listeners/NotifyMessageThreadParticipants.php
+++ b/app/Community/Listeners/NotifyMessageThreadParticipants.php
@@ -74,7 +74,7 @@ class NotifyMessageThreadParticipants
         MessageThread $messageThread,
         Message $message
     ): void {
-        $message->body = Shortcode::stripAndClamp($message->body);
+        $message->body = Shortcode::stripAndClamp($message->body, 38000);
 
         $inboxConfig = config('services.discord.inbox_webhook.' . $userTo->username);
         $webhookUrl = $inboxConfig['url'] ?? null;

--- a/app/Community/Listeners/NotifyMessageThreadParticipants.php
+++ b/app/Community/Listeners/NotifyMessageThreadParticipants.php
@@ -74,7 +74,7 @@ class NotifyMessageThreadParticipants
         MessageThread $messageThread,
         Message $message
     ): void {
-        $message->body = Shortcode::stripAndClamp($message->body, 38000);
+        $message->body = Shortcode::stripAndClamp($message->body, 1850);
 
         $inboxConfig = config('services.discord.inbox_webhook.' . $userTo->username);
         $webhookUrl = $inboxConfig['url'] ?? null;

--- a/app/Helpers/util/mail.php
+++ b/app/Helpers/util/mail.php
@@ -365,7 +365,7 @@ function SendPrivateMessageEmail(
     }
 
     $content = stripslashes(nl2br($contentIn));
-    $content = Shortcode::stripAndClamp($content, 38000);
+    $content = Shortcode::stripAndClamp($content, 1850);
 
     // Also used for Generic text:
     $emailTitle = "New Private Message from $fromUser";

--- a/app/Helpers/util/mail.php
+++ b/app/Helpers/util/mail.php
@@ -365,7 +365,7 @@ function SendPrivateMessageEmail(
     }
 
     $content = stripslashes(nl2br($contentIn));
-    $content = Shortcode::stripAndClamp($content);
+    $content = Shortcode::stripAndClamp($content, 38000);
 
     // Also used for Generic text:
     $emailTitle = "New Private Message from $fromUser";


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1286304271847129150.