### PR TITLE
fix(user): allow writing on own wall when only followers setting is enabled

### DIFF
--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Policies;
 
 use App\Community\Enums\ArticleType;
-use App\Enums\Permissions;
 use App\Models\Comment;
 use App\Models\Role;
 use App\Models\User;
@@ -21,7 +20,7 @@ class CommentPolicy
     {
         return $user->hasAnyRole([
             Role::MODERATOR,
-        ]) || $user->getAttribute('Permissions') >= Permissions::Moderator;
+        ]);
     }
 
     public function view(?User $user, Comment $comment): bool
@@ -41,14 +40,7 @@ class CommentPolicy
                 return
                     $didAuthorAchievement
                     && $commentable->is_open
-                    && (
-                        $user->hasAnyRole([
-                            Role::DEVELOPER_STAFF,
-                            Role::DEVELOPER,
-                        ])
-                            || $user->getAttribute('Permissions') >= Permissions::Developer
-                    );
-
+                    && $user->hasAnyRole([Role::DEVELOPER_STAFF, Role::DEVELOPER]);
             }
 
             return false;

--- a/app/Policies/UserCommentPolicy.php
+++ b/app/Policies/UserCommentPolicy.php
@@ -59,7 +59,11 @@ class UserCommentPolicy
             || !$user->hasVerifiedEmail()
             || $commentable->isBlocking($user)
             || !$commentable->UserWallActive
-            || ($commentable->only_allows_contact_from_followers && !$commentable->isFollowing($user))
+            || (
+                $commentable->only_allows_contact_from_followers
+                && !$commentable->isFollowing($user)
+                && !$user->is($commentable)
+            )
         ) {
             return false;
         }


### PR DESCRIPTION
This PR fixes a minor bug on the user profile.

Currently, if the "Only people I follow can message me or post on my wall" setting is enabled, users cannot post on their own walls because they are not following themselves. This PR slightly adjusts the policy to fix this issue.