### PR TITLE
fix(ProcessPlausibleUrlAction): remediate exception thrown on base URLs

### DIFF
--- a/app/Actions/ProcessPlausibleUrlAction.php
+++ b/app/Actions/ProcessPlausibleUrlAction.php
@@ -87,6 +87,13 @@ class ProcessPlausibleUrlAction
         $route = $this->routes[$routePath];
         $props = [];
 
+        if ($param === null) {
+            return [
+                'redactedUrl' => "/{$routePath}",
+                'props' => $defaultProps,
+            ];
+        }
+
         switch ($route['type']) {
             case 'model':
                 $id = $this->extractId($param);
@@ -197,8 +204,12 @@ class ProcessPlausibleUrlAction
     /**
      * Extracts an ID from either a direct ID or a slug-with-ID route.
      */
-    private function extractId(string $param): ?int
+    private function extractId(?string $param): ?int
     {
+        if (!$param) {
+            return null;
+        }
+
         // Check for slug format first (eg: "sonic-3-123").
         if (preg_match('/-(\d+)$/', $param, $matches)) {
             return (int) $matches[1];

--- a/app/Actions/ProcessPlausibleUrlAction.php
+++ b/app/Actions/ProcessPlausibleUrlAction.php
@@ -87,15 +87,15 @@ class ProcessPlausibleUrlAction
         $route = $this->routes[$routePath];
         $props = [];
 
-        if ($param === null) {
-            return [
-                'redactedUrl' => "/{$routePath}",
-                'props' => $defaultProps,
-            ];
-        }
-
         switch ($route['type']) {
             case 'model':
+                if ($param === null) {
+                    return [
+                        'redactedUrl' => "/{$routePath}",
+                        'props' => $defaultProps,
+                    ];
+                }
+
                 $id = $this->extractId($param);
                 if ($id && $model = $route['model']::find($id)) {
                     $props = [
@@ -108,10 +108,24 @@ class ProcessPlausibleUrlAction
                 break;
 
             case 'string':
+                if ($param === null) {
+                    return [
+                        'redactedUrl' => "/{$routePath}",
+                        'props' => $defaultProps,
+                    ];
+                }
+
                 $props = [$route['propName'] => $param];
                 break;
 
             case 'id':
+                if ($param === null) {
+                    return [
+                        'redactedUrl' => "/{$routePath}",
+                        'props' => $defaultProps,
+                    ];
+                }
+
                 if ($param && is_numeric($param)) {
                     $props = ['id' => (int) $param];
                 }

--- a/tests/Feature/Actions/ProcessPlausibleUrlActionTest.php
+++ b/tests/Feature/Actions/ProcessPlausibleUrlActionTest.php
@@ -34,6 +34,20 @@ class ProcessPlausibleUrlActionTest extends TestCase
         ];
     }
 
+    public function testItCorrectlyHandlesBaseUrls(): void
+    {
+        // Act
+        $result = $this->action->execute('game', [], $this->defaultProps);
+
+        // Assert
+        $this->assertEquals('/game', $result['redactedUrl']);
+        $this->assertEquals([
+            'isAuthenticated' => true,
+            'scheme' => 'dark',
+            'theme' => 'default',
+        ], $result['props']);
+    }
+
     public function testItCorrectlyHandlesLegacyGameUrls(): void
     {
         // Arrange


### PR DESCRIPTION
Resolves:
> App\Actions\ProcessPlausibleUrlAction::extractId(): Argument #1 ($param) must be of type string, null given, called in /home/forge/retroachievements.org/releases/2025-01-11T035058-6.25.1-0bc6fb3e/app/Actions/ProcessPlausibleUrlAction.php on line 92 (View: /home/forge/retroachievements.org/releases/2025-01-11T035058-6.25.1-0bc6fb3e/resources/views/components/head-analytics.blade.php) (View: /home/forge/retroachievements.org/releases/2025-01-11T035058-6.25.1-0bc6fb3e/resources/views/components/head-analytics.blade.php) (View: /home/forge/retroachievements.org/releases/2025-01-11T035058-6.25.1-0bc6fb3e/resources/views/components/head-analytics.blade.php) (View: /home/forge/retroachievements.org/releases/2025-01-11T035058-6.25.1-0bc6fb3e/resources/views/components/head-analytics.blade.php) (View: /home/forge/retroachievements.org/releases/2025-01-11T035058-6.25.1-0bc6fb3e/resources/views/components/head-analytics.blade.php) (View: /home/forge/retroachievements.org/releases/2025-01-11T035058-6.25.1-0bc6fb3e/resources/views/components/head-analytics.blade.php)

The action is not correctly handling the case where a base URL is given with no path params. The route is still going to 404, but it should not throw an exception.