### PR TITLE
fix(hubs): discard client-side state on navigation

### DIFF
--- a/resources/js/features/game-list/components/HubMainRoot/HubBreadcrumbs/HubBreadcrumbs.tsx
+++ b/resources/js/features/game-list/components/HubMainRoot/HubBreadcrumbs/HubBreadcrumbs.tsx
@@ -9,7 +9,6 @@ import {
   BaseBreadcrumbPage,
   BaseBreadcrumbSeparator,
 } from '@/common/components/+vendor/BaseBreadcrumb';
-import { InertiaLink } from '@/common/components/InertiaLink';
 import { cleanHubTitle } from '@/common/utils/cleanHubTitle';
 
 interface HubBreadcrumbsProps {

--- a/resources/js/features/game-list/components/HubMainRoot/HubBreadcrumbs/HubBreadcrumbs.tsx
+++ b/resources/js/features/game-list/components/HubMainRoot/HubBreadcrumbs/HubBreadcrumbs.tsx
@@ -38,10 +38,8 @@ export const HubBreadcrumbs: FC<HubBreadcrumbsProps> = ({ breadcrumbs }) => {
                 {index !== breadcrumbs.length - 1 ? (
                   <>
                     <BaseBreadcrumbItem aria-label={breadcrumb.title!}>
-                      <BaseBreadcrumbLink asChild>
-                        <InertiaLink href={route('hub.show', { gameSet: breadcrumb.id })}>
-                          {currentTitle}
-                        </InertiaLink>
+                      <BaseBreadcrumbLink href={route('hub.show', { gameSet: breadcrumb.id })}>
+                        {currentTitle}
                       </BaseBreadcrumbLink>
                     </BaseBreadcrumbItem>
 

--- a/resources/js/features/game-list/components/HubMainRoot/RelatedHubs/RelatedHubs.tsx
+++ b/resources/js/features/game-list/components/HubMainRoot/RelatedHubs/RelatedHubs.tsx
@@ -10,7 +10,6 @@ import {
   BaseTableRow,
 } from '@/common/components/+vendor/BaseTable';
 import { GameTitle } from '@/common/components/GameTitle';
-import { InertiaLink } from '@/common/components/InertiaLink';
 import { useFormatNumber } from '@/common/hooks/useFormatNumber';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import { cleanHubTitle } from '@/common/utils/cleanHubTitle';

--- a/resources/js/features/game-list/components/HubMainRoot/RelatedHubs/RelatedHubs.tsx
+++ b/resources/js/features/game-list/components/HubMainRoot/RelatedHubs/RelatedHubs.tsx
@@ -42,7 +42,7 @@ export const RelatedHubs: FC = () => {
             {relatedHubs.map((relatedHub) => (
               <BaseTableRow key={`related-${relatedHub.id}`}>
                 <BaseTableCell>
-                  <InertiaLink
+                  <a
                     href={route('hub.show', { gameSet: relatedHub.id })}
                     className="flex max-w-fit items-center gap-2"
                   >
@@ -57,7 +57,7 @@ export const RelatedHubs: FC = () => {
                     />
 
                     <GameTitle title={cleanHubTitle(relatedHub.title!)} />
-                  </InertiaLink>
+                  </a>
                 </BaseTableCell>
 
                 <BaseTableCell className="text-right">


### PR DESCRIPTION
Resolves https://retroachievements.org/viewtopic.php?t=29663&c=265459#265459.

There appears to be a bug in the Inertia link component. When performing a client-side navigation to the same route, but with a different parameter, some client-side state is retained, which can lead to unexpected behavior.

How to reproduce this issue:
* Navigate to https://retroachievements.org/hub/26879.
* Sort by Achievements (More).
* Scroll to the bottom of the page, click on "Subgenre - Dating Simulation".
* Before doing anything on this page, observe the count of games.
* Sort by Achievements (More).
* Observe the count of games has changed.