### PR TITLE
fix(code-notes): allow jr devs with custom display names to edit on site

### DIFF
--- a/app/Helpers/render/code-note.php
+++ b/app/Helpers/render/code-note.php
@@ -1,8 +1,9 @@
 <?php
 
 use App\Enums\Permissions;
+use App\Models\User;
 
-function RenderCodeNotes(array $codeNotes, ?string $editingUser = null, ?int $editingPermissions = null): void
+function RenderCodeNotes(array $codeNotes, ?User $editingUser = null, ?int $editingPermissions = null): void
 {
     $isEditable = $editingUser && $editingPermissions >= Permissions::JuniorDeveloper;
 
@@ -29,7 +30,7 @@ function RenderCodeNotes(array $codeNotes, ?string $editingUser = null, ?int $ed
 
         $canEditNote = (
             $editingPermissions >= Permissions::Developer
-            || ($editingPermissions === Permissions::JuniorDeveloper && $nextCodeNote['User'] === $editingUser)
+            || ($editingPermissions === Permissions::JuniorDeveloper && $nextCodeNote['User'] === $editingUser?->display_name)
         );
 
         echo "<tr id='row-$rowIndex' class='note-row'>";

--- a/resources/views/pages-legacy/codenotes.blade.php
+++ b/resources/views/pages-legacy/codenotes.blade.php
@@ -236,7 +236,7 @@ function saveCodeNote(rowIndex, isDeleting = false) {
     <p>There are currently <span class='font-bold code-note-count'><?= $codeNoteCount ?></span> code notes for this game.</p>
     <?php
     if (isset($user) && $permissions >= Permissions::Registered) {
-        RenderCodeNotes($codeNotes, $user, $permissions);
+        RenderCodeNotes($codeNotes, $userModel, $permissions);
     }
     ?>
 </x-app-layout>


### PR DESCRIPTION
Will cherry-pick to `release` and deploy. Currently, if a Jr Dev has a custom display_name, they can no longer edit their own code notes on-site. This is due to a mismatch between `User` and `display_name` in a conditional specific to JrDevs on the page.

**Before**
![Screenshot 2025-02-08 at 4 36 50 PM](https://github.com/user-attachments/assets/9472ce07-a9be-473e-b836-42832b1584da)


**After**
![Screenshot 2025-02-08 at 4 34 04 PM](https://github.com/user-attachments/assets/2bb4e4ca-d89a-4d8e-9cbf-56b077c38ce8)
