### PR TITLE
feat(manage): add in-line display order editing for leaderboards and achievements

### DIFF
--- a/app/Filament/Resources/AchievementResource.php
+++ b/app/Filament/Resources/AchievementResource.php
@@ -310,10 +310,10 @@ class AchievementResource extends Resource
                     ->searchable()
                     ->toggleable(isToggledHiddenByDefault: true),
 
-                Tables\Columns\TextColumn::make('DisplayOrder')
-                    ->numeric()
+                Tables\Columns\TextInputColumn::make('DisplayOrder')
+                    ->label('Display Order')
                     ->sortable()
-                    ->alignEnd()
+                    ->rules(['required', 'integer'])
                     ->toggleable(isToggledHiddenByDefault: true),
 
                 Tables\Columns\TextColumn::make('DateCreated')

--- a/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
@@ -20,6 +20,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 class AchievementsRelationManager extends RelationManager
@@ -29,7 +30,7 @@ class AchievementsRelationManager extends RelationManager
     public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
     {
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
 
         if ($ownerRecord instanceof Game) {
             return $user->can('manage', $ownerRecord);
@@ -51,7 +52,7 @@ class AchievementsRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
 
         return $table
             ->recordTitleAttribute('title')
@@ -95,7 +96,9 @@ class AchievementsRelationManager extends RelationManager
                     ->date()
                     ->toggleable(),
 
-                Tables\Columns\TextColumn::make('DisplayOrder')
+                Tables\Columns\TextInputColumn::make('DisplayOrder')
+                    ->label('Display Order')
+                    ->rules(['required', 'integer'])
                     ->toggleable(),
             ])
             ->filters([
@@ -223,7 +226,7 @@ class AchievementsRelationManager extends RelationManager
             ])
             ->recordUrl(function (Achievement $record): string {
                 /** @var User $user */
-                $user = auth()->user();
+                $user = Auth::user();
 
                 if ($user->can('update', $record)) {
                     return route('filament.admin.resources.achievements.edit', ['record' => $record]);
@@ -254,7 +257,7 @@ class AchievementsRelationManager extends RelationManager
         parent::reorderTable($order);
 
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
         /** @var Game $game */
         $game = $this->getOwnerRecord();
 
@@ -272,7 +275,7 @@ class AchievementsRelationManager extends RelationManager
         if (!$recentReorderingActivity) {
             activity()
                 ->useLog('default')
-                ->causedBy(auth()->user())
+                ->causedBy($user)
                 ->performedOn($game)
                 ->event('reorderedAchievements')
                 ->log('Reordered Achievements');
@@ -287,7 +290,7 @@ class AchievementsRelationManager extends RelationManager
     private function canReorderAchievements(): bool
     {
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
 
         /** @var Game $game */
         $game = $this->getOwnerRecord();

--- a/app/Filament/Resources/GameResource/RelationManagers/LeaderboardsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/LeaderboardsRelationManager.php
@@ -72,10 +72,9 @@ class LeaderboardsRelationManager extends RelationManager
                     ->label('Lower Is Better')
                     ->toggleable(isToggledHiddenByDefault: true),
 
-                Tables\Columns\TextColumn::make('DisplayOrder')
+                Tables\Columns\TextInputColumn::make('DisplayOrder')
                     ->label('Display Order')
-                    ->color(fn ($record) => $record->DisplayOrder < 0 ? 'danger' : null)
-                    ->toggleable(),
+                    ->rules(['required', 'integer']),
             ])
             ->searchPlaceholder('Search (ID, Title)')
             ->filters([
@@ -114,7 +113,7 @@ class LeaderboardsRelationManager extends RelationManager
             ->bulkActions([
 
             ])
-            ->paginated([25, 50, 100])
+            ->paginated([50, 100, 150])
             ->defaultSort(function (Builder $query): Builder {
                 return $query
                     ->orderBy('DisplayOrder')

--- a/app/Filament/Resources/LeaderboardResource.php
+++ b/app/Filament/Resources/LeaderboardResource.php
@@ -201,8 +201,9 @@ class LeaderboardResource extends Resource
                         });
                     }),
 
-                Tables\Columns\TextColumn::make('DisplayOrder')
+                Tables\Columns\TextInputColumn::make('DisplayOrder')
                     ->label('Display Order')
+                    ->rules(['required', 'integer'])
                     ->sortable()
                     ->toggleable(),
             ])

--- a/app/Models/Achievement.php
+++ b/app/Models/Achievement.php
@@ -185,6 +185,7 @@ class Achievement extends BaseModel implements HasComments
                 'Points',
                 'Title',
                 'type',
+                'DisplayOrder',
             ])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs();

--- a/app/Models/Leaderboard.php
+++ b/app/Models/Leaderboard.php
@@ -75,6 +75,7 @@ class Leaderboard extends BaseModel
                 'Description',
                 'Format',
                 'LowerIsBetter',
+                'DisplayOrder',
             ])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs();


### PR DESCRIPTION
Users now have the option of using drag and drop reordering or inline editing.

![Screenshot 2024-09-22 at 4 49 21 PM](https://github.com/user-attachments/assets/01d9272a-e124-4008-b33a-f06d9247a91c)

![Screenshot 2024-09-22 at 4 49 28 PM](https://github.com/user-attachments/assets/b47bd2af-ae0d-4b14-95d5-f38535a98bf8)
