### PR TITLE
fix(Event): change how current state is calculated

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -98,23 +98,23 @@ class Event extends BaseModel
         }
 
         /**
+         * An event is concluded if:
+         * - The event's end date is before the current date, or
+         * - Every event achievement has an activeUntil date which is before the current date.
+         */
+        if (
+            $this->active_through?->isBefore($now)
+            || $this->achievements->every(fn ($a) => $a->active_until?->isBefore($now))
+        ) {
+            return EventState::Concluded;
+        }
+
+        /**
          * An event is evergreen (never expires) if:
          * - Every event achievement has a null activeUntil value, meaning they can be earned indefinitely.
          */
         if ($this->achievements->every(fn ($a) => !$a->active_until)) {
             return EventState::Evergreen;
-        }
-
-        /**
-         * An event is concluded if:
-         * - The event's end date is before the current date, and
-         * - Every event achievement has an activeUntil date which is before the current date.
-         */
-        if (
-            $this->active_through?->isBefore($now)
-            && $this->achievements->every(fn ($a) => $a->active_until?->isBefore($now))
-        ) {
-            return EventState::Concluded;
         }
 
         // This shouldn't happen.


### PR DESCRIPTION
This PR changes how events determine if they're concluded vs evergreen:
* If an event has no end date, it will always be considered evergreen.
* If an event has an end date in the past, it will always be considered concluded.