### PR TITLE
fix(ticket): properly link hash urls

### DIFF
--- a/app/Community/Actions/FormatLegacyCommentPayloadAction.php
+++ b/app/Community/Actions/FormatLegacyCommentPayloadAction.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Community\Actions;
+
+class FormatLegacyCommentPayloadAction
+{
+    // Only allow `href` and `title` attributes. Anything else is malicious.
+    private const LINK_PATTERN = '/<a\s+href=[\'"](?:https?:\/\/[^\/]+)?\/game\/[\w\-]+\/hashes[\'"](?:\s+title=[\'"][^"\']*[\'"])?\s*>[^<>]*<\/a>/i';
+
+    public function execute(string $payload, bool $isTicketComment): string
+    {
+        // Replace all <br /> tags with newlines for consistent processing.
+        $text = str_replace('<br />', "\n", $payload);
+
+        if (!$isTicketComment) {
+            return $this->formatText($text);
+        }
+
+        // Store original link tags with angle brackets in markers.
+        $marker = '@@LINK_PLACEHOLDER_' . uniqid() . '_@@';
+        $links = [];
+
+        // Replace each link with a marker, storing the full HTML tag.
+        $text = preg_replace_callback(self::LINK_PATTERN, function ($match) use (&$links, $marker) {
+            $links[] = $match[0];
+
+            return $marker . (count($links) - 1) . $marker;
+        }, $text);
+
+        // Process the text and restore links.
+        $text = $this->formatText($text);
+        foreach ($links as $i => $link) {
+            $text = str_replace($marker . $i . $marker, $link, $text);
+        }
+
+        return $text;
+    }
+
+    private function formatText(string $text): string
+    {
+        // Convert special characters to HTML entities.
+        $text = htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+
+        // Convert newlines to <br /> tags and normalize multiple line breaks.
+        return preg_replace(
+            '/<br\s*\/?>(\s*<br\s*\/?>)+/',
+            '<br /><br />',
+            nl2br($text)
+        );
+    }
+}

--- a/app/Platform/Services/TicketViewService.php
+++ b/app/Platform/Services/TicketViewService.php
@@ -65,8 +65,10 @@ class TicketViewService
         $this->ticketNotes = nl2br($ticket->ReportNotes);
         foreach ($ticket->achievement->game->hashes as $hash) {
             if (stripos($this->ticketNotes, $hash->md5) !== false) {
-                $replacement = '<a href="/linkedhashes.php?g=' . $ticket->achievement->game->id . '" title="' .
-                    attributeEscape($hash->name) . '">' . $hash->md5 . '</a>';
+                $hashesRoute = route('game.hashes.index', ['game' => $ticket->achievement->game]);
+                $escapedHashName = attributeEscape($hash->name);
+                $replacement = "<a href='{$hashesRoute}' title='{$escapedHashName}'>{$hash->md5}</a>";
+
                 $this->ticketNotes = str_ireplace($hash->md5, $replacement, $this->ticketNotes);
             }
         }

--- a/resources/views/components/comment/item.blade.php
+++ b/resources/views/components/comment/item.blade.php
@@ -10,6 +10,7 @@
 
 @php
 
+use App\Community\Actions\FormatLegacyCommentPayloadAction;
 use App\Community\Enums\ArticleType;
 
 settype($articleType, 'integer');
@@ -62,8 +63,14 @@ settype($articleType, 'integer');
             </div>
 
             {{-- Specially handle newlines in comments, render everything else as plain text. --}}
-            <div style="word-break: break-word">
-                {!! preg_replace('/<br\s*\/?>(\s*<br\s*\/?>)+/', '<br /><br />', nl2br(htmlspecialchars(str_replace('<br />', "\n", $payload)))) !!}
+            @php
+                $formattedPayload = (new FormatLegacyCommentPayloadAction())->execute(
+                    $payload,
+                    isTicketComment: (int) $articleType === ArticleType::AchievementTicket,
+                );
+            @endphp
+            <div style="word-break: break-word;">
+                {!! $formattedPayload !!}
             </div>
         </td>
     </tr>

