### PR TITLE
fix(forum): remediate missing topics on recent posts pagination

### DIFF
--- a/app/Community/Controllers/ForumTopicController.php
+++ b/app/Community/Controllers/ForumTopicController.php
@@ -17,6 +17,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 
@@ -127,7 +128,7 @@ class ForumTopicController extends \App\Http\Controller
         $count = 25;
 
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
         $permissions = Permissions::Unregistered;
         if ($user) {
             $permissions = (int) $user->getAttribute('Permissions');
@@ -194,7 +195,6 @@ class ForumTopicController extends \App\Http\Controller
                 FORCE INDEX (idx_permissions_deleted_latest)
                 WHERE ft.RequiredPermissions <= :permissions AND ft.deleted_at IS NULL
                 ORDER BY ft.LatestCommentID DESC
-                LIMIT 100
             ) AS ft
             INNER JOIN Forum AS f ON f.ID = ft.ForumID
             INNER JOIN ForumTopicComment AS lftc ON lftc.ID = ft.LatestCommentID AND lftc.Authorised = 1


### PR DESCRIPTION
This PR resolves an issue on the forum recent posts view.

If you paginate too far, topics vanish: https://retroachievements.org/forums/recent-posts?page=10

This is caused by a `LIMIT 100` in the query which has now been removed.