### PR TITLE
fix(home): remediate carousel flickering issues

### DIFF
--- a/resources/js/tall-stack/alpine/newsCarouselComponent/newsCarouselComponent.ts
+++ b/resources/js/tall-stack/alpine/newsCarouselComponent/newsCarouselComponent.ts
@@ -121,7 +121,7 @@ const newsCarouselStore = {
       this.resetCarouselToIndex(imageListEl, this.totalSlideCount - 1);
     } else {
       this.activeIndex = direction === 'next' ? this.activeIndex + 1 : this.activeIndex - 1;
-      privateUtils.scrollToIndex(imageListEl, this.activeIndex);
+      this.resetCarouselToIndex(imageListEl, this.activeIndex);
     }
 
     this.updateActiveSlideTextVisibility();


### PR DESCRIPTION
After slide 2, the home page carousel is flickering and becoming unreadable. This PR fixes the issue.

![Screenshot 2024-10-22 at 6 04 54 PM](https://github.com/user-attachments/assets/276a2dab-882b-43fd-b5ee-2f2194142c5c)
