### PR TITLE
Adjust achievement unlock rate to display Hardcore unlock rate

### DIFF
--- a/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
+++ b/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
@@ -7,8 +7,8 @@
 $wonBy = 0;
 $wonByHardcore = 0;
 $unlockRate = 0;
+$hardcoreUnlockRate = 0;
 $hardcoreProgressBarWidth = 0;
-$softcoreUnlockRate = 0;
 $softcoreProgressBarWidth = 0;
 
 if ($totalPlayerCount > 0) {
@@ -24,25 +24,39 @@ if ($totalPlayerCount > 0) {
     }
 
     $unlockRate = sprintf("%01.2f", ($wonBy / $totalPlayerCount) * 100);
-    $hardcoreProgressBarWidth = sprintf("%01.2f", ($wonByHardcore / $totalPlayerCount) * 100);
-    $softcoreUnlockRate = sprintf("%01.2f", ($wonBy / $totalPlayerCount) * 100);
-    $softcoreProgressBarWidth = $softcoreUnlockRate - $hardcoreProgressBarWidth;
+    $hardcoreUnlockRate = sprintf("%01.2f", ($wonByHardcore / $totalPlayerCount) * 100);
+    $hardcoreProgressBarWidth = $hardcoreUnlockRate;
+    $softcoreProgressBarWidth = $unlockRate - $hardcoreProgressBarWidth;
 }
 ?>
 
 
 <p class="text-2xs text-center hidden md:block -mt-1.5">
-    {{ number_format($unlockRate, 2) }}% unlock rate
+    @if ($wonByHardcore > 0)
+        <span class="font-bold">{{ $hardcoreUnlockRate }}%</span>
+        <span>({{ $unlockRate }})</span>
+    @else
+        <span>{{ $unlockRate }}%</span>
+    @endif
+    unlock rate
 </p>
 
 <p id="progress-label-{{ $achievement['ID'] }}" class="mb-0.5 text-2xs md:text-center md:mb-0">
-    <span title="Total unlocks" class="cursor-help">{{ localized_number($wonBy) }}</span>
     @if ($wonByHardcore > 0)
-        <span class="font-bold cursor-help" title="Hardcore unlocks">({{ localized_number($wonByHardcore) }})</span>
+        <span class="font-bold cursor-help" title="Hardcore unlocks">{{ localized_number($wonByHardcore) }}</span>
+        <span title="Total unlocks" class="cursor-help">({{ localized_number($wonBy) }})</span>
+    @else
+        <span title="Total unlocks" class="cursor-help">{{ localized_number($wonBy) }}</span>
     @endif
     of 
     <span title="Total players" class="cursor-help">{{ localized_number($totalPlayerCount) }}</span>
-    <span class="md:hidden">– {{ $unlockRate }}%</span>
+    @if ($wonByHardcore > 0)
+        <span class="md:hidden">–</span>
+        <span class="font-bold md:hidden">{{ $hardcoreUnlockRate }}%</span>
+        <span class="md:hidden">({{ $unlockRate }})</span>
+    @else
+        <span class="md:hidden">– {{ $unlockRate }}%</span>
+    @endif
     <span class="hidden sm:inline md:hidden">unlock rate</span>
 </p>
 
