### PR TITLE
perf(achievementInfo): resolve N+1 query problem

### DIFF
--- a/resources/views/pages-legacy/achievementInfo.blade.php
+++ b/resources/views/pages-legacy/achievementInfo.blade.php
@@ -470,18 +470,31 @@ if ($game->system->id === System::Events) {
     if ($unlocks->isEmpty()) {
         echo "Nobody yet! Will you be the first?!<br>";
     } else {
+        $userWinners = $unlocks->pluck('User')->filter()->unique()->values()->toArray();
+        $usersMap = [];
+
+        if (!empty($userWinners)) {
+            $users = User::whereIn('User', $userWinners)->get();
+
+            foreach ($users as $user) {
+                $usersMap[$user->username] = $user;
+            }
+        }
+
         echo "<table class='table-highlight'><tbody>";
         echo "<tr class='do-not-highlight'><th class='w-[50%] xl:w-[60%]'>User</th><th>Mode</th><th class='text-right'>Unlocked</th></tr>";
         $iter = 0;
+
         foreach ($unlocks as $userObject) {
             $userWinner = $userObject['User'];
-            if ($userWinner == null || $userObject['DateAwarded'] == null) {
+            if ($userWinner == null || $userObject['DateAwarded'] == null || !isset($usersMap[$userWinner])) {
                 continue;
             }
+
             $niceDateWon = date("d M, Y H:i", strtotime($userObject['DateAwarded']));
             echo "<tr>";
             echo "<td class='w-[32px]'>";
-            echo userAvatar($userWinner, iconClass: 'mr-2');
+            echo userAvatar($usersMap[$userWinner], iconClass: 'mr-2');
             echo "</td>";
             echo "<td>";
             if ($userObject['HardcoreMode']) {

--- a/resources/views/pages-legacy/achievementInfo.blade.php
+++ b/resources/views/pages-legacy/achievementInfo.blade.php
@@ -470,7 +470,7 @@ if ($game->system->id === System::Events) {
     if ($unlocks->isEmpty()) {
         echo "Nobody yet! Will you be the first?!<br>";
     } else {
-        $userWinners = $unlocks->pluck('User')->filter()->unique()->values()->toArray();
+        $userWinners = $unlocks->pluck('User')->toArray();
         $usersMap = [];
 
         if (!empty($userWinners)) {


### PR DESCRIPTION
Resolves https://retroachievementsorg.sentry.io/issues/35231528/?environment=production&query=is%3Aunresolved%20is%3Afor_review%20assigned_or_suggested%3A%5Bme%2C%20my_teams%2C%20none%5D&referrer=issue-stream&sort=inbox&stream_index=0.

Easily observable at a URL like http://localhost:64000/achievement/237679.

This drops my local query count on the page from 82 to 33.