### PR TITLE
fix: remediate excessive box-shadow on nav dropdown menu

### DIFF
--- a/resources/css/dropdown.css
+++ b/resources/css/dropdown.css
@@ -10,8 +10,9 @@
   left: 0;
   margin: 0;
   background-color: var(--embed-highlight-color);
-  box-shadow: var(--box-shadow-color) 0 30px 60px -12px, var(--box-shadow-color) 0px 18px 36px -18px;
   z-index: 20;
+
+  @apply shadow-lg;
 }
 
 .dropdown-menu-right {

--- a/resources/css/dropdown.css
+++ b/resources/css/dropdown.css
@@ -9,10 +9,9 @@
   position: absolute;
   left: 0;
   margin: 0;
+  box-shadow: var(--box-shadow-color) 0 10px 30px -8px, var(--box-shadow-color) 0px 8px 16px -8px;
   background-color: var(--embed-highlight-color);
   z-index: 20;
-
-  @apply shadow-lg;
 }
 
 .dropdown-menu-right {


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/3240.
Resolves https://github.com/RetroAchievements/RAWeb/issues/2711.

The `box-shadow` on this classname is kinda overkill at the moment. Switched to a Tailwind sane default in this branch.

![Screenshot 2025-02-23 at 6 48 42 PM](https://github.com/user-attachments/assets/169b73c2-50e4-4643-9a03-a3dd14d50b7c)
