### PR TITLE
fix(manage): block adding similar games from `System::Hubs`

### DIFF
--- a/app/Filament/Resources/GameResource/Pages/SimilarGames.php
+++ b/app/Filament/Resources/GameResource/Pages/SimilarGames.php
@@ -98,6 +98,7 @@ class SimilarGames extends ManageRelatedRecords
                             ->multiple()
                             ->options(function () {
                                 return Game::whereNot('ID', $this->getOwnerRecord()->id)
+                                    ->where('ConsoleID', '!=', System::Hubs)
                                     ->limit(50)
                                     ->with('system')
                                     ->get()
@@ -105,6 +106,7 @@ class SimilarGames extends ManageRelatedRecords
                             })
                             ->getOptionLabelsUsing(function (array $values): array {
                                 return Game::whereIn('ID', $values)
+                                    ->where('ConsoleID', '!=', System::Hubs)
                                     ->with('system')
                                     ->get()
                                     ->mapWithKeys(fn ($game) => [$game->id => "[{$game->id}] {$game->title} ({$game->system->name})"])
@@ -113,6 +115,7 @@ class SimilarGames extends ManageRelatedRecords
                             ->searchable()
                             ->getSearchResultsUsing(function (string $search) {
                                 return Game::whereNot('ID', $this->getOwnerRecord()->id)
+                                    ->where('ConsoleID', '!=', System::Hubs)
                                     ->where(function ($query) use ($search) {
                                         $query->where('ID', 'LIKE', "%{$search}%")
                                             ->orWhere('Title', 'LIKE', "%{$search}%");


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1002696640001478769/1337524345790140478.

Currently, on pages like http://localhost:64000/manage/games/1/similar-games, it is possible to add a hub game to the similar games list:

![Screenshot 2025-02-07 at 5 54 14 PM](https://github.com/user-attachments/assets/b60c659b-3467-41b3-a81d-a52cfa2fa304)
