### PR TITLE
test(DataTableToolbar): remediate flaky test that keeps failing in ci

### DIFF
--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableToolbar.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableToolbar.test.tsx
@@ -129,9 +129,12 @@ describe('Component: DataTableToolbar', () => {
     await userEvent.click(screen.getByRole('option', { name: /GameCube/i }));
 
     // ASSERT
-    await waitFor(() => {
-      expect(screen.getByText(/3 selected/i)).toBeVisible();
-    });
+    await waitFor(
+      () => {
+        expect(screen.getByText(/3 selected/i)).toBeVisible();
+      },
+      { timeout: 3000 },
+    );
   });
 
   it('given the unfiltered total is different than the row count, displays both counts to the user', () => {


### PR DESCRIPTION
GitHub Actions runs tests slowly enough that one of them in particular that renders a lot of DOM is occasionally failing due to exceeding a timeout window: https://github.com/RetroAchievements/RAWeb/actions/runs/11646542081/job/32430738923?pr=2802