### PR TITLE
fix(user): show followed users ranking when display name is set

### DIFF
--- a/resources/views/pages-legacy/userInfo.blade.php
+++ b/resources/views/pages-legacy/userInfo.blade.php
@@ -198,7 +198,7 @@ if (getActiveClaimCount($userPageModel, true, true) > 0) {
             :userScoreData="$userScoreData"
         />
 
-        @if ($user !== null && $user === $userPage)
+        @if ($user !== null && $user === $userPageModel['User'])
             <x-user.followed-leaderboard :user="$userPageModel" />
         @endif
     </x-slot>


### PR DESCRIPTION
This PR remediates an issue on the user profile where, if the user's display name differs from their username, they can no longer see their "Followed Users Ranking" component in the profile sidebar.