### PR TITLE
fix(message): preserve whitespace in previews

### DIFF
--- a/app/Community/Listeners/NotifyMessageThreadParticipants.php
+++ b/app/Community/Listeners/NotifyMessageThreadParticipants.php
@@ -74,7 +74,7 @@ class NotifyMessageThreadParticipants
         MessageThread $messageThread,
         Message $message
     ): void {
-        $message->body = Shortcode::stripAndClamp($message->body, 1850);
+        $message->body = Shortcode::stripAndClamp($message->body, 1850, preserveWhitespace: true);
 
         $inboxConfig = config('services.discord.inbox_webhook.' . $userTo->username);
         $webhookUrl = $inboxConfig['url'] ?? null;

--- a/app/Helpers/util/mail.php
+++ b/app/Helpers/util/mail.php
@@ -365,7 +365,7 @@ function SendPrivateMessageEmail(
     }
 
     $content = stripslashes(nl2br($contentIn));
-    $content = Shortcode::stripAndClamp($content, 1850);
+    $content = Shortcode::stripAndClamp($content, 1850, preserveWhitespace: true);
 
     // Also used for Generic text:
     $emailTitle = "New Private Message from $fromUser";

--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -72,8 +72,11 @@ final class Shortcode
         }, $input);
     }
 
-    public static function stripAndClamp(string $input, int $previewLength = 100): string
-    {
+    public static function stripAndClamp(
+        string $input,
+        int $previewLength = 100,
+        bool $preserveWhitespace = false
+    ): string {
         // Inject game and achievement data for shortcodes.
         // This is more desirable than showing "Game 123" or "Achievement 123".
         $injectionShortcodes = [
@@ -143,7 +146,9 @@ final class Shortcode
         }
 
         // For cleaner previews, strip all unnecessary whitespace.
-        $input = trim(preg_replace('/\s+/', ' ', $input));
+        if (!$preserveWhitespace) {
+            $input = trim(preg_replace('/\s+/', ' ', $input));
+        }
 
         // As a failsafe, check the last 6 characters for any fragmented shortcodes and purge them.
         $lastSixChars = substr($input, -6);


### PR DESCRIPTION
Preview messages in email/Discord are currently stripping all whitespace from `Shortcode::stripAndClamp()`. This change allows the whitespace to be preserved. Issue can be observed here: https://discord.com/channels/476211979464343552/1286306295325917256/1286306295325917256