### PR TITLE
fix(DataTablePagination): auto-scroll on first and last pages

### DIFF
--- a/resources/js/features/game-list/components/DataTablePagination/DataTablePagination.tsx
+++ b/resources/js/features/game-list/components/DataTablePagination/DataTablePagination.tsx
@@ -35,15 +35,23 @@ export function DataTablePagination<TData>({
   );
 
   const scrollToTopOfPage = () => {
-    const scrollTarget = document.getElementById('pagination-scroll-target');
+    /**
+     * We use a `setTimeout()` without any time here to deliberately
+     * push the scroll event to the end of the browser's event queue.
+     * If we don't do this, scroll events for navigating to the first
+     * and last page may not occur on some browsers.
+     */
+    setTimeout(() => {
+      const scrollTarget = document.getElementById('pagination-scroll-target');
 
-    if (!scrollTarget) {
-      return;
-    }
+      if (!scrollTarget) {
+        return;
+      }
 
-    window.scrollTo({
-      top: scrollTarget.offsetTop,
-      behavior: 'smooth',
+      window.scrollTo({
+        top: scrollTarget.offsetTop,
+        behavior: 'smooth',
+      });
     });
   };
 


### PR DESCRIPTION
This PR resolves an issue in the `DataTablePagination` component.

Right now, on Google Chrome (and possibly others), auto-scroll on pagination does not occur if the user is going to the first or last page. This is due to a race condition between React state and the browser event queue.

The issue can be reproduced by paginating at this URL:
http://localhost:64000/games?filter%5Btitle%5D=zelda&page%5Bsize%5D=50&page%5Bnumber%5D=1