### PR TITLE
fix(RandomGameButton): disable when there are no games in the list

### DIFF
--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableDesktopToolbar.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableDesktopToolbar.tsx
@@ -97,6 +97,7 @@ export function DataTableDesktopToolbar<TData>({
               apiRouteName={randomGameApiRouteName}
               apiRouteParams={tableApiRouteParams}
               columnFilters={currentFilters}
+              disabled={table.getRowCount() === 0}
             />
 
             <DataTableViewOptions table={table} />

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableMobileToolbar/DataTableMobileToolbar.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableMobileToolbar/DataTableMobileToolbar.test.tsx
@@ -26,6 +26,7 @@ describe('Component: DataTableMobileToolbar', () => {
       }),
       getColumn: vi.fn(),
       getAllColumns: () => [],
+      getRowCount: () => 0,
     };
 
     const { container } = render(
@@ -53,6 +54,7 @@ describe('Component: DataTableMobileToolbar', () => {
       }),
       getColumn: vi.fn(),
       getAllColumns: () => [],
+      getRowCount: () => 0,
     };
 
     vi.mocked(useGameListInfiniteQuery).mockReturnValue({
@@ -85,6 +87,7 @@ describe('Component: DataTableMobileToolbar', () => {
       }),
       getColumn: vi.fn(),
       getAllColumns: () => [],
+      getRowCount: () => 0,
     };
 
     vi.mocked(useGameListInfiniteQuery).mockReturnValue({

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.test.tsx
@@ -45,6 +45,7 @@ const TestHarness: FC<TestHarnessProps> = ({
       buildAchievementsPublishedColumnDef({ t_label: i18n.t('Achievements') }),
     ],
     data: [],
+    rowCount: 0,
     getCoreRowModel: getCoreRowModel(),
     state: {
       columnFilters,

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.tsx
@@ -151,6 +151,7 @@ export function DataTableSuperFilter<TData>({
                 apiRouteName={randomGameApiRouteName}
                 apiRouteParams={randomGameApiRouteParams}
                 columnFilters={currentFilters}
+                disabled={table.getRowCount() === 0}
               />
 
               <BaseDrawerClose asChild>

--- a/resources/js/features/game-list/components/DataTableToolbar/RandomGameButton/RandomGameButton.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/RandomGameButton/RandomGameButton.test.tsx
@@ -30,7 +30,12 @@ describe('Component: RandomGameButton', () => {
   it('renders without crashing', () => {
     // ARRANGE
     const { container } = render(
-      <RandomGameButton columnFilters={[]} variant="toolbar" apiRouteName="api.game.random" />,
+      <RandomGameButton
+        columnFilters={[]}
+        variant="toolbar"
+        apiRouteName="api.game.random"
+        disabled={false}
+      />,
       { pageProps: { ziggy: createZiggyProps({ device: 'desktop' }) } },
     );
 
@@ -43,7 +48,12 @@ describe('Component: RandomGameButton', () => {
     vi.spyOn(axios, 'get').mockResolvedValue({ data: { gameId: 12345 } });
 
     render(
-      <RandomGameButton columnFilters={[]} variant="toolbar" apiRouteName="api.game.random" />,
+      <RandomGameButton
+        columnFilters={[]}
+        variant="toolbar"
+        apiRouteName="api.game.random"
+        disabled={false}
+      />,
       {
         pageProps: {
           ziggy: createZiggyProps({ device: 'desktop' }),
@@ -69,6 +79,7 @@ describe('Component: RandomGameButton', () => {
         columnFilters={[]}
         variant="mobile-drawer"
         apiRouteName="api.game.random"
+        disabled={false}
       />,
       {
         pageProps: {
@@ -84,5 +95,25 @@ describe('Component: RandomGameButton', () => {
     await waitFor(() => {
       expect(mockLocationAssign).toHaveBeenCalledWith(['game.show', 12345]);
     });
+  });
+
+  it('given the disabled prop is truthy, disables the button', () => {
+    // ARRANGE
+    render(
+      <RandomGameButton
+        columnFilters={[]}
+        variant="toolbar"
+        apiRouteName="api.game.random"
+        disabled={true}
+      />,
+      {
+        pageProps: {
+          ziggy: createZiggyProps({ device: 'desktop' }),
+        },
+      },
+    );
+
+    // ASSERT
+    expect(screen.getByRole('button', { name: /surprise me/i })).toBeDisabled();
   });
 });

--- a/resources/js/features/game-list/components/DataTableToolbar/RandomGameButton/RandomGameButton.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/RandomGameButton/RandomGameButton.tsx
@@ -12,6 +12,7 @@ import { useRandomGameId } from './useRandomGameId';
 
 interface RandomGameButtonProps {
   columnFilters: ColumnFiltersState;
+  disabled: boolean;
   variant: 'mobile-drawer' | 'toolbar';
 
   apiRouteName?: RouteName;
@@ -21,6 +22,7 @@ interface RandomGameButtonProps {
 export const RandomGameButton: FC<RandomGameButtonProps> = ({
   apiRouteParams,
   columnFilters,
+  disabled,
   variant,
   apiRouteName = 'api.game.random',
 }) => {
@@ -56,6 +58,7 @@ export const RandomGameButton: FC<RandomGameButtonProps> = ({
     <BaseButton
       onClick={handleClick}
       onMouseEnter={() => prefetchRandomGameId()}
+      disabled={disabled}
       size={variant === 'toolbar' ? 'sm' : undefined}
       className={variant === 'mobile-drawer' ? 'gap-1.5' : 'group gap-1'}
       variant={variant === 'mobile-drawer' ? 'secondary' : undefined}


### PR DESCRIPTION
Should resolve a bunch of errors we're seeing in the server logs.

This PR disables the "Surprise me" button when there are no results in the list (there is nothing to randomize, the returned game ID will always be null).