### PR TITLE
raise PlayerRankStatusChanged event when banning user

### DIFF
--- a/app/Helpers/database/user-permission.php
+++ b/app/Helpers/database/user-permission.php
@@ -3,6 +3,7 @@
 use App\Community\Enums\ArticleType;
 use App\Enums\Permissions;
 use App\Models\User;
+use App\Platform\Events\PlayerRankedStatusChanged;
 
 function getUserPermissions(?string $user): int
 {
@@ -176,4 +177,6 @@ function banAccountByUsername(string $username, int $permissions): void
 
     removeAvatar($username);
     $user->subscriptions()->delete();
+
+    PlayerRankedStatusChanged::dispatch($user, true);
 }


### PR DESCRIPTION
extension of #2722 - ensures the same logic is executed when a user is untracked during the ban process