### PR TITLE
fix(forums): normalize newlines from synthetic events

### DIFF
--- a/resources/js/features/forums/components/ShortcodeRenderer/ShortcodeCode/ShortcodeCode.tsx
+++ b/resources/js/features/forums/components/ShortcodeRenderer/ShortcodeCode/ShortcodeCode.tsx
@@ -15,8 +15,8 @@ export const ShortcodeCode: FC<ShortcodeCodeProps> = ({ children }) => {
       return true;
     });
 
-    return <span className="codetags font-mono">{processedChildren}</span>;
+    return <span className="codetags mb-3 font-mono">{processedChildren}</span>;
   }
 
-  return <span className="codetags">{children}</span>;
+  return <span className="codetags mb-3 font-mono">{children}</span>;
 };

--- a/resources/js/features/forums/components/ShortcodeRenderer/ShortcodeCode/ShortcodeCode.tsx
+++ b/resources/js/features/forums/components/ShortcodeRenderer/ShortcodeCode/ShortcodeCode.tsx
@@ -15,8 +15,8 @@ export const ShortcodeCode: FC<ShortcodeCodeProps> = ({ children }) => {
       return true;
     });
 
-    return <span className="codetags mb-3 font-mono">{processedChildren}</span>;
+    return <span className="codetags font-mono">{processedChildren}</span>;
   }
 
-  return <span className="codetags mb-3 font-mono">{children}</span>;
+  return <span className="codetags">{children}</span>;
 };

--- a/resources/js/features/forums/utils/preProcessShortcodesInBody.test.ts
+++ b/resources/js/features/forums/utils/preProcessShortcodesInBody.test.ts
@@ -139,4 +139,15 @@ describe('Util: preProcessShortcodesInBody', () => {
     // ASSERT
     expect(result).toEqual('  indented\n  still indented  \n\n  more space  ');
   });
+
+  it('preserves whitespace while normalizing encoded line endings', () => {
+    // ARRANGE
+    const input = '  indented\u21B5\n  still indented  \u21B5\n\n  more space  ';
+
+    // ACT
+    const result = preProcessShortcodesInBody(input);
+
+    // ASSERT
+    expect(result).toEqual('  indented\n  still indented  \n\n  more space  ');
+  });
 });

--- a/resources/js/features/forums/utils/preProcessShortcodesInBody.test.ts
+++ b/resources/js/features/forums/utils/preProcessShortcodesInBody.test.ts
@@ -83,4 +83,60 @@ describe('Util: preProcessShortcodesInBody', () => {
     // ASSERT
     expect(result).toEqual(input);
   });
+
+  it('normalizes escaped newlines to actual newlines', () => {
+    // ARRANGE
+    const input = 'first line↵\nsecond line';
+
+    // ACT
+    const result = preProcessShortcodesInBody(input);
+
+    // ASSERT
+    expect(result).toEqual('first line\nsecond line');
+  });
+
+  it('handles mixed escaped and actual newlines', () => {
+    // ARRANGE
+    const input = 'first line↵\nsecond line\nthird line↵\nfourth line';
+
+    // ACT
+    const result = preProcessShortcodesInBody(input);
+
+    // ASSERT
+    expect(result).toEqual('first line\nsecond line\nthird line\nfourth line');
+  });
+
+  it('normalizes line endings when content includes shortcodes', () => {
+    // ARRANGE
+    const input =
+      'Check out https://retroachievements.org/user/ScottAdams↵\nAnd also↵\nhttps://retroachievements.org/game/1234';
+
+    // ACT
+    const result = preProcessShortcodesInBody(input);
+
+    // ASSERT
+    expect(result).toEqual('Check out [user=ScottAdams]\nAnd also\n[game=1234]');
+  });
+
+  it('handles carriage returns and different line ending styles', () => {
+    // ARRANGE
+    const input = 'line1\r\nline2\rline3\nline4';
+
+    // ACT
+    const result = preProcessShortcodesInBody(input);
+
+    // ASSERT
+    expect(result).toEqual('line1\nline2\nline3\nline4');
+  });
+
+  it('preserves whitespace while normalizing line endings', () => {
+    // ARRANGE
+    const input = '  indented↵\n  still indented  ↵\n\n  more space  ';
+
+    // ACT
+    const result = preProcessShortcodesInBody(input);
+
+    // ASSERT
+    expect(result).toEqual('  indented\n  still indented  \n\n  more space  ');
+  });
 });

--- a/resources/js/features/forums/utils/preProcessShortcodesInBody.ts
+++ b/resources/js/features/forums/utils/preProcessShortcodesInBody.ts
@@ -30,7 +30,11 @@ const createPatterns = (type: string) => [
 ];
 
 export function preProcessShortcodesInBody(body: string): string {
-  let result = body;
+  // First, normalize any escaped newlines back to actual newlines.
+  let result = body.replace(/↵\n/g, '\n');
+
+  // Then, normalize any remaining line endings.
+  result = result.replace(/\r\n|\r|\n/g, '\n');
 
   for (const { type, shortcode } of shortcodeTypes) {
     const patterns = createPatterns(type);

--- a/resources/js/features/forums/utils/preProcessShortcodesInBody.ts
+++ b/resources/js/features/forums/utils/preProcessShortcodesInBody.ts
@@ -31,7 +31,7 @@ const createPatterns = (type: string) => [
 
 export function preProcessShortcodesInBody(body: string): string {
   // First, normalize any escaped newlines back to actual newlines.
-  let result = body.replace(/↵\n/g, '\n');
+  let result = body.replace(/\u21B5\n/g, '\n');
 
   // Then, normalize any remaining line endings.
   result = result.replace(/\r\n|\r|\n/g, '\n');


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/pull/3074#discussion_r1921615916.

Also, adds margin bottom to code tags (we should probably also apply the same margin bottom to quote tags).

**Root Cause**
React uses its own synthetic event system to maximize browser compatibility. For example, when a component has `onClick={(event) => {...}}`, this is not a native `onclick="..."` event. It's running through React's synthetic event system that _emulates_ native events.

I've worked with React for a number of years and haven't hit a bug caused by synthetic events until now.

In our case, newlines were being sent to the preview component as escaped sequences (↵\n) after making any edit (ie: when initiating a synthetic event), but are served as actual newlines (\n) on load. I was able to observe this after putting a ton of logging in all the BBCode processors.

This fix normalizes all line endings to actual newlines (\n) during the preprocessing stage, ensuring consistent handling of whitespace regardless of how the newlines are represented in the input.