### PR TITLE
fix(leaderboardinfo): don't ignore display names for local user

### DIFF
--- a/resources/views/pages-legacy/leaderboardinfo.blade.php
+++ b/resources/views/pages-legacy/leaderboardinfo.blade.php
@@ -27,7 +27,8 @@ if (!$leaderboard) {
     abort(404);
 }
 
-$lbData = GetLeaderboardData($leaderboard, Auth::user(), $count, $offset);
+$userModel = Auth::user();
+$lbData = GetLeaderboardData($leaderboard, $userModel, $count, $offset);
 
 $numEntries = is_countable($lbData['Entries']) ? count($lbData['Entries']) : 0;
 $totalEntries = $leaderboard->entries()->count();
@@ -210,7 +211,7 @@ $pageTitle = "$lbTitle in $gameTitle ($consoleName)";
             $nextSubmitAt = $nextEntry['DateSubmitted'];
             $nextSubmitAtNice = getNiceDate($nextSubmitAt);
 
-            $isLocal = (strcmp($nextUser, $user) == 0);
+            $isLocal = $nextUser === $userModel->display_name;
             $lastEntry = ($resultsDrawn + 1 == $numEntries);
             $userAppendedInResults = ($numEntries > $count);
 


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/859938399468388362/1337200540043710506.

Currently, the leaderboardinfo page does not detect if the authenticated user is using a custom display name. As a result, it doesn't highlight their score and still shows the CTA telling them to consider participating.

**Before**
![Screenshot 2025-02-07 at 5 41 29 PM](https://github.com/user-attachments/assets/80b5dcf2-0bd2-4d81-bf33-f2782e2fff5d)

![Screenshot 2025-02-07 at 5 41 32 PM](https://github.com/user-attachments/assets/559cca60-a92f-409a-bfe8-6782978cfbe8)


**After**
![Screenshot 2025-02-07 at 5 41 17 PM](https://github.com/user-attachments/assets/2af6299e-d52b-4465-8d74-095e770e231c)

![Screenshot 2025-02-07 at 5 41 21 PM](https://github.com/user-attachments/assets/4f41ca99-6989-4b68-98d0-cfc0451c4d74)
