### PR TITLE
add create event admin tool

### DIFF
--- a/app/Models/EventAchievement.php
+++ b/app/Models/EventAchievement.php
@@ -30,6 +30,8 @@ class EventAchievement extends BaseModel
         'active_through',
     ];
 
+    public const RAEVENTS_USER_ID = 279854;
+
     // == accessors
 
     public function getActiveThroughAttribute(): ?Carbon

--- a/app/Platform/Actions/CreateAchievementOfTheWeek.php
+++ b/app/Platform/Actions/CreateAchievementOfTheWeek.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Platform\Actions;
 
 use App\Models\Achievement;
-use App\Models\Comment;
 use App\Models\EventAchievement;
 use App\Models\Game;
 use App\Models\System;
@@ -29,6 +28,7 @@ class CreateAchievementOfTheWeek
             $event = Game::Create([
                 'Title' => $eventTitle,
                 'sort_title' => (new ComputeGameSortTitleAction())->execute($eventTitle),
+                'Publisher' => 'RetroAchievements',
                 'ConsoleID' => System::Events,
             ]);
         }
@@ -42,7 +42,7 @@ class CreateAchievementOfTheWeek
                 'MemAddr' => '0=1',
                 'Flags' => AchievementFlag::OfficialCore->value,
                 'GameID' => $event->id,
-                'user_id' => Comment::SYSTEM_USER_ID,
+                'user_id' => EventAchievement::RAEVENTS_USER_ID,
                 'BadgeName' => '00000',
                 'DisplayOrder' => $achievementCount,
             ]);

