### PR TITLE
fix(user): remediate some jrdevs having dead hrefs on their profile

### DIFF
--- a/app/Community/Components/UserProfileMeta.php
+++ b/app/Community/Components/UserProfileMeta.php
@@ -100,7 +100,7 @@ class UserProfileMeta extends Component
         $codeNotesCreatedStat = [
             'label' => 'Code notes created',
             'value' => localized_number($totalAuthoredCodeNotes),
-            'href' => $totalAuthoredCodeNotes ? '/individualdevstats.php?u=' . $user->display_name . '#code-notes' : null,
+            'href' => $userMassData['ContribCount'] > 0 && $totalAuthoredCodeNotes ? '/individualdevstats.php?u=' . $user->display_name . '#code-notes' : null,
             'isMuted' => !$totalAuthoredCodeNotes,
         ];
 
@@ -111,7 +111,7 @@ class UserProfileMeta extends Component
         $leaderboardsCreatedStat = [
             'label' => 'Leaderboards created',
             'value' => localized_number($totalAuthoredLeaderboards),
-            'href' => $totalAuthoredLeaderboards ? '/individualdevstats.php?u=' . $user->display_name : null,
+            'href' => $userMassData['ContribCount'] > 0 && $totalAuthoredLeaderboards ? '/individualdevstats.php?u=' . $user->display_name : null,
             'isMuted' => !$totalAuthoredLeaderboards,
         ];
 


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/3091.

Individual dev stats cannot be viewed if the user has no published achievements on the website.

**Before**
<img width="427" alt="Screenshot 2025-03-18 at 4 32 20 PM" src="https://github.com/user-attachments/assets/f3d9c96a-6bd3-4b49-97d9-6f9cf31ec8be" />


**After**
<img width="427" alt="Screenshot 2025-03-18 at 4 32 10 PM" src="https://github.com/user-attachments/assets/23bce5f5-68cf-4ace-acac-6456bb7bf120" />
