### PR TITLE
fix(AchievementAuthorPolicy): prevent errors on update policy checks

### DIFF
--- a/app/Policies/AchievementAuthorPolicy.php
+++ b/app/Policies/AchievementAuthorPolicy.php
@@ -42,6 +42,11 @@ class AchievementAuthorPolicy
 
     public function update(User $user, AchievementAuthor $achievementAuthor): bool
     {
+        // If no task is set, fall back to the manage permission check.
+        if (!$achievementAuthor->task) {
+            return $this->manage($user);
+        }
+
         return $this->canUpsertTask($user, AchievementAuthorTask::tryFrom($achievementAuthor->task));
     }
 


### PR DESCRIPTION
Resolves https://retroachievements.org/log-viewer?file=c05820c7-laravel-2024-12-19.log&query=log-index%3A175.

Errors are being thrown on the achievement update page in the management app due to the policy check exploding when `task` is null.