### PR TITLE
reduce memory required to start recap command

### DIFF
--- a/app/Community/Commands/GenerateAnnualRecap.php
+++ b/app/Community/Commands/GenerateAnnualRecap.php
@@ -39,10 +39,11 @@ class GenerateAnnualRecap extends Command
 
             $users = User::where('LastLogin', '>=', $december)
                 ->where('Created', '<', $september)
-                ->orderByDesc('LastLogin');
+                ->orderByDesc('LastLogin')
+                ->pluck('ID');
 
-            foreach ($users->get() as $user) {
-                GenerateAnnualRecapJob::dispatch($user->id)->onQueue('player-metrics');
+            foreach ($users as $userId) {
+                GenerateAnnualRecapJob::dispatch($userId)->onQueue('player-metrics');
             }
         }
     }


### PR DESCRIPTION
Addresses error:
```
PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes) in /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php on line 414
```
Encountered when trying to do a dry run of the `ra:community:generate-annual-recap` command.