### PR TITLE
feat(connect): label AOTW and AOTM in the patch response

### DIFF
--- a/app/Connect/Actions/InjectPatchAotwEventDataAction.php
+++ b/app/Connect/Actions/InjectPatchAotwEventDataAction.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Connect\Actions;
+
+use App\Models\EventAchievement;
+use Illuminate\Support\Facades\Cache;
+
+class InjectPatchAotwEventDataAction
+{
+    /**
+     * Cache keys and TTL configuration for stale-while-revalidate pattern.
+     * @see https://laravel.com/docs/11.x/cache#swr
+     */
+    private const CACHE_KEY_AOTW = 'aotw_achievement_data';
+    private const CACHE_KEY_AOTM = 'aotm_achievement_data';
+    private const CACHE_TTL_CONFIG = [30, 60]; // [fresh for 30s, stale but usable for 60s]
+
+    /**
+     * Add special achievement of the week labels to AOTW/AOTM achievement descriptions.
+     *
+     * @param array<string, mixed> $response Patch response data
+     * @return array<string, mixed> modified response with AOTW/AOTM labels in descriptions
+     */
+    public function execute(array $response): array
+    {
+        $eventAchievements = $this->getEventAchievements();
+
+        // If no event achievements were found, return an unmodified response.
+        if (empty($eventAchievements)) {
+            return $response;
+        }
+
+        // Update the main achievements list.
+        if (!empty($response['PatchData']['Achievements'])) {
+            $response['PatchData']['Achievements'] = $this->processAchievements(
+                $response['PatchData']['Achievements'],
+                $eventAchievements
+            );
+        }
+
+        // Update the sets achievement list(s).
+        if (!empty($response['PatchData']['Sets'])) {
+            foreach ($response['PatchData']['Sets'] as &$set) {
+                if (!empty($set['Achievements'])) {
+                    $set['Achievements'] = $this->processAchievements(
+                        $set['Achievements'],
+                        $eventAchievements
+                    );
+                }
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * Load the current AOTW and AOTM achievements.
+     *
+     * @return array<int, string> map of achievement IDs to their event labels
+     */
+    private function getEventAchievements(): array
+    {
+        $eventAchievements = [];
+
+        $aotwAchievement = Cache::flexible(self::CACHE_KEY_AOTW, self::CACHE_TTL_CONFIG, function () {
+            return EventAchievement::currentAchievementOfTheWeek()
+                ->with(['achievement', 'sourceAchievement'])
+                ->first();
+        });
+        $aotmAchievement = Cache::flexible(self::CACHE_KEY_AOTM, self::CACHE_TTL_CONFIG, function () {
+            return EventAchievement::currentAchievementOfTheMonth()
+                ->with(['achievement', 'sourceAchievement'])
+                ->first();
+        });
+
+        // Build ID-to-label mappings.
+        if ($aotwAchievement && $aotwAchievement->source_achievement_id) {
+            $eventAchievements[$aotwAchievement->source_achievement_id] = '[Achievement of the Week] ';
+        }
+        if ($aotmAchievement && $aotmAchievement->source_achievement_id) {
+            $eventAchievements[$aotmAchievement->source_achievement_id] = '[Achievement of the Month] ';
+        }
+
+        return $eventAchievements;
+    }
+
+    /**
+     * Add event labels to achievements that match event IDs.
+     *
+     * @param array<int, array<string, mixed>> $achievements achievements to process
+     * @param array<int, string> $eventAchievements map of achievement IDs to event labels
+     * @return array<int, array<string, mixed>> processed achievements with labels
+     */
+    private function processAchievements(array $achievements, array $eventAchievements): array
+    {
+        return array_map(function ($achievement) use ($eventAchievements) {
+            $achievementId = $achievement['ID'] ?? null;
+
+            if ($achievementId && isset($eventAchievements[$achievementId])) {
+                $achievement['Description'] = $eventAchievements[$achievementId] . $achievement['Description'];
+            }
+
+            return $achievement;
+        }, $achievements);
+    }
+}

--- a/app/Models/EventAchievement.php
+++ b/app/Models/EventAchievement.php
@@ -142,6 +142,21 @@ class EventAchievement extends BaseModel
      * @param Builder<EventAchievement> $query
      * @return Builder<EventAchievement>
      */
+    public function scopeCurrentAchievementOfTheMonth(Builder $query): Builder
+    {
+        return $query->active()
+            ->whereHas('achievement.game', function ($query) { // only from the current AotW event
+                $query->where('Title', 'like', '%of the week%');
+            })
+            ->whereNotNull('active_from')
+            ->whereNotNull('active_until')
+            ->whereRaw(dateCompareStatement('active_until', 'active_from', '> 20')); // ignore AotW achievements.
+    }
+
+    /**
+     * @param Builder<EventAchievement> $query
+     * @return Builder<EventAchievement>
+     */
     public function scopeActive(Builder $query, ?Carbon $timestamp = null): Builder
     {
         $timestamp ??= Carbon::now();

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -4,6 +4,7 @@ use App\Actions\FindUserByIdentifierAction;
 use App\Community\Enums\ActivityType;
 use App\Connect\Actions\BuildClientPatchDataAction;
 use App\Connect\Actions\GetClientSupportLevelAction;
+use App\Connect\Actions\InjectPatchAotwEventDataAction;
 use App\Connect\Actions\InjectPatchClientSupportLevelDataAction;
 use App\Connect\Actions\ResolveRootGameIdFromGameAndGameHashAction;
 use App\Connect\Actions\ResolveRootGameIdFromGameIdAction;
@@ -581,6 +582,9 @@ switch ($requestType) {
                 $gameHash,
                 $game,
             );
+
+            // Add Achievement of the Week/Month labels to achievement descriptions.
+            $response = (new InjectPatchAotwEventDataAction())->execute($response);
         } catch (InvalidArgumentException $e) {
             return DoRequestError('Unknown game', 404, 'not_found');
         }

--- a/tests/Feature/Connect/Actions/InjectPatchAotwEventDataActionTest.php
+++ b/tests/Feature/Connect/Actions/InjectPatchAotwEventDataActionTest.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Connect\Actions;
+
+use App\Connect\Actions\InjectPatchAotwEventDataAction;
+use App\Models\Achievement;
+use App\Models\EventAchievement;
+use App\Models\Game;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class InjectPatchAotwEventDataActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Clear any cached data to ensure tests start fresh.
+        Cache::forget('aotw_achievement_data');
+        Cache::forget('aotm_achievement_data');
+    }
+
+    private function createSamplePatchResponse(array $achievements = []): array
+    {
+        return [
+            'Success' => true,
+            'PatchData' => [
+                'ID' => 123,
+                'Title' => 'Test Game',
+                'ImageIcon' => '/Images/000123.png',
+                'RichPresencePatch' => 'Display:\nTest',
+                'ConsoleID' => 1,
+                'ImageIconURL' => 'http://example.com/Images/000123.png',
+                'Achievements' => $achievements,
+                'Leaderboards' => [],
+            ],
+        ];
+    }
+
+    private function createSampleAchievement(int $id, string $title, string $description): array
+    {
+        return [
+            'ID' => $id,
+            'Title' => $title,
+            'Description' => $description,
+            'MemAddr' => '0x000000',
+            'Points' => 10,
+            'Author' => 'TestAuthor',
+            'Modified' => Carbon::now()->unix(),
+            'Created' => Carbon::now()->subDays(5)->unix(),
+            'BadgeName' => '00001',
+            'Flags' => 3,
+            'Type' => 'progression',
+            'Rarity' => 25.5,
+            'RarityHardcore' => 15.2,
+            'BadgeURL' => 'http://example.com/Badge/00001.png',
+            'BadgeLockedURL' => 'http://example.com/Badge/00001_lock.png',
+        ];
+    }
+
+    public function testItReturnsUnmodifiedResponseWhenNoEventAchievements(): void
+    {
+        // Arrange
+        $achievements = [
+            $this->createSampleAchievement(1, 'Test Achievement 1', 'Test Description 1'),
+            $this->createSampleAchievement(2, 'Test Achievement 2', 'Test Description 2'),
+        ];
+
+        $response = $this->createSamplePatchResponse($achievements);
+
+        // Act
+        $result = (new InjectPatchAotwEventDataAction())->execute($response);
+
+        // Assert
+        $this->assertEquals($response, $result);
+        $this->assertEquals('Test Description 1', $result['PatchData']['Achievements'][0]['Description']);
+        $this->assertEquals('Test Description 2', $result['PatchData']['Achievements'][1]['Description']);
+    }
+
+    public function testItAddsAchievementOfTheWeekLabel(): void
+    {
+        // Arrange
+        // ... create a game with "of the week" in the title ...
+        $game = Game::factory()->create(['Title' => 'Achievement of the Week']);
+
+        $sourceAchievement = Achievement::factory()->published()->create([
+            'ID' => 48615,
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        $eventAchievement = Achievement::factory()->published()->create([
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        EventAchievement::factory()->create([
+            'achievement_id' => $eventAchievement->id,
+            'source_achievement_id' => $sourceAchievement->id,
+            'active_from' => Carbon::now()->subDays(3),
+            'active_until' => Carbon::now()->addDays(4), // !! less than 20 days -> AOTW
+        ]);
+
+        $achievements = [
+            $this->createSampleAchievement(48615, 'Shadow Wood', 'Enter the second hub Shadow Wood'),
+            $this->createSampleAchievement(2, 'Test Achievement 2', 'Test Description 2'),
+        ];
+
+        $response = $this->createSamplePatchResponse($achievements);
+
+        // Act
+        $result = (new InjectPatchAotwEventDataAction())->execute($response);
+
+        // Assert
+        $this->assertEquals('[Achievement of the Week] Enter the second hub Shadow Wood', $result['PatchData']['Achievements'][0]['Description']);
+        $this->assertEquals('Test Description 2', $result['PatchData']['Achievements'][1]['Description']);
+    }
+
+    public function testItAddsAchievementOfTheMonthLabel(): void
+    {
+        // Arrange
+        // ... create a game with "of the week" in the title ...
+        $game = Game::factory()->create(['Title' => 'Achievement of the Week']);
+
+        $sourceAchievement = Achievement::factory()->published()->create([
+            'ID' => 12345,
+            'GameID' => $game->id,
+            'Title' => 'Something\'s Fishy',
+            'Description' => 'Complete the fishing quest',
+        ]);
+
+        $eventAchievement = Achievement::factory()->published()->create([
+            'GameID' => $game->id,
+            'Title' => 'Something\'s Fishy',
+            'Description' => 'Complete the fishing quest',
+        ]);
+
+        EventAchievement::factory()->create([
+            'achievement_id' => $eventAchievement->id,
+            'source_achievement_id' => $sourceAchievement->id,
+            'active_from' => Carbon::now()->subDays(10),
+            'active_until' => Carbon::now()->addDays(25), // !! more than 20 days -> AOTM
+        ]);
+
+        $achievements = [
+            $this->createSampleAchievement(1, 'Test Achievement 1', 'Test Description 1'),
+            $this->createSampleAchievement(12345, 'Something\'s Fishy', 'Complete the fishing quest'),
+        ];
+
+        $response = $this->createSamplePatchResponse($achievements);
+
+        // Act
+        $result = (new InjectPatchAotwEventDataAction())->execute($response);
+
+        // Assert
+        $this->assertEquals('Test Description 1', $result['PatchData']['Achievements'][0]['Description']);
+        $this->assertEquals('[Achievement of the Month] Complete the fishing quest', $result['PatchData']['Achievements'][1]['Description']);
+    }
+
+    public function testItProcessesAchievementsInSets(): void
+    {
+        // Arrange
+        // ... create a game with "of the week" in the title ...
+        $game = Game::factory()->create(['Title' => 'Achievement of the Week']);
+
+        $sourceAchievement = Achievement::factory()->published()->create([
+            'ID' => 48615,
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        $eventAchievement = Achievement::factory()->published()->create([
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        EventAchievement::factory()->create([
+            'achievement_id' => $eventAchievement->id,
+            'source_achievement_id' => $sourceAchievement->id,
+            'active_from' => Carbon::now()->subDays(3),
+            'active_until' => Carbon::now()->addDays(4),
+        ]);
+
+        // ... create a response that contains multiple sets ...
+        $achievements = [
+            $this->createSampleAchievement(1, 'Test Achievement 1', 'Test Description 1'),
+        ];
+        $setAchievements = [
+            $this->createSampleAchievement(48615, 'Shadow Wood', 'Enter the second hub Shadow Wood'),
+        ];
+
+        $response = $this->createSamplePatchResponse($achievements);
+        $response['PatchData']['Sets'] = [
+            [
+                'GameAchievementSetID' => 1,
+                'SetTitle' => 'Bonus Set',
+                'Type' => 'bonus',
+                'ImageIcon' => '/Images/000124.png',
+                'ImageIconURL' => 'http://example.com/Images/000124.png',
+                'Achievements' => $setAchievements,
+                'Leaderboards' => [],
+            ],
+        ];
+
+        // Act
+        $result = (new InjectPatchAotwEventDataAction())->execute($response);
+
+        // Assert
+        // ... the main achievement list should be unchanged ...
+        $this->assertEquals('Test Description 1', $result['PatchData']['Achievements'][0]['Description']);
+
+        // ... the achievement in the set should have the AOTW label ...
+        $this->assertEquals(
+            '[Achievement of the Week] Enter the second hub Shadow Wood',
+            $result['PatchData']['Sets'][0]['Achievements'][0]['Description']
+        );
+    }
+
+    public function testItHandlesBothAotwAndAotmAtTheSameTime(): void
+    {
+        // Arrange
+        // ... create a game with "of the week" in the title ...
+        $game = Game::factory()->create(['Title' => 'Achievement of the Week']);
+
+        $aotwSourceAchievement = Achievement::factory()->published()->create([
+            'ID' => 48615,
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        $aotwEventAchievement = Achievement::factory()->published()->create([
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        EventAchievement::factory()->create([
+            'achievement_id' => $aotwEventAchievement->id,
+            'source_achievement_id' => $aotwSourceAchievement->id,
+            'active_from' => Carbon::now()->subDays(3),
+            'active_until' => Carbon::now()->addDays(4), // !! less than 20 days -> AOTW
+        ]);
+
+        $aotmSourceAchievement = Achievement::factory()->published()->create([
+            'ID' => 12345,
+            'GameID' => $game->id,
+            'Title' => 'Something\'s Fishy',
+            'Description' => 'Complete the fishing quest',
+        ]);
+
+        $aotmEventAchievement = Achievement::factory()->published()->create([
+            'GameID' => $game->id,
+            'Title' => 'Something\'s Fishy',
+            'Description' => 'Complete the fishing quest',
+        ]);
+
+        EventAchievement::factory()->create([
+            'achievement_id' => $aotmEventAchievement->id,
+            'source_achievement_id' => $aotmSourceAchievement->id,
+            'active_from' => Carbon::now()->subDays(10),
+            'active_until' => Carbon::now()->addDays(25), // !! more than 20 days -> AOTM
+        ]);
+
+        // ... create a response which contains both achievements ...
+        $achievements = [
+            $this->createSampleAchievement(48615, 'Shadow Wood', 'Enter the second hub Shadow Wood'),
+            $this->createSampleAchievement(12345, 'Something\'s Fishy', 'Complete the fishing quest'),
+        ];
+
+        $response = $this->createSamplePatchResponse($achievements);
+
+        // Act
+        $result = (new InjectPatchAotwEventDataAction())->execute($response);
+
+        // Assert
+        $this->assertEquals('[Achievement of the Week] Enter the second hub Shadow Wood', $result['PatchData']['Achievements'][0]['Description']);
+        $this->assertEquals('[Achievement of the Month] Complete the fishing quest', $result['PatchData']['Achievements'][1]['Description']);
+    }
+
+    public function testItHandlesEmptyAchievementsList(): void
+    {
+        // Arrange
+        // ... create a game with "of the week" in the title ...
+        $game = Game::factory()->create(['Title' => 'Achievement of the Week']);
+
+        $sourceAchievement = Achievement::factory()->published()->create([
+            'ID' => 48615,
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        $eventAchievement = Achievement::factory()->published()->create([
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        EventAchievement::factory()->create([
+            'achievement_id' => $eventAchievement->id,
+            'source_achievement_id' => $sourceAchievement->id,
+            'active_from' => Carbon::now()->subDays(3),
+            'active_until' => Carbon::now()->addDays(4),
+        ]);
+
+        $response = $this->createSamplePatchResponse([]);
+
+        // Act
+        $result = (new InjectPatchAotwEventDataAction())->execute($response);
+
+        // Assert
+        $this->assertEquals($response, $result); // !! should be unchanged
+    }
+
+    public function testItHandlesResponseWithoutAchievements(): void
+    {
+        // Arrange
+        // ... create a game with "of the week" in the title ...
+        $game = Game::factory()->create(['Title' => 'Achievement of the Week']);
+
+        $sourceAchievement = Achievement::factory()->published()->create([
+            'ID' => 48615,
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        $eventAchievement = Achievement::factory()->published()->create([
+            'GameID' => $game->id,
+            'Title' => 'Shadow Wood',
+            'Description' => 'Enter the second hub Shadow Wood',
+        ]);
+
+        EventAchievement::factory()->create([
+            'achievement_id' => $eventAchievement->id,
+            'source_achievement_id' => $sourceAchievement->id,
+            'active_from' => Carbon::now()->subDays(3),
+            'active_until' => Carbon::now()->addDays(4),
+        ]);
+
+        $response = [
+            'Success' => true,
+            'PatchData' => [
+                'ID' => 123,
+                'Title' => 'Test Game',
+                // !! no 'Achievements' key
+            ],
+        ];
+
+        // Act
+        $result = (new InjectPatchAotwEventDataAction())->execute($response);
+
+        // Assert
+        $this->assertEquals($response, $result); // !! should be unchanged
+    }
+}


### PR DESCRIPTION
This PR makes a minor quality of life improvement to Connect API `patch` responses.

Now, if a `patch` response contains either the Achievement of the Week or the Achievement of the Month, the description of the achievement will be updated, ie:

```json
{
    "ID": 2508,
    "MemAddr": "0xH000652=1.1._0xH000652=0.100._R:0xH0006b1<10.1._0xH0006b1>=10.1._R:0x 000e94=0.1._0xH0006b1<=14.1._R:0xH0006b1>14.1._R:0xH00064b=0_0xH0006a6=2_0xH00001c=31",
    "Title": "Something's Fishy",
    "Description": "[Achievement of the Month] Defeat Kaptain K. Rool in the Lost World",
    "Points": 25,
    "Author": "Brian",
    "Modified": 1738858114,
    "Created": 1377544462,
    "BadgeName": "123989",
    "Flags": 3,
    "Type": null,
    "Rarity": 12.76,
    "RarityHardcore": 9.9,
    "BadgeURL": "http:\/\/media.retroachievements.org\/Badge\/123989.png",
    "BadgeLockedURL": "http:\/\/media.retroachievements.org\/Badge\/123989_lock.png"
},
```

Oftentimes when I start going for Achievement of the Week, I boot up the game on my couch and can't remember which achievement I actually am going for. This leads to me having to pull my phone out and jump around on our website. Inserting these "[Achievement of the Week]" and "[Achievement of the Month]" labels solves this inconvenience.