### PR TITLE
fix: add max-w-fit classname to avatar components

### DIFF
--- a/resources/js/common/components/AchievementAvatar/AchievementAvatar.tsx
+++ b/resources/js/common/components/AchievementAvatar/AchievementAvatar.tsx
@@ -23,7 +23,7 @@ export const AchievementAvatar: FC<AchievementAvatarProps> = ({
   return (
     <a
       href={route('achievement.show', { achievement: id })}
-      className="flex items-center gap-2"
+      className="flex max-w-fit items-center gap-2"
       {...(hasTooltip ? cardTooltipProps : undefined)}
     >
       {showImage ? (

--- a/resources/js/common/components/ActivePlayerFeed/ActivePlayerFeedList.tsx
+++ b/resources/js/common/components/ActivePlayerFeed/ActivePlayerFeedList.tsx
@@ -24,9 +24,7 @@ export const ActivePlayerFeedList: FC<ActivePlayerFeedListProps> = ({ onLoadMore
           </div>
 
           <div className="flex flex-col">
-            <div className="max-w-fit">
-              <GameAvatar {...player.game} showImage={false} />
-            </div>
+            <GameAvatar {...player.game} showImage={false} />
 
             <p className="line-clamp-1 text-2xs" style={{ wordBreak: 'break-word' }}>
               <RichPresenceMessage

--- a/resources/js/common/components/GameAvatar/GameAvatar.tsx
+++ b/resources/js/common/components/GameAvatar/GameAvatar.tsx
@@ -49,7 +49,7 @@ export const GameAvatar: FC<GameAvatarProps> = ({
   return (
     <Wrapper
       href={shouldLink ? route('game.show', { game: id }) : undefined}
-      className="flex items-center gap-2"
+      className="flex max-w-fit items-center gap-2"
       {...(hasTooltip && shouldLink ? cardTooltipProps : undefined)}
     >
       {showImage ? (

--- a/resources/js/common/components/MultilineGameAvatar/MultilineGameAvatar.tsx
+++ b/resources/js/common/components/MultilineGameAvatar/MultilineGameAvatar.tsx
@@ -33,7 +33,7 @@ export const MultilineGameAvatar: FC<MultilineGameAvatarProps> = ({
   });
 
   return (
-    <div className="relative flex items-center gap-x-2">
+    <div className="relative flex max-w-fit items-center gap-x-2">
       {/* Keep the image and game title in a single tooltipped container. Do not tooltip the system name. */}
       <a href={route('game.show', { game: id })} {...(hasTooltip ? cardTooltipProps : undefined)}>
         <img

--- a/resources/js/common/components/UserAvatar/UserAvatar.tsx
+++ b/resources/js/common/components/UserAvatar/UserAvatar.tsx
@@ -22,7 +22,7 @@ export const UserAvatar: FC<UserAvatarProps> = ({
   return (
     <Wrapper
       href={canLinkToUser ? route('user.show', [displayName]) : undefined}
-      className="flex items-center gap-2"
+      className="flex max-w-fit items-center gap-2"
       {...(hasTooltip && canLinkToUser ? cardTooltipProps : undefined)}
     >
       {showImage ? (

--- a/resources/js/features/games/components/TopAchieversMainRoot/TopAchieversList/TopAchieversList.tsx
+++ b/resources/js/features/games/components/TopAchieversMainRoot/TopAchieversList/TopAchieversList.tsx
@@ -49,9 +49,7 @@ export const TopAchieversList: FC = () => {
             <BaseTableCell>{formatNumber(achiever.rank)}</BaseTableCell>
 
             <BaseTableCell>
-              <div className="max-w-fit">
-                <UserAvatar {...achiever.user} size={32} />
-              </div>
+              <UserAvatar {...achiever.user} size={32} />
             </BaseTableCell>
 
             <BaseTableCell>


### PR DESCRIPTION
One less thing to remember. This tiny change is intended to mitigate the need to have a div wrapper around these elements. Currently without a max-w-fit wrapper, if the avatar components appear within a table cell, the tooltip will appear when hovering over any part of the cell rather than just the avatar's title label/image.

**Before**
```tsx
<div className="max-w-fit">
  <UserAvatar {...user} />
</div>
```

**After**
```tsx
<UserAvatar {...user} />
```