### PR TITLE
fix(games): support configurable default page size

### DIFF
--- a/app/Platform/Controllers/HubController.php
+++ b/app/Platform/Controllers/HubController.php
@@ -67,6 +67,8 @@ class HubController extends Controller
         $persistenceCookieName = 'datatable_view_preference_hub_games';
         $request->setPersistenceCookieName($persistenceCookieName);
 
+        $request->setDefaultPageSize(50);
+
         $isMobile = (new GetUserDeviceKindAction())->execute() === 'mobile';
 
         $paginatedData = (new BuildGameListAction())->execute(
@@ -75,7 +77,7 @@ class HubController extends Controller
             user: $user,
             filters: $request->getFilters(defaultAchievementsPublishedFilter: 'either'),
             sort: $request->getSort(),
-            perPage: $isMobile ? 100 : 25,
+            perPage: $isMobile ? 100 : $request->getPageSize(),
 
             /**
              * Ignore page params on mobile.

--- a/app/Platform/Controllers/SystemController.php
+++ b/app/Platform/Controllers/SystemController.php
@@ -54,6 +54,8 @@ class SystemController extends Controller
         $persistenceCookieName = 'datatable_view_preference_system_games';
         $request->setPersistenceCookieName($persistenceCookieName);
 
+        $request->setDefaultPageSize(100);
+
         $isMobile = (new GetUserDeviceKindAction())->execute() === 'mobile';
 
         $paginatedData = (new BuildGameListAction())->execute(
@@ -62,7 +64,7 @@ class SystemController extends Controller
             user: $user,
             filters: $request->getFilters(targetSystemId: $system->id),
             sort: $request->getSort(),
-            perPage: 100,
+            perPage: $request->getPageSize(),
 
             /**
              * Ignore page params on mobile.


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/453242743292952578/1332366852780851282.

To reproduce the issue, in `master`:
* Go to any system games page.
* Ensure "Remember my view" is checked.
* Set the page size to 10.
* Navigate to a different console's system games page.
* Observe that 100 rows are shown, even though the state suggests the page size should still be 10.

This is occurring because the default page size of a games table is not configurable - it is a hardcoded value that is not respecting your persistence cookie.

Additionally, this PR increases the hubs table row count from 25 to 50.