### PR TITLE
fix(setRequestList): show 'Next request in...' after username change

### DIFF
--- a/resources/views/pages-legacy/setRequestList.blade.php
+++ b/resources/views/pages-legacy/setRequestList.blade.php
@@ -166,7 +166,7 @@ if (empty($username)) {
             . $userSetRequestInformation['used'] . " of " . $userSetRequestInformation['total'] . " Requests Made</h2>";
 
         if ($flag == 0) {
-            if ($username === $user) {
+            if ($username === $userDetails['User'] || $username === $userDetails['display_name']) {
                 echo "<div class='float-right'>Next request in " . localized_number($userSetRequestInformation['pointsForNext']) . " points</div>";
             }
             echo "<a href='/setRequestList.php?u=$username&f=1'>View All User Set Requests</a>";


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/453242743292952578/1337765957765959771.

There's a bug on the page where if the user changes their username, they no longer see the "Next request in..." label when viewing their own requests list.