### PR TITLE
fix(DiffTimestamp): suppress hydration errors

### DIFF
--- a/resources/js/common/components/DiffTimestamp/DiffTimestamp.tsx
+++ b/resources/js/common/components/DiffTimestamp/DiffTimestamp.tsx
@@ -36,13 +36,19 @@ export const DiffTimestamp: FC<DiffTimestampProps> = ({
   }
 
   if (!enableTooltip) {
-    return <span className={className}>{diffForHumans(at, renderedAt)}</span>;
+    return (
+      <span className={className} suppressHydrationWarning>
+        {diffForHumans(at, renderedAt)}
+      </span>
+    );
   }
 
   return (
     <BaseTooltip>
       <BaseTooltipTrigger className="cursor-default">
-        <span className={className}>{diffForHumans(at, renderedAt)}</span>
+        <span className={className} suppressHydrationWarning>
+          {diffForHumans(at, renderedAt)}
+        </span>
       </BaseTooltipTrigger>
 
       <BaseTooltipContent>

--- a/resources/js/common/components/DiffTimestamp/DiffTimestamp.tsx
+++ b/resources/js/common/components/DiffTimestamp/DiffTimestamp.tsx
@@ -37,7 +37,7 @@ export const DiffTimestamp: FC<DiffTimestampProps> = ({
 
   if (!enableTooltip) {
     return (
-      <span className={className} suppressHydrationWarning>
+      <span className={className} suppressHydrationWarning={true}>
         {diffForHumans(at, renderedAt)}
       </span>
     );
@@ -46,7 +46,7 @@ export const DiffTimestamp: FC<DiffTimestampProps> = ({
   return (
     <BaseTooltip>
       <BaseTooltipTrigger className="cursor-default">
-        <span className={className} suppressHydrationWarning>
+        <span className={className} suppressHydrationWarning={true}>
           {diffForHumans(at, renderedAt)}
         </span>
       </BaseTooltipTrigger>


### PR DESCRIPTION
DiffTimestamp is reporting hundreds of hydration errors to Sentry. However, the React team has specified these specific kinds of hydration errors are safe to suppress, as they are unavoidable: https://react.dev/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors

I've confirmed the hydration errors coming from this component do not cause the component tree to panic and remount.