### PR TITLE
fix(manage): don't link to deleted user pages

### DIFF
--- a/app/Filament/Resources/AchievementSetClaimResource.php
+++ b/app/Filament/Resources/AchievementSetClaimResource.php
@@ -66,7 +66,7 @@ class AchievementSetClaimResource extends Resource
                         }
 
                         if ($record->user && is_null($record->user->deleted_at)) {
-                            return route('user.show', $record->game->user);
+                            return route('user.show', $record->user);
                         }
 
                         return null;

--- a/app/Filament/Resources/AchievementSetClaimResource.php
+++ b/app/Filament/Resources/AchievementSetClaimResource.php
@@ -65,7 +65,7 @@ class AchievementSetClaimResource extends Resource
                             return UserResource::getUrl('view', ['record' => $record->user]);
                         }
 
-                        if ($record->user && is_null($record->user->deleted_at)) {
+                        if ($record->user && is_null($record->user->Deleted)) {
                             return route('user.show', $record->user);
                         }
 

--- a/app/Filament/Resources/AchievementSetClaimResource.php
+++ b/app/Filament/Resources/AchievementSetClaimResource.php
@@ -65,7 +65,11 @@ class AchievementSetClaimResource extends Resource
                             return UserResource::getUrl('view', ['record' => $record->user]);
                         }
 
-                        return route('user.show', $record->game->user);
+                        if ($record->user && is_null($record->user->deleted_at)) {
+                            return route('user.show', $record->game->user);
+                        }
+
+                        return null;
                     })
                     ->searchable()
                     ->sortable(query: function (Builder $query, string $direction): Builder {


### PR DESCRIPTION
Resolves https://retroachievements.org/log-viewer?file=034cd6ea-laravel-2024-10-01.log&query=log-index%3A87

> Missing required parameter for [Route: user.show] [URI: user/{user}] [Missing parameter: user]. (View: /home/forge/retroachievements.org/releases/2024-10-01T102815-6.15.0-cb4a2326/vendor/filament/tables/resources/views/components/columns/column.blade.php) (View: /home/forge/retroachievements.org/releases/2024-10-01T102815-6.15.0-cb4a2326/vendor/filament/tables/resources/views/components/columns/column.blade.php) (View: /home/forge/retroachievements.org/releases/2024-10-01T102815-6.15.0-cb4a2326/vendor/filament/tables/resources/views/components/columns/column.blade.php)
