### PR TITLE
fix: have hub tooltip cards use game_sets

### DIFF
--- a/app/Platform/Components/GameCard.php
+++ b/app/Platform/Components/GameCard.php
@@ -85,6 +85,7 @@ class GameCard extends Component
                 return null;
             }
 
+            $title = $foundGame->title;
             $imageIcon = $foundGame->ImageIcon;
             $foundGameSystemId = $foundGame->system->id;
 
@@ -100,6 +101,7 @@ class GameCard extends Component
                     return null;
                 }
 
+                $title = $gameSet->title;
                 $hubGamesCount = $gameSet->games->count();
                 $hubLinksCount = $gameSet->children->count();
                 $imageIcon = $gameSet->image_asset_path;
@@ -119,6 +121,7 @@ class GameCard extends Component
 
             return array_merge(
                 $foundGame->toArray(), [
+                    'Title' => $title,
                     'ConsoleID' => $foundGameSystemId,
                     'ConsoleName' => $foundGame->system->Name,
                     'Achievements' => $foundGameAchievements,

--- a/resources/views/components/cards/game.blade.php
+++ b/resources/views/components/cards/game.blade.php
@@ -65,12 +65,12 @@
             <div class="mb-2"></div>
 
             @if ($isHub)
-                <x-card.info-row label="Links">
-                    {{ localized_number($altGamesCount) }}
+                <x-card.info-row label="Games">
+                    {{ localized_number($hubGamesCount )}}
                 </x-card.info-row>
 
-                <x-card.info-row label="Last Updated">
-                    {{ $lastUpdated->format('j F Y') }}
+                <x-card.info-row label="Links">
+                    {{ localized_number($hubLinksCount) }}
                 </x-card.info-row>
             @elseif (count($activeDeveloperUsernames) === 0)
                 <p>


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1338916310792405034.

Currently, hub tooltip cards are still using all the properties of the associated legacy "hub game", including the game icon, which is likely to go stale.

**Before**
<img width="410" alt="Screenshot 2025-02-11 at 4 56 03 PM" src="https://github.com/user-attachments/assets/54d9e9ba-d3c0-431a-b172-a600d471be46" />

**After**
<img width="413" alt="Screenshot 2025-02-11 at 4 55 00 PM" src="https://github.com/user-attachments/assets/12122688-3a8e-4f09-acee-bd5016efe2c1" />

"Last Updated" has been removed, as most of the values in `game_sets` will be identical.