### PR TITLE
fix(home): use correct `isHomeRoute` condition

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -96,7 +96,7 @@
                 const navBrandWrapper = document.getElementById('nav-brand-wrapper');
 
                 const newRoute = event.detail.page.component.toLowerCase();
-                const isHomeRoute = newRoute === 'home';
+                const isHomeRoute = @json(Route::is('home'));
 
                 if (brandTopWrapper) {
                     brandTopWrapper.classList.toggle('hidden', !isHomeRoute);

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -95,7 +95,6 @@
                 const brandTopWrapper = document.getElementById('brand-top-wrapper');
                 const navBrandWrapper = document.getElementById('nav-brand-wrapper');
 
-                const newRoute = event.detail.page.component.toLowerCase();
                 const isHomeRoute = @json(Route::is('home'));
 
                 if (brandTopWrapper) {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -95,7 +95,7 @@
                 const brandTopWrapper = document.getElementById('brand-top-wrapper');
                 const navBrandWrapper = document.getElementById('nav-brand-wrapper');
 
-                const isHomeRoute = @json(Route::is('home'));
+                const isHomeRoute = event.detail.page.url === '/';
 
                 if (brandTopWrapper) {
                     brandTopWrapper.classList.toggle('hidden', !isHomeRoute);


### PR DESCRIPTION
Currently, `isHomeRoute` is being incorrectly set. This is resulting in the app layout's branding not being updated correctly on navigation from the home page to another React page.

`newRoute` represents the name of the _.tsx_ file, not the name of the route. For safety, we should use the pathname itself.