### PR TITLE
fix(BaseTooltip): add even more intelligence to the cursor classname

### DIFF
--- a/resources/js/common/components/+vendor/BaseTooltip.tsx
+++ b/resources/js/common/components/+vendor/BaseTooltip.tsx
@@ -4,39 +4,11 @@ import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import * as React from 'react';
 
 import { cn } from '@/common/utils/cn';
+import { getIsInteractiveElement } from '@/common/utils/getIsInteractiveElement';
 
 const BaseTooltipProvider = TooltipPrimitive.Provider;
 
 const BaseTooltip = TooltipPrimitive.Root;
-
-const isInteractiveElement = (children: React.ReactNode): boolean => {
-  if (!React.isValidElement(children)) return false;
-
-  // Check if the element type matches interactive elements.
-  const isInteractiveType = (type: string): boolean =>
-    ['button', 'a', 'input', 'select', 'textarea'].includes(type.toLowerCase());
-
-  // For native elements, just check the HTML tag.
-  if (typeof children.type === 'string') {
-    return isInteractiveType(children.type);
-  }
-
-  // For custom components, check if they render to an interactive element.
-  // Look for common props that indicate interactive elements.
-  const props = children.props as {
-    role?: string;
-    onClick?: unknown;
-    href?: string;
-    as?: string | React.ComponentType;
-  };
-
-  return !!(
-    props.onClick ||
-    props.href ||
-    props.role === 'button' ||
-    (props.as && typeof props.as === 'string' && isInteractiveType(props.as))
-  );
-};
 
 const BaseTooltipTrigger = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Trigger>,
@@ -45,7 +17,7 @@ const BaseTooltipTrigger = React.forwardRef<
     hasHelpCursor?: boolean;
   }
 >(({ className, hasHelpCursor, children, ...props }, ref) => {
-  const shouldShowHelpCursor = hasHelpCursor ?? !isInteractiveElement(children);
+  const shouldShowHelpCursor = hasHelpCursor ?? !getIsInteractiveElement(children);
 
   return (
     <TooltipPrimitive.Trigger

--- a/resources/js/common/utils/getIsInteractiveElement.test.tsx
+++ b/resources/js/common/utils/getIsInteractiveElement.test.tsx
@@ -1,0 +1,77 @@
+import { getIsInteractiveElement } from './getIsInteractiveElement';
+
+describe('Util: getIsInteractiveElement', () => {
+  it('is defined', () => {
+    // ASSERT
+    expect(getIsInteractiveElement).toBeDefined();
+  });
+
+  it('given a non-React element, returns false', () => {
+    // ARRANGE
+    const notAnElement = 'just a string';
+
+    // ACT
+    const result = getIsInteractiveElement(notAnElement);
+
+    // ASSERT
+    expect(result).toEqual(false);
+  });
+
+  it('given a native button element, returns true', () => {
+    // ARRANGE
+    const buttonElement = <button>Click me</button>;
+
+    // ACT
+    const result = getIsInteractiveElement(buttonElement);
+
+    // ASSERT
+    expect(result).toEqual(true);
+  });
+
+  it('given a native div element, returns false', () => {
+    // ARRANGE
+    const divElement = <div>Content</div>;
+
+    // ACT
+    const result = getIsInteractiveElement(divElement);
+
+    // ASSERT
+    expect(result).toEqual(false);
+  });
+
+  it('given a custom interactive component, returns true', () => {
+    // ARRANGE
+    const BaseButton = () => <button>Click</button>;
+    BaseButton.displayName = 'BaseButton';
+    const element = <BaseButton />;
+
+    // ACT
+    const result = getIsInteractiveElement(element);
+
+    // ASSERT
+    expect(result).toEqual(true);
+  });
+
+  it('given an element with an href prop, returns true', () => {
+    // ARRANGE
+    const element = <a href="/some-path">Click me</a>;
+
+    // ACT
+    const result = getIsInteractiveElement(element);
+
+    // ASSERT
+    expect(result).toEqual(true);
+  });
+
+  it('given a component without an explicit displayName or name, returns false', () => {
+    // ARRANGE
+    const AnonymousComponent = () => <div>Content</div>;
+    const element = <AnonymousComponent />;
+
+    // ACT
+    const result = getIsInteractiveElement(element);
+
+    // ASSERT
+    expect(result).toEqual(false);
+  });
+});

--- a/resources/js/common/utils/getIsInteractiveElement.ts
+++ b/resources/js/common/utils/getIsInteractiveElement.ts
@@ -1,0 +1,51 @@
+import {
+  type ComponentType,
+  type ElementType,
+  type FC,
+  isValidElement,
+  type ReactNode,
+} from 'react';
+
+export function getIsInteractiveElement(children: ReactNode): boolean {
+  if (!isValidElement(children)) {
+    return false;
+  }
+
+  // Check if the element type matches interactive elements.
+  const isInteractiveType = (type: string): boolean =>
+    ['button', 'a', 'input', 'select', 'textarea'].includes(type.toLowerCase());
+
+  // Check if the component name indicates it's interactive.
+  const isInteractiveComponent = (component: ElementType): boolean => {
+    const componentName = (component as FC).displayName || (component as FC).name;
+
+    return [
+      'BaseButton',
+      'InertiaLink',
+      'Popover',
+      'Dialog',
+      'BaseSelectTrigger',
+      'BaseSwitch',
+    ].some((name) => componentName.includes(name));
+  };
+
+  // For native elements, just check the HTML tag.
+  if (typeof children.type === 'string') {
+    return isInteractiveType(children.type);
+  }
+
+  // Check if the component itself is interactive.
+  if (isInteractiveComponent(children.type)) {
+    return true;
+  }
+
+  // For custom components, check if they render to an interactive element.
+  const props = children.props as {
+    role?: string;
+    onClick?: unknown;
+    href?: string;
+    as?: string | ComponentType;
+  };
+
+  return !!(props.onClick || props.href || props.role === 'button');
+}


### PR DESCRIPTION
This PR fixes an issue where these buttons are still showing `cursor-help` on hover:
![Screenshot 2025-02-03 at 5 29 04 PM](https://github.com/user-attachments/assets/47cd4e4a-dfc2-41ec-8c8b-fec2b0d76be6)

This is due to the elements being wrapped in `<BasePopover>`. The tooltip component currently is not intelligent enough to handle this sort of nesting.

This PR extracts the util that drives the intelligence, adds more intelligence, and adds tests to cover the intelligence.