### PR TITLE
perf: reduce supervisor-2 maxProcesses to 8

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -221,7 +221,7 @@ return [
             ],
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
-            'maxProcesses' => 15,
+            'maxProcesses' => 8,
             'maxTime' => 0,
             'maxJobs' => 0,
             'memory' => 128,


### PR DESCRIPTION
https://discord.com/channels/476211979464343552/718091467893243937/1339221412661170289

If this is too slow, we can try bumping from 8 to 10. Especially on Sundays, this is putting too much pressure on the server.