### PR TITLE
fix(games): don't malform persisted game type filter

### DIFF
--- a/app/Platform/Requests/GameListRequest.php
+++ b/app/Platform/Requests/GameListRequest.php
@@ -156,8 +156,10 @@ class GameListRequest extends FormRequest
         // If no URL params, check the cookie next.
         if (empty($filters)) {
             $preferences = $this->getCookiePreferences();
-            if ($preferences && !empty($preferences['columnFilters'])) {
-                foreach ($preferences['columnFilters'] as $filter) {
+            $columnFilters = $preferences['columnFilters'] ?? [];
+
+            foreach ($columnFilters as $filter) {
+                if (isset($filter['id'], $filter['value'])) {
                     $value = $filter['value'];
                     $filters[$filter['id']] = is_array($value) ? $value : [$value];
                 }

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/MobileGameTypeFilterSelect/MobileGameTypeFilterSelect.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/MobileGameTypeFilterSelect/MobileGameTypeFilterSelect.test.tsx
@@ -123,4 +123,31 @@ describe('Component: MobileGameTypeFilterSelect', () => {
     // ASSERT
     expect(screen.getByRole('combobox')).toHaveTextContent(/homebrew/i);
   });
+
+  it('given the user selects the "All Games" option, clears the filter value', async () => {
+    // ARRANGE
+    const setColumnFiltersSpy = vi.fn();
+    const mockTable = createMockTable({
+      getState: vi.fn().mockReturnValue({
+        columnFilters: [{ id: 'otherFilter', value: 'someValue' }],
+      }),
+      setColumnFilters: setColumnFiltersSpy,
+    });
+
+    render(<MobileGameTypeFilterSelect table={mockTable as Table<any>} />);
+
+    // ACT
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByTestId('hack-option'));
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByTestId('all-games-option'));
+
+    // ASSERT
+    expect(setColumnFiltersSpy).toHaveBeenCalledWith(expect.any(Function));
+
+    const updateFn = setColumnFiltersSpy.mock.calls[1][0];
+    const result = updateFn([{ id: 'otherFilter', value: 'someValue' }]);
+    expect(result).toEqual([{ id: 'otherFilter', value: 'someValue' }]);
+  });
 });

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/MobileGameTypeFilterSelect/MobileGameTypeFilterSelect.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/MobileGameTypeFilterSelect/MobileGameTypeFilterSelect.tsx
@@ -27,6 +27,12 @@ export function MobileGameTypeFilterSelect<TData>({
       table.getState().columnFilters.find((f) => f.id === 'game-type')?.value ?? [],
 
     setFilterValue: (value) => {
+      if (value[0] === 'null') {
+        table.setColumnFilters((prev) => [...prev.filter((f) => f.id !== 'game-type')]);
+
+        return;
+      }
+
       table.setColumnFilters((prev) => [
         ...prev.filter((f) => f.id !== 'game-type'),
         { id: 'game-type', value },
@@ -52,6 +58,10 @@ export function MobileGameTypeFilterSelect<TData>({
         </BaseSelectTrigger>
 
         <BaseSelectContent>
+          <BaseSelectItem value="null" data-testid="all-games-option">
+            {t('All Games')}
+          </BaseSelectItem>
+
           <BaseSelectItem value="retail" data-testid="retail-option">
             {t('Retail')}
           </BaseSelectItem>

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/MobileSetTypeFilterSelect/MobileSetTypeFilterSelect.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/MobileSetTypeFilterSelect/MobileSetTypeFilterSelect.test.tsx
@@ -114,6 +114,9 @@ describe('Component: MobileSetTypeFilterSelect', () => {
 
     // ACT
     await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(screen.getByTestId('only-games-option'));
+
+    await userEvent.click(screen.getByRole('combobox'));
     await userEvent.click(screen.getByTestId('all-sets-option'));
 
     // ASSERT

--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/MobileSetTypeFilterSelect/MobileSetTypeFilterSelect.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/MobileSetTypeFilterSelect/MobileSetTypeFilterSelect.tsx
@@ -27,6 +27,12 @@ export function MobileSetTypeFilterSelect<TData>({
       table.getState().columnFilters.find((f) => f.id === 'subsets')?.value ?? [],
 
     setFilterValue: (value) => {
+      if (value === undefined) {
+        table.setColumnFilters((prev) => [...prev.filter((f) => f.id !== 'subsets')]);
+
+        return;
+      }
+
       table.setColumnFilters((prev) => [
         ...prev.filter((f) => f.id !== 'subsets'),
         { id: 'subsets', value },

--- a/resources/js/features/game-list/components/DataTableToolbar/GameTypeFilter/GameTypeFilter.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/GameTypeFilter/GameTypeFilter.test.tsx
@@ -123,9 +123,6 @@ describe('Component: GameTypeFilter', () => {
 
     const updateFn = setFiltersSpy.mock.calls[0][0];
     const result = updateFn([{ id: 'otherFilter', value: 'someValue' }]);
-    expect(result).toEqual([
-      { id: 'otherFilter', value: 'someValue' },
-      { id: 'game-type', value: undefined },
-    ]);
+    expect(result).toEqual([{ id: 'otherFilter', value: 'someValue' }]);
   });
 });

--- a/resources/js/features/game-list/components/DataTableToolbar/GameTypeFilter/GameTypeFilter.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/GameTypeFilter/GameTypeFilter.tsx
@@ -18,6 +18,12 @@ export function GameTypeFilter<TData>({ table }: GameTypeFilterProps<TData>) {
       table.getState().columnFilters.find((f) => f.id === 'game-type')?.value ?? [],
 
     setFilterValue: (value) => {
+      if (value === undefined) {
+        table.setColumnFilters((prev) => [...prev.filter((f) => f.id !== 'game-type')]);
+
+        return;
+      }
+
       table.setColumnFilters((prev) => [
         ...prev.filter((f) => f.id !== 'game-type'),
         { id: 'game-type', value },

--- a/resources/js/features/game-list/components/DataTableToolbar/SetTypeFilter/SetTypeFilter.test.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/SetTypeFilter/SetTypeFilter.test.tsx
@@ -111,4 +111,25 @@ describe('Component: SetTypeFilter', () => {
       { id: 'subsets', value: ['only-games'] },
     ]);
   });
+
+  it('given the "All Sets" option is selected, removes the filter from filter state', async () => {
+    // ARRANGE
+    const setFiltersSpy = vi.fn();
+    const mockTableWithSpy = createMockTable({
+      setColumnFilters: setFiltersSpy,
+    });
+
+    render(<SetTypeFilter table={mockTableWithSpy as Table<any>} />);
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: /set type/i }));
+
+    await userEvent.click(screen.getByText(/main sets only/i));
+    await userEvent.click(screen.getByText(/all sets/i));
+
+    // ASSERT
+    const updateFn = setFiltersSpy.mock.calls[1][0]; // !! the 2nd call
+    const result = updateFn([{ id: 'otherFilter', value: 'someValue' }]);
+    expect(result).toEqual([{ id: 'otherFilter', value: 'someValue' }]);
+  });
 });

--- a/resources/js/features/game-list/components/DataTableToolbar/SetTypeFilter/SetTypeFilter.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/SetTypeFilter/SetTypeFilter.tsx
@@ -18,6 +18,12 @@ export function SetTypeFilter<TData>({ table }: SetTypeFilterProps<TData>) {
       table.getState().columnFilters.find((f) => f.id === 'subsets')?.value ?? [],
 
     setFilterValue: (value) => {
+      if (value === undefined) {
+        table.setColumnFilters((prev) => [...prev.filter((f) => f.id !== 'subsets')]);
+
+        return;
+      }
+
       table.setColumnFilters((prev) => [
         ...prev.filter((f) => f.id !== 'subsets'),
         { id: 'subsets', value },


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/3359.

**How to reproduce:**
* Go to any game list page.
* Ensure "Remember my view" is enabled.
* Open the game type filter.
* Select a game type, such as "Hacks".
* Open the game type filter again, and select "All Games".
* Refresh the page.