### PR TITLE
fix(events): always show a virtual tier if there are masteries

### DIFF
--- a/resources/js/features/events/components/EventAwardTiers/EventAwardTiers.test.tsx
+++ b/resources/js/features/events/components/EventAwardTiers/EventAwardTiers.test.tsx
@@ -89,7 +89,21 @@ describe('Component: EventAwardTiers', () => {
     expect(screen.getByText(/1,000 players have earned this/i)).toBeVisible();
   });
 
-  it('given there are no event awards and no event achievements, does not display a virtual award tier', () => {
+  it('given there are no event awards, no event achievements, and no masteries, does not display a virtual award tier', () => {
+    // ARRANGE
+    const event = createRaEvent({
+      legacyGame: createGame(),
+      eventAchievements: [], // !!
+      eventAwards: [], // !!
+    });
+
+    render(<EventAwardTiers event={event} numMasters={0} />);
+
+    // ASSERT
+    expect(screen.queryByText(/1,000 players have earned this/i)).not.toBeInTheDocument();
+  });
+
+  it('given there are no event awards, no event achievements, and masteries, displays a virtual award tier', () => {
     // ARRANGE
     const event = createRaEvent({
       legacyGame: createGame(),
@@ -100,7 +114,7 @@ describe('Component: EventAwardTiers', () => {
     render(<EventAwardTiers event={event} numMasters={1000} />);
 
     // ASSERT
-    expect(screen.queryByText(/1,000 players have earned this/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/1,000 players have earned this/i)).toBeVisible();
   });
 
   it('given we need to create a virtual award tier and some lazy properties are missing, does not crash', () => {

--- a/resources/js/features/events/components/EventAwardTiers/EventAwardTiers.tsx
+++ b/resources/js/features/events/components/EventAwardTiers/EventAwardTiers.tsx
@@ -12,7 +12,7 @@ interface EventAwardTiersProps {
 export const EventAwardTiers: FC<EventAwardTiersProps> = ({ event, numMasters }) => {
   const { t } = useTranslation();
 
-  if (!event.legacyGame?.badgeUrl || !event.eventAchievements?.length) {
+  if (!event.legacyGame?.badgeUrl || (!event.eventAchievements?.length && numMasters === 0)) {
     return null;
   }
 

--- a/resources/js/features/events/utils/createVirtualAward.test.ts
+++ b/resources/js/features/events/utils/createVirtualAward.test.ts
@@ -13,24 +13,6 @@ describe('Util: createVirtualAward', () => {
     expect(createVirtualAward).toBeDefined();
   });
 
-  it('given the event is missing eventAchievements, returns null', () => {
-    // ARRANGE
-    const event = createRaEvent({
-      id: 1,
-      eventAchievements: [], // !!
-      legacyGame: createGame({
-        badgeUrl: 'https://example.com/badge.jpg',
-        title: 'Test Game',
-      }),
-    });
-
-    // ACT
-    const result = createVirtualAward(event, 100);
-
-    // ASSERT
-    expect(result).toBeNull();
-  });
-
   it('given the event is missing legacyGame.badgeUrl, returns null', () => {
     // ARRANGE
     const event = createRaEvent({
@@ -129,26 +111,6 @@ describe('Util: createVirtualAward', () => {
       tierIndex: 0,
       badgeCount: 3,
     });
-  });
-
-  it('given the event has no achievements with points, returns null', () => {
-    // ARRANGE
-    const event = createRaEvent({
-      id: 123,
-      eventAchievements: [
-        createEventAchievement({ achievement: createAchievement({ points: 0 }) }), // !!
-      ],
-      legacyGame: createGame({
-        badgeUrl: 'https://example.com/badge.jpg',
-        title: 'Test Game',
-      }),
-    });
-
-    // ACT
-    const result = createVirtualAward(event, 1);
-
-    // ASSERT
-    expect(result).toBeNull();
   });
 
   it('passes numMasters through to the badgeCount property', () => {

--- a/resources/js/features/events/utils/createVirtualAward.ts
+++ b/resources/js/features/events/utils/createVirtualAward.ts
@@ -8,10 +8,6 @@ export function createVirtualAward(
 
   const pointedEventAchievements = event.eventAchievements.filter((ea) => !!ea.achievement?.points);
 
-  if (!pointedEventAchievements?.length) {
-    return null;
-  }
-
   let totalPoints = 0;
   for (const ea of pointedEventAchievements) {
     // This will always be truthy due to the filter above.


### PR DESCRIPTION
Resolves an issue mentioned in #3346.

Adds some conditional logic for events that have no event achievements but should still have an award tier. The fallback logic is now driven by `numMasters`, which has an extra query in the back-end controller.

<img width="358" alt="Screenshot 2025-03-25 at 4 06 01 PM" src="https://github.com/user-attachments/assets/b56aefc7-925f-4ada-a63a-7b782d1f11ad" />
