### PR TITLE
fix(Event): add more logic to the status property

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -78,6 +78,14 @@ class Event extends BaseModel
         $now = now();
 
         /**
+         * If there are no event achievements, we have nothing to derive an
+         * event state from. It must be concluded.
+         */
+        if ($this->achievements->isEmpty()) {
+            return EventState::Concluded;
+        }
+
+        /**
          * An event is active if:
          * - The conclusion date is in the future, or
          * - Any of the event achievements have an activeUntil date in the future.


### PR DESCRIPTION
If an event has 0 event achievements, it must be concluded.

**Before**
<img width="315" alt="Screenshot 2025-03-25 at 4 30 52 PM" src="https://github.com/user-attachments/assets/094401cc-c61f-4b97-90c5-1ab095f9df49" />


**After**
<img width="328" alt="Screenshot 2025-03-25 at 4 29 53 PM" src="https://github.com/user-attachments/assets/feb6695b-a6fb-413e-8b76-4df6456623eb" />
