### PR TITLE
fix(email): don't leak stable usernames on set request/revision notifications

### DIFF
--- a/app/Community/Actions/UpdateGameClaimAction.php
+++ b/app/Community/Actions/UpdateGameClaimAction.php
@@ -114,7 +114,7 @@ class UpdateGameClaimAction
 
             foreach ($userAwards as $userAward) {
                 sendSetRevisionEmail(
-                    $userAward->user->User,
+                    $userAward->user->display_name,
                     $userAward->user->EmailAddress,
                     $userAward->AwardDataExtra === 1,
                     $game->ID,

--- a/app/Helpers/database/set-request.php
+++ b/app/Helpers/database/set-request.php
@@ -70,7 +70,7 @@ function getSetRequestorsList(int $gameId, bool $getEmailInfo = false): array
 
     $processedValues = $setRequests->map(function ($setRequest) use ($getEmailInfo) {
         $record = [
-            'Requestor' => $setRequest->user->User,
+            'Requestor' => $setRequest->user->display_name,
         ];
 
         if ($getEmailInfo) {


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/3220.