### PR TITLE
chore: disable Sentry masking

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -15,7 +15,10 @@ Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   integrations: [
     Sentry.browserTracingIntegration(),
-    Sentry.replayIntegration(),
+    Sentry.replayIntegration({
+      maskAllText: false,
+      blockAllMedia: false,
+    }),
     Sentry.captureConsoleIntegration({ levels: ['warn', 'error'] }),
   ],
   environment: import.meta.env.APP_ENV,


### PR DESCRIPTION
I can see hydration error replays, but their causes are imperceptible. This change is fine - we're not storing any PII.