### PR TITLE
fix(email): remediate wrap and line break issues

### DIFF
--- a/resources/views/mail/community/activity.blade.php
+++ b/resources/views/mail/community/activity.blade.php
@@ -3,11 +3,10 @@
 @php
     $body = '';
     if (!empty($payload)) {
-        $body = htmlspecialchars($payload, ENT_QUOTES, 'UTF-8');
+        $body = $payload;
         $body = Shortcode::stripAndClamp($body, 1850, preserveWhitespace: true);
         $body = str_replace(["\r\n", "\r"], "\n", $body); // Convert to Unix newlines.
-        $body = preg_replace('/\n{3,}/', "\n\n", $body);
-        $body = nl2br($body);
+        $body = preg_replace('/\n{3,}|(<br\s*\/?>\s*){3,}/i', "\n\n", $body);
     }
 
     $url = $urlTarget;

--- a/resources/views/mail/community/activity.blade.php
+++ b/resources/views/mail/community/activity.blade.php
@@ -3,10 +3,11 @@
 @php
     $body = '';
     if (!empty($payload)) {
-        $body = nl2br(Shortcode::stripAndClamp($payload, 1850, preserveWhitespace: true));
+        $body = htmlspecialchars($payload, ENT_QUOTES, 'UTF-8');
+        $body = Shortcode::stripAndClamp($body, 1850, preserveWhitespace: true);
         $body = str_replace(["\r\n", "\r"], "\n", $body); // Convert to Unix newlines.
-        $body = preg_replace('/\n{3,}|(<br\s*\/?>\s*){3,}/i', "\n\n", $body); // Handle both \n and <br>.
-        $body = htmlspecialchars($body, ENT_QUOTES, 'UTF-8');
+        $body = preg_replace('/\n{3,}/', "\n\n", $body);
+        $body = nl2br($body);
     }
 
     $url = $urlTarget;

--- a/resources/views/mail/community/private-message.blade.php
+++ b/resources/views/mail/community/private-message.blade.php
@@ -3,12 +3,13 @@
 @php
     $url = route('message-thread.show', ['messageThread' => $messageThread]);
 
-    $payload = $message->body ?? '';
-    $body = Shortcode::stripAndClamp($payload, 1850, preserveWhitespace: true);
-    $body = str_replace(["\r\n", "\r"], "\n", $body);
-    $body = preg_replace('/\n{3,}/', "\n\n", $body);
-    $body = htmlspecialchars($body, ENT_QUOTES, 'UTF-8');
-    $body = nl2br($body);
+    $body = $message->body ?? '';
+    if (!empty($body)) {
+        $body = Shortcode::stripAndClamp($body, 1850, preserveWhitespace: true);
+        $body = str_replace(["\r\n", "\r"], "\n", $body); // Convert to Unix newlines.
+        $body = preg_replace('/\n{3,}|(<br\s*\/?>\s*){3,}/i', "\n\n", $body);
+        $body = nl2br($body);
+    }
 @endphp
 
 <x-mail::message>

--- a/resources/views/mail/community/private-message.blade.php
+++ b/resources/views/mail/community/private-message.blade.php
@@ -2,12 +2,13 @@
 
 @php
     $url = route('message-thread.show', ['messageThread' => $messageThread]);
-    
+
     $payload = $message->body ?? '';
-    $body = nl2br(Shortcode::stripAndClamp($payload, 1850, preserveWhitespace: true));
-    $body = str_replace(["\r\n", "\r"], "\n", $body); // Convert to Unix newlines.
-    $body = preg_replace('/\n{3,}|(<br\s*\/?>\s*){3,}/i', "\n\n", $body); // Handle both \n and <br>.
+    $body = Shortcode::stripAndClamp($payload, 1850, preserveWhitespace: true);
+    $body = str_replace(["\r\n", "\r"], "\n", $body);
+    $body = preg_replace('/\n{3,}/', "\n\n", $body);
     $body = htmlspecialchars($body, ENT_QUOTES, 'UTF-8');
+    $body = nl2br($body);
 @endphp
 
 <x-mail::message>

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -270,6 +270,7 @@ img {
     background-color: #edf2f7;
     color: #718096;
     padding: 16px;
+    word-break: break-all;
 }
 
 .panel-content p {


### PR DESCRIPTION
This PR remediates two issues in Blade email templates:

* `<br />` tags are no longer printed into the email content.
* Sane line wrapping styles are now applied.