### PR TITLE
fix(individualdevstats): remediate Own Awards stats when using custom display_name

### DIFF
--- a/resources/views/pages-legacy/individualdevstats.blade.php
+++ b/resources/views/pages-legacy/individualdevstats.blade.php
@@ -500,7 +500,7 @@ $totalTicketPlusMinus = ($totalTicketPlusMinus > 0) ? '+' . $totalTicketPlusMinu
                 :numGamesWithRichPresence="$anyDevRichPresenceCount"
                 :numTotalLeaderboards="$anyDevLeaderboardTotal"
                 statsKind="any"
-                :targetDeveloperUsername="$dev"
+                :targetDeveloperUsername="$devUser->username"
                 :targetGameIds="$anyDevGameIDs"
             />
 
@@ -512,7 +512,7 @@ $totalTicketPlusMinus = ($totalTicketPlusMinus > 0) ? '+' . $totalTicketPlusMinu
                 :numGamesWithRichPresence="$majorityDevRichPresenceCount"
                 :numTotalLeaderboards="$majorityDevLeaderboardTotal"
                 statsKind="majority"
-                :targetDeveloperUsername="$dev"
+                :targetDeveloperUsername="$devUser->username"
                 :targetGameIds="$majorityDevGameIDs"
             />
 
@@ -524,7 +524,7 @@ $totalTicketPlusMinus = ($totalTicketPlusMinus > 0) ? '+' . $totalTicketPlusMinu
                 :numGamesWithRichPresence="$onlyDevRichPresenceCount"
                 :numTotalLeaderboards="$onlyDevLeaderboardTotal"
                 statsKind="sole"
-                :targetDeveloperUsername="$dev"
+                :targetDeveloperUsername="$devUser->username"
                 :targetGameIds="$onlyDevGameIDs"
             />
 


### PR DESCRIPTION
Remediates an issue on the individual dev stats page where if the `display_name` differs from `User`, Own Awards show up as N/A.

**Before**
![Screenshot 2025-01-23 at 5 28 56 PM](https://github.com/user-attachments/assets/d603c303-187f-489f-ba2e-0750bec48d08)


**After**
![Screenshot 2025-01-23 at 5 28 49 PM](https://github.com/user-attachments/assets/3ca9f433-0c2a-4502-be99-d8619ab0e6f0)
