### PR TITLE
feat(hash): surface source URLs on the Supported Game Files page

### DIFF
--- a/app/Platform/Data/GameHashData.php
+++ b/app/Platform/Data/GameHashData.php
@@ -20,6 +20,8 @@ class GameHashData extends Data
         #[TypeScriptType('App\\Platform\\Data\\GameHashLabelData[]')]
         public array $labels,
         public ?string $patchUrl,
+        /** "Resource Page URL" */
+        public ?string $source,
     ) {
     }
 
@@ -31,6 +33,7 @@ class GameHashData extends Data
             name: $gameHash->name,
             labels: GameHashLabelData::fromLabelsString($gameHash->labels),
             patchUrl: $gameHash->patch_url,
+            source: $gameHash->source,
         );
     }
 

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -520,5 +520,7 @@
     "This page may contain content that is not appropriate for all ages.": "This page may contain content that is not appropriate for all ages.",
     "Are you sure you want to view this page?": "Are you sure you want to view this page?",
     "Yes, and don't ask again": "Yes, and don't ask again",
-    "Yes, I'm an adult": "Yes, I'm an adult"
+    "Yes, I'm an adult": "Yes, I'm an adult",
+    "Download from Original Source (Recommended)": "Download from Original Source (Recommended)",
+    "Mirror": "Mirror"
 }

--- a/resources/js/features/games/components/HashesMainRoot/HashesList/HashesList.test.tsx
+++ b/resources/js/features/games/components/HashesMainRoot/HashesList/HashesList.test.tsx
@@ -68,20 +68,6 @@ describe('Component: HashesList', () => {
     expect(screen.getByText(hash.md5)).toBeVisible();
   });
 
