### PR TITLE
fix(SharedHubReason): remediate ssr crash

### DIFF
--- a/resources/js/features/game-list/components/SuggestionReasonCell/SharedHubReason/SharedHubReason.tsx
+++ b/resources/js/features/game-list/components/SuggestionReasonCell/SharedHubReason/SharedHubReason.tsx
@@ -33,7 +33,7 @@ export const SharedHubReason: FC<SharedHubReasonProps> = ({ relatedGame, related
         components={{
           1: <BaseTooltip></BaseTooltip>,
           2: <BaseTooltipTrigger></BaseTooltipTrigger>,
-          3: <a href={route('game.show', { game: relatedGameSet.gameId! })}>{'hub'}</a>,
+          3: <a href={route('hub.show', { gameSet: relatedGameSet.id })}>{'hub'}</a>,
           4: <BaseTooltipContent>{cleanHubTitle(relatedGameSet.title!)}</BaseTooltipContent>,
         }}
         values={{ hubName: cleanHubTitle(relatedGameSet.title!) }}


### PR DESCRIPTION
Resolves this persistent error in the logs:
> Error: Ziggy error: 'game' parameter is required for route 'game.show'.

The root cause is newer hubs without backing games do not have a game ID for `game.show` to use. However, the route should actually be pointed at `hub.show` now.