### PR TITLE
feat(game-list): colorize the backlog toggle button

### DIFF
--- a/resources/js/features/game-list/components/DataTableRowActions/DataTableRowActions.tsx
+++ b/resources/js/features/game-list/components/DataTableRowActions/DataTableRowActions.tsx
@@ -75,10 +75,11 @@ export function DataTableRowActions<TData>({
                 'h-4 w-4',
                 'hover:text-neutral-50 disabled:!text-neutral-50 light:hover:text-neutral-900 light:disabled:text-neutral-900',
 
-                !shouldAnimateBacklogIconOnChange ? initialRotationClassName : null,
-                shouldAnimateBacklogIconOnChange ? 'transition-transform' : null,
+                shouldAnimateBacklogIconOnChange ? 'transition' : initialRotationClassName,
 
-                isInBacklogMaybeOptimistic ? 'rotate-0' : 'rotate-45',
+                isInBacklogMaybeOptimistic
+                  ? 'rotate-0 text-red-500 group-hover:text-neutral-50'
+                  : 'rotate-45',
               )}
             />
           </BaseButton>

--- a/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemContent/GameListItemContent.tsx
+++ b/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemContent/GameListItemContent.tsx
@@ -89,7 +89,8 @@ export const GameListItemContent: FC<GameListItemContentProps> = ({
               className={cn(
                 'h-4 w-4 transition-transform',
                 'disabled:!text-neutral-100 light:disabled:text-neutral-950',
-                backlogState.isInBacklogMaybeOptimistic ? '' : 'rotate-45',
+
+                backlogState.isInBacklogMaybeOptimistic ? 'text-red-500' : 'rotate-45',
               )}
             />
 


### PR DESCRIPTION
Right now it's pretty tough to visually parse at a glance if a game is on the user's backlog or not. This PR colorizes the button in "Remove" mode so it's easier to see at a glance what the current state is.

**Before**
![Screenshot 2024-11-10 at 10 01 16 AM](https://github.com/user-attachments/assets/f4ef729c-c5f3-4a6f-b4f6-32234a8fd5ef)

![Screenshot 2024-11-10 at 10 01 32 AM](https://github.com/user-attachments/assets/a11a4094-0099-48de-8e85-e996a1f1dd46)


**After**
![Screenshot 2024-11-10 at 10 00 39 AM](https://github.com/user-attachments/assets/427fa02f-0356-408e-9d1c-3b2e2a669f99)

![Screenshot 2024-11-10 at 10 00 51 AM](https://github.com/user-attachments/assets/d8a6daf2-47f4-42a4-82f0-932ace485c52)
