### PR TITLE
fix(useGameListState): ignore persisted page index of 0

### DIFF
--- a/resources/js/features/game-list/hooks/useGameListState.test.ts
+++ b/resources/js/features/game-list/hooks/useGameListState.test.ts
@@ -230,7 +230,7 @@ describe('Hook: useGameListState', () => {
     });
 
     // ASSERT
-    expect(result.current.pagination).toEqual({ pageIndex: 2, pageSize: 50 });
+    expect(result.current.pagination).toEqual({ pageIndex: 0, pageSize: 50 });
   });
 
   it('given persisted view preferences exist and there is no sort query param, uses those for initial sorting state', () => {

--- a/resources/js/features/game-list/hooks/useGameListState.ts
+++ b/resources/js/features/game-list/hooks/useGameListState.ts
@@ -80,7 +80,14 @@ function generateInitialPaginationState<TData = unknown>(
   persistedViewPreferences: Partial<TableState> | null,
 ): PaginationState {
   if (persistedViewPreferences?.pagination) {
-    return persistedViewPreferences.pagination;
+    return {
+      // The page index is persisted to keep types fully in sync between
+      // the cookie store and the data table library. However, we'll always
+      // use whatever the server says the page should be.
+      pageIndex: paginatedGames.currentPage - 1,
+
+      pageSize: persistedViewPreferences.pagination.pageSize,
+    };
   }
 
   return mapPaginatedGamesToPaginationState(paginatedGames);

--- a/resources/js/features/game-list/hooks/useTableSync.ts
+++ b/resources/js/features/game-list/hooks/useTableSync.ts
@@ -49,7 +49,7 @@ export function useTableSync({
         columnVisibility,
         sorting,
         columnFilters: persistedFilters,
-        pagination: { ...pagination, pageIndex: 0 }, // don't persist the page index
+        pagination: { ...pagination, pageIndex: 0 }, // we won't respect the persisted page index
       };
 
       setCookie(JSON.stringify(tableState), { expires: 180 }); // 180 day (6 month) expiry


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1326579342230159360/1327411224249368748.

**Root Cause**
We're actually always persisting a page index of 0 in the "Remember My View" cookie.

I think it's actually desirable to do this so the types between pagination state in the cookie and datatable are perfectly aligned. Our logic error is that we weren't throwing away this persisted 0.

In other words, when a user currently has "Remember My View" checked:
* They navigate to page N of the table.
* They click a game.
* They click the back button.
* The table now thinks they're on page 1 even though they aren't, and this messes up table state.