### PR TITLE
fix(user): send correct name to request/user/update.php

### DIFF
--- a/resources/views/components/forum/topic-comment/manage.blade.php
+++ b/resources/views/components/forum/topic-comment/manage.blade.php
@@ -13,7 +13,7 @@
 >
     {{ csrf_field() }}
     <input type='hidden' name='property' value="{{ UserAction::UpdateForumPostPermissions }}" />
-    <input type='hidden' name='target' value="{{ $forumTopicComment->user->username }}" />
+    <input type='hidden' name='target' value="{{ $forumTopicComment->user->display_name }}" />
     <input type='hidden' name='value' value='1' />
     <button class='btn p-1 lg:text-xs'>Authorise</button>
 </form>
@@ -25,7 +25,7 @@
 >
     {{ csrf_field() }}
     <input type='hidden' name='property' value="{{ UserAction::UpdateForumPostPermissions }}" />
-    <input type='hidden' name='target' value="{{ $forumTopicComment->user->username }}" />
+    <input type='hidden' name='target' value="{{ $forumTopicComment->user->display_name }}" />
     <input type='hidden' name='value' value='0' />
     <button class='btn btn-danger p-1 lg:text-xs'>Block</button>
 </form>

--- a/resources/views/components/user/profile/moderation-tools.blade.php
+++ b/resources/views/components/user/profile/moderation-tools.blade.php
@@ -40,7 +40,7 @@ $hasCertifiedLegendBadge = HasCertifiedLegendBadge($targetUser);
                 <form method="post" action="/request/user/update.php">
                     @csrf
                     <input type="hidden" name="property" value="{{ UserAction::UpdatePermissions }}">
-                    <input type="hidden" name="target" value="{{ $targetUsername }}">
+                    <input type="hidden" name="target" value="{{ $targetUser->display_name }}">
                     
                     <td class="text-right">
                         <button class="btn">Update Account Type</button>
@@ -66,7 +66,7 @@ $hasCertifiedLegendBadge = HasCertifiedLegendBadge($targetUser);
                 <form method="post" action="/request/user/update.php">
                     @csrf
                     <input type="hidden" name="property" value="{{ UserAction::PatreonBadge }}">
-                    <input type="hidden" name="target" value="{{ $targetUsername }}">
+                    <input type="hidden" name="target" value="{{ $targetUser->display_name }}">
                     <input type="hidden" name="value" value="0" />
                     <button class="btn">Toggle Patreon Supporter</button>
                 </form>
@@ -81,7 +81,7 @@ $hasCertifiedLegendBadge = HasCertifiedLegendBadge($targetUser);
                 <form method="post" action="/request/user/update.php">
                     @csrf
                     <input type="hidden" name="property" value="{{ UserAction::LegendBadge }}">
-                    <input type="hidden" name="target" value="{{ $targetUsername }}">
+                    <input type="hidden" name="target" value="{{ $targetUser->display_name }}">
                     <input type="hidden" name="value" value="0" />
                     <button class="btn">Toggle Certified Legend</button>
                 </form>
@@ -96,7 +96,7 @@ $hasCertifiedLegendBadge = HasCertifiedLegendBadge($targetUser);
                 <form method="post" action="/request/user/update.php">
                     @csrf
                     <input type="hidden" name="property" value="{{ UserAction::TrackedStatus }}">
-                    <input type="hidden" name="target" value="{{ $targetUsername }}">
+                    <input type="hidden" name="target" value="{{ $targetUser->display_name }}">
                     <input type="hidden" name="value" value="{{ $isTargetUserUntracked ? 0 : 1 }}" />
                     <button class="btn btn-danger">Toggle Tracked Status</button>
                 </form>


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1337132630369370266.

**Root Cause**
`/request/user/update.php` expects a display_name to be given, but it's receiving `->User` instead.