### PR TITLE
feat(event): add Hubs component to the sidebar

### DIFF
--- a/app/Platform/Controllers/EventController.php
+++ b/app/Platform/Controllers/EventController.php
@@ -10,6 +10,7 @@ use App\Models\Event;
 use App\Models\User;
 use App\Platform\Data\EventData;
 use App\Platform\Data\EventShowPagePropsData;
+use App\Platform\Data\GameSetData;
 use App\Platform\Data\PlayerGameData;
 use App\Platform\Data\PlayerGameProgressionAwardsData;
 use Illuminate\Http\Request;
@@ -89,6 +90,7 @@ class EventController extends Controller
                 'legacyGame',
                 'state',
             ),
+            hubs: $event->legacyGame->hubs->map(fn ($hub) => GameSetData::from($hub))->all(),
             playerGame: $playerGame ? PlayerGameData::fromPlayerGame($playerGame) : null,
             playerGameProgressionAwards: $user
                 ? PlayerGameProgressionAwardsData::fromArray(getUserGameProgressionAwards($event->legacyGame->id, $user))

--- a/app/Platform/Data/EventShowPagePropsData.php
+++ b/app/Platform/Data/EventShowPagePropsData.php
@@ -14,6 +14,8 @@ class EventShowPagePropsData extends Data
     public function __construct(
         public EventData $event,
         public UserPermissionsData $can,
+        /** @var GameSetData[] */
+        public array $hubs,
         public ?PlayerGameData $playerGame,
         public ?PlayerGameProgressionAwardsData $playerGameProgressionAwards,
     ) {

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -782,5 +782,6 @@
     "When in doubt, <1>consult the docs.</1>": "When in doubt, <1>consult the docs.</1>",
     "Please provide as much information as possible about the issue.": "Please provide as much information as possible about the issue.",
     "No users found.": "No users found.",
-    "type a username...": "type a username..."
+    "type a username...": "type a username...",
+    "Hubs": "Hubs"
 }

--- a/resources/css/utilities.css
+++ b/resources/css/utilities.css
@@ -6,6 +6,24 @@
   .container {
     @apply sm:max-w-[theme('screens.lg')] xl:max-w-[theme('screens.xl')];
   }
+
+  .zebra-list > * {
+    @apply outline outline-1 outline-transparent -outline-offset-1;
+  }
+  .zebra-list > *:nth-child(odd) {
+    @apply bg-[rgba(50,50,50,0.3)];
+  }
+  [data-scheme='light'] .zebra-list > *:nth-child(odd),
+  [data-scheme='system'] .zebra-list > *:nth-child(odd) {
+    @apply bg-[rgba(80,80,80,0.09)];
+  }
+  .zebra-list > *:hover:not(.no-hover) {
+    @apply outline-[rgba(128,128,128,0.3)] bg-[rgba(128,128,128,0.2)];
+  }
+  [data-scheme='light'] .zebra-list > *:hover:not(.no-hover),
+  [data-scheme='system'] .zebra-list > *:hover:not(.no-hover) {
+    @apply outline-[rgba(128,128,128,0.4)] bg-[rgba(128,128,128,0.22)];
+  }
 }
 
 @layer utilities {

--- a/resources/js/common/components/GameAvatar/GameAvatar.test.tsx
+++ b/resources/js/common/components/GameAvatar/GameAvatar.test.tsx
@@ -193,4 +193,15 @@ describe('Component: GameAvatar', () => {
     expect(wrapperEl).toHaveClass('ml-0.5', 'mt-0.5', 'inline-block', 'min-h-7', 'gap-2');
     expect(screen.getByRole('img')).toHaveClass('mr-1.5');
   });
+
+  it('given a custom href, uses it', () => {
+    // ARRANGE
+    const game = createGame();
+
+    render(<GameAvatar {...game} href="https://google.com" />);
+
+    // ASSERT
+    const wrapperEl = screen.getByRole('link');
+    expect(wrapperEl).toHaveAttribute('href', 'https://google.com');
+  });
 });

--- a/resources/js/common/components/GameAvatar/GameAvatar.tsx
+++ b/resources/js/common/components/GameAvatar/GameAvatar.tsx
@@ -15,6 +15,7 @@ type GameAvatarProps = BaseAvatarProps &
     decoding?: ImgHTMLAttributes<HTMLImageElement>['decoding'];
     dynamicTooltipType?: 'game' | 'hub';
     gameTitleClassName?: string;
+    href?: string;
     loading?: ImgHTMLAttributes<HTMLImageElement>['loading'];
     shouldGlow?: boolean;
     showHoverCardProgressForUsername?: string;