@@ -70,7 +84,7 @@ if ($totalPlayerCount > 0) {
         class="bg-neutral-500 h-full"
     >
         <span class="sr-only">
-            {{ $softcoreUnlockRate }}% of players have earned the achievement in softcore mode
+            {{ $unlockRate }}% of players have earned the achievement in either hardcore or softcore mode
         </span>
     </div>
 </div>

--- a/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
+++ b/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
@@ -54,7 +54,7 @@ if ($totalPlayerCount > 0) {
     <span class="md:hidden">–</span>
     @if ($wonByHardcore > 0 && $wonBy > $wonByHardcore)
         <span title="Hardcore unlock rate" class="font-bold cursor-help md:hidden">{{ $hardcoreUnlockRate }}%</span>
-        <span title="Total unlock rate" class="cursor-help md:hidden">({{ $unlockRate }})%</span>
+        <span title="Total unlock rate" class="cursor-help md:hidden">({{ $unlockRate }}%)</span>
     @else
         <span title="Total unlock rate" class="{{ $wonByHardcore > 0 ? 'font-bold' : '' }} cursor-help md:hidden">{{ $unlockRate }}%</span>
     @endif

--- a/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
+++ b/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
@@ -38,6 +38,7 @@ if ($totalPlayerCount > 0) {
     @else
         <span title="Total unlock rate" class="{{ $wonByHardcore > 0 ? 'font-bold' : '' }} cursor-help">{{ $unlockRate }}%</span>
     @endif
+    <span>{{ $wonByHardcore == 0 && $wonBy > 0 ? 'softcore' : '' }}</span>
     unlock rate
 </p>
 
@@ -57,6 +58,7 @@ if ($totalPlayerCount > 0) {
     @else
         <span title="Total unlock rate" class="{{ $wonByHardcore > 0 ? 'font-bold' : '' }} cursor-help md:hidden">{{ $unlockRate }}%</span>
     @endif
+    <span class="md:hidden">{{ $wonByHardcore == 0 && $wonBy > 0 ? 'softcore' : '' }}</span>
     <span class="hidden sm:inline md:hidden">unlock rate</span>
 </p>
 

--- a/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
+++ b/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
@@ -34,11 +34,11 @@ if ($totalPlayerCount > 0) {
 <p class="text-2xs text-center hidden md:block -mt-1.5">
     @if ($wonByHardcore > 0 && $wonBy > $wonByHardcore)
         <span title="Hardcore unlock rate" class="font-bold cursor-help">{{ $hardcoreUnlockRate }}%</span>
-        <span title="Total unlock rate" class="cursor-help">({{ $unlockRate }}%)</span>
+        <span title="Total unlock rate" class="cursor-help lg:hidden xl:inline">({{ $unlockRate }}%)</span>
     @else
         <span title="Total unlock rate" class="{{ $wonByHardcore > 0 ? 'font-bold' : '' }} cursor-help">{{ $unlockRate }}%</span>
     @endif
-    <span>{{ $wonByHardcore == 0 && $wonBy > 0 ? 'softcore' : '' }}</span>
+    <span class="lg:hidden xl:inline">{{ $wonByHardcore == 0 && $wonBy > 0 ? 'softcore' : '' }}</span>
     unlock rate
 </p>
 
@@ -54,11 +54,11 @@ if ($totalPlayerCount > 0) {
     <span class="md:hidden">–</span>
     @if ($wonByHardcore > 0 && $wonBy > $wonByHardcore)
         <span title="Hardcore unlock rate" class="font-bold cursor-help md:hidden">{{ $hardcoreUnlockRate }}%</span>
-        <span title="Total unlock rate" class="cursor-help md:hidden">({{ $unlockRate }}%)</span>
+        <span title="Total unlock rate" class="cursor-help hidden sm:inline md:hidden">({{ $unlockRate }}%)</span>
     @else
         <span title="Total unlock rate" class="{{ $wonByHardcore > 0 ? 'font-bold' : '' }} cursor-help md:hidden">{{ $unlockRate }}%</span>
     @endif
-    <span class="md:hidden">{{ $wonByHardcore == 0 && $wonBy > 0 ? 'softcore' : '' }}</span>
+    <span class="hidden sm:inline md:hidden">{{ $wonByHardcore == 0 && $wonBy > 0 ? 'softcore' : '' }}</span>
     <span class="hidden sm:inline md:hidden">unlock rate</span>
 </p>
 

--- a/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
+++ b/resources/views/components/game/achievements-list/list-item-global-progress.blade.php
@@ -32,30 +32,30 @@ if ($totalPlayerCount > 0) {
 
 
 <p class="text-2xs text-center hidden md:block -mt-1.5">
-    @if ($wonByHardcore > 0)
-        <span class="font-bold">{{ $hardcoreUnlockRate }}%</span>
-        <span>({{ $unlockRate }})</span>
+    @if ($wonByHardcore > 0 && $wonBy > $wonByHardcore)
+        <span title="Hardcore unlock rate" class="font-bold cursor-help">{{ $hardcoreUnlockRate }}%</span>
+        <span title="Total unlock rate" class="cursor-help">({{ $unlockRate }}%)</span>
     @else
-        <span>{{ $unlockRate }}%</span>
+        <span title="Total unlock rate" class="{{ $wonByHardcore > 0 ? 'font-bold' : '' }} cursor-help">{{ $unlockRate }}%</span>
     @endif
     unlock rate
 </p>
 
 <p id="progress-label-{{ $achievement['ID'] }}" class="mb-0.5 text-2xs md:text-center md:mb-0">
-    @if ($wonByHardcore > 0)
-        <span class="font-bold cursor-help" title="Hardcore unlocks">{{ localized_number($wonByHardcore) }}</span>
+    @if ($wonByHardcore > 0 && $wonBy > $wonByHardcore)
+        <span title="Hardcore unlocks" class="font-bold cursor-help">{{ localized_number($wonByHardcore) }}</span>
         <span title="Total unlocks" class="cursor-help">({{ localized_number($wonBy) }})</span>
     @else
-        <span title="Total unlocks" class="cursor-help">{{ localized_number($wonBy) }}</span>
+        <span title="Total unlocks" class="{{ $wonByHardcore > 0 ? 'font-bold' : '' }} cursor-help">{{ localized_number($wonBy) }}</span>
     @endif
     of 
     <span title="Total players" class="cursor-help">{{ localized_number($totalPlayerCount) }}</span>
-    @if ($wonByHardcore > 0)
-        <span class="md:hidden">–</span>
-        <span class="font-bold md:hidden">{{ $hardcoreUnlockRate }}%</span>
-        <span class="md:hidden">({{ $unlockRate }})</span>
+    <span class="md:hidden">–</span>
+    @if ($wonByHardcore > 0 && $wonBy > $wonByHardcore)
+        <span title="Hardcore unlock rate" class="font-bold cursor-help md:hidden">{{ $hardcoreUnlockRate }}%</span>
+        <span title="Total unlock rate" class="cursor-help md:hidden">({{ $unlockRate }})%</span>
     @else
-        <span class="md:hidden">– {{ $unlockRate }}%</span>
+        <span title="Total unlock rate" class="{{ $wonByHardcore > 0 ? 'font-bold' : '' }} cursor-help md:hidden">{{ $unlockRate }}%</span>
     @endif
     <span class="hidden sm:inline md:hidden">unlock rate</span>
 </p>


### PR DESCRIPTION
This changes an achievement's unlock rate current UI:

183 **(63)** of 3,235
5.66% unlock rate

To:

**63** (183) of 3,235
**1.95%** (5.66) unlock rate

If the achievement has no hardcore unlock, it will default to (just like current behavior):

183 of 3,235
5.66% unlock rate

Showing hardcore unlock rate as a more useful metric for achievement difficulty is a requested feature in:

https://retroachievements.org/viewtopic.php?t=28159
https://retroachievements.org/viewtopic.php?t=28500
https://retroachievements.org/viewtopic.php?t=28575
