### PR TITLE
perf(user): resolve more N+1 query issues

### DIFF
--- a/app/Community/Components/UserProgressionStatus.php
+++ b/app/Community/Components/UserProgressionStatus.php
@@ -55,6 +55,9 @@ class UserProgressionStatus extends Component
         $totalCompletedCount = $totalCountsMetrics['numCompleted'];
         $totalMasteredCount = $totalCountsMetrics['numMastered'];
 
+        $systemIds = array_keys($consoleProgress);
+        $systems = System::whereIn('ID', $systemIds)->get()->keyBy('ID');
+
         return view('components.user.progression-status.root', [
             'userCompletionProgress' => $this->userCompletionProgress,
             'userSiteAwards' => $this->userSiteAwards,
@@ -68,6 +71,7 @@ class UserProgressionStatus extends Component
             'totalMasteredCount' => $totalMasteredCount,
             'userHardcorePoints' => $this->userHardcorePoints,
             'userSoftcorePoints' => $this->userSoftcorePoints,
+            'systems' => $systems,
         ]);
     }
 

--- a/resources/views/components/user/progression-status/console-progression-list-item.blade.php
+++ b/resources/views/components/user/progression-status/console-progression-list-item.blade.php
@@ -6,11 +6,10 @@
     'beatenHardcoreCount' => 0,
     'completedCount' => 0,
     'masteredCount' => 0,
+    'systems' => null,
 ])
 
 <?php
-
-use App\Models\System;
 
 $totalBeatenGamesCount = $beatenSoftcoreCount + $beatenHardcoreCount;
 $totalMasteredGamesCount = $completedCount + $masteredCount;
@@ -27,7 +26,11 @@ if ($widthMode !== 'equal' && $widthMode !== 'dynamic') {
     $widthMode = 'equal';
 }
 
-$system = System::find($consoleId);
+$system = null;
+if ($systems && isset($systems[$consoleId])) {
+    $system = $systems[$consoleId];
+}
+
 if ($system) {
     $gameSystemIconSrc = getSystemIconUrl($system);
     $displayLabel = $label ?? $system->name_short;

--- a/resources/views/components/user/progression-status/root.blade.php
+++ b/resources/views/components/user/progression-status/root.blade.php
@@ -38,6 +38,7 @@ if ($widthMode !== 'equal' && $widthMode !== 'dynamic') {
                 :beatenHardcoreCount="$totalBeatenHardcoreCount"
                 :completedCount="$totalCompletedCount"
                 :masteredCount="$totalMasteredCount"
+                :systems="$systems"
             />
         </div>
     @endif
@@ -52,6 +53,7 @@ if ($widthMode !== 'equal' && $widthMode !== 'dynamic') {
                 :beatenHardcoreCount="$consoleProgress[$topConsole]['beatenHardcoreCount'] ?? 0"
                 :completedCount="$consoleProgress[$topConsole]['completedCount'] ?? 0"
                 :masteredCount="$consoleProgress[$topConsole]['masteredCount'] ?? 0"
+                :systems="$systems"
             />
         </div>
     @endif
@@ -72,6 +74,7 @@ if ($widthMode !== 'equal' && $widthMode !== 'dynamic') {
                             :beatenHardcoreCount="$progress['beatenHardcoreCount']"
                             :completedCount="$progress['completedCount']"
                             :masteredCount="$progress['masteredCount']"
+                            :systems="$systems"
                         />
                     @endif
                 @endforeach


### PR DESCRIPTION
Tackles more N+1 query issues being reported in Sentry.

This PR lowers the query count on http://localhost:64000/user/tele from 137 to 79 on my local.