### PR TITLE
add total entry count to leaderboard details page

### DIFF
--- a/resources/views/pages-legacy/leaderboardinfo.blade.php
+++ b/resources/views/pages-legacy/leaderboardinfo.blade.php
@@ -30,6 +30,7 @@ if (!$leaderboard) {
 $lbData = GetLeaderboardData($leaderboard, Auth::user(), $count, $offset);
 
 $numEntries = is_countable($lbData['Entries']) ? count($lbData['Entries']) : 0;
+$totalEntries = $leaderboard->entries()->count();
 $lbTitle = $leaderboard->title;
 $lbDescription = $leaderboard->description;
 $lbFormat = $leaderboard->format;
@@ -51,7 +52,7 @@ $pageTitle = "$lbTitle in $gameTitle ($consoleName)";
 
 <x-app-layout
     :pageTitle="$pageTitle"
-    pageDescription="{{ $lbDescription ?? $lbTitle }}, {{ $numEntries }} entries."
+    pageDescription="{{ $lbDescription ?? $lbTitle }}, {{ $totalEntries }} entries."
     :pageImage="media_asset($gameIcon)"
     pageType="retroachievements:leaderboard"
 >
@@ -79,6 +80,7 @@ $pageTitle = "$lbTitle in $gameTitle ($consoleName)";
         echo "<div>";
         echo "<a href='/leaderboard/$lbID'><strong>$lbTitle</strong></a><br>";
         echo "$lbDescription";
+        echo "<br><span class='smalltext'>$totalEntries entries</span>";
         echo "</div>";
         echo "</div>";
         echo "</td>";


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1190827552491716608/1301955044672798832

Fixes the value in the embed metadata, and displays the value in the page itself:
![image](https://github.com/user-attachments/assets/9452793a-2c48-4c85-9db0-add88ee784f9)

This query is slightly more expensive than I'd like (~5ms for 1500 entries), but we don't have denormalized data to leverage yet.