@@ -27,6 +28,7 @@ type GameAvatarProps = BaseAvatarProps &
 export const GameAvatar: FC<GameAvatarProps> = ({
   badgeUrl,
   gameTitleClassName,
+  href,
   id,
   showHoverCardProgressForUsername,
   system,
@@ -57,9 +59,11 @@ export const GameAvatar: FC<GameAvatarProps> = ({
 
   const gameTitle = showSystemInTitle ? `${title} (${system?.name})` : title;
 
+  const usedHref = href ?? route('game.show', { game: id });
+
   return (
     <Wrapper
-      href={shouldLink ? route('game.show', { game: id }) : undefined}
+      href={shouldLink ? usedHref : undefined}
       className={cn(
         variant === 'base' ? 'flex max-w-fit items-center gap-2' : null,
         variant === 'inline' ? 'ml-0.5 mt-0.5 inline-block min-h-7 gap-2' : null,

--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeHub/ShortcodeHub.test.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeHub/ShortcodeHub.test.tsx
@@ -49,4 +49,21 @@ describe('Component: ShortcodeHub', () => {
     expect(screen.getByText(/central/i)).toBeVisible();
     expect(screen.getByRole('link')).toBeVisible();
   });
+
+  it('links to the correct page', () => {
+    // ARRANGE
+    const hub = createGameSet({ id: 1, title: '[Central]' });
+
+    render(<ShortcodeHub hubId={1} />, {
+      jotaiAtoms: [
+        [persistedHubsAtom, [hub]],
+        //
+      ],
+    });
+
+    // ASSERT
+    const linkEl = screen.getByRole('link');
+    expect(linkEl).toBeVisible();
+    expect(linkEl).toHaveAttribute('href', expect.stringContaining('hub.show'));
+  });
 });

--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeHub/ShortcodeHub.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeHub/ShortcodeHub.tsx
@@ -29,6 +29,7 @@ export const ShortcodeHub: FC<ShortcodeHubProps> = ({ hubId }) => {
         badgeUrl={foundHub.badgeUrl!}
         size={24}
         variant="inline"
+        href={route('hub.show', { gameSet: foundHub })}
       />
     </span>
   );

--- a/resources/js/common/models/base-avatar-props.model.ts
+++ b/resources/js/common/models/base-avatar-props.model.ts
@@ -3,7 +3,7 @@
  * If possible, use one of these sane defaults.
  * When adding another one, try to ensure it corresponds to a Tailwind size-* class.
  */
-export type AvatarSize = 8 | 16 | 24 | 28 | 32 | 40 | 48 | 64 | 96 | 128;
+export type AvatarSize = 8 | 16 | 24 | 28 | 32 | 36 | 40 | 48 | 64 | 96 | 128;
 
 export interface BaseAvatarProps {
   hasTooltip?: boolean;

--- a/resources/js/features/events/components/+show-sidebar/EventShowSidebarRoot.tsx
+++ b/resources/js/features/events/components/+show-sidebar/EventShowSidebarRoot.tsx
@@ -5,10 +5,11 @@ import { usePageProps } from '@/common/hooks/usePageProps';
 import { BoxArtImage } from '../BoxArtImage';
 import { EventAwardTiers } from '../EventAwardTiers';
 import { EventProgress } from '../EventProgress';
+import { HubsList } from '../HubsList';
 import { OfficialForumTopicButton } from '../OfficialForumTopicButton';
 
 export const EventShowSidebarRoot: FC = () => {
-  const { event, playerGame } = usePageProps<App.Platform.Data.EventShowPagePropsData>();
+  const { event, hubs, playerGame } = usePageProps<App.Platform.Data.EventShowPagePropsData>();
 
   return (
     <div data-testid="sidebar" className="flex flex-col gap-6">
@@ -16,6 +17,7 @@ export const EventShowSidebarRoot: FC = () => {
       <OfficialForumTopicButton event={event} />
       <EventProgress event={event} playerGame={playerGame} />
       <EventAwardTiers event={event} />
+      <HubsList hubs={hubs} />
     </div>
   );
 };

--- a/resources/js/features/events/components/EventAwardTiers/EventAwardTiers.tsx
+++ b/resources/js/features/events/components/EventAwardTiers/EventAwardTiers.tsx
@@ -18,13 +18,15 @@ export const EventAwardTiers: FC<EventAwardTiersProps> = ({ event }) => {
   const sortedByPoints = event.eventAwards.sort((a, b) => b.pointsRequired - a.pointsRequired);
 
   return (
-    <div data-testid="award-tiers" className="rounded-lg bg-embed p-2">
-      <h2 className="border-0 text-lg font-semibold">{t('Award Tiers')}</h2>
+    <div data-testid="award-tiers">
+      <h2 className="mb-0 border-0 text-lg font-semibold">{t('Award Tiers')}</h2>
 
-      <div className="flex flex-col gap-3">
-        {sortedByPoints.map((eventAward) => (
-          <AwardTierItem key={eventAward.label} event={event} eventAward={eventAward} />
-        ))}
+      <div className="rounded-lg bg-embed p-2">
+        <div className="flex flex-col gap-3">
+          {sortedByPoints.map((eventAward) => (
+            <AwardTierItem key={eventAward.label} event={event} eventAward={eventAward} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/resources/js/features/events/components/HubsList/HubsList.test.tsx
+++ b/resources/js/features/events/components/HubsList/HubsList.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@/test';
+import { createGameSet } from '@/test/factories';
+
+import { HubsList } from './HubsList';
+
+describe('Component: HubsList', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const { container } = render(<HubsList hubs={[]} />);
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given there are no hubs, renders nothing', () => {
+    // ARRANGE
+    render(<HubsList hubs={[]} />);
+
+    // ASSERT
+    expect(screen.queryByTestId('hubs-list')).not.toBeInTheDocument();
+  });
+
+  it('given there are hubs, renders the hubs list with the correct title', () => {
+    // ARRANGE
+    const mockHubs = [createGameSet({ title: 'AAAAA' }), createGameSet({ title: 'BBBBB' })];
+
+    render(<HubsList hubs={mockHubs} />);
+
+    // ASSERT
+    expect(screen.getByTestId('hubs-list')).toBeVisible();
+    expect(screen.getByText(/hubs/i)).toBeVisible();
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(screen.getByText(/aaaaa/i)).toBeVisible();
+    expect(screen.getByText(/bbbbb/i)).toBeVisible();
+  });
+
+  it('cleans hub titles', () => {
+    // ARRANGE
+    const mockHubs = [createGameSet({ title: '[Events - Achievement of the Week]' })];
+
+    render(<HubsList hubs={mockHubs} />);
+
+    // ASSERT
+    expect(screen.queryByText(/\[/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\]/i)).not.toBeInTheDocument();
+    expect(screen.getByText('Events - Achievement of the Week')).toBeVisible();
+  });
+});

--- a/resources/js/features/events/components/HubsList/HubsList.tsx
+++ b/resources/js/features/events/components/HubsList/HubsList.tsx
@@ -1,0 +1,43 @@
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { GameAvatar } from '@/common/components/GameAvatar';
+import { cleanHubTitle } from '@/common/utils/cleanHubTitle';
+
+interface HubsListProps {
+  hubs: App.Platform.Data.GameSet[];
+}
+
+export const HubsList: FC<HubsListProps> = ({ hubs }) => {
+  const { t } = useTranslation();
+
+  if (!hubs?.length) {
+    return null;
+  }
+
+  return (
+    <div data-testid="hubs-list">
+      <h2 className="mb-0 border-0 text-lg font-semibold">{t('Hubs')}</h2>
+
+      <div className="rounded-lg bg-embed p-1">
+        <ul className="zebra-list overflow-hidden rounded-lg">
+          {hubs.map((hub) => (
+            <li
+              key={`hub-list-item-${hub.id}`}
+              className="w-full p-2 first:rounded-t-lg last:rounded-b-lg"
+            >
+              <GameAvatar
+                id={hub.id}
+                title={cleanHubTitle(hub.title!)}
+                dynamicTooltipType="hub"
+                badgeUrl={hub.badgeUrl!}
+                size={36}
+                href={route('hub.show', { gameSet: hub })}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/resources/js/features/events/components/HubsList/index.ts
+++ b/resources/js/features/events/components/HubsList/index.ts
@@ -1,0 +1,1 @@
+export * from './HubsList';

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -494,6 +494,7 @@ declare namespace App.Platform.Data {
   export type EventShowPagePropsData = {
     event: App.Platform.Data.Event;
     can: App.Data.UserPermissions;
+    hubs: Array<App.Platform.Data.GameSet>;
     playerGame: App.Platform.Data.PlayerGame | null;
     playerGameProgressionAwards: App.Platform.Data.PlayerGameProgressionAwards | null;
   };


### PR DESCRIPTION
This PR adds a Hubs component to the React event page sidebar. IDs 1 and 4 are good to test on.

Additionally, a `GameAvatar`'s `href` can now be overridden. This also fixes a bug where `ShortcodeHub` was linking to the legacy game ID route.

![Screenshot 2025-03-01 at 2 51 33 PM](https://github.com/user-attachments/assets/e04a392f-c4f4-418e-ad65-a49ec56b211d)

![Screenshot 2025-03-01 at 2 52 07 PM](https://github.com/user-attachments/assets/822e5c60-c703-43ac-bdef-339e7eeff061)
