### PR TITLE
feat(GuestWelcomeCta): auto-sort all games link by player count

### DIFF
--- a/resources/js/common/utils/cn.ts
+++ b/resources/js/common/utils/cn.ts
@@ -1,5 +1,3 @@
-// TODO move to @/common/utils
-
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 

--- a/resources/js/features/home/components/+root/GuestWelcomeCta/GuestWelcomeCta.test.tsx
+++ b/resources/js/features/home/components/+root/GuestWelcomeCta/GuestWelcomeCta.test.tsx
@@ -48,7 +48,7 @@ describe('Component: GuestWelcomeCta', () => {
     const linkEl = screen.getByRole('link', { name: /the games/i });
 
     expect(linkEl).toBeVisible();
-    expect(linkEl).toHaveAttribute('href', 'game.index');
+    expect(linkEl).toHaveAttribute('href', expect.stringContaining('game.index'));
   });
 
   it('has an accessible link to some random game', () => {

--- a/resources/js/features/home/components/+root/GuestWelcomeCta/GuestWelcomeCta.tsx
+++ b/resources/js/features/home/components/+root/GuestWelcomeCta/GuestWelcomeCta.tsx
@@ -41,7 +41,7 @@ export const GuestWelcomeCta: FC = () => {
                   ),
                   2: (
                     <Link
-                      href={route('game.index')}
+                      href={route('game.index', { sort: '-playersTotal' })}
                       className={buildTrackingClassNames('Click Guest All Games Link')}
                     />
                   ),


### PR DESCRIPTION
Makes a tiny modification to this component that appears on the home page if the user is a guest:
![Screenshot 2024-12-15 at 3 58 20 PM](https://github.com/user-attachments/assets/a8871d4a-18ad-46cf-94c6-ce12596ee6a7)

Now, the link to the All Games page ("the games") is sorted by player count.