### PR TITLE
fix: remediate broken avatar image on game cards

### DIFF
--- a/app/Platform/Components/GameCard.php
+++ b/app/Platform/Components/GameCard.php
@@ -92,7 +92,8 @@ class GameCard extends Component
             $processedClaims = [];
             foreach ($foundClaims as $foundClaim) {
                 $processedClaim = $foundClaim->toArray();
-                $processedClaim['User'] = $foundClaim->user->display_name;
+                $processedClaim['User'] = $foundClaim->user->username;
+                $processedClaim['DisplayName'] = $foundClaim->user->display_name;
 
                 $processedClaims[] = $processedClaim;
             }
@@ -179,7 +180,8 @@ class GameCard extends Component
 
         $activeClaims = array_filter($rawGameData['Claims'], fn ($claim) => ClaimStatus::isActive($claim['Status']));
         $activeDeveloperUsernames = array_map(fn ($activeClaim) => $activeClaim['User'], array_values($activeClaims));
-        $activeDevelopersLabel = $this->buildActiveDevelopersLabel($activeDeveloperUsernames);
+        $activeDeveloperDisplayNames = array_map(fn ($activeClaim) => $activeClaim['DisplayName'], array_values($activeClaims));
+        $activeDevelopersLabel = $this->buildActiveDevelopersLabel($activeDeveloperDisplayNames);
 
         return compact(
             'achievementsCount',


### PR DESCRIPTION
Resolves an issue where game cards show the wrong avatar if the user has a display_name which differs from their username.

**Before**
![Screenshot 2025-01-23 at 5 36 02 PM](https://github.com/user-attachments/assets/83b360ec-a305-46d0-84d1-bbdc164ac930)

**After**
![Screenshot 2025-01-23 at 5 35 53 PM](https://github.com/user-attachments/assets/b7201d57-fe9d-46db-9bda-29345ba3c9a7)
