### PR TITLE
fix(EditPostForm): resolve untranslated string

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -631,5 +631,6 @@
     "See your full recommendation feed": "See your full recommendation feed",
     "Beaten by same players": "Beaten by same players",
     "Mastered by same players": "Mastered by same players",
-    "<1>{{achievementTitle}}</1> from <2>{{gameTitle}}</2>": "<1>{{achievementTitle}}</1> from <2>{{gameTitle}}</2>"
+    "<1>{{achievementTitle}}</1> from <2>{{gameTitle}}</2>": "<1>{{achievementTitle}}</1> from <2>{{gameTitle}}</2>",
+    "Don't ask for links to copyrighted ROMs. Don't share links to copyrighted ROMs.": "Don't ask for links to copyrighted ROMs. Don't share links to copyrighted ROMs."
 }

--- a/resources/js/common/components/+vendor/BaseAutosizeTextarea.tsx
+++ b/resources/js/common/components/+vendor/BaseAutosizeTextarea.tsx
@@ -3,6 +3,7 @@ import { useImperativeHandle } from 'react';
 import { useIsomorphicLayoutEffect } from 'react-use';
 
 import { cn } from '@/common/utils/cn';
+import type { TranslatedString } from '@/types/i18next';
 
 interface UseBaseAutosizeTextAreaProps {
   textAreaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
@@ -61,7 +62,8 @@ export type BaseAutosizeTextAreaRef = {
 type BaseAutosizeTextAreaProps = {
   maxHeight?: number;
   minHeight?: number;
-} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+  placeholder?: TranslatedString;
+} & Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'placeholder'>;
 
 export const BaseAutosizeTextarea = React.forwardRef<
   BaseAutosizeTextAreaRef,

--- a/resources/js/common/components/+vendor/BaseInput.tsx
+++ b/resources/js/common/components/+vendor/BaseInput.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 
 import { cn } from '@/common/utils/cn';
+import type { TranslatedString } from '@/types/i18next';
 
-export type BaseInputProps = React.InputHTMLAttributes<HTMLInputElement>;
+export type BaseInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'placeholder'> & {
+  placeholder?: TranslatedString;
+};
 
 const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
   ({ className, type, ...props }, ref) => {

--- a/resources/js/features/forums/components/EditPostMainRoot/EditPostForm/EditPostForm.tsx
+++ b/resources/js/features/forums/components/EditPostMainRoot/EditPostForm/EditPostForm.tsx
@@ -47,7 +47,9 @@ export const EditPostForm: FC<EditPostFormProps> = ({ onPreview }) => {
                 <BaseFormControl>
                   <BaseAutosizeTextarea
                     className="p-3"
-                    placeholder="Don't ask for links to copyrighted ROMs. Don't share links to copyrighted ROMs."
+                    placeholder={t(
+                      "Don't ask for links to copyrighted ROMs. Don't share links to copyrighted ROMs.",
+                    )}
                     maxLength={60_000}
                     minHeight={308}
                     {...field}


### PR DESCRIPTION
The `placeholder` prop currently uses hardcoded text.