--- a/app/Platform/Services/GameTopAchieversService.php
+++ b/app/Platform/Services/GameTopAchieversService.php
@@ -21,8 +21,8 @@ class GameTopAchieversService
     public function initialize(Game $game): void
     {
         $this->gameId = $game->id;
-        $this->masteryAchievements = $game->achievements_published;
-        $this->masteryPoints = $game->points_total;
+        $this->masteryAchievements = $game->achievements_published ?? 0;
+        $this->masteryPoints = $game->points_total ?? 0;
     }
 
     /**

--- a/resources/views/filament/pages/admin-tools.blade.php
+++ b/resources/views/filament/pages/admin-tools.blade.php
@@ -23,6 +23,16 @@
         <x-filament::section>
             <div class="flex flex-col gap-y-4">
                 <x-filament::section.heading>
+                    Create Event
+                </x-filament::section.heading>
+
+                <livewire:administrative-tools.create-event />
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="flex flex-col gap-y-4">
+                <x-filament::section.heading>
                     Migrate Achievements
                 </x-filament::section.heading>
 

--- a/resources/views/livewire/administrative-tools/create-event.blade.php
+++ b/resources/views/livewire/administrative-tools/create-event.blade.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Models\Achievement;
+use App\Models\EventAchievement;
+use App\Models\Game;
+use App\Models\System;
+use App\Models\User;
+use App\Platform\Actions\ComputeGameSortTitleAction;
+use App\Platform\Enums\AchievementFlag;
+use Filament\Forms;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Volt\Component;
+
+new class extends Component implements HasForms {
+    use InteractsWithForms;
+
+    public ?string $title = null;
+    public int $numberOfAchievements = 6;
+
+    public function submit(): void
+    {
+        // Validate.
+        $this->form->getState();
+
+        $eventTitle = $this->title ?? 'New Event';
+        $event = Game::Create([
+            'Title' => $eventTitle,
+            'sort_title' => (new ComputeGameSortTitleAction())->execute($eventTitle),
+            'Publisher' => 'RetroAchievements',
+            'ConsoleID' => System::Events,
+        ]);
+
+        for ($i = 0; $i < $this->numberOfAchievements; $i++) {
+            $achievement = Achievement::Create([
+                'Title' => "$eventTitle",
+                'Description' => 'TBD',
+                'MemAddr' => '0=1',
+                'Flags' => AchievementFlag::OfficialCore->value,
+                'GameID' => $event->id,
+                'user_id' => EventAchievement::RAEVENTS_USER_ID,
+                'BadgeName' => '00000',
+                'DisplayOrder' => $i + 1,
+            ]);
+        }
+
+        Notification::make()
+            ->success()
+            ->title('Success')
+            ->body('Created!')
+            ->send();
+
+        // Reset the form.
+        $this->form->fill();
+        $this->title = null;
+        $this->numberOfAchievements = 6;
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title')
+                    ->label('Title')
+                    ->placeholder('New Event')
+                    ->minLength(2)
+                    ->maxLength(80)
+                    ->required(),
+
+                Forms\Components\TextInput::make('numberOfAchievements')
+                    ->label('Number of achievements')
+                    ->numeric()
+                    ->default(6)
+                    ->required(),
+        ]);
+    }
+}
+
+?>
+
+<div>
+    <form wire:submit.prevent="submit">
+        <div class="flex flex-col gap-y-4">
+            {{ $this->form }}
+
+            <div class="flex w-full justify-end">
+                <x-filament::button type="submit">Submit</x-filament::button>
+            </div>
+        </div>
+    </form>
+</div>

--- a/tests/Feature/Platform/Action/CreateAchievementOfTheWeekTest.php
+++ b/tests/Feature/Platform/Action/CreateAchievementOfTheWeekTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Platform\Action;
 
 use App\Models\Achievement;
-use App\Models\Comment;
+use App\Models\EventAchievement;
 use App\Models\Game;
 use App\Models\System;
 use App\Models\User;
@@ -37,7 +37,7 @@ class CreateAchievementOfTheWeekTest extends TestCase
         $this->assertEquals('TBD', $achievement->Description);
         $this->assertEquals('0=1', $achievement->MemAddr);
         $this->assertEquals(AchievementFlag::OfficialCore->value, $achievement->Flags);
-        $this->assertEquals(Comment::SYSTEM_USER_ID, $achievement->user_id);
+        $this->assertEquals(EventAchievement::RAEVENTS_USER_ID, $achievement->user_id);
         $this->assertEquals('00000', $achievement->BadgeName);
         $this->assertEquals(1, $achievement->DisplayOrder);
         $this->assertEquals(null, $achievement->eventData->sourceAchievement);
@@ -49,7 +49,7 @@ class CreateAchievementOfTheWeekTest extends TestCase
         $this->assertEquals('TBD', $achievement->Description);
         $this->assertEquals('0=1', $achievement->MemAddr);
         $this->assertEquals(AchievementFlag::OfficialCore->value, $achievement->Flags);
-        $this->assertEquals(Comment::SYSTEM_USER_ID, $achievement->user_id);
+        $this->assertEquals(EventAchievement::RAEVENTS_USER_ID, $achievement->user_id);
         $this->assertEquals('00000', $achievement->BadgeName);
         $this->assertEquals(52, $achievement->DisplayOrder);
         $this->assertEquals(null, $achievement->eventData->sourceAchievement);
@@ -106,7 +106,7 @@ class CreateAchievementOfTheWeekTest extends TestCase
         $this->assertEquals($sourceAchievement1->Description, $achievement->Description);
         $this->assertEquals('0=1', $achievement->MemAddr);
         $this->assertEquals(AchievementFlag::OfficialCore->value, $achievement->Flags);
-        $this->assertEquals(Comment::SYSTEM_USER_ID, $achievement->user_id);
+        $this->assertEquals(EventAchievement::RAEVENTS_USER_ID, $achievement->user_id);
         $this->assertEquals($sourceAchievement1->BadgeName, $achievement->BadgeName);
         $this->assertEquals(1, $achievement->DisplayOrder);
         $this->assertEquals($sourceAchievement1->id, $achievement->eventData->sourceAchievement->id);
@@ -120,7 +120,7 @@ class CreateAchievementOfTheWeekTest extends TestCase
         $this->assertEquals($sourceAchievement2->Description, $achievement->Description);
         $this->assertEquals('0=1', $achievement->MemAddr);
         $this->assertEquals(AchievementFlag::OfficialCore->value, $achievement->Flags);
-        $this->assertEquals(Comment::SYSTEM_USER_ID, $achievement->user_id);
+        $this->assertEquals(EventAchievement::RAEVENTS_USER_ID, $achievement->user_id);
         $this->assertEquals($sourceAchievement2->BadgeName, $achievement->BadgeName);
         $this->assertEquals(2, $achievement->DisplayOrder);
         $this->assertEquals($sourceAchievement2->id, $achievement->eventData->sourceAchievement->id);
@@ -134,7 +134,7 @@ class CreateAchievementOfTheWeekTest extends TestCase
         $this->assertEquals('TBD', $achievement->Description);
         $this->assertEquals('0=1', $achievement->MemAddr);
         $this->assertEquals(AchievementFlag::OfficialCore->value, $achievement->Flags);
-        $this->assertEquals(Comment::SYSTEM_USER_ID, $achievement->user_id);
+        $this->assertEquals(EventAchievement::RAEVENTS_USER_ID, $achievement->user_id);
         $this->assertEquals('00000', $achievement->BadgeName);
         $this->assertEquals(52, $achievement->DisplayOrder);
         $this->assertEquals(null, $achievement->eventData->sourceAchievement);


### PR DESCRIPTION
Simple tool to generate an event game with _n_ achievements owned by RAEvents. The existing game and achievement edit pages can be used to flesh out the event after its been created.