### PR TITLE
fix: restore JrDev access to the management app

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -40,6 +40,7 @@ class AuthServiceProvider extends ServiceProvider
             Role::RELEASE_MANAGER,
             Role::TICKET_MANAGER,
             Role::DEVELOPER,
+            Role::DEVELOPER_JUNIOR,
             Role::ARTIST,
             Role::WRITER,
             Role::GAME_EDITOR,


### PR DESCRIPTION
Resolves a regression where JrDevs are no longer able to access the management app. The conditional on these roles was previously checking for a legacy permissions value.