### PR TITLE
fix(game): show mobile event progress component

### DIFF
--- a/resources/views/components/game/current-progress/root.blade.php
+++ b/resources/views/components/game/current-progress/root.blade.php
@@ -40,7 +40,7 @@ $canShowGlow = $hasUnlockedAnyAchievements && $hasAnyProgressionAward;
                 <p class="sr-only">Your Progress</p>
 
                 @if (!$hasUnlockedAnyAchievements)
-                    <p class="leading-4 mt-2">You haven't unlocked any achievements for this game.</p>
+                    <p class="leading-4 mt-2">You haven't unlocked any achievements for this {{ $isEvent ? 'event' : 'game'}}.</p>
                 @else
                     <x-game.current-progress.big-status-label
                         :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"

--- a/resources/views/pages-legacy/gameInfo.blade.php
+++ b/resources/views/pages-legacy/gameInfo.blade.php
@@ -886,7 +886,7 @@ if ($isFullyFeaturedGame) {
             <?php
             echo "</div>";
 
-            // Progression component (desktop only)
+            // Progression component (mobile only)
             if ($user !== null && $numAchievements > 0) {
                 echo "<div class='mt-4 mb-4 lg:hidden'>";
                 ?>
@@ -926,6 +926,31 @@ if ($isFullyFeaturedGame) {
                 echo "</div>";
             }
         } elseif ($isEventGame) {
+            // Progression component (mobile only)
+            if ($user !== null && $numAchievements > 0) {
+                echo "<div class='mt-4 mb-4 lg:hidden'>";
+                ?>
+                <x-game.current-progress.root
+                    :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
+                    :gameId="$gameID"
+                    :isBeatable="$isGameBeatable"
+                    :isBeatenHardcore="$isBeatenHardcore"
+                    :isBeatenSoftcore="$isBeatenSoftcore"
+                    :isCompleted="!is_null($userGameProgressionAwards['completed'])"
+                    :isMastered="!is_null($userGameProgressionAwards['mastered'])"
+                    :isEvent="$isEventGame"
+                    :numEarnedHardcoreAchievements="$numEarnedHardcore"
+                    :numEarnedHardcorePoints="$totalEarnedHardcore"
+                    :numEarnedSoftcoreAchievements="$numEarnedCasual"
+                    :numEarnedSoftcorePoints="$totalEarnedCasual"
+                    :numEarnedWeightedPoints="$totalEarnedTrueRatio"
+                    :totalAchievementsCount="$numAchievements"
+                    :totalPointsCount="$totalPossible"
+                />
+                <?php
+                echo "</div>";
+            }
+
             echo "<div class='justify-between w-full py-3'>";
             RenderGameSort(System::Events, $flagParam?->value, $officialFlag->value, $gameID, $sortBy, canSortByType: $isGameBeatable);
             echo "</div>";
@@ -1056,7 +1081,7 @@ if ($isFullyFeaturedGame) {
             echo "</div>";
         }
 
-        // Progression component (mobile only)
+        // Progression component (desktop only)
         if ($user !== null && $numAchievements > 0 && $isOfficial) {
             echo "<div class='mb-5 hidden lg:block'>";
             ?>


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/490333108621672448/1327646752068735098.

Also makes a slight change to the progress component itself. It already has an `isEvent` prop being passed in, so no harm in adding a conditional:
![Screenshot 2025-01-11 at 10 15 07 AM](https://github.com/user-attachments/assets/5b9703ba-491f-40e3-87f4-4ede6cd5bc08)
