### PR TITLE
fix(manage): dont error when restoring deleted achievement credit

### DIFF
--- a/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
+++ b/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
@@ -58,6 +58,24 @@ class AuthorshipCreditsRelationManager extends RelationManager
                         $achievement = $this->ownerRecord;
 
                         $task = $data['task'];
+                        $userId = (int) $data['user_id'];
+
+                        // First, check for and restore any soft-deleted record.
+                        $existingRecord = AchievementAuthor::withTrashed()
+                            ->whereAchievementId($achievement->id)
+                            ->whereUserId($userId)
+                            ->whereTask($task)
+                            ->first();
+
+                        if ($existingRecord) {
+                            if ($existingRecord->trashed()) {
+                                $existingRecord->restore();
+
+                                return $existingRecord;
+                            }
+
+                            return $existingRecord;
+                        }
 
                         /**
                          * An achievement developer doing most tasks is implied. If someone

--- a/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
+++ b/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
@@ -70,8 +70,6 @@ class AuthorshipCreditsRelationManager extends RelationManager
                         if ($existingRecord) {
                             if ($existingRecord->trashed()) {
                                 $existingRecord->restore();
-
-                                return $existingRecord;
                             }
 
                             return $existingRecord;
@@ -134,6 +132,7 @@ class AuthorshipCreditsRelationManager extends RelationManager
                             'user_id' => (int) $data['user_id'],
                             'achievement_id' => $achievement->id,
                             'task' => $task,
+                            'created_at' => $data['created_at'] ?? now(),
                         ]);
                     }),
             ])


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/310195377993416714/1314263872303005750.

To reproduce the bug:
* Add any form of achievement credit for a user.
* Delete the credit.
* Try to re-add the same credit for the user.

This surfaces a SQL error because it's a soft-deleted record that actually needs to be restored.