### PR TITLE
fix(BaseSelect): remediate Android overflow issue

### DIFF
--- a/resources/js/common/components/+vendor/BaseSelect.tsx
+++ b/resources/js/common/components/+vendor/BaseSelect.tsx
@@ -46,12 +46,15 @@ const BaseSelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border light:border-neutral-200 light:bg-white',
+        'relative z-50 min-w-[8rem] overflow-hidden rounded-md border light:border-neutral-200 light:bg-white',
         'shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out light:text-neutral-950',
         'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95',
         'data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
         'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         'border-neutral-800 bg-neutral-950 text-neutral-50',
+
+        // Don't overflow on mobile Android Chrome.
+        'max-h-[var(--radix-select-content-available-height)]',
 
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/3081.

This issue **only** occurs on Android Chrome - no other browser or environment.

I discovered a solution here: https://stackoverflow.com/a/76771880. From the Radix docs:

> When using position="popper" on Select.Content, you may want to constrain the width of the content so that it matches the trigger width. You may also want to constrain its height to not exceed the viewport.
> 
> We expose several CSS custom properties such as --radix-select-trigger-width and --radix-select-content-available-height to support this. Use them to constrain the content dimensions.

