### PR TITLE
fix(GamesRelationManager): resolve server error on search

### DIFF
--- a/app/Filament/Resources/HubResource/RelationManagers/GamesRelationManager.php
+++ b/app/Filament/Resources/HubResource/RelationManagers/GamesRelationManager.php
@@ -53,7 +53,9 @@ class GamesRelationManager extends RelationManager
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('GameData.ID', $direction);
                     })
-                    ->searchable()
+                    ->searchable(query: function (Builder $query, string $search): Builder {
+                        return $query->where('GameData.ID', 'like', "%{$search}%");
+                    })
                     ->url(function (Game $record) {
                         if (request()->user()->can('manage', Game::class)) {
                             return GameResource::getUrl('view', ['record' => $record]);


### PR DESCRIPTION
Resolves these errors in the logs: https://retroachievements.org/log-viewer?file=5003fe9a-laravel-2025-02-15.log&query=log-index%3A19

`GameData.ID` needs to be fully-qualified, otherwise the column name is ambiguous in the query.