### PR TITLE
feat(user): auto-approve username changes for casing

### DIFF
--- a/app/Community/Controllers/UserSettingsController.php
+++ b/app/Community/Controllers/UserSettingsController.php
@@ -97,10 +97,16 @@ class UserSettingsController extends Controller
         /** @var User $user */
         $user = $request->user();
 
-        UserUsername::create([
-            'user_id' => $user->id,
-            'username' => $data->newDisplayName,
-        ]);
+        $isOnlyCapitalizationChange = strtolower($user->display_name) === strtolower($data->newDisplayName);
+        if ($isOnlyCapitalizationChange) {
+            $user->display_name = $data->newDisplayName;
+            $user->save();
+        } else {
+            UserUsername::create([
+                'user_id' => $user->id,
+                'username' => $data->newDisplayName,
+            ]);
+        }
 
         return response()->json(['success' => true]);
     }

--- a/app/Community/RouteServiceProvider.php
+++ b/app/Community/RouteServiceProvider.php
@@ -374,7 +374,7 @@ class RouteServiceProvider extends ServiceProvider
                     Route::put('email', [UserSettingsController::class, 'updateEmail'])->name('api.settings.email.update');
 
                     Route::post('username-change-request', [UserSettingsController::class, 'storeUsernameChangeRequest'])
-                        ->name('api.settings.username-change-request.store');
+                        ->name('api.settings.name-change-request.store');
 
                     Route::delete('keys/web', [UserSettingsController::class, 'resetWebApiKey'])->name('api.settings.keys.web.destroy');
                     Route::delete('keys/connect', [UserSettingsController::class, 'resetConnectApiKey'])->name('api.settings.keys.connect.destroy');

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -130,8 +130,8 @@ declare namespace App.Community.Data {
   export type UserSettingsPageProps = {
     userSettings: App.Data.User;
     can: App.Data.UserPermissions;
-    requestedUsername: string | null;
     displayableRoles: Array<App.Data.Role>;
+    requestedUsername: string | null;
   };
 }
 declare namespace App.Community.Enums {

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -581,7 +581,7 @@ declare module 'ziggy-js' {
     "api.settings.preferences.update": [],
     "api.settings.password.update": [],
     "api.settings.email.update": [],
-    "api.settings.username-change-request.store": [],
+    "api.settings.name-change-request.store": [],
     "api.settings.keys.web.destroy": [],
     "api.settings.keys.connect.destroy": [],
     "api.active-player.index": [],

--- a/tests/Feature/Community/Controllers/UserSettingsControllerTest.php
+++ b/tests/Feature/Community/Controllers/UserSettingsControllerTest.php
@@ -125,7 +125,7 @@ class UserSettingsControllerTest extends TestCase
 
         // Act
         $response = $this->actingAs($user)
-            ->postJson(route('api.settings.username-change-request.store'), [
+            ->postJson(route('api.settings.name-change-request.store'), [
                 'newDisplayName' => 'Scott123456712',
             ]);
 
@@ -136,6 +136,35 @@ class UserSettingsControllerTest extends TestCase
             'user_id' => $user->id,
             'username' => 'Scott123456712',
             'approved_at' => null,
+        ]);
+    }
+
+    public function testUpdateUsernameWithOnlyCapitalizationChange(): void
+    {
+        // Arrange
+        $this->withoutMiddleware();
+
+        /** @var User $user */
+        $user = User::factory()->create([
+            'User' => 'scott',
+            'display_name' => 'scott',
+        ]);
+
+        // Act
+        $response = $this->actingAs($user)
+            ->postJson(route('api.settings.name-change-request.store'), [
+                'newDisplayName' => 'Scott',
+            ]);
+
+        // Assert
+        $response->assertStatus(200);
+
+        $user = $user->fresh();
+        $this->assertEquals('Scott', $user->display_name); // instantly makes the update
+
+        $this->assertDatabaseMissing('user_usernames', [ // does not make an approval request record
+            'user_id' => $user->id,
+            'username' => 'Scott',
         ]);
     }
 


### PR DESCRIPTION
When requesting a username change, if the request only has a difference in casing (ie: "Scott" -> "scott"), the request is auto-approved, with no `user_usernames` entry written to the database.

Addresses https://github.com/RetroAchievements/RAWeb/pull/3071#issuecomment-2608580032.