### PR TITLE
fix(useSearchInputHotkey): remediate hydration issue

### DIFF
--- a/resources/js/features/game-list/components/DataTableSearchInput/useSearchInputHotkey.ts
+++ b/resources/js/features/game-list/components/DataTableSearchInput/useSearchInputHotkey.ts
@@ -10,7 +10,8 @@ export function useSearchInputHotkey({ isEnabled, key }: UseSearchInputHotkeyPro
   // Attach this to the input.
   const hotkeyInputRef = useRef<HTMLInputElement>(null);
 
-  const isCurrentlyFocused = document.activeElement === hotkeyInputRef.current;
+  const isCurrentlyFocused =
+    typeof document !== 'undefined' && document.activeElement === hotkeyInputRef.current;
 
   // When the user presses the given key on the keyboard, auto-focus the input.
   useKeyPressEvent(key, (event) => {


### PR DESCRIPTION
Fixes a regression from https://github.com/RetroAchievements/RAWeb/pull/2813.

`document` can't be accessed in the code without first checking that `document` exists. It's undefined during SSR, which causes the server to panic.

I mistakenly believed only `window` was affected by this -- in another project, the runtime monkey patches `document` during SSR, but Inertia does not.

It seems in the next major release of Inertia, it will be possible to run dev mode in SSR, which should greatly mitigate this sort of thing. To the best of my knowledge, there is no linting rule that can catch this.