### PR TITLE
fix: remediate some minor issues on the Create Ticket page

### DIFF
--- a/resources/js/common/components/+vendor/BaseToggle.tsx
+++ b/resources/js/common/components/+vendor/BaseToggle.tsx
@@ -9,11 +9,11 @@ import { cn } from '@/utils/cn';
 const baseToggleVariants = cva(
   cn(
     'inline-flex items-center justify-center rounded-md text-sm text-neutral-500 font-medium transition-colors',
-    'hover:bg-neutral-900 hover:text-link-hover',
+    'hover:bg-neutral-900 light:hover:bg-neutral-500 hover:text-neutral-50',
     'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
     'disabled:pointer-events-none disabled:opacity-50',
     'data-[state=on]:bg-embed-highlight data-[state=on]:text-neutral-50',
-    'data-[state=on]:light:bg-neutral-500',
+    'data-[state=on]:light:bg-neutral-600',
   ),
   {
     variants: {

--- a/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketForm/DescriptionField.tsx
+++ b/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketForm/DescriptionField.tsx
@@ -25,8 +25,7 @@ export const DescriptionField: FC = () => {
 
   const showTriggerWarning =
     (description.length < 25 && /(n'?t|not?).*(work|trigger)/gi.test(description)) ||
-    form.formState.errors.description?.type === 'too_small' ||
-    form.formState.errors.description?.message === 'BE_MORE_DESCRIPTIVE';
+    form.formState.errors.description?.type === 'too_small';
 
   const showNetworkWarning = /(manual\s+unlock|internet)/gi.test(description);
 

--- a/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketForm/useCreateAchievementTicketForm.ts
+++ b/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketForm/useCreateAchievementTicketForm.ts
@@ -17,12 +17,7 @@ const createAchievementTicketFormSchema = z.object({
   core: z.string().optional(),
   mode: z.enum(['hardcore', 'softcore']),
   hash: z.string().min(1),
-  description: z
-    .string()
-    .min(25, { message: 'Please be more detailed in your description.' })
-    .refine((desc) => !/(n'?t|not?).*(work|trigger)/i.test(desc), {
-      message: 'BE_MORE_DESCRIPTIVE',
-    }),
+  description: z.string().min(25, { message: 'Please be more detailed in your description.' }),
 });
 
 export type CreateAchievementTicketFormValues = z.infer<typeof createAchievementTicketFormSchema>;

--- a/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketMainRoot.test.tsx
+++ b/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketMainRoot.test.tsx
@@ -1026,7 +1026,7 @@ describe('Component: CreateAchievementTicketMainRoot', () => {
   });
 
   it(
-    'given the user writes a perfectly valid description with the word "trigger", does not pop validation on submit',
+    'given the user writes a perfectly valid description with the phrase "not trigger", does not pop validation on submit',
     { timeout: 20_000 },
     async () => {
       // ARRANGE
@@ -1068,7 +1068,7 @@ describe('Component: CreateAchievementTicketMainRoot', () => {
         Battle Mode. After that, I went straight into Party Mode to attempt this achievement.
 
         Other than the handicap, default settings were used (no teams, 10 turns, all minigames, bonus on).
-      `,
+        `,
       );
 
       await userEvent.click(screen.getByRole('button', { name: /submit/i }));

--- a/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketMainRoot.test.tsx
+++ b/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketMainRoot.test.tsx
@@ -1025,33 +1025,36 @@ describe('Component: CreateAchievementTicketMainRoot', () => {
     });
   });
 
-  it('given the user writes a perfectly valid description with the word "trigger", does not pop validation on submit', async () => {
-    // ARRANGE
-    const achievement = createAchievement();
-    const gameHashes = [createGameHash({ name: 'Hash A' }), createGameHash({ name: 'Hash B' })];
-    const emulators = [
-      createEmulator({ name: 'Bizhawk' }),
-      createEmulator({ name: 'RALibRetro' }),
-      createEmulator({ name: 'RetroArch' }),
-    ];
+  it(
+    'given the user writes a perfectly valid description with the word "trigger", does not pop validation on submit',
+    { timeout: 20_000 },
+    async () => {
+      // ARRANGE
+      const achievement = createAchievement();
+      const gameHashes = [createGameHash({ name: 'Hash A' }), createGameHash({ name: 'Hash B' })];
+      const emulators = [
+        createEmulator({ name: 'Bizhawk' }),
+        createEmulator({ name: 'RALibRetro' }),
+        createEmulator({ name: 'RetroArch' }),
+      ];
 
-    render<App.Platform.Data.CreateAchievementTicketPageProps>(
-      <CreateAchievementTicketMainRoot />,
-      {
-        pageProps: {
-          achievement,
-          emulators,
-          gameHashes,
-          auth: { user: createAuthenticatedUser({ points: 500 }) },
-          ziggy: createZiggyProps({ query: {} }),
+      render<App.Platform.Data.CreateAchievementTicketPageProps>(
+        <CreateAchievementTicketMainRoot />,
+        {
+          pageProps: {
+            achievement,
+            emulators,
+            gameHashes,
+            auth: { user: createAuthenticatedUser({ points: 500 }) },
+            ziggy: createZiggyProps({ query: {} }),
+          },
         },
-      },
-    );
+      );
 
-    // ACT
-    await userEvent.type(
-      screen.getByRole('textbox', { name: /description/i }),
-      `
+      // ACT
+      await userEvent.type(
+        screen.getByRole('textbox', { name: /description/i }),
+        `
         Steps to reproduce: 
         Played as Waluigi in Party Mode on Shy Guy's board, 10 turns, 3 easy CPUs (Mario, Luigi and Peach) and 
         handicap of 1 star to each CPU. Mario and Peach collected 1 star each, I stayed at 0 stars all game. 
@@ -1066,15 +1069,16 @@ describe('Component: CreateAchievementTicketMainRoot', () => {
 
         Other than the handicap, default settings were used (no teams, 10 turns, all minigames, bonus on).
       `,
-    );
+      );
 
-    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+      await userEvent.click(screen.getByRole('button', { name: /submit/i }));
 
-    // ASSERT
-    await waitFor(() => {
-      expect(screen.queryByText(/please be more specific/i)).not.toBeInTheDocument();
-    });
-  });
+      // ASSERT
+      await waitFor(() => {
+        expect(screen.queryByText(/please be more specific/i)).not.toBeInTheDocument();
+      });
+    },
+  );
 
   it('given the user does not select an emulator and a hash, shows required validation messages', async () => {
     // ARRANGE

--- a/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketMainRoot.test.tsx
+++ b/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketMainRoot.test.tsx
@@ -991,7 +991,41 @@ describe('Component: CreateAchievementTicketMainRoot', () => {
     expect(linkEl).toHaveAttribute('href', expect.stringContaining('docs.retroachievements.org'));
   });
 
-  it('given the user writes a description "this achievement doesn\'t work", displays a warning on attempted submit', async () => {
+  it('given the user writes a description "doesn\'t work", displays a warning on attempted submit', async () => {
+    // ARRANGE
+    const achievement = createAchievement();
+    const gameHashes = [createGameHash({ name: 'Hash A' }), createGameHash({ name: 'Hash B' })];
+    const emulators = [
+      createEmulator({ name: 'Bizhawk' }),
+      createEmulator({ name: 'RALibRetro' }),
+      createEmulator({ name: 'RetroArch' }),
+    ];
+
+    render<App.Platform.Data.CreateAchievementTicketPageProps>(
+      <CreateAchievementTicketMainRoot />,
+      {
+        pageProps: {
+          achievement,
+          emulators,
+          gameHashes,
+          auth: { user: createAuthenticatedUser({ points: 500 }) },
+          ziggy: createZiggyProps({ query: {} }),
+        },
+      },
+    );
+
+    // ACT
+    await userEvent.type(screen.getByRole('textbox', { name: /description/i }), "doesn't work");
+
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/please be more specific/i)).toBeVisible();
+    });
+  });
+
+  it('given the user writes a perfectly valid description with the word "trigger", does not pop validation on submit', async () => {
     // ARRANGE
     const achievement = createAchievement();
     const gameHashes = [createGameHash({ name: 'Hash A' }), createGameHash({ name: 'Hash B' })];
@@ -1017,14 +1051,28 @@ describe('Component: CreateAchievementTicketMainRoot', () => {
     // ACT
     await userEvent.type(
       screen.getByRole('textbox', { name: /description/i }),
-      "this achievement doesn't work",
+      `
+        Steps to reproduce: 
+        Played as Waluigi in Party Mode on Shy Guy's board, 10 turns, 3 easy CPUs (Mario, Luigi and Peach) and 
+        handicap of 1 star to each CPU. Mario and Peach collected 1 star each, I stayed at 0 stars all game. 
+        During the last 5 turns, the challenge marker correctly appeared. When the board finished, 
+        I won by getting the minigame and coin stars. No one got the happening space star. 
+        The achievement did not trigger, but the marker continued to be displayed through the display 
+        results screen, all the way until the game booted me back to the mode selection screen. Once I 
+        selected Party Mode again, the icon disappeared.
+        As extra information, before encountering this issue, I started this playing session by playing 
+        some minigames in the Extra Room. I tried Doors of Doom and Bob-omb X-ing, then won the Volleyball 
+        Battle Mode. After that, I went straight into Party Mode to attempt this achievement.
+
+        Other than the handicap, default settings were used (no teams, 10 turns, all minigames, bonus on).
+      `,
     );
 
     await userEvent.click(screen.getByRole('button', { name: /submit/i }));
 
     // ASSERT
     await waitFor(() => {
-      expect(screen.getByText(/please be more specific/i)).toBeVisible();
+      expect(screen.queryByText(/please be more specific/i)).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
This PR remediates two minor issues present in the new Create Ticket page.

1: Unhelpful description validation is a little too aggressive.
https://discord.com/channels/310192285306454017/453242743292952578/1309231489845559296

2: The toggle button text is hard to read on light mode when hovered.
![Screenshot 2024-11-21 at 8 00 46 PM](https://github.com/user-attachments/assets/12dcbc80-5c4c-4d1a-86d0-ba555acdbf5f)