--- a/tests/Feature/Community/Actions/FormatLegacyCommentPayloadActionTest.php
+++ b/tests/Feature/Community/Actions/FormatLegacyCommentPayloadActionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Community\Actions\FormatLegacyCommentPayloadAction;
+use Tests\TestCase;
+
+class FormatLegacyCommentPayloadActionTest extends TestCase
+{
+    private FormatLegacyCommentPayloadAction $action;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->action = new FormatLegacyCommentPayloadAction();
+    }
+
+    public function testItFormatsBasicText(): void
+    {
+        $input = 'Hello World';
+        $expected = 'Hello World';
+
+        $this->assertEquals($expected, $this->action->execute($input, isTicketComment: false));
+    }
+
+    public function testItEscapesHtmlContent(): void
+    {
+        $input = '<script>alert("xss")</script><b>bold</b>';
+        $expected = '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;&lt;b&gt;bold&lt;/b&gt;';
+
+        $this->assertEquals($expected, $this->action->execute($input, isTicketComment: true));
+    }
+
+    public function testGivenTicketCommentItAcceptsRenderingGameHashLinks(): void
+    {
+        $link = '<a href="/game/253/hashes" title="Test Game">hash123</a>';
+        $input = "Check this hash: {$link}";
+        $expected = "Check this hash: {$link}";
+
+        $this->assertEquals($expected, $this->action->execute($input, isTicketComment: true));
+    }
+
+    public function testGivenNotATicketCommentItDoesNotRenderGameHashLinks(): void
+    {
+        $link = '<a href="/game/253/hashes" title="Test Game">hash123</a>';
+        $input = "Check this hash: {$link}";
+        $expected = "Check this hash: &lt;a href=&quot;/game/253/hashes&quot; title=&quot;Test Game&quot;&gt;hash123&lt;/a&gt;";
+
+        $this->assertEquals($expected, $this->action->execute($input, isTicketComment: false));
+    }
+
+    public function testItNormalizesMultipleLineBreaks(): void
+    {
+        $input = "Line 1\n\n\n\nLine 2";
+        $expected = "Line 1<br /><br />\nLine 2";
+
+        $this->assertEquals($expected, $this->action->execute($input, isTicketComment: false));
+    }
+
+    public function testItHandlesAttemptedMaliciousInput(): void
+    {
+        $cases = [
+            // Script injection.
+            '<script>alert(1)</script>' => '&lt;script&gt;alert(1)&lt;/script&gt;',
+
+            // Non-game hash links.
+            '<a href="/malicious/path">click me</a>' => '&lt;a href=&quot;/malicious/path&quot;&gt;click me&lt;/a&gt;',
+
+            // Invalid game hash paths.
+            '<a href="/game/index.php">hack</a>' => '&lt;a href=&quot;/game/index.php&quot;&gt;hack&lt;/a&gt;',
+            '<a href="/game/../../etc/passwd/hashes">hack</a>' => '&lt;a href=&quot;/game/../../etc/passwd/hashes&quot;&gt;hack&lt;/a&gt;',
+
+            // XSS in link text.
+            '<a href="/game/123/hashes"><script>alert(1)</script></a>' => '&lt;a href=&quot;/game/123/hashes&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;/a&gt;',
+
+            // Quote escaping attempts.
+            '<a href="/game/123/hashes" onmouseover="alert(1)">hack</a>' => '&lt;a href=&quot;/game/123/hashes&quot; onmouseover=&quot;alert(1)&quot;&gt;hack&lt;/a&gt;',
+
+            // HTML entity encoding bypasses.
+            '&#60;script&#62;alert(1)&#60;/script&#62;' => '&amp;#60;script&amp;#62;alert(1)&amp;#60;/script&amp;#62;',
+        ];
+
+        foreach ($cases as $input => $expected) {
+            $output = $this->action->execute($input, isTicketComment: true);
+            $this->assertEquals($expected, $output, "Failed on case {$input}");
+        }
+    }
+}


### PR DESCRIPTION
This PR restores hash linking capabilities for ticket comments:

![Screenshot 2024-12-27 at 2 30 07 PM](https://github.com/user-attachments/assets/71c04a8e-49a4-49e5-9d99-16d256cdf12b)

Blade UI ticket payloads are now sent through a sanitization/formatting action which properly safeguards against malicious injection. Comprehensive tests are included.