### PR TITLE
fix(DataTableSearchInput): prevent auto-zoom on iOS

### DIFF
--- a/resources/js/features/game-list/components/DataTableSearchInput/DataTableSearchInput.test.tsx
+++ b/resources/js/features/game-list/components/DataTableSearchInput/DataTableSearchInput.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import type { FC } from 'react';
 
 import { render, screen } from '@/test';
+import { createZiggyProps } from '@/test/factories';
 
 import { DataTableSearchInput } from './DataTableSearchInput';
 
@@ -26,7 +27,9 @@ const TestHarness: FC<TestHarnessProps> = ({ hasClearButton, hasHotkey }) => {
 describe('Component: DataTableSearchInput', () => {
   it('renders without crashing', () => {
     // ARRANGE
-    const { container } = render(<TestHarness />);
+    const { container } = render(<TestHarness />, {
+      pageProps: { ziggy: createZiggyProps({ device: 'mobile' }) },
+    });
 
     // ASSERT
     expect(container).toBeTruthy();
@@ -34,7 +37,9 @@ describe('Component: DataTableSearchInput', () => {
 
   it('is accessible', () => {
     // ARRANGE
-    render(<TestHarness />);
+    render(<TestHarness />, {
+      pageProps: { ziggy: createZiggyProps({ device: 'desktop' }) },
+    });
 
     // ASSERT
     expect(screen.getByLabelText(/search games/i)).toBeVisible();
@@ -42,7 +47,9 @@ describe('Component: DataTableSearchInput', () => {
 
   it('displays placeholder text', () => {
     // ARRANGE
-    render(<TestHarness />);
+    render(<TestHarness />, {
+      pageProps: { ziggy: createZiggyProps({ device: 'desktop' }) },
+    });
 
     // ASSERT
     expect(screen.getByPlaceholderText(/search games.../i)).toBeVisible();
@@ -50,7 +57,9 @@ describe('Component: DataTableSearchInput', () => {
 
   it('given the global hotkey is not enabled, does not display the hotkey badge', () => {
     // ARRANGE
-    render(<TestHarness hasHotkey={false} />);
+    render(<TestHarness hasHotkey={false} />, {
+      pageProps: { ziggy: createZiggyProps({ device: 'desktop' }) },
+    });
 
     // ASSERT
     expect(screen.queryByText('/')).not.toBeInTheDocument();
@@ -58,7 +67,9 @@ describe('Component: DataTableSearchInput', () => {
 
   it('given the global hotkey is enabled, displays the hotkey badge', () => {
     // ARRANGE
-    render(<TestHarness hasHotkey={true} />);
+    render(<TestHarness hasHotkey={true} />, {
+      pageProps: { ziggy: createZiggyProps({ device: 'desktop' }) },
+    });
 
     // ASSERT
     expect(screen.getByText('/')).toBeVisible();
@@ -66,7 +77,9 @@ describe('Component: DataTableSearchInput', () => {
 
   it('given the clear button is enabled and there is user input, displays the clear button', async () => {
     // ARRANGE
-    render(<TestHarness hasClearButton={true} />);
+    render(<TestHarness hasClearButton={true} />, {
+      pageProps: { ziggy: createZiggyProps({ device: 'desktop' }) },
+    });
 
     // ACT
     await userEvent.type(screen.getByPlaceholderText(/search games/i), 'test');
@@ -77,7 +90,9 @@ describe('Component: DataTableSearchInput', () => {
 
   it('given the clear button is clicked, clears user input', async () => {
     // ARRANGE
-    render(<TestHarness hasClearButton={true} />);
+    render(<TestHarness hasClearButton={true} />, {
+      pageProps: { ziggy: createZiggyProps({ device: 'desktop' }) },
+    });
 
     // ACT
     await userEvent.type(screen.getByPlaceholderText(/search games/i), 'test');
@@ -90,7 +105,9 @@ describe('Component: DataTableSearchInput', () => {
 
   it('given the "/" key is pressed, focuses the input', async () => {
     // ARRANGE
-    render(<TestHarness hasHotkey={true} />);
+    render(<TestHarness hasHotkey={true} />, {
+      pageProps: { ziggy: createZiggyProps({ device: 'desktop' }) },
+    });
 
     // ACT
     await userEvent.keyboard('/');

--- a/resources/js/features/game-list/components/DataTableSearchInput/DataTableSearchInput.tsx
+++ b/resources/js/features/game-list/components/DataTableSearchInput/DataTableSearchInput.tsx
@@ -10,6 +10,7 @@ import {
   BaseTooltipContent,
   BaseTooltipTrigger,
 } from '@/common/components/+vendor/BaseTooltip';
+import { usePageProps } from '@/common/hooks/usePageProps';
 import { cn } from '@/utils/cn';
 
 import { useSearchInputHotkey } from './useSearchInputHotkey';
@@ -36,6 +37,10 @@ export function DataTableSearchInput<TData>({
   hasHotkey = true,
   searchColumnId = 'title',
 }: DataTableSearchInputProps<TData>) {
+  const {
+    ziggy: { device },
+  } = usePageProps();
+
   const { t } = useTranslation();
 
   const initialValue = (table.getColumn(searchColumnId)?.getFilterValue() as string) ?? '';
@@ -94,7 +99,10 @@ export function DataTableSearchInput<TData>({
           placeholder={t('Search games...')}
           value={rawInputValue}
           onChange={(event) => setRawInputValue(event.target.value)}
-          className="peer h-8 sm:w-[150px] lg:w-[250px]"
+          className={cn(
+            'peer h-8 sm:w-[150px] lg:w-[250px]',
+            device === 'mobile' ? 'text-[16px]' : '',
+          )}
           aria-describedby="search-shortcut"
         />
 

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableToolbar.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableToolbar.test.tsx
@@ -104,10 +104,11 @@ describe('Component: DataTableToolbar', () => {
     await userEvent.click(screen.getByRole('option', { name: /GameCube/i }));
 
     // ASSERT
-    const selectedLabelEl = screen.getByTestId('filter-selected-label');
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-selected-label')).toBeVisible();
+    });
 
-    expect(selectedLabelEl).toBeVisible();
-    expect(selectedLabelEl).toHaveTextContent('GC');
+    expect(screen.getByTestId('filter-selected-label')).toHaveTextContent('GC');
   });
 
   it(


### PR DESCRIPTION
This PR fixes an annoying issue on the mobile games list that only happens on iOS.

When focusing on an input field, iOS auto-zooms the window if the input field has a font size smaller than 16px. Unfortunately, it isn't possible to repro this issue without a real device or the iPhone simulator built into macOS. I've recorded the videos below using the simulator.

**Before**

https://github.com/user-attachments/assets/f80d96dd-7492-4a49-a72b-5ab198769fa6



**After**


https://github.com/user-attachments/assets/757455cf-ddbc-4c3f-a5e1-ec2b9d77ca79

