### PR TITLE
ci: raise composer analyse pre-push memory limit

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -6,7 +6,7 @@ printf "\n⏳ composer lint\n"
 vendor/bin/pint --test
 
 printf "\n⏳ composer analyse\n"
-vendor/bin/phpstan analyse --memory-limit 512M
+vendor/bin/phpstan analyse --memory-limit 768M
 
 printf "\n⏳ pnpm lint:eslint\n"
 pnpm lint:eslint


### PR DESCRIPTION
`composer analyse` in pre-push does not currently reflect the memory limit that we use in _composer.json_.