### PR TITLE
fix(code-note): allow jr devs with custom display names to edit their own notes

### DIFF
--- a/app/Helpers/database/code-note.php
+++ b/app/Helpers/database/code-note.php
@@ -64,7 +64,7 @@ function submitCodeNote2(string $username, int $gameID, int $address, string $no
     if (
         $i !== false
         && $permissions <= Permissions::JuniorDeveloper
-        && $currentNotes[$i]['User'] !== $user->User
+        && $currentNotes[$i]['User'] !== $user->display_name
         && !empty($currentNotes[$i]['Note'])
     ) {
         return false;


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/533411674162593812/1337123500321673309.

**Root Cause**
$currentNotes[$i]['User'] comes from `getCodeNotesData()`, which actually returns `display_name` as `User`.