-  it('given the hash has a patch URL, adds a link to it', () => {
-    // ARRANGE
-    const hash = createGameHash({ patchUrl: faker.internet.url() });
-
-    render<App.Platform.Data.GameHashesPageProps>(<HashesList />, {
-      pageProps: { hashes: [hash] },
-    });
-
-    // ASSERT
-    const linkEl = screen.getByRole('link', { name: /download patch file/i });
-    expect(linkEl).toBeVisible();
-    expect(linkEl).toHaveAttribute('href', hash.patchUrl);
-  });
-
   it('given the hash has no patch URL, does not display a download link', () => {
     // ARRANGE
     const hash = createGameHash({ patchUrl: null });
@@ -185,5 +171,80 @@ describe('Component: HashesList', () => {
     expect(renderedMd5s[0]).toContain('48e2e4493149fb481852f9ca9e70315f');
     expect(renderedMd5s[1]).toContain('77057d9d14b99e465ea9e29783af0ae3');
     expect(renderedMd5s[2]).toContain('a78d58b97eddb7c70647d939e20bef4f');
+  });
+
+  it('given the hash has both source and patch URLs, displays links to both', () => {
+    // ARRANGE
+    const hash = createGameHash({
+      source: faker.internet.url(),
+      patchUrl: faker.internet.url(),
+    });
+
+    render<App.Platform.Data.GameHashesPageProps>(<HashesList />, {
+      pageProps: { hashes: [hash] },
+    });
+
+    // ASSERT
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', hash.source);
+    expect(links[1]).toHaveAttribute('href', hash.patchUrl);
+
+    expect(screen.getByText(/download from original source/i)).toBeVisible();
+    expect(screen.getByText(/mirror/i)).toBeVisible();
+  });
+
+  it('given the hash only has a patch URL, displays a single download link', () => {
+    // ARRANGE
+    const hash = createGameHash({
+      source: null,
+      patchUrl: faker.internet.url(),
+    });
+
+    render<App.Platform.Data.GameHashesPageProps>(<HashesList />, {
+      pageProps: { hashes: [hash] },
+    });
+
+    // ASSERT
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', hash.patchUrl);
+    expect(screen.getByText(/download patch file/i)).toBeVisible();
+
+    expect(screen.queryByText(/mirror/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/download from original source/i)).not.toBeInTheDocument();
+  });
+
+  it('given the hash only has a source URL, does not display any links', () => {
+    // ARRANGE
+    const hash = createGameHash({
+      source: faker.internet.url(),
+      patchUrl: null,
+    });
+
+    render<App.Platform.Data.GameHashesPageProps>(<HashesList />, {
+      pageProps: { hashes: [hash] },
+    });
+
+    // ASSERT
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('given the hash only has a patch URL, displays a single download link', () => {
+    // ARRANGE
+    const hash = createGameHash({
+      source: null,
+      patchUrl: faker.internet.url(),
+    });
+
+    render<App.Platform.Data.GameHashesPageProps>(<HashesList />, {
+      pageProps: { hashes: [hash] },
+    });
+
+    // ASSERT
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', hash.patchUrl);
+    expect(screen.getByText(/download patch file/i)).toBeVisible();
+
+    expect(screen.queryByText(/mirror/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/download from original source/i)).not.toBeInTheDocument();
   });
 });

--- a/resources/js/features/games/components/HashesMainRoot/HashesList/HashesListItem.tsx
+++ b/resources/js/features/games/components/HashesMainRoot/HashesList/HashesListItem.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { buildTrackingClassNames } from '@/common/utils/buildTrackingClassNames';
+import { cn } from '@/common/utils/cn';
 
 interface HashListingProps {
   hash: App.Platform.Data.GameHash;
@@ -27,7 +28,27 @@ export const HashesListItem: FC<HashListingProps> = ({ hash }) => {
       <div className="flex flex-col border-l-2 border-neutral-700 pl-2 light:border-embed-highlight black:border-neutral-700">
         <p className="font-mono text-neutral-200 light:text-neutral-700">{hash.md5}</p>
 
-        {hash.patchUrl ? (
+        {/* Can show RAPatches as the mirror */}
+        {hash.source && hash.patchUrl ? (
+          <div className="mt-1 flex flex-col">
+            <a
+              href={hash.source}
+              className={cn(buildTrackingClassNames('Open Patch Source URL', { md5: hash.md5 }))}
+            >
+              {t('Download from Original Source (Recommended)')}
+            </a>
+
+            <a
+              href={hash.patchUrl}
+              className={cn(buildTrackingClassNames('Download Patch File', { md5: hash.md5 }))}
+            >
+              {t('Mirror')}
+            </a>
+          </div>
+        ) : null}
+
+        {/* Show RAPatches as the direct download link */}
+        {!hash.source && hash.patchUrl ? (
           <a
             href={hash.patchUrl}
             className={buildTrackingClassNames('Download Patch File', { md5: hash.md5 })}

--- a/resources/js/test/factories/createGameHash.ts
+++ b/resources/js/test/factories/createGameHash.ts
@@ -15,5 +15,6 @@ export const createGameHash = createFactory<App.Platform.Data.GameHash>((faker) 
     md5: faker.string.alphanumeric(32),
     name: faker.word.words(3),
     patchUrl: faker.internet.url(),
+    source: null,
   };
 });

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -225,7 +225,7 @@ declare namespace App.Data {
   };
 }
 declare namespace App.Enums {
-  export type ClientSupportLevel = 0 | 1 | 2 | 3;
+  export type ClientSupportLevel = 0 | 1 | 2 | 3 | 4;
   export type UserPreference =
     | 0
     | 1
@@ -353,6 +353,7 @@ declare namespace App.Platform.Data {
     name: string | null;
     labels: Array<App.Platform.Data.GameHashLabel>;
     patchUrl: string | null;
+    source: string | null;
   };
   export type GameHashLabel = {
     label: string;


### PR DESCRIPTION
Implements https://github.com/RetroAchievements/RAWeb/discussions/2712.

If a hash has **both** an RAPatches URL and a Resource Page URL, the user is recommended to visit the resource page URL. The RAPatches URL is _always_ shown as a mirror (we can't constantly check the source URL to see if it's still online).

![Screenshot 2025-01-01 at 4 21 49 PM](https://github.com/user-attachments/assets/72728e30-d029-437f-8a65-fbb9b8b643dd)
