### PR TITLE
fix: remediate 'tap behind' effect for mobile drawers

### DIFF
--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.tsx
@@ -84,7 +84,7 @@ export function DataTableSuperFilter<TData>({
   };
 
   return (
-    <BaseDrawer shouldScaleBackground={false} modal={false}>
+    <BaseDrawer shouldScaleBackground={false}>
       <BaseDrawerTrigger asChild>
         <button className="flex items-center gap-1 tracking-tight text-neutral-200 light:text-neutral-950">
           {currentSuperFilterLabel}

--- a/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemElement.tsx
+++ b/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemElement.tsx
@@ -55,12 +55,7 @@ export const GameListItemElement: FC<GameListItemElementProps> = ({
   };
 
   return (
-    <BaseDrawer
-      open={isDrawerOpen}
-      onOpenChange={setIsDrawerOpen}
-      shouldScaleBackground={false}
-      modal={false}
-    >
+    <BaseDrawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen} shouldScaleBackground={false}>
       <GameListItemContent
         backlogState={backlogState}
         gameListEntry={gameListEntry}


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/3245.

**How to repro the issue:**
The issue is actually caused by a bad interaction between the BaseSelect and BaseDrawer components on the page. To repro the issue, double-tap the same spot on a BaseSelect, like so:

https://github.com/user-attachments/assets/0ea438ac-d7d2-4e11-a608-4ac156f706e2

This is occurring because the drawer's `modal` prop is currently set to `false`. Flipping it to true resolves the issue, with the side effect that Safari's address bar is going to slightly pop when the drawer opens. This is the lesser of the two evils though. More info here: https://github.com/emilkowalski/vaul/issues/494