### PR TITLE
prevent exception accessing achievement checklist page without list parameter

### DIFF
--- a/app/Community/Actions/BuildAchievementChecklistAction.php
+++ b/app/Community/Actions/BuildAchievementChecklistAction.php
@@ -13,11 +13,11 @@ use App\Platform\Data\AchievementData;
 class BuildAchievementChecklistAction
 {
     public function execute(
-        string $encoded,
+        ?string $encoded,
         User $user,
     ): array {
         $groups = [];
-        foreach (explode('|', $encoded) as $group) {
+        foreach (explode('|', $encoded ?? '') as $group) {
             if (!empty($group)) {
                 $groups[] = $this->parseGroup($group);
             }


### PR DESCRIPTION
fixes
```
App\Community\Actions\BuildAchievementChecklistAction::execute(): Argument #1 ($encoded) must be of type string, null given,
 called in /home/forge/retroachievements.org/releases/2025-01-10T122158-6.25.1-1591de2b/app/Community/Controllers/UserAchievementChecklistController.php on line 24
```