### PR TITLE
fix: block jr devs from updating credit

### DIFF
--- a/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
+++ b/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
@@ -13,6 +13,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 
 class AuthorshipCreditsRelationManager extends RelationManager
 {
@@ -28,6 +29,17 @@ class AuthorshipCreditsRelationManager extends RelationManager
 
     public function table(Table $table): Table
     {
+        /** @var User $user */
+        $user = Auth::user();
+
+        // Create a dummy model for generic permission checks.
+        $dummyModel = new AchievementAuthor();
+        $dummyModel->achievement_id = $this->ownerRecord->id;
+
+        $canCreate = $user->can('create', $dummyModel);
+        $canDelete = $user->can('delete', $dummyModel);
+        $canUpdate = $user->can('update', $dummyModel);
+
         $earliestLogicCredit = AchievementAuthor::where('achievement_id', $this->ownerRecord->id)
             ->where('task', AchievementAuthorTask::Logic->value)
             ->orderBy('created_at', 'asc')
@@ -134,19 +146,22 @@ class AuthorshipCreditsRelationManager extends RelationManager
                             'task' => $task,
                             'created_at' => $data['created_at'] ?? now(),
                         ]);
-                    }),
+                    })
+                    ->visible(fn () => $canCreate),
             ])
             ->actions([
                 Tables\Actions\EditAction::make()
-                    ->modalHeading('Edit contribution credit'),
+                    ->modalHeading('Edit contribution credit')
+                    ->visible(fn () => $canUpdate),
 
                 Tables\Actions\DeleteAction::make()
                     ->modalHeading('Delete contribution credit')
-                    ->hidden(fn (AchievementAuthor $record) => $earliestLogicCredit && $earliestLogicCredit->id === $record->id),
+                    ->hidden(fn (AchievementAuthor $record) => !$canDelete || ($earliestLogicCredit && $earliestLogicCredit->id === $record->id)),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->visible(fn () => $canDelete),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
+++ b/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
@@ -7,6 +7,7 @@ namespace App\Filament\Resources\AchievementResource\RelationManagers;
 use App\Filament\Resources\AchievementAuthorshipCreditFormSchema;
 use App\Models\Achievement;
 use App\Models\AchievementAuthor;
+use App\Models\User;
 use App\Platform\Enums\AchievementAuthorTask;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;

--- a/app/Filament/Resources/GameResource/RelationManagers/CoreSetAuthorshipCreditsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/CoreSetAuthorshipCreditsRelationManager.php
@@ -70,6 +70,8 @@ class CoreSetAuthorshipCreditsRelationManager extends RelationManager
         /** @var User $user */
         $user = Auth::user();
 
+        $canManageContributionCredit = $user->can('manageContributionCredit', $this->ownerRecord);
+
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('user.display_name')
@@ -127,18 +129,21 @@ class CoreSetAuthorshipCreditsRelationManager extends RelationManager
                             date: Carbon::parse($data['created_at']),
                         );
                     })
-                    ->visible(fn () => $user->can('addContributionCredit', $this->ownerRecord)),
+                    ->visible(fn () => $canManageContributionCredit),
             ])
             ->actions([
                 Tables\Actions\EditAction::make()
-                    ->modalHeading('Edit contribution credit'),
+                    ->modalHeading('Edit contribution credit')
+                    ->visible(fn () => $canManageContributionCredit),
 
                 Tables\Actions\DeleteAction::make()
-                    ->modalHeading('Delete contribution credit'),
+                    ->modalHeading('Delete contribution credit')
+                    ->visible(fn () => $canManageContributionCredit),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->visible(fn () => $canManageContributionCredit),
                 ]),
             ])
             ->emptyStateHeading('No contribution credits')

--- a/app/Policies/GamePolicy.php
+++ b/app/Policies/GamePolicy.php
@@ -147,7 +147,7 @@ class GamePolicy
         ]);
     }
 
-    public function addContributionCredit(User $user, Game $game): bool
+    public function manageContributionCredit(User $user, Game $game): bool
     {
         return $user->hasAnyRole([
             Role::DEVELOPER_STAFF,


### PR DESCRIPTION
Jr Devs currently have the ability to update credit by means of bulk actions. This should not be permitted.