### PR TITLE
reactivate achievements associated to active events

### DIFF
--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -92,6 +92,12 @@ function unlockAchievement(User $user, int $achievementId, bool $isHardcore, ?Ga
     }
 
     if ($alreadyAwarded) {
+        if ($isHardcore && $achievement->eventAchievements()->active()->exists()) {
+            // if event achievements are active, assume they still need to be unlocked and indicate
+            // success. this allows dorequest to forward the unlocks for the event achievements.
+            $retVal['Success'] = true;
+        }
+
         // =============================================================================
         // ===== DO NOT CHANGE THESE MESSAGES ==========================================
         // The client detects the "User already has" and does not report them as errors.

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -541,7 +541,9 @@ switch ($requestType) {
         PlayerSessionHeartbeat::dispatch($user, $game, null, $gameHash);
 
         $response['Success'] = true;
-        $userUnlocks = getUserAchievementUnlocksForGame($username, $gameID);
+        $userModel = User::firstWhere('User', $username);
+        $userUnlocks = getUserAchievementUnlocksForGame($userModel, $gameID);
+        $userUnlocks = reactivateUserEventAchievements($userModel, $userUnlocks);
         foreach ($userUnlocks as $achId => $unlock) {
             if (array_key_exists('DateEarnedHardcore', $unlock)) {
                 $response['HardcoreUnlocks'][] = [
@@ -636,8 +638,10 @@ switch ($requestType) {
 
     case "unlocks":
         $hardcoreMode = (int) request()->input('h', 0) === UnlockMode::Hardcore;
-        $userUnlocks = getUserAchievementUnlocksForGame($username, $gameID);
+        $userModel = User::firstWhere('User', $username);
+        $userUnlocks = getUserAchievementUnlocksForGame($userModel, $gameID);
         if ($hardcoreMode) {
+            $userUnlocks = reactivateUserEventAchievements($userModel, $userUnlocks);
             $response['UserUnlocks'] = collect($userUnlocks)
                 ->filter(fn ($value, $key) => array_key_exists('DateEarnedHardcore', $value))
                 ->keys();


### PR DESCRIPTION
followup to #2778 

  [X] Modify Connect unlocks and startsession APIs to not indicate the achievement is unlocked if there's an active event achievement that the user hasn't unlocked. This will allow users to earn the event achievement without having to reset the achievement or use an alt.

this completes the player-side of things - a user can now earn an active event achievement while having previously unlocked the source achievement.