### PR TITLE
feat(Shortcode): add [hub] and [quote] to stripAndClamp

### DIFF
--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -144,6 +144,21 @@ final class Shortcode
                 return "";
             },
 
+            // "[hub=1]" --> "[Central]"
+            '~\[hub=(\d+)]~i' => function ($matches) {
+                $hubId = (int) $matches[1];
+                $hubData = GameSet::query()
+                    ->where('id', $hubId)
+                    ->where('type', GameSetType::Hub)
+                    ->first();
+
+                if ($hubData) {
+                    return "{$hubData->title} (Hubs)";
+                }
+
+                return "";
+            },
+
             // "[ach=1]" --> "Ring Collector (5)"
             '~\[ach=(\d+)]~i' => function ($matches) {
                 $achievementData = GetAchievementData((int) $matches[1]);
@@ -176,6 +191,9 @@ final class Shortcode
 
             // "[img]https://google.com/icon.png[/img]" --> ""
             '~\[img\](.*?)\[/img\]~i' => '',
+
+            // "[quote]some stuff[/quote]" --> ""
+            '~\[quote\](.*?)\[/quote\]~i' => '',
 
             // "[b]Hello[/b]" --> "Hello"
             '~\[(b|i|u|s|code)\](.*?)\[/\1\]~i' => '$2',

--- a/tests/Feature/Community/ShortcodeTest.php
+++ b/tests/Feature/Community/ShortcodeTest.php
@@ -64,6 +64,14 @@ final class ShortcodeTest extends TestCase
         );
     }
 
+    public function testStripAndClampQuotes(): void
+    {
+        $this->assertSame(
+            '',
+            Shortcode::stripAndClamp('[quote]hello there[/quote]')
+        );
+    }
+
     public function testStripAndClampImages(): void
     {
         $this->assertSame(


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/discussions/3246.

This PR adds `[hub]` and `[quote]` to `Shortcode::stripAndClamp()`, which is responsible for rendering post previews on the home page and recent topics page.

---

**Before**
```
[quote]you are stupid[/quote]
no i'm not
```

**After**
```
no i'm not
```

---

**Before**
```
[hub=1]
```

**After**
```
[Central] (Hubs)
```