### PR TITLE
fix(user): properly handle null param in whereName()

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -358,7 +358,7 @@ class User extends Authenticatable implements CommunityMember, Developer, HasLoc
     public static function whereName(?string $displayNameOrUsername): Builder
     {
         if ($displayNameOrUsername === null) {
-            return static::query();
+            return static::query()->whereRaw('1 = 0');
         }
 
         return static::query()


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1333204742427377684.

Currently, if the given display name param is null, the first user on the table (Scott) will get grabbed instead, ie:
```php
$this->userContext = User::whereName($targetUsername)->first() ?? Auth::user() ?? null;
```
In the case of the bug reported, `$targetUsername` is null, so Scott's user record is being pulled by the query.