### PR TITLE
fix(home): remediate aotw 'Unlocked' style issues on light mode

### DIFF
--- a/resources/js/features/home/components/+sidebar/AchievementOfTheWeek/AotwUnlockedIndicator/AotwUnlockedIndicator.tsx
+++ b/resources/js/features/home/components/+sidebar/AchievementOfTheWeek/AotwUnlockedIndicator/AotwUnlockedIndicator.tsx
@@ -13,8 +13,8 @@ export const AotwUnlockedIndicator: FC = () => {
   }
 
   return (
-    <div data-testid="aotw-progress" className="bg-neutral-950 px-2 py-1.5">
-      <p className="text-center text-xs text-neutral-300">{t('Unlocked')}</p>
+    <div data-testid="aotw-progress" className="bg-neutral-950 px-2 py-1.5 light:bg-neutral-200">
+      <p className="text-center text-xs text-neutral-300 light:text-neutral-800">{t('Unlocked')}</p>
     </div>
   );
 };


### PR DESCRIPTION
This PR resolves a style issue for the home page's AOTW "Unlocked" indicator on light mode.

**Before**
![Screenshot 2025-02-23 at 6 44 57 PM](https://github.com/user-attachments/assets/11d568a3-0d06-48d3-84cf-6ca0d2b26c0e)


**After**
![Screenshot 2025-02-23 at 6 45 35 PM](https://github.com/user-attachments/assets/fd60819a-ba6c-4181-b0f4-d566d2e7e34e)
