### PR TITLE
fix(game): remediate error on set request after username change

### DIFF
--- a/resources/views/components/game/set-requests.blade.php
+++ b/resources/views/components/game/set-requests.blade.php
@@ -59,7 +59,7 @@ function submitSetRequest(user, gameID) {
         type: '<?= UserGameListType::AchievementSetRequest ?>'
     })
         .done(function () {
-            getSetRequestInformation('<?= $user->User ?>', <?= $gameId ?>);
+            getSetRequestInformation('<?= $user->display_name ?>', <?= $gameId ?>);
         });
 }
 


### PR DESCRIPTION
This PR remediates an error where if a user's display name differs from their username, an error message appears when clicking the "Request Set" button on the game page.