### PR TITLE
feat(events): add Compare Progress sidebar component

### DIFF
--- a/app/Models/UserRelation.php
+++ b/app/Models/UserRelation.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Support\Database\Eloquent\BaseModel;
+use Database\Factories\UserRelationFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class UserRelation extends BaseModel
 {
+    /** @use HasFactory<UserRelationFactory> */
+    use HasFactory;
+
     // TODO rename Friends table to user_relations
     // TODO migrate Friendship column to status, remove getStatusAttribute()
     protected $table = 'Friends';
@@ -20,6 +25,11 @@ class UserRelation extends BaseModel
         'related_user_id',
         'Friendship',
     ];
+
+    protected static function newFactory(): UserRelationFactory
+    {
+        return UserRelationFactory::new();
+    }
 
     // == accessors
 

--- a/app/Platform/Actions/BuildFollowedPlayerCompletionAction.php
+++ b/app/Platform/Actions/BuildFollowedPlayerCompletionAction.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Actions;
+
+use App\Community\Enums\UserRelationship;
+use App\Data\UserData;
+use App\Models\Game;
+use App\Models\PlayerGame;
+use App\Models\User;
+use App\Models\UserRelation;
+use App\Platform\Data\FollowedPlayerCompletionData;
+use App\Platform\Data\PlayerGameData;
+use Illuminate\Support\Collection;
+
+class BuildFollowedPlayerCompletionAction
+{
+    /**
+     * @return Collection<int, FollowedPlayerCompletionData>
+     */
+    public function execute(?User $user, Game $game): Collection
+    {
+        if ($user === null) {
+            return collect();
+        }
+
+        $followedPlayerCompletion = null;
+
+        $limitedFollowedUsers = UserRelation::query()
+            ->join('UserAccounts', 'Friends.related_user_id', '=', 'UserAccounts.ID')
+            ->where('Friends.user_id', '=', $user->id)
+            ->where('Friends.Friendship', '=', UserRelationship::Following)
+            ->select('UserAccounts.ID')
+            ->limit(1000)
+            ->pluck('ID')
+            ->toArray();
+
+        $fields = [
+            'user_id',
+            'achievements_unlocked',
+            'achievements_unlocked_hardcore',
+            'achievements_unlocked_softcore',
+            'beaten_at',
+            'beaten_hardcore_at',
+            'completed_at',
+            'completed_hardcore_at',
+            'achievements_total',
+            'points',
+            'points_hardcore',
+            'points_total',
+            'last_played_at',
+        ];
+
+        $followedPlayerCompletion = PlayerGame::where('game_id', $game->id)
+            ->whereIn('user_id', $limitedFollowedUsers)
+            ->where(function ($query) {
+                $query->where('achievements_unlocked', '>', 0)
+                    ->orWhere('achievements_unlocked_hardcore', '>', 0);
+            })
+            ->select($fields)
+            ->orderBy('achievements_unlocked_hardcore', 'DESC')
+            ->orderBy('achievements_unlocked', 'DESC')
+            ->limit(50)
+            ->get();
+
+        $userIds = $followedPlayerCompletion->pluck('user_id')->toArray();
+        $followedPlayers = User::whereIn('ID', $userIds)->get()->keyBy('ID');
+
+        return $followedPlayerCompletion->map(function (PlayerGame $playerGame) use ($followedPlayers) {
+            $user = $followedPlayers[$playerGame->user_id] ?? null;
+
+            if (!$user) {
+                return null;
+            }
+
+            return new FollowedPlayerCompletionData(
+                user: UserData::fromUser($user),
+                playerGame: PlayerGameData::from($playerGame),
+            );
+        })->filter()->values();
+    }
+}

--- a/app/Platform/Controllers/EventController.php
+++ b/app/Platform/Controllers/EventController.php
@@ -8,6 +8,7 @@ use App\Data\UserPermissionsData;
 use App\Http\Controller;
 use App\Models\Event;
 use App\Models\User;
+use App\Platform\Actions\BuildFollowedPlayerCompletionAction;
 use App\Platform\Data\EventData;
 use App\Platform\Data\EventShowPagePropsData;
 use App\Platform\Data\GameSetData;
@@ -80,6 +81,7 @@ class EventController extends Controller
                 'eventAchievements',
                 'eventAwards',
                 'eventAwards.badgeCount',
+                'legacyGame.achievementsPublished',
                 'legacyGame.badgeUrl',
                 'legacyGame.forumTopicId',
                 'legacyGame.imageBoxArtUrl',
@@ -87,10 +89,12 @@ class EventController extends Controller
                 'legacyGame.imageTitleUrl',
                 'legacyGame.playersHardcore',
                 'legacyGame.playersTotal',
+                'legacyGame.pointsTotal',
                 'legacyGame',
                 'state',
             ),
             hubs: $event->legacyGame->hubs->map(fn ($hub) => GameSetData::from($hub))->all(),
