### PR TITLE
feat(DataTableToolbar): if only one filterable system, hide the System filter

### DIFF
--- a/resources/js/features/game-list/components/AllGamesMainRoot/AllGamesMainRoot.test.tsx
+++ b/resources/js/features/game-list/components/AllGamesMainRoot/AllGamesMainRoot.test.tsx
@@ -383,6 +383,7 @@ describe('Component: AllGamesMainRoot', () => {
         auth: { user: createAuthenticatedUser() },
         filterableSystemOptions: [
           createSystem({ id: 1, name: 'Genesis/Mega Drive', nameShort: 'MD' }),
+          createSystem({ id: 2, name: 'NES/Famicom', nameShort: 'NES' }),
         ],
         paginatedGameListEntries: createPaginatedData([]),
         can: { develop: false },
@@ -424,6 +425,7 @@ describe('Component: AllGamesMainRoot', () => {
         auth: { user: createAuthenticatedUser() },
         filterableSystemOptions: [
           createSystem({ id: 1, name: 'Genesis/Mega Drive', nameShort: 'MD' }),
+          createSystem({ id: 2, name: 'NES/Famicom', nameShort: 'NES' }),
         ],
         paginatedGameListEntries: createPaginatedData([]),
         can: { develop: false },
@@ -455,7 +457,10 @@ describe('Component: AllGamesMainRoot', () => {
     render<App.Platform.Data.GameListPageProps>(<AllGamesMainRoot />, {
       pageProps: {
         auth: { user: createAuthenticatedUser() },
-        filterableSystemOptions: [createSystem({ id: 1, name: 'Genesis/Mega Drive' })],
+        filterableSystemOptions: [
+          createSystem({ id: 1, name: 'Genesis/Mega Drive' }),
+          createSystem({ id: 2, name: 'NES/Famicom', nameShort: 'NES' }),
+        ],
         paginatedGameListEntries: createPaginatedData([]),
         can: { develop: false },
         ziggy: createZiggyProps({ device: 'desktop' }),

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableDesktopToolbar.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableDesktopToolbar.tsx
@@ -46,7 +46,7 @@ export function DataTableDesktopToolbar<TData>({
   return (
     <div className="flex w-full flex-col justify-between gap-2">
       <div className="flex flex-col gap-2 rounded bg-embed p-2 sm:flex-row sm:gap-2 md:gap-3">
-        {doesColumnExist(allColumns, 'system') && filterableSystemOptions ? (
+        {doesColumnExist(allColumns, 'system') && filterableSystemOptions?.length > 1 ? (
           <DataTableSystemFilter table={table} filterableSystemOptions={filterableSystemOptions} />
         ) : null}
 

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.test.tsx
@@ -201,6 +201,29 @@ describe('Component: DataTableSuperFilter', () => {
       ]);
     });
 
+    it('given there is only one filterable system option, does not show the system filter', async () => {
+      // ARRANGE
+      const onColumnFiltersChange = vi.fn();
+
+      render<{ filterableSystemOptions: App.Platform.Data.System[] }>(
+        <TestHarness
+          columnFilters={[{ id: 'achievementsPublished', value: 'has' }]}
+          onColumnFiltersChange={onColumnFiltersChange}
+        />,
+        {
+          pageProps: {
+            filterableSystemOptions: [createSystem({ id: 1, name: 'NES/Famicom' })],
+          },
+        },
+      );
+
+      // ACT
+      await userEvent.click(screen.getByRole('button', { name: /playable/i }));
+
+      // ASSERT
+      expect(screen.queryByRole('option', { name: 'NES/Famicom' })).not.toBeInTheDocument();
+    });
+
     it('allows the user to change the current sort order to an ascending sort', async () => {
       // ARRANGE
       const onSortingChange = vi.fn();

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.tsx
@@ -99,7 +99,7 @@ export function DataTableSuperFilter<TData>({
           <div className="flex flex-col gap-4 p-4">
             <DataTableAchievementsPublishedFilter table={table} variant="drawer" />
 
-            {doesColumnExist(allColumns, 'system') ? (
+            {doesColumnExist(allColumns, 'system') && filterableSystemOptions?.length > 1 ? (
               <DataTableSystemFilter
                 filterableSystemOptions={filterableSystemOptions}
                 table={table}

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableToolbar.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableToolbar.test.tsx
@@ -122,6 +122,19 @@ describe('Component: DataTableToolbar', () => {
     expect(screen.getAllByTestId('filter-selected-label')[0]).toHaveTextContent('GC');
   });
 
+  it('given there is only one filterable system option, does not show the System filter', async () => {
+    // ARRANGE
+    render(<DataTableToolbarHarness />, {
+      pageProps: {
+        filterableSystemOptions: [createSystem({ name: 'Nintendo 64', nameShort: 'N64' })],
+        ziggy: createZiggyProps({ device: 'desktop' }),
+      },
+    });
+
+    // ASSERT
+    expect(screen.queryByRole('button', { name: /system/i })).not.toBeInTheDocument();
+  });
+
   it(
     'given more than three options are selected, shows the selected count',
     { retry: 2, timeout: 15000 },

--- a/resources/js/features/game-list/components/WantToPlayGamesMainRoot/WantToPlayGamesMainRoot.test.tsx
+++ b/resources/js/features/game-list/components/WantToPlayGamesMainRoot/WantToPlayGamesMainRoot.test.tsx
@@ -347,6 +347,7 @@ describe('Component: WantToPlayGamesMainRoot', () => {
         auth: { user: createAuthenticatedUser() },
         filterableSystemOptions: [
           createSystem({ id: 1, name: 'Genesis/Mega Drive', nameShort: 'MD' }),
+          createSystem({ id: 2, name: 'NES/Famicom', nameShort: 'NES' }),
         ],
         paginatedGameListEntries: createPaginatedData([]),
         can: { develop: false },
@@ -388,6 +389,7 @@ describe('Component: WantToPlayGamesMainRoot', () => {
         auth: { user: createAuthenticatedUser() },
         filterableSystemOptions: [
           createSystem({ id: 1, name: 'Genesis/Mega Drive', nameShort: 'MD' }),
+          createSystem({ id: 2, name: 'NES/Famicom', nameShort: 'NES' }),
         ],
         paginatedGameListEntries: createPaginatedData([]),
         can: { develop: false },
@@ -419,7 +421,10 @@ describe('Component: WantToPlayGamesMainRoot', () => {
     render<App.Community.Data.UserGameListPageProps>(<WantToPlayGamesMainRoot />, {
       pageProps: {
         auth: { user: createAuthenticatedUser() },
-        filterableSystemOptions: [createSystem({ id: 1, name: 'Genesis/Mega Drive' })],
+        filterableSystemOptions: [
+          createSystem({ id: 1, name: 'Genesis/Mega Drive' }),
+          createSystem({ id: 2, name: 'NES/Famicom', nameShort: 'NES' }),
+        ],
         paginatedGameListEntries: createPaginatedData([]),
         can: { develop: false },
         ziggy: createZiggyProps({ device: 'desktop' }),


### PR DESCRIPTION
Small QoL improvement to the React datatable.

If all the games on the table are of the same system, hide the now-redundant system filter on both desktop and mobile. 