### PR TITLE
fix: save user's LastLogin value on page navigation

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -44,6 +44,7 @@ class Kernel extends HttpKernel
             Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             Middleware\UserPreferences::class,
+            Middleware\UpdateLastLogin::class,
             // TODO Web Interceptor middleware
             // TODO \Illuminate\Routing\Middleware\ThrottleRequests::class.':web',
         ],

--- a/app/Http/Middleware/UpdateLastLogin.php
+++ b/app/Http/Middleware/UpdateLastLogin.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Carbon\Carbon;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class UpdateLastLogin
+{
+    public function handle(Request $request, Closure $next): mixed
+    {
+        /** @var ?User $user */
+        $user = Auth::user();
+
+        if ($user) {
+            $user->LastLogin = Carbon::now();
+            $user->save();
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Currently, `$user->LastLogin` is being set when `authenticateFromCookie()` is called and when a player activity record is stored.

In other words, for any page that doesn't use `authenticateFromCookie()`, the `LastLogin` value is not updated when navigating to that page (ie: all Inertia pages, maybe Folio pages too?).

Our active player count on the home page is being underreported as a result of this issue.

This PR:
* Adds a new middleware which runs on page navigation. The middleware updates the user's `LastLogin` value if they are authenticated.