+            followedPlayerCompletions: (new BuildFollowedPlayerCompletionAction())->execute($user, $event->legacyGame),
             playerGame: $playerGame ? PlayerGameData::fromPlayerGame($playerGame) : null,
             playerGameProgressionAwards: $user
                 ? PlayerGameProgressionAwardsData::fromArray(getUserGameProgressionAwards($event->legacyGame->id, $user))

--- a/app/Platform/Data/EventShowPagePropsData.php
+++ b/app/Platform/Data/EventShowPagePropsData.php
@@ -5,17 +5,22 @@ declare(strict_types=1);
 namespace App\Platform\Data;
 
 use App\Data\UserPermissionsData;
+use Illuminate\Support\Collection;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
 #[TypeScript('EventShowPagePropsData')]
 class EventShowPagePropsData extends Data
 {
+    /**
+     * @param Collection<int, FollowedPlayerCompletionData> $followedPlayerCompletions
+     */
     public function __construct(
         public EventData $event,
         public UserPermissionsData $can,
         /** @var GameSetData[] */
         public array $hubs,
+        public Collection $followedPlayerCompletions,
         public ?PlayerGameData $playerGame,
         public ?PlayerGameProgressionAwardsData $playerGameProgressionAwards,
     ) {

--- a/app/Platform/Data/FollowedPlayerCompletionData.php
+++ b/app/Platform/Data/FollowedPlayerCompletionData.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Data;
+
+use App\Data\UserData;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript('FollowedPlayerCompletion')]
+class FollowedPlayerCompletionData extends Data
+{
+    public function __construct(
+        public UserData $user,
+        public PlayerGameData $playerGame,
+    ) {
+    }
+}

--- a/database/factories/UserRelationFactory.php
+++ b/database/factories/UserRelationFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Community\Enums\UserRelationship;
+use App\Models\User;
+use App\Models\UserRelation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<UserRelation>
+ */
+class UserRelationFactory extends Factory
+{
+    protected $model = UserRelation::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'related_user_id' => User::factory(),
+            'Friendship' => fake()->randomElement(UserRelationship::cases()),
+            'Created' => now(),
+            'Updated' => now(),
+        ];
+    }
+
+    public function following(): self
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'Friendship' => UserRelationship::Following,
+            ];
+        });
+    }
+
+    public function notFollowing(): self
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'Friendship' => UserRelationship::NotFollowing,
+            ];
+        });
+    }
+
+    public function blocked(): self
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'Friendship' => UserRelationship::Blocked,
+            ];
+        });
+    }
+}

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -783,5 +783,10 @@
     "Please provide as much information as possible about the issue.": "Please provide as much information as possible about the issue.",
     "No users found.": "No users found.",
     "type a username...": "type a username...",
-    "Hubs": "Hubs"
+    "Hubs": "Hubs",
+    "Compare Progress": "Compare Progress",
+    "Navigate to {{gameTitle}}": "Navigate to {{gameTitle}}",
+    "No one you follow has unlocked any achievements for this event.": "No one you follow has unlocked any achievements for this event.",
+    "compare with any user...": "compare with any user...",
+    "See {{val, number}} more": "See {{val, number}} more"
 }

--- a/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.test.tsx
+++ b/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.test.tsx
@@ -168,6 +168,33 @@ describe('Component: PlayerGameProgressBar', () => {
     expect(tooltipEl).toHaveTextContent(/mastered/i);
   });
 
+  it('given variant is "event" and pointsTotal equals achievementsPublished, does not show points metadata in the tooltip', async () => {
+    // ARRANGE
+    const system = createSystem({ id: 1 });
+    const game = createGame({ system, achievementsPublished: 400, pointsTotal: 400 });
+    const playerGame = createPlayerGame({
+      achievementsUnlocked: 8,
+      achievementsUnlockedHardcore: 8,
+      achievementsUnlockedSoftcore: 0,
+      pointsHardcore: 285,
+      highestAward: createPlayerBadge({
+        awardType: AwardType.Mastery,
+        awardDataExtra: 1,
+        awardDate: new Date('2023-05-06').toISOString(),
+      }),
+    });
+
+    render(<PlayerGameProgressBar game={game} playerGame={playerGame} variant="event" />);
+
+    // ACT
+    await userEvent.hover(screen.getByRole('progressbar'));
+
+    // ASSERT
+    const tooltipEl = await screen.findByRole('tooltip');
+
+    expect(tooltipEl).not.toHaveTextContent(/points/i);
+  });
+
   it('given the user has unlocked all the achievements for the game, shows no achievements or points metadata in the tooltip', async () => {
     // ARRANGE
     const system = createSystem({ id: 1 });

--- a/resources/js/common/components/UserAvatar/UserAvatar.tsx
+++ b/resources/js/common/components/UserAvatar/UserAvatar.tsx
@@ -6,14 +6,16 @@ import { cn } from '@/common/utils/cn';
 
 type UserAvatarProps = BaseAvatarProps &
   App.Data.User & {
+    labelClassName?: string;
     wrapperClassName?: string;
   };
 
 export const UserAvatar: FC<UserAvatarProps> = ({
   avatarUrl,
-  displayName,
   deletedAt,
+  displayName,
   imgClassName,
+  labelClassName,
   wrapperClassName,
   hasTooltip = true,
   showImage = true,
@@ -44,7 +46,7 @@ export const UserAvatar: FC<UserAvatarProps> = ({
       ) : null}
 
       {displayName && showLabel ? (
-        <span className={cn(deletedAt ? 'line-through' : null)}>{displayName}</span>
+        <span className={cn(deletedAt ? 'line-through' : null, labelClassName)}>{displayName}</span>
       ) : null}
     </Wrapper>
   );

--- a/resources/js/features/events/components/+show-sidebar/EventShowSidebarRoot.tsx
+++ b/resources/js/features/events/components/+show-sidebar/EventShowSidebarRoot.tsx
@@ -3,13 +3,15 @@ import type { FC } from 'react';
 import { usePageProps } from '@/common/hooks/usePageProps';
 
 import { BoxArtImage } from '../BoxArtImage';
+import { CompareProgress } from '../CompareProgress';
 import { EventAwardTiers } from '../EventAwardTiers';
 import { EventProgress } from '../EventProgress';
 import { HubsList } from '../HubsList';
 import { OfficialForumTopicButton } from '../OfficialForumTopicButton';
 
 export const EventShowSidebarRoot: FC = () => {
-  const { event, hubs, playerGame } = usePageProps<App.Platform.Data.EventShowPagePropsData>();
+  const { event, followedPlayerCompletions, hubs, playerGame } =
+    usePageProps<App.Platform.Data.EventShowPagePropsData>();
 
   return (
     <div data-testid="sidebar" className="flex flex-col gap-6">
@@ -18,6 +20,10 @@ export const EventShowSidebarRoot: FC = () => {
       <EventProgress event={event} playerGame={playerGame} />
       <EventAwardTiers event={event} />
       <HubsList hubs={hubs} />
+      <CompareProgress
+        followedPlayerCompletions={followedPlayerCompletions}
+        game={event.legacyGame!}
+      />
     </div>
   );
 };

--- a/resources/js/features/events/components/CompareProgress/CompareProgress.test.tsx
+++ b/resources/js/features/events/components/CompareProgress/CompareProgress.test.tsx
@@ -1,0 +1,159 @@
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+
+import { createAuthenticatedUser } from '@/common/models';
+import { render, screen, waitFor } from '@/test';
+import { createFollowedPlayerCompletion, createGame, createUser } from '@/test/factories';
+
+import { CompareProgress } from './CompareProgress';
+
+// Suppress JSDOM errors that are not relevant.
+console.error = vi.fn();
+
+describe('Component: CompareProgress', () => {
+  const mockLocationAssign = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    Object.defineProperty(window, 'location', {
+      value: { assign: mockLocationAssign },
+      writable: true,
+    });
+  });
+
+  it('renders without crashing', () => {
+    // ARRANGE
+    const followedPlayerCompletions = [createFollowedPlayerCompletion()];
+    const game = createGame();
+
+    const { container } = render(
+      <CompareProgress followedPlayerCompletions={followedPlayerCompletions} game={game} />,
+      {
+        pageProps: {
+          auth: { user: createAuthenticatedUser() },
+        },
+      },
+    );
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given the user is not authenticated, renders nothing', () => {
+    // ARRANGE
+    const followedPlayerCompletions = [createFollowedPlayerCompletion()];
+    const game = createGame();
+
+    render(<CompareProgress followedPlayerCompletions={followedPlayerCompletions} game={game} />, {
+      pageProps: {
+        auth: null,
+      },
+    });
+
+    // ASSERT
+    expect(screen.queryByTestId('compare-progress')).not.toBeInTheDocument();
+  });
+
+  it('given no followed users, shows a message', () => {
+    // ARRANGE
+    const followedPlayerCompletions: App.Platform.Data.FollowedPlayerCompletion[] = [];
+    const game = createGame();
+
+    render(<CompareProgress followedPlayerCompletions={followedPlayerCompletions} game={game} />, {
+      pageProps: {
+        auth: { user: createAuthenticatedUser() },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText(/no one you follow has unlocked any achievements/i)).toBeVisible();
+  });
+
+  it('given there are followed users, renders the PopulatedPlayerCompletions component', () => {
+    // ARRANGE
+    const followedPlayerCompletions = [
+      createFollowedPlayerCompletion({
+        user: createUser({ displayName: 'FollowedUser1' }),
+      }),
+    ];
+    const game = createGame();
+
+    render(<CompareProgress followedPlayerCompletions={followedPlayerCompletions} game={game} />, {
+      pageProps: {
+        auth: { user: createAuthenticatedUser() },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText('FollowedUser1')).toBeVisible();
+    expect(
+      screen.queryByText(/no one you follow has unlocked any achievements/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('given the user selects a player to compare with, navigates to the compare page', async () => {
+    // ARRANGE
+    const followedPlayerCompletions = [createFollowedPlayerCompletion()];
+    const game = createGame({ id: 123 });
+    const searchResult = createUser({ displayName: 'CompareUser' });
+
+    // Use the same pattern as in CreateMessageThreadForm test
+    vi.spyOn(axios, 'get').mockImplementation((url) => {
+      if (url.includes('api.search.index')) {
+        return Promise.resolve({ data: { users: [searchResult] } });
+      }
+
+      return Promise.reject(new Error('Not mocked'));
+    });
+
+    render(<CompareProgress followedPlayerCompletions={followedPlayerCompletions} game={game} />, {
+      pageProps: {
+        auth: { user: createAuthenticatedUser() },
+      },
+    });
+
+    // ACT
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.type(screen.getByPlaceholderText(/type a username/i), 'CompareUser');
+    await waitFor(() => {
+      expect(screen.getByText('CompareUser')).toBeVisible();
+    });
+    await userEvent.click(screen.getByText('CompareUser'));
+
+    // ASSERT
+    expect(mockLocationAssign).toHaveBeenCalledWith(
+      route('game.compare-unlocks', { user: 'CompareUser', game: 123 }),
+    );
+  });
+
+  it('given the component renders, displays the correct heading', () => {
+    // ARRANGE
+    const followedPlayerCompletions = [createFollowedPlayerCompletion()];
+    const game = createGame();
+
+    render(<CompareProgress followedPlayerCompletions={followedPlayerCompletions} game={game} />, {
+      pageProps: {
+        auth: { user: createAuthenticatedUser() },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText(/compare progress/i)).toBeVisible();
+  });
+
+  it('given the component renders, displays the select with the correct placeholder', () => {
+    // ARRANGE
+    const followedPlayerCompletions = [createFollowedPlayerCompletion()];
+    const game = createGame();
+
+    render(<CompareProgress followedPlayerCompletions={followedPlayerCompletions} game={game} />, {
+      pageProps: {
+        auth: { user: createAuthenticatedUser() },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText(/compare with any user/i)).toBeVisible();
+  });
+});

--- a/resources/js/features/events/components/CompareProgress/CompareProgress.tsx
+++ b/resources/js/features/events/components/CompareProgress/CompareProgress.tsx
@@ -1,0 +1,90 @@
+import { type FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { BaseSelectAsync } from '@/common/components/+vendor/BaseSelectAsync';
+import { BaseSeparator } from '@/common/components/+vendor/BaseSeparator';
+import { useSearchQuery } from '@/common/hooks/queries/useSearchQuery';
+import { usePageProps } from '@/common/hooks/usePageProps';
+
+import { PopulatedPlayerCompletions } from './PopulatedPlayerCompletions';
+import { useSelectAutoWidth } from './useSelectAutoWidth';
+
+interface CompareProgressProps {
+  followedPlayerCompletions: App.Platform.Data.FollowedPlayerCompletion[];
+  game: App.Platform.Data.Game;
+
+  // TODO variant: 'game' | 'event'
+}
+
+export const CompareProgress: FC<CompareProgressProps> = ({ followedPlayerCompletions, game }) => {
+  const { auth } = usePageProps();
+
+  const { t } = useTranslation();
+
+  const query = useSearchQuery();
+
+  const { autoWidth, autoWidthContainerRef } = useSelectAutoWidth();
+
+  const [userValue, setUserValue] = useState('');
+
+  if (!auth?.user) {
+    return null;
+  }
+
+  const handleUserSelect = (selectedDisplayName: string) => {
+    setUserValue(selectedDisplayName);
+
+    window.location.assign(
+      route('game.compare-unlocks', { user: selectedDisplayName, game: game.id }),
+    );
+  };
+
+  const canShowPlayerCompletions = !!followedPlayerCompletions.length;
+
+  return (
+    <div data-testid="compare-progress">
+      <h2 className="mb-0 border-0 text-lg font-semibold">{t('Compare Progress')}</h2>
+
+      <div className="flex flex-col gap-3 rounded-lg bg-embed p-3">
+        <div className="flex flex-col">
+          {canShowPlayerCompletions ? (
+            <PopulatedPlayerCompletions
+              followedPlayerCompletions={followedPlayerCompletions}
+              game={game}
+            />
+          ) : (
+            <p>{t('No one you follow has unlocked any achievements for this event.')}</p>
+          )}
+        </div>
+
+        <BaseSeparator />
+
+        <div className="w-full" ref={autoWidthContainerRef}>
+          <BaseSelectAsync<App.Data.User>
+            query={query}
+            noResultsMessage={t('No users found.')}
+            popoverPlaceholder={t('type a username...')}
+            triggerClassName="w-full"
+            value={userValue}
+            onChange={handleUserSelect}
+            width={autoWidth}
+            placeholder={t('compare with any user...')}
+            getOptionValue={(user) => user.displayName}
+            getDisplayValue={(user) => (
+              <div className="flex items-center gap-2">
+                <img className="size-6 rounded-sm" src={user.avatarUrl} />
+                <span className="font-medium">{user.displayName}</span>
+              </div>
+            )}
+            renderOption={(user) => (
+              <div className="flex items-center gap-2">
+                <img className="size-6 rounded-sm" src={user.avatarUrl} />
+                <span className="font-medium">{user.displayName}</span>
+              </div>
+            )}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/resources/js/features/events/components/CompareProgress/PopulatedPlayerCompletions/PopulatedPlayerCompletions.test.tsx
+++ b/resources/js/features/events/components/CompareProgress/PopulatedPlayerCompletions/PopulatedPlayerCompletions.test.tsx
@@ -1,0 +1,99 @@
+import userEvent from '@testing-library/user-event';
+
+import { render, screen, waitFor } from '@/test';
+import { createFollowedPlayerCompletion, createGame, createUser } from '@/test/factories';
+
+import { PopulatedPlayerCompletions } from './PopulatedPlayerCompletions';
+
+describe('Component: PopulatedPlayerCompletions', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const followedPlayerCompletions = [createFollowedPlayerCompletion()];
+    const game = createGame();
+
+    const { container } = render(
+      <PopulatedPlayerCompletions
+        followedPlayerCompletions={followedPlayerCompletions}
+        game={game}
+      />,
+    );
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given more than 11 users, displays the first 10 and hides the rest', () => {
+    // ARRANGE
+    const followedPlayerCompletions = Array.from({ length: 15 }, (_, index) =>
+      createFollowedPlayerCompletion({ user: createUser({ displayName: `User ${index + 1}` }) }),
+    );
+    const game = createGame();
+
+    render(
+      <PopulatedPlayerCompletions
+        followedPlayerCompletions={followedPlayerCompletions}
+        game={game}
+      />,
+    );
+
+    // ASSERT
+    // ... only the first 10 should be visible initially ...
+    for (let i = 1; i <= 10; i += 1) {
+      expect(screen.getByText(`User ${i}`)).toBeVisible();
+    }
+
+    // ... users 11-15 should not be visible initially ...
+    for (let i = 11; i <= 15; i += 1) {
+      expect(screen.queryByText(`User ${i}`)).not.toBeInTheDocument();
+    }
+
+    expect(screen.getByText(/see 5 more/i)).toBeVisible();
+  });
+
+  it('given exactly 11 users, displays all of them without a "See more" button', () => {
+    // ARRANGE
+    const followedPlayerCompletions = Array.from({ length: 11 }, (_, index) =>
+      createFollowedPlayerCompletion({ user: createUser({ displayName: `User ${index + 1}` }) }),
+    );
+    const game = createGame();
+
+    render(
+      <PopulatedPlayerCompletions
+        followedPlayerCompletions={followedPlayerCompletions}
+        game={game}
+      />,
+    );
+
+    // ASSERT
+    for (let i = 1; i <= 11; i += 1) {
+      expect(screen.getByText(`User ${i}`)).toBeVisible();
+    }
+
+    expect(screen.queryByText(/see more/i)).not.toBeInTheDocument();
+  });
+
+  it('given the user clicks the "See more" button, expands to show all users', async () => {
+    // ARRANGE
+    const followedPlayerCompletions = Array.from({ length: 15 }, (_, index) =>
+      createFollowedPlayerCompletion({ user: createUser({ displayName: `User ${index + 1}` }) }),
+    );
+    const game = createGame();
+
+    render(
+      <PopulatedPlayerCompletions
+        followedPlayerCompletions={followedPlayerCompletions}
+        game={game}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: /see 5 more/i }));
+
+    // ASSERT
+    await waitFor(() => {
+      for (let i = 1; i <= 15; i += 1) {
+        expect(screen.getByText(`User ${i}`)).toBeVisible();
+      }
+    });
+  });
+});

--- a/resources/js/features/events/components/CompareProgress/PopulatedPlayerCompletions/PopulatedPlayerCompletions.tsx
+++ b/resources/js/features/events/components/CompareProgress/PopulatedPlayerCompletions/PopulatedPlayerCompletions.tsx
@@ -1,0 +1,125 @@
+import { AnimatePresence } from 'motion/react';
+import * as motion from 'motion/react-m';
+import { type FC, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LuChevronDown } from 'react-icons/lu';
+
+import { BaseButton } from '@/common/components/+vendor/BaseButton';
+import {
+  BaseCollapsible,
+  BaseCollapsibleContent,
+  BaseCollapsibleTrigger,
+} from '@/common/components/+vendor/BaseCollapsible';
+import { PlayerGameProgressBar } from '@/common/components/PlayerGameProgressBar';
+import { UserAvatar } from '@/common/components/UserAvatar';
+import { cn } from '@/common/utils/cn';
+
+interface PopulatedPlayerCompletionsProps {
+  followedPlayerCompletions: App.Platform.Data.FollowedPlayerCompletion[];
+  game: App.Platform.Data.Game;
+}
+
+export const PopulatedPlayerCompletions: FC<PopulatedPlayerCompletionsProps> = ({
+  followedPlayerCompletions,
+  game,
+}) => {
+  const { t } = useTranslation();
+
+  const [isRemainingContentOpen, setIsRemainingContentOpen] = useState(false);
+
+  const remainingContentRef = useRef<HTMLDivElement>(null);
+  const [remainingContentHeight, setRemainingContentHeight] = useState(0);
+
+  useEffect(() => {
+    if (remainingContentRef.current) {
+      setRemainingContentHeight(remainingContentRef.current.offsetHeight);
+    }
+  }, [isRemainingContentOpen]);
+
+  // If there are 11 total players (10 + 1), show all of them at once.
+  const shouldShowAllAtOnce = followedPlayerCompletions.length === 11;
+
+  // If showing all at once, display all completions, otherwise only display the first 10.
+  const initialVisible = shouldShowAllAtOnce
+    ? followedPlayerCompletions
+    : followedPlayerCompletions.slice(0, 10);
+
+  // Only calculate remaining if we're not showing all at once.
+  const remaining = shouldShowAllAtOnce ? [] : followedPlayerCompletions.slice(10);
+
+  return (
+    <div>
+      <PlayerCompletionList completions={initialVisible} game={game} />
+
+      {remaining.length > 0 ? (
+        <BaseCollapsible open={isRemainingContentOpen} onOpenChange={setIsRemainingContentOpen}>
+          <BaseCollapsibleTrigger asChild>
+            <BaseButton size="sm" className="mt-2 w-full justify-center border-none">
+              {t('See {{val, number}} more', { val: remaining.length })}
+
+              <LuChevronDown
+                className={cn(
+                  'ml-1 size-4 transition-transform duration-300',
+                  isRemainingContentOpen ? 'rotate-180' : 'rotate-0',
+                )}
+              />
+            </BaseButton>
+          </BaseCollapsibleTrigger>
+
+          <AnimatePresence initial={false}>
+            {isRemainingContentOpen ? (
+              <BaseCollapsibleContent forceMount asChild>
+                <motion.div
+                  initial={{ height: 0 }}
+                  animate={{ height: remainingContentHeight }}
+                  exit={{ height: 0 }}
+                  transition={{
+                    duration: 0.3,
+                    ease: [0.4, 0, 0.2, 1],
+                  }}
+                  className="overflow-hidden"
+                >
+                  <div ref={remainingContentRef}>
+                    <PlayerCompletionList completions={remaining} game={game} />
+                  </div>
+                </motion.div>
+              </BaseCollapsibleContent>
+            ) : null}
+          </AnimatePresence>
+        </BaseCollapsible>
+      ) : null}
+    </div>
+  );
+};
+
+interface PlayerCompletionListProps {
+  completions: App.Platform.Data.FollowedPlayerCompletion[];
+  game: App.Platform.Data.Game;
+}
+
+const PlayerCompletionList: FC<PlayerCompletionListProps> = ({ completions, game }) => {
+  return (
+    <ul className="zebra-list">
+      {completions.map((completion) => (
+        <li
+          className="flex w-full items-center justify-between gap-2 p-2"
+          key={`completion-${completion.user.displayName}`}
+        >
+          <span className="lg:w-[130px] xl:w-[176px]">
+            <UserAvatar {...completion.user} size={24} labelClassName="truncate" />
+          </span>
+          <PlayerGameProgressBar
+            playerGame={completion.playerGame}
+            game={game}
+            variant="event"
+            width={108}
+            href={route('game.compare-unlocks', {
+              game: game.id,
+              user: completion.user.displayName,
+            })}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/resources/js/features/events/components/CompareProgress/PopulatedPlayerCompletions/index.ts
+++ b/resources/js/features/events/components/CompareProgress/PopulatedPlayerCompletions/index.ts
@@ -1,0 +1,1 @@
+export * from './PopulatedPlayerCompletions';

--- a/resources/js/features/events/components/CompareProgress/index.ts
+++ b/resources/js/features/events/components/CompareProgress/index.ts
@@ -1,0 +1,1 @@
+export * from './CompareProgress';

--- a/resources/js/features/events/components/CompareProgress/useSelectAutoWidth.ts
+++ b/resources/js/features/events/components/CompareProgress/useSelectAutoWidth.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useSelectAutoWidth() {
+  const [autoWidth, setAutoWidth] = useState(0);
+
+  const autoWidthContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const updateWidth = () => {
+      if (autoWidthContainerRef.current) {
+        setAutoWidth(autoWidthContainerRef.current.offsetWidth);
+      }
+    };
+
+    updateWidth();
+    window.addEventListener('resize', updateWidth);
+
+    return () => {
+      window.removeEventListener('resize', updateWidth);
+    };
+  }, []);
+
+  return { autoWidth, autoWidthContainerRef };
+}

--- a/resources/js/test/factories/createFollowedPlayerCompletion.ts
+++ b/resources/js/test/factories/createFollowedPlayerCompletion.ts
@@ -1,0 +1,11 @@
+import { createFactory } from '../createFactory';
+import { createPlayerGame } from './createPlayerGame';
+import { createUser } from './createUser';
+
+export const createFollowedPlayerCompletion =
+  createFactory<App.Platform.Data.FollowedPlayerCompletion>(() => {
+    return {
+      playerGame: createPlayerGame(),
+      user: createUser(),
+    };
+  });

--- a/resources/js/test/factories/index.ts
+++ b/resources/js/test/factories/index.ts
@@ -6,6 +6,7 @@ export * from './createComment';
 export * from './createEmulator';
 export * from './createEventAchievement';
 export * from './createEventAward';
+export * from './createFollowedPlayerCompletion';
 export * from './createForum';
 export * from './createForumCategory';
 export * from './createForumTopic';

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -495,8 +495,13 @@ declare namespace App.Platform.Data {
     event: App.Platform.Data.Event;
     can: App.Data.UserPermissions;
     hubs: Array<App.Platform.Data.GameSet>;
+    followedPlayerCompletions: Array<App.Platform.Data.FollowedPlayerCompletion>;
     playerGame: App.Platform.Data.PlayerGame | null;
     playerGameProgressionAwards: App.Platform.Data.PlayerGameProgressionAwards | null;
+  };
+  export type FollowedPlayerCompletion = {
+    user: App.Data.User;
+    playerGame: App.Platform.Data.PlayerGame;
   };
   export type GameClaimant = {
     user: App.Data.User;

--- a/tests/Feature/Platform/Action/BuildFollowedPlayerCompletionActionTest.php
+++ b/tests/Feature/Platform/Action/BuildFollowedPlayerCompletionActionTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Platform\Actions;
+
+use App\Models\Game;
+use App\Models\PlayerGame;
+use App\Models\System;
+use App\Models\User;
+use App\Models\UserRelation;
+use App\Platform\Actions\BuildFollowedPlayerCompletionAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BuildFollowedPlayerCompletionActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testItReturnsEmptyCollectionWhenUserIsNull(): void
+    {
+        // Arrange
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['ConsoleID' => $system->id]);
+
+        $action = new BuildFollowedPlayerCompletionAction();
+
+        // Act
+        $result = $action->execute(null, $game);
+
+        // Assert
+        $this->assertCount(0, $result);
+    }
+
+    public function testItReturnsEmptyCollectionWhenUserHasNoFollowedPlayers(): void
+    {
+        // Arrange
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['ConsoleID' => $system->id]);
+        $user = User::factory()->create();
+
+        $action = new BuildFollowedPlayerCompletionAction();
+
+        // Act
+        $result = $action->execute($user, $game);
+
+        // Assert
+        $this->assertCount(0, $result);
+    }
+
+    public function testItReturnsEmptyCollectionWhenFollowedPlayersHaveNoGameProgress(): void
+    {
+        // Arrange
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['ConsoleID' => $system->id]);
+        $user = User::factory()->create();
+        $followedUser = User::factory()->create();
+
+        UserRelation::factory()->following()->create([
+            'user_id' => $user->id,
+            'related_user_id' => $followedUser->id,
+        ]);
+
+        PlayerGame::factory()->create([
+            'user_id' => $followedUser->id,
+            'game_id' => $game->id,
+            'achievements_unlocked' => 0,
+            'achievements_unlocked_hardcore' => 0,
+        ]);
+
+        $action = new BuildFollowedPlayerCompletionAction();
+
+        // Act
+        $result = $action->execute($user, $game);
+
+        // Assert
+        $this->assertCount(0, $result);
+    }
+
+    public function testItReturnsFollowedPlayersWithUnlockedAchievements(): void
+    {
+        // Arrange
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['ConsoleID' => $system->id]);
+        $user = User::factory()->create();
+        $followedUser = User::factory()->create();
+
+        UserRelation::factory()->following()->create([
+            'user_id' => $user->id,
+            'related_user_id' => $followedUser->id,
+        ]);
+
+        PlayerGame::factory()->create([
+            'user_id' => $followedUser->id,
+            'game_id' => $game->id,
+            'achievements_unlocked' => 5,
+            'achievements_unlocked_hardcore' => 3,
+            'achievements_unlocked_softcore' => 2,
+            'achievements_total' => 10,
+            'points' => 50,
+            'points_hardcore' => 30,
+            'points_total' => 100,
+        ]);
+
+        $action = new BuildFollowedPlayerCompletionAction();
+
+        // Act
+        $result = $action->execute($user, $game);
+
+        // Assert
+        $this->assertCount(1, $result);
+        $this->assertEquals($followedUser->id, $result->first()->user->id->resolve());
+        $this->assertEquals(5, $result->first()->playerGame->achievementsUnlocked);
+        $this->assertEquals(3, $result->first()->playerGame->achievementsUnlockedHardcore);
+        $this->assertEquals(2, $result->first()->playerGame->achievementsUnlockedSoftcore);
+        $this->assertEquals(50, $result->first()->playerGame->points);
+        $this->assertEquals(30, $result->first()->playerGame->pointsHardcore);
+    }
+
+    public function testItSortsFollowedPlayersByHardcoreUnlocksThenSoftcoreUnlocks(): void
+    {
+        // Arrange
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['ConsoleID' => $system->id]);
+        $user = User::factory()->create();
+
+        // ... create three followed users with different unlock patterns ...
+        $user1 = User::factory()->create(['User' => 'User1']); // will have most hardcore unlocks
+        $user2 = User::factory()->create(['User' => 'User2']); // will have second-most hardcore, but most total
+        $user3 = User::factory()->create(['User' => 'User3']); // will have least unlocks overall
+
+        UserRelation::factory()->following()->create([
+            'user_id' => $user->id,
+            'related_user_id' => $user1->id,
+        ]);
+        UserRelation::factory()->following()->create([
+            'user_id' => $user->id,
+            'related_user_id' => $user2->id,
+        ]);
+        UserRelation::factory()->following()->create([
+            'user_id' => $user->id,
+            'related_user_id' => $user3->id,
+        ]);
+
+        PlayerGame::factory()->create([
+            'user_id' => $user1->id,
+            'game_id' => $game->id,
+            'achievements_unlocked' => 8,
+            'achievements_unlocked_hardcore' => 7, // !! most hardcore
+            'achievements_unlocked_softcore' => 1,
+        ]);
+
+        PlayerGame::factory()->create([
+            'user_id' => $user2->id,
+            'game_id' => $game->id,
+            'achievements_unlocked' => 10, // !! most total
+            'achievements_unlocked_hardcore' => 5,
+            'achievements_unlocked_softcore' => 5,
+        ]);
+
+        PlayerGame::factory()->create([
+            'user_id' => $user3->id,
+            'game_id' => $game->id,
+            'achievements_unlocked' => 3,
+            'achievements_unlocked_hardcore' => 2,
+            'achievements_unlocked_softcore' => 1,
+        ]);
+
+        $action = new BuildFollowedPlayerCompletionAction();
+
+        // Act
+        $result = $action->execute($user, $game);
+
+        // Assert
+        $this->assertCount(3, $result);
+
+        // ... user1 (most hardcore) ...
+        $this->assertEquals($user1->id, $result[0]->user->id->resolve());
+        $this->assertEquals(7, $result[0]->playerGame->achievementsUnlockedHardcore);
+
+        // ... user2 (second most hardcore) ...
+        $this->assertEquals($user2->id, $result[1]->user->id->resolve());
+        $this->assertEquals(5, $result[1]->playerGame->achievementsUnlockedHardcore);
+
+        // ... user3 (least hardcore) ...
+        $this->assertEquals($user3->id, $result[2]->user->id->resolve());
+        $this->assertEquals(2, $result[2]->playerGame->achievementsUnlockedHardcore);
+    }
+
+    public function testItOnlyIncludesFollowingRelationshipsNotOtherTypes(): void
+    {
+        // Arrange
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['ConsoleID' => $system->id]);
+        $user = User::factory()->create();
+
+        $followedUser = User::factory()->create();
+        $blockedUser = User::factory()->create();
+
+        UserRelation::factory()->following()->create([
+            'user_id' => $user->id,
+            'related_user_id' => $followedUser->id,
+        ]);
+        UserRelation::factory()->blocked()->create([
+            'user_id' => $user->id,
+            'related_user_id' => $blockedUser->id,
+        ]);
+
+        PlayerGame::factory()->create([
+            'user_id' => $followedUser->id,
+            'game_id' => $game->id,
+            'achievements_unlocked' => 5,
+            'achievements_unlocked_hardcore' => 3,
+        ]);
+        PlayerGame::factory()->create([
+            'user_id' => $blockedUser->id,
+            'game_id' => $game->id,
+            'achievements_unlocked' => 8,
+            'achievements_unlocked_hardcore' => 6,
+        ]);
+
+        $action = new BuildFollowedPlayerCompletionAction();
+
+        // Act
+        $result = $action->execute($user, $game);
+
+        // Assert
+        $this->assertCount(1, $result);
+        $this->assertEquals($followedUser->id, $result->first()->user->id->resolve());
+
+        // ... ensure the blocked user is not included ...
+        $this->assertFalse($result->contains(fn ($item) => $item->user->id->resolve() === $blockedUser->id));
+    }
+}


### PR DESCRIPTION
This PR adds the "Compare Progress" component to the event page sidebar.

The back-end code includes optimizations from #3263.

An additional nuance of this new UI is the "See N more" button. Returning 50 results is still probably fine, but showing them all on load is very likely undesirable, as it forces the component to occupy the great majority of sidebar space.

The button will never read "See 1 more":
* If there are 50 results, 10 will be shown and 40 will be inside the collapse.
* If there are 11 results, all 11 will be shown.
* If there are 12 results, 10 will be shown and 2 will be inside the collapse.

I don't like buttons that expand to show just 1 thing, so trying to avoid that here.

https://github.com/user-attachments/assets/7ef66bd2-3091-488b-8ad6-48cfad31e78c

