### PR TITLE
feat(events): add a proper empty state for achievements

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -846,5 +846,6 @@
     "Homebrew": "Homebrew",
     "Prototype": "Prototype",
     "Unlicensed": "Unlicensed",
-    "Demo": "Demo"
+    "Demo": "Demo",
+    "There aren't any achievements for this event.": "There aren't any achievements for this event."
 }

--- a/resources/js/common/components/EmptyState/EmptyState.test.tsx
+++ b/resources/js/common/components/EmptyState/EmptyState.test.tsx
@@ -11,7 +11,7 @@ describe('Component: EmptyState', () => {
     expect(container).toBeTruthy();
   });
 
-  it('displays an image', () => {
+  it('displays an image by default', () => {
     // ARRANGE
     render(<EmptyState>no results</EmptyState>);
 
@@ -25,5 +25,13 @@ describe('Component: EmptyState', () => {
 
     // ASSERT
     expect(screen.getByText(/no results/i)).toBeVisible();
+  });
+
+  it('allows disabling the image', () => {
+    // ARRANGE
+    render(<EmptyState shouldShowImage={false}>no results</EmptyState>);
+
+    // ASSERT
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 });

--- a/resources/js/common/components/EmptyState/EmptyState.tsx
+++ b/resources/js/common/components/EmptyState/EmptyState.tsx
@@ -2,18 +2,22 @@ import type { FC, ReactNode } from 'react';
 
 interface EmptyStateProps {
   children: ReactNode;
+
+  shouldShowImage?: boolean;
 }
 
-export const EmptyState: FC<EmptyStateProps> = ({ children }) => {
+export const EmptyState: FC<EmptyStateProps> = ({ children, shouldShowImage = true }) => {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-y-2 rounded py-8">
-      <img
-        src="/assets/images/cheevo/confused.webp"
-        alt="empty state"
-        className="h-32 w-32"
-        width={128}
-        height={128}
-      />
+      {shouldShowImage ? (
+        <img
+          src="/assets/images/cheevo/confused.webp"
+          alt="empty state"
+          className="h-32 w-32"
+          width={128}
+          height={128}
+        />
+      ) : null}
 
       <p className="text-balance text-center">{children}</p>
     </div>

--- a/resources/js/features/events/components/EventAchievementSets/EventAchievementSets.test.tsx
+++ b/resources/js/features/events/components/EventAchievementSets/EventAchievementSets.test.tsx
@@ -15,7 +15,7 @@ describe('Component: EventAchievementSets', () => {
     expect(container).toBeTruthy();
   });
 
-  it('given the event has no achievements, renders nothing', () => {
+  it('given the event has no achievements, renders an empty state', () => {
     // ARRANGE
     const event = createRaEvent({
       eventAchievements: undefined,
@@ -25,6 +25,7 @@ describe('Component: EventAchievementSets', () => {
 
     // ASSERT
     expect(screen.queryByTestId('event-achievement-sets')).not.toBeInTheDocument();
+    expect(screen.getByText(/there aren't any achievements for this event/i)).toBeVisible();
   });
 
   it('given the event is evergreen, defaults to display order sort and hides active option', () => {

--- a/resources/js/features/events/components/EventAchievementSets/EventAchievementSets.tsx
+++ b/resources/js/features/events/components/EventAchievementSets/EventAchievementSets.tsx
@@ -1,4 +1,7 @@
 import { type FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { EmptyState } from '@/common/components/EmptyState';
 
 import type { AchievementSortOrder } from '../../models';
 import { AchievementSet } from '../AchievementSet';
@@ -13,13 +16,20 @@ interface EventAchievementSetsProps {
 }
 
 export const EventAchievementSets: FC<EventAchievementSetsProps> = ({ event }) => {
+  const { t } = useTranslation();
+
   const [currentSort, setCurrentSort] = useState<AchievementSortOrder>(
     event.state! === 'evergreen' ? 'displayOrder' : 'active',
   );
 
-  if (!event.eventAchievements) {
-    // TODO empty state
-    return null;
+  if (!event.eventAchievements?.length) {
+    return (
+      <div className="rounded bg-embed">
+        <EmptyState shouldShowImage={false}>
+          {t("There aren't any achievements for this event.")}
+        </EmptyState>
+      </div>
+    );
   }
 
   const achievements = mapEventAchievementsToAchievements(event.eventAchievements);


### PR DESCRIPTION
Implements a TODO on event achievement sets.

**Before**
<img width="888" alt="Screenshot 2025-03-25 at 4 15 11 PM" src="https://github.com/user-attachments/assets/c1e8351d-1b3a-435c-b358-15ea9106b737" />

**After**
<img width="888" alt="Screenshot 2025-03-25 at 4 15 25 PM" src="https://github.com/user-attachments/assets/025318f7-bff9-4892-bcf5-64c702e4e567" />
