### PR TITLE
fix(manage): remediate server error on searching similar games

### DIFF
--- a/app/Filament/Resources/GameResource/Pages/SimilarGames.php
+++ b/app/Filament/Resources/GameResource/Pages/SimilarGames.php
@@ -51,14 +51,22 @@ class SimilarGames extends ManageRelatedRecords
                     ->label('')
                     ->size(config('media.icon.sm.width')),
 
-                Tables\Columns\TextColumn::make('id')
+                Tables\Columns\TextColumn::make('ID')
                     ->label('ID')
-                    ->sortable()
-                    ->searchable(),
+                    ->sortable(query: function (Builder $query, string $direction): Builder {
+                        return $query->orderBy('GameData.ID', $direction);
+                    })
+                    ->searchable(query: function (Builder $query, string $search): Builder {
+                        return $query->where('GameData.ID', 'LIKE', "%{$search}%");
+                    }),
 
                 Tables\Columns\TextColumn::make('Title')
-                    ->sortable()
-                    ->searchable(),
+                    ->sortable(query: function (Builder $query, string $direction): Builder {
+                        return $query->orderBy('GameData.Title', $direction);
+                    })
+                    ->searchable(query: function (Builder $query, string $search): Builder {
+                        return $query->where('GameData.Title', 'LIKE', "%{$search}%");
+                    }),
 
                 Tables\Columns\TextColumn::make('system')
                     ->label('System')


### PR DESCRIPTION
Resolves:
> SQLSTATE: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous (Connection: mysql, SQL: select count(*) as aggregate from `GameData` inner join `game_set_games` on `GameData`.`ID` = `game_set_games`.`game_id` where `game_set_games`.`game_set_id` = 23163 and (`id` like %123% or `Title` like %123%) and `GameData`.`deleted_at` is null) (View: /home/forge/retroachievements.org/releases/2025-02-16T191921-2025.02.06-B-3fa49552/vendor/filament/tables/resources/views/index.blade.php) (View: /home/forge/retroachievements.org/releases/2025-02-16T191921-2025.02.06-B-3fa49552/vendor/filament/tables/resources/views/index.blade.php) {"userId":117089,"exception":"[object] (Illuminate\\View\\ViewException(code: 0): SQLSTATE: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous (Connection: mysql, SQL: select count(*) as aggregate from `GameData` inner join `game_set_games` on `GameData`.`ID` = `game_set_games`.`game_id` where `game_set_games`.`game_set_id` = 23163 and (`id` like %123% or `Title` like %123%) and `GameData`.`deleted_at` is null) (View: /home/forge/retroachievements.org/releases/2025-02-16T191921-2025.02.06-B-3fa49552/vendor/filament/tables/resources/views/index.blade.php) (View: /home/forge/retroachievements.org/releases/2025-02-16T191921-2025.02.06-B-3fa49552/vendor/filament/tables/resources/views/index.blade.php) at /home/forge/retroachievements.org/releases/2025-02-16T191921-2025.02.06-B-3fa49552/vendor/laravel/framework/src/Illuminate/Database/Connection.php:825)

https://retroachievements.org/log-viewer?file=8dd92017-laravel-2025-02-19.log&query=log-index%3A80