### PR TITLE
only allow event managers to view future events

### DIFF
--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -114,7 +114,7 @@ class EventResource extends Resource
                     ->schema([
                         Forms\Components\TextInput::make('Title')
                             ->label('Title')
-                            ->unique()
+                            ->unique(ignoreRecord: true)
                             ->required()
                             ->minLength(2)
                             ->maxLength(80),
@@ -135,7 +135,7 @@ class EventResource extends Resource
                             ->rules(['alpha_dash'])
                             ->minLength(4)
                             ->maxLength(20)
-                            ->unique()
+                            ->unique(ignoreRecord: true)
                             ->required()
                             ->columnSpan(2),
 

--- a/app/Filament/Resources/EventResource/Pages/Create.php
+++ b/app/Filament/Resources/EventResource/Pages/Create.php
@@ -38,7 +38,7 @@ class Create extends CreateRecord
         // these fields don't actually exist on the event record. don't pass to create().
         $numberOfAchievements = (int) $data['numberOfAchievements'];
         unset($data['numberOfAchievements']);
-        $user_id = $data['user_id'];
+        $user_id = (int) $data['user_id'];
         unset($data['user_id']);
 
         // create the event record

--- a/app/Policies/EventPolicy.php
+++ b/app/Policies/EventPolicy.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Event;
 use App\Models\Role;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class EventPolicy
@@ -25,8 +27,15 @@ class EventPolicy
         return true;
     }
 
-    public function view(?User $user): bool
+    public function view(?User $user, Event $event): bool
     {
+        if ($event->active_from != null && $event->active_from > Carbon::now()) {
+            // future events can only be viewed by users who can manage events
+            if (!$user || !$this->manage($user)) {
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/app/Policies/EventPolicy.php
+++ b/app/Policies/EventPolicy.php
@@ -29,7 +29,7 @@ class EventPolicy
 
     public function view(?User $user, Event $event): bool
     {
-        if ($event->active_from != null && $event->active_from > Carbon::now()) {
+        if ($event->active_from !== null && $event->active_from > Carbon::now()) {
             // future events can only be viewed by users who can manage events
             if (!$user || !$this->manage($user)) {
                 return false;

--- a/resources/views/pages-legacy/gameInfo.blade.php
+++ b/resources/views/pages-legacy/gameInfo.blade.php
@@ -110,6 +110,13 @@ $guideURL = $gameData['GuideURL'];
 $isFullyFeaturedGame = System::isGameSystem($gameData['ConsoleID']);
 $isEventGame = $gameData['ConsoleID'] == System::Events;
 
+// future events can only be viewed by users who can manage events.
+if ($isEventGame && $gameModel->event?->active_from != null
+    && $gameModel->event->active_from > Carbon::now()
+    && !$userModel?->can('manage', $gameModel->event)) {
+    abort(401);
+}
+
 $pageTitle = "$gameTitle ($consoleName)";
 
 $unlockedAchievements = array_filter($achievementData, function ($achievement) {

--- a/resources/views/pages-legacy/gameInfo.blade.php
+++ b/resources/views/pages-legacy/gameInfo.blade.php
@@ -22,6 +22,7 @@ use App\Platform\Enums\GameSetType;
 use App\Platform\Enums\ImageType;
 use App\Platform\Enums\UnlockMode;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Gate;
 
 $gameID = (int) request('game');
 if (empty($gameID)) {
@@ -111,7 +112,7 @@ $isFullyFeaturedGame = System::isGameSystem($gameData['ConsoleID']);
 $isEventGame = $gameData['ConsoleID'] == System::Events;
 
 // future events can only be viewed by users who can manage events.
-if ($isEventGame && $gameModel->event && !$userModel?->can('view', $gameModel->event)) {
+if ($isEventGame && $gameModel->event && !Gate::allows('view', $gameModel->event)) {
     abort(401);
 }
 

--- a/resources/views/pages-legacy/gameInfo.blade.php
+++ b/resources/views/pages-legacy/gameInfo.blade.php
@@ -111,9 +111,7 @@ $isFullyFeaturedGame = System::isGameSystem($gameData['ConsoleID']);
 $isEventGame = $gameData['ConsoleID'] == System::Events;
 
 // future events can only be viewed by users who can manage events.
-if ($isEventGame && $gameModel->event?->active_from != null
-    && $gameModel->event->active_from > Carbon::now()
-    && !$userModel?->can('manage', $gameModel->event)) {
+if ($isEventGame && $gameModel->event && !$userModel?->can('view', $gameModel->event)) {
     abort(401);
 }
 


### PR DESCRIPTION
If an event has a start date in the future, anyone without access to the event management console will get an Unauthorized message trying to view it.

https://discord.com/channels/310192285306454017/1334630307915104316/1335134440359329872