### PR TITLE
fix(MessageRequest): use display_name for recipient validation

### DIFF
--- a/app/Community/Requests/MessageRequest.php
+++ b/app/Community/Requests/MessageRequest.php
@@ -18,7 +18,7 @@ class MessageRequest extends FormRequest
                 'max:60000',
                 new ContainsRegularCharacter(),
             ],
-            'recipient' => 'required_without:thread_id|exists:UserAccounts,User',
+            'recipient' => 'required_without:thread_id|exists:UserAccounts,display_name',
             'thread_id' => 'nullable|integer',
             'title' => 'required_without:thread_id|string|max:255',
         ];


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1335990807097770036.

This PR only resolves the validation issue. Avatars still don't render correctly after selecting a user whose display_name value is different from their `User` value. That bug will be fixed in the imminent React migration of the page.