### PR TITLE
fix(DataTableFacetedFilter): respect isSingleSelect on initial values

### DIFF
--- a/app/Platform/Concerns/BuildsGameListQueries.php
+++ b/app/Platform/Concerns/BuildsGameListQueries.php
@@ -405,8 +405,8 @@ trait BuildsGameListQueries
      */
     private function applyAchievementsPublishedFilter(Builder $query, array $filterValues): void
     {
-        // Bail early if necessary. If the user gives both options, it's the "either" case.
-        if (empty($filterValues) || count($filterValues) === 2) {
+        // Bail early if necessary.
+        if (empty($filterValues)) {
             return;
         }
 

--- a/resources/js/features/game-list/components/DataTableFacetedFilter/DataTableFacetedFilter.test.tsx
+++ b/resources/js/features/game-list/components/DataTableFacetedFilter/DataTableFacetedFilter.test.tsx
@@ -434,4 +434,41 @@ describe('Component: DataTableFacetedFilter', () => {
     // ASSERT
     expect(setFilterValueSpy).toHaveBeenCalledWith(['opt1']);
   });
+
+  it('given single select mode with multiple filter values, only keeps the first value in selectedValues', async () => {
+    // ARRANGE
+    const multipleValuesColumn = {
+      ...mockColumn,
+      getFilterValue: vi.fn().mockReturnValue(['opt1', 'opt2', 'opt3']), // !! multiple values
+    } as unknown as Column<any, any>;
+
+    render(
+      <DataTableFacetedFilter
+        options={mockOptions}
+        column={multipleValuesColumn}
+        t_title={'Test Filter' as TranslatedString}
+        isSingleSelect={true} // !!
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: /test filter/i }));
+
+    // ASSERT
+    const option1 = screen.getByRole('option', { name: /option 1/i });
+    const option2 = screen.getByRole('option', { name: /option 2/i });
+    const option3 = screen.getByRole('option', { name: /option 3/i });
+
+    expect(within(option1).getByTestId('filter-option-indicator')).toHaveClass('bg-neutral-700'); // !! selected
+
+    expect(within(option2).getByTestId('filter-option-indicator')).not.toHaveClass(
+      'bg-neutral-700',
+    ); // !! not selected
+    expect(within(option3).getByTestId('filter-option-indicator')).not.toHaveClass(
+      'bg-neutral-700',
+    ); // !! not selected
+
+    expect(screen.getAllByTestId('filter-selected-label')).toHaveLength(1);
+    expect(screen.getByTestId('filter-selected-label')).toHaveTextContent('Option 1');
+  });
 });

--- a/resources/js/features/game-list/components/DataTableFacetedFilter/DataTableFacetedFilter.tsx
+++ b/resources/js/features/game-list/components/DataTableFacetedFilter/DataTableFacetedFilter.tsx
@@ -77,9 +77,15 @@ export function DataTableFacetedFilter<TData, TValue>({
   const { t } = useTranslation();
 
   const facets = column?.getFacetedUniqueValues();
-  const selectedValues = new Set(column?.getFilterValue() as string[]);
   const columnId = column?.id;
   const allFlatOptions = getAllFlatOptions(options);
+
+  const filterValue = column?.getFilterValue() as string[];
+  const selectedValues = new Set(
+    isSingleSelect && Array.isArray(filterValue) && filterValue.length > 1
+      ? [filterValue[0]]
+      : filterValue,
+  );
 
   if (variant === 'drawer') {
     return (


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/pull/3320#discussion_r2009133718.

Now, if multiple values are given for a single-select field, only the first will be respected. Can be tested with a URL like: http://localhost:64000/games?filter%5BachievementsPublished%5D=none%2Ceither