### PR TITLE
chore(NewsPolicy): adjust access

### DIFF
--- a/app/Policies/NewsPolicy.php
+++ b/app/Policies/NewsPolicy.php
@@ -17,7 +17,6 @@ class NewsPolicy
     {
         return $user->hasAnyRole([
             Role::ADMINISTRATOR,
-            Role::DEVELOPER,
             Role::EVENT_MANAGER,
             Role::MODERATOR,
             Role::NEWS_MANAGER,
@@ -39,7 +38,6 @@ class NewsPolicy
     {
         return $user->hasAnyRole([
             Role::ADMINISTRATOR,
-            Role::DEVELOPER,
             Role::EVENT_MANAGER,
             Role::MODERATOR,
             Role::NEWS_MANAGER,
@@ -51,7 +49,6 @@ class NewsPolicy
     {
         return $user->hasAnyRole([
             Role::ADMINISTRATOR,
-            Role::DEVELOPER,
             Role::EVENT_MANAGER,
             Role::MODERATOR,
             Role::NEWS_MANAGER,
@@ -106,7 +103,6 @@ class NewsPolicy
     {
         return $user->hasAnyRole([
             Role::ADMINISTRATOR,
-            Role::NEWS_MANAGER,
         ]);
     }
 }


### PR DESCRIPTION
Now that role-driven policies are the norm and the events team roles are all situated, I think it's appropriate to lock this down a bit more.

Note also with this change that only admins will be able to pin/unpin posts.