### PR TITLE
chore(deps): upgrade to inertia 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "filament/filament": "^3.2.124",
         "graham-campbell/markdown": "^15.0",
         "guzzlehttp/guzzle": "^7.5",
-        "inertiajs/inertia-laravel": "^1.3",
+        "inertiajs/inertia-laravel": "^2.0",
         "jenssegers/agent": "^2.6",
         "jenssegers/optimus": "^1.1",
         "laravel-notification-channels/webhook": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59ec045e41e6b81501a6d22e0dd5e6b5",
+    "content-hash": "b1b48afdcc014564fa8b77c560678315",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3781,28 +3781,29 @@
         },
         {
             "name": "inertiajs/inertia-laravel",
-            "version": "v1.3.0",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/inertiajs/inertia-laravel.git",
-                "reference": "36730d13b1dab9017069004fd458b3e67449a326"
+                "reference": "0259e37f802bc39c814c42ba92c04ada17921f70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/36730d13b1dab9017069004fd458b3e67449a326",
-                "reference": "36730d13b1dab9017069004fd458b3e67449a326",
+                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/0259e37f802bc39c814c42ba92c04ada17921f70",
+                "reference": "0259e37f802bc39c814c42ba92c04ada17921f70",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "laravel/framework": "^8.74|^9.0|^10.0|^11.0",
-                "php": "^7.3|~8.0.0|~8.1.0|~8.2.0|~8.3.0",
-                "symfony/console": "^5.3|^6.0|^7.0"
+                "laravel/framework": "^10.0|^11.0",
+                "php": "^8.1.0",
+                "symfony/console": "^6.2|^7.0"
             },
             "require-dev": {
+                "laravel/pint": "^1.16",
                 "mockery/mockery": "^1.3.3",
-                "orchestra/testbench": "^6.4|^7.0|^8.0|^9.0",
-                "phpunit/phpunit": "^8.0|^9.5.8|^10.4",
+                "orchestra/testbench": "^8.0|^9.2",
+                "phpunit/phpunit": "^10.4|^11.0",
                 "roave/security-advisories": "dev-master"
             },
             "suggest": {
@@ -3814,9 +3815,6 @@
                     "providers": [
                         "Inertia\\ServiceProvider"
                     ]
-                },
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -3845,7 +3843,7 @@
             ],
             "support": {
                 "issues": "https://github.com/inertiajs/inertia-laravel/issues",
-                "source": "https://github.com/inertiajs/inertia-laravel/tree/v1.3.0"
+                "source": "https://github.com/inertiajs/inertia-laravel/tree/v2.0.0"
             },
             "funding": [
                 {
@@ -3853,7 +3851,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-13T01:25:09+00:00"
+            "time": "2024-12-13T02:48:29+00:00"
         },
         {
             "name": "jaybizzle/crawler-detect",
@@ -18388,7 +18386,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -18405,7 +18403,7 @@
         "ext-pdo": "*",
         "ext-simplexml": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "ext-pcntl": "8.2",
         "ext-posix": "8.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "devDependencies": {
         "@crowdin/crowdin-api-client": "^1.39.1",
         "@faker-js/faker": "^8.4.1",
-        "@inertiajs/react": "^1.2.0",
+        "@inertiajs/react": "^2.0.0",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/forms": "^0.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^8.4.1
         version: 8.4.1
       '@inertiajs/react':
-        specifier: ^1.2.0
-        version: 1.2.0(react@18.3.1)
+        specifier: ^2.0.0
+        version: 2.0.0(react@18.3.1)
       '@tailwindcss/aspect-ratio':
         specifier: ^0.4.2
         version: 0.4.2(tailwindcss@3.4.15)
@@ -777,10 +777,13 @@ packages:
   '@inertiajs/core@1.2.0':
     resolution: {integrity: sha512-6U0gqCPbGGGMcLoDm+ckKipc5gptZMmfVFfPGdO7vlO7yipWf1RD+TKkcZGJklFvfgFMKwK2VPw8GAv1OctuQA==}
 
-  '@inertiajs/react@1.2.0':
-    resolution: {integrity: sha512-Q3wTaQJdoUbUB8YIGeQ0y2Tf/k8dNtz9Nu2dYr1pbYUBv++6d45iC/CFB/lIpqVvvUw8XuIai2bdsUcRSIbPCQ==}
+  '@inertiajs/core@2.0.0':
+    resolution: {integrity: sha512-2kvlk731NjwfXUku/ZoXsZNcOzx985icHtTC1dgN+8sAZtJfEg9QBrQ7sBjeLYiWtKgobJdwwpeDaexEneAtLQ==}
+
+  '@inertiajs/react@2.0.0':
+    resolution: {integrity: sha512-7X6TMYe7FcjG05UjRBkPYjTw/U+CrMeVDxxRolncuNYp6LmifPs1xOjTOC5M7gbpKaDEL/LuxNAX7ePJC3cbPg==}
     peerDependencies:
-      react: ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -4794,9 +4797,17 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@inertiajs/react@1.2.0(react@18.3.1)':
+  '@inertiajs/core@2.0.0':
     dependencies:
-      '@inertiajs/core': 1.2.0
+      axios: 1.7.7
+      deepmerge: 4.3.1
+      qs: 6.13.0
+    transitivePeerDependencies:
+      - debug
+
+  '@inertiajs/react@2.0.0(react@18.3.1)':
+    dependencies:
+      '@inertiajs/core': 2.0.0
       lodash.isequal: 4.5.0
       react: 18.3.1
     transitivePeerDependencies:

--- a/resources/js/test/setup.tsx
+++ b/resources/js/test/setup.tsx
@@ -69,6 +69,8 @@ export function render<TPageProps = Record<string, unknown>>(
     scrollRegions: vi.fn() as any,
     url: '',
     version: '',
+    clearHistory: false,
+    encryptHistory: false,
   }));
 
   if (!wrapper) {
@@ -111,6 +113,8 @@ export function renderHook<Result, Props = undefined>(
     scrollRegions: vi.fn() as any,
     url: '',
     version: '',
+    clearHistory: false,
+    encryptHistory: false,
   }));
 
   if (!wrapper) {


### PR DESCRIPTION
As of today, Inertia 2.0 is no longer in beta. This PR migrates us to Inertia 2.0. There are no breaking changes in the upgrade.

In the future, we'll be able to leverage some of Inertia 2.0's features to make the front-end performance even faster.

**How to test this PR**
```
composer install
sail pnpm install
sail pnpm build
sail artisan inertia:start-ssr
```

You should be able to navigate around the React pages and not observe any hydration errors.