### PR TITLE
fix(AchievementSetsRelationManager): remediate SQL error on order_column update

### DIFF
--- a/app/Filament/Resources/GameResource/RelationManagers/AchievementSetsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/AchievementSetsRelationManager.php
@@ -94,6 +94,21 @@ class AchievementSetsRelationManager extends RelationManager
                         'integer',
                         'min:1',
                     ])
+                    ->updateStateUsing(function ($record, $state) {
+                        // Filament is going to automatically try to use the updated_at
+                        // column name of the parent resource, which is `Updated`. The mismatch
+                        // between parent (`Updated`) and child (`updated_at`) throws a SQL error
+                        // unless we intervene.
+                        $record->games()->updateExistingPivot(
+                            $this->getOwnerRecord()->id,
+                            [
+                                'order_column' => $state,
+                                'updated_at' => now(),
+                            ]
+                        );
+
+                        return $state;
+                    })
                     ->disabled(fn ($record) => $record->type === AchievementSetType::Core->value),
             ])
             ->filters([


### PR DESCRIPTION
When working with the achievement sets relation manager for a game (ie: http://localhost:64000/manage/games/1?activeRelationManager=1), if you try to update the Display Order column value, a SQL error is thrown.

To repro, just change the value of the Display Order here:
![Screenshot 2025-02-01 at 9 53 25 AM](https://github.com/user-attachments/assets/c7a8c16c-aa5d-4732-8a9e-d72fdc06e91e)

**Root Cause**
For some reason, Filament is trying to use the owner record's "updated" field name (`GameData.Updated`) instead of the relation record's (`game_achievement_sets.updated_at`). This causes a SQL error because `game_achievement_sets.Updated` obviously does not exist.