### PR TITLE
ci: use phpstan result cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,29 +78,6 @@ jobs:
         if: ${{ needs.changes.outputs.php == 'true' && steps.composer-cache.outputs.cache-hit != 'true' }}
         run: composer install --prefer-dist
 
-  node-setup:
-    needs: changes
-    runs-on: ubuntu-22.04
-    name: Node.js Setup
-    steps:
-      - name: Checkout code
-        if: ${{ needs.changes.outputs.node == 'true' }}
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        if: ${{ needs.changes.outputs.node == 'true' }}
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Use Node 20
-        if: ${{ needs.changes.outputs.node == 'true' }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
   php-checks:
     needs: [changes, php-setup]
     runs-on: ubuntu-22.04
@@ -146,9 +123,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-php-
 
+      - name: Restore PHPStan result cache
+        if: ${{ needs.changes.outputs.php == 'true' && matrix.check == 'analyse' }}
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp
+          key: phpstan-result-cache-${{ github.run_id }}
+          restore-keys: |
+            phpstan-result-cache-
+
       - name: Run ${{ matrix.check }}
         if: ${{ needs.changes.outputs.php == 'true' }}
         run: ${{ matrix.command }}
+
+      - name: Save PHPStan result cache
+        if: ${{ needs.changes.outputs.php == 'true' && matrix.check == 'analyse' }}
+        uses: actions/cache/save@v4
+        with:
+          path: tmp
+          key: phpstan-result-cache-${{ github.run_id }}
 
   node-checks:
     needs: [changes, node-setup]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,29 @@ jobs:
         if: ${{ needs.changes.outputs.php == 'true' && steps.composer-cache.outputs.cache-hit != 'true' }}
         run: composer install --prefer-dist
 
+  node-setup:
+    needs: changes
+    runs-on: ubuntu-22.04
+    name: Node.js Setup
+    steps:
+      - name: Checkout code
+        if: ${{ needs.changes.outputs.node == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        if: ${{ needs.changes.outputs.node == 'true' }}
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Use Node 20
+        if: ${{ needs.changes.outputs.node == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
   php-checks:
     needs: [changes, php-setup]
     runs-on: ubuntu-22.04

--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -594,7 +594,7 @@ class GameResource extends Resource
                     }),
 
                 Tables\Filters\TernaryFilter::make('has_dynamic_rp')
-                    ->label('Has dynamic rich presence')
+                    ->label('111Has dynamic rich presence')
                     ->placeholder('Any')
                     ->trueLabel('Yes')
                     ->falseLabel('No')

--- a/app/Filament/Resources/GameResource.php
+++ b/app/Filament/Resources/GameResource.php
@@ -594,7 +594,7 @@ class GameResource extends Resource
                     }),
 
                 Tables\Filters\TernaryFilter::make('has_dynamic_rp')
-                    ->label('111Has dynamic rich presence')
+                    ->label('Has dynamic rich presence')
                     ->placeholder('Any')
                     ->trueLabel('Yes')
                     ->falseLabel('No')

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
         - resources/views
         - tests
     level: 6
+    tmpDir: tmp
     treatPhpDocTypesAsCertain: false
     # TODO figure out why github actions phpstan does not find the same
     reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
Another PR to improve CI performance. This specifically targets `analyse` (PHPStan) while running in GitHub Actions.

As the project grows and grows, the `analyse` step is going to take exponentially longer because, currently, there is no cache to leverage in the actions containers.

This branch incorporates the official instructions for setting up the PHPStan cache in GitHub Actions from https://phpstan.org/user-guide/result-cache#setup-in-github-actions.