### PR TITLE
hide future event achievement selection

### DIFF
--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -345,9 +345,9 @@ final class Shortcode
 
         if ($data['ConsoleID'] === System::Events) {
             $achievement = Achievement::find($id);
-            if ($achievement->eventData?->source_achievement_id &&
-                $achievement->eventData?->active_from > Carbon::now()) {
-                $data['Title'] = $data['AchievementTitle'] = '?????';
+            if ($achievement->eventData?->source_achievement_id
+                && $achievement->eventData->active_from > Carbon::now()) {
+                $data['Title'] = $data['AchievementTitle'] = 'Upcoming Challenge';
                 $data['Description'] = '?????';
                 $data['BadgeName'] = '00000';
             }

--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Support\Shortcode;
 
+use App\Models\Achievement;
+use App\Models\System;
 use App\Models\Ticket;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Thunder\Shortcode\Event\FilterShortcodesEvent;
@@ -338,6 +341,16 @@ final class Shortcode
 
         if (empty($data)) {
             return '';
+        }
+
+        if ($data['ConsoleID'] === System::Events) {
+            $achievement = Achievement::find($id);
+            if ($achievement->eventData?->source_achievement_id &&
+                $achievement->eventData?->active_from > Carbon::now()) {
+                $data['Title'] = $data['AchievementTitle'] = '?????';
+                $data['Description'] = '?????';
+                $data['BadgeName'] = '00000';
+            }
         }
 
         return achievementAvatar($data, iconSize: 24);

--- a/resources/views/components/game/achievements-list/achievements-list-item.blade.php
+++ b/resources/views/components/game/achievements-list/achievements-list-item.blade.php
@@ -47,7 +47,7 @@ if ($achievement['ActiveFrom'] ?? null && $achievement['ActiveUntil'] ?? null) {
     } elseif ($achievement['SourceAchievementId']) {
         // future event has been picked. don't show it until it's active
         $achBadgeName = '00000';
-        $achievement['Title'] = '?????';
+        $achievement['Title'] = 'Upcoming Challenge';
         $achievement['Description'] = '?????';
         $achievement['SourceGameId'] = null;
     }

--- a/resources/views/components/game/achievements-list/achievements-list-item.blade.php
+++ b/resources/views/components/game/achievements-list/achievements-list-item.blade.php
@@ -26,15 +26,6 @@ if (!$isUnlocked) {
 $imgClass = $isUnlockedOnHardcore ? 'goldimagebig' : 'badgeimg';
 $imgClass .= ' w-[54px] h-[54px] sm:w-16 sm:h-16';
 
-$renderedAchievementAvatar = achievementAvatar(
-    $achievement,
-    label: false,
-    icon: $achBadgeName,
-    iconSize: 64,
-    iconClass: $imgClass,
-    tooltip: false
-);
-
 $unlockDate = '';
 if (isset($achievement['DateEarned'])) {
     $unlockDate = Carbon::parse($achievement['DateEarned'])->format('F j Y, g:ia');
@@ -53,8 +44,23 @@ if ($achievement['ActiveFrom'] ?? null && $achievement['ActiveUntil'] ?? null) {
         if ($activeUntil > Carbon::now()) {
             $isActive = true;
         }
+    } elseif ($achievement['SourceAchievementId']) {
+        // future event has been picked. don't show it until it's active
+        $achBadgeName = '00000';
+        $achievement['Title'] = '?????';
+        $achievement['Description'] = '?????';
+        $achievement['SourceGameId'] = null;
     }
 }
+
+$renderedAchievementAvatar = achievementAvatar(
+    $achievement,
+    label: false,
+    icon: $achBadgeName,
+    iconSize: 64,
+    iconClass: $imgClass,
+    tooltip: false
+);
 ?>
 
 <li class="flex gap-x-3 odd:bg-[rgba(50,50,50,0.4)] light:odd:bg-neutral-200  px-2 py-3 md:py-1 w-full {{ $isUnlocked ? 'unlocked-row' : '' }} {{ $achievement['type'] === 'missable' ? 'missable-row' : '' }} {{ $isActive ? 'active-row' : '' }}">

--- a/resources/views/pages-legacy/achievementInfo.blade.php
+++ b/resources/views/pages-legacy/achievementInfo.blade.php
@@ -138,7 +138,7 @@ if ($game->system->id === System::Events) {
             // future event has been picked. don't show it until it's active
             $eventAchievement = null;
             $badgeName = $dataOut['BadgeName'] = '00000';
-            $achievementTitleRaw = $achievementTitle = $dataOut['Title'] = '?????';
+            $achievementTitleRaw = $achievementTitle = $dataOut['Title'] = 'Upcoming Challenge';
             $achievementDescriptionRaw = $dataOut['Description'] = '?????';
             $dataOut['SourceGameId'] = null;
         } else {

--- a/resources/views/pages-legacy/achievementInfo.blade.php
+++ b/resources/views/pages-legacy/achievementInfo.blade.php
@@ -15,6 +15,7 @@ use App\Platform\Enums\AchievementPoints;
 use App\Platform\Enums\AchievementType;
 use App\Platform\Services\TriggerDecoderService;
 use App\Support\Shortcode\Shortcode;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Blade;
 
 authenticateFromCookie($user, $permissions, $userDetails);
@@ -132,9 +133,18 @@ if ($game->system->id === System::Events) {
     $eventAchievement = EventAchievement::where('achievement_id', '=', $achievementID)
         ->with('sourceAchievement')->first();
 
-    // update the ID of the dataOut so the link goes to the source achievement
     if ($eventAchievement?->sourceAchievement) {
-        $dataOut['ID'] = $eventAchievement->sourceAchievement->ID;
+        if ($eventAchievement->active_from > Carbon::now()) {
+            // future event has been picked. don't show it until it's active
+            $eventAchievement = null;
+            $badgeName = $dataOut['BadgeName'] = '00000';
+            $achievementTitleRaw = $achievementTitle = $dataOut['Title'] = '?????';
+            $achievementDescriptionRaw = $dataOut['Description'] = '?????';
+            $dataOut['SourceGameId'] = null;
+        } else {
+            // update the ID of the dataOut so the link goes to the source achievement
+            $dataOut['ID'] = $eventAchievement->sourceAchievement->ID;
+        }
     }
 }
 


### PR DESCRIPTION
Allows event managers to assign an achievement prior to it becoming active without exposing it to players until it does become active.

https://discord.com/channels/310192285306454017/1328443350889795635/1330687821429608500

If an event achievement is associated to a source achievement, it's title and description and image will be obscured on the event page and achievement page.

![image](https://github.com/user-attachments/assets/e280b4bc-e59c-4d04-9ce2-2bde37d2dc50)
![image](https://github.com/user-attachments/assets/03b52d22-2239-4cb0-9d7d-deadbdfe8cf7)

There are still ways to get to the unobscured data, but this should be sufficient for the largest portion of the playerbase.