### PR TITLE
fix: ensure drawers have a valid aria description

### DIFF
--- a/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.tsx
+++ b/resources/js/features/game-list/components/DataTableToolbar/DataTableSuperFilter/DataTableSuperFilter.tsx
@@ -9,6 +9,7 @@ import {
   BaseDrawer,
   BaseDrawerClose,
   BaseDrawerContent,
+  BaseDrawerDescription,
   BaseDrawerFooter,
   BaseDrawerHeader,
   BaseDrawerTitle,
@@ -98,6 +99,7 @@ export function DataTableSuperFilter<TData>({
         <div className="mx-auto w-full max-w-sm">
           <BaseDrawerHeader>
             <BaseDrawerTitle>{t('Customize View')}</BaseDrawerTitle>
+            <BaseDrawerDescription className="sr-only">{t('Customize View')}</BaseDrawerDescription>
           </BaseDrawerHeader>
 
           <div className="flex flex-col gap-4 p-4">

--- a/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemDrawerContent/GameListItemDrawerContent.test.tsx
+++ b/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemDrawerContent/GameListItemDrawerContent.test.tsx
@@ -88,7 +88,7 @@ describe('Component: GameListItemDrawerContent', () => {
     );
 
     // ASSERT
-    expect(screen.getByText(/sonic the hedgehog/i)).toBeVisible();
+    expect(screen.getAllByText(/sonic the hedgehog/i)[0]).toBeVisible();
   });
 
   it('there is always one or more tappable links directly to the game page', () => {
@@ -161,7 +161,7 @@ describe('Component: GameListItemDrawerContent', () => {
     );
 
     // ASSERT
-    expect(screen.getByText(/sonic the hedgehog/i)).toBeVisible();
+    expect(screen.getAllByText(/sonic the hedgehog/i)[0]).toBeVisible();
   });
 
   it('given a game has a release date, displays it', () => {

--- a/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemDrawerContent/GameListItemDrawerContent.tsx
+++ b/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemDrawerContent/GameListItemDrawerContent.tsx
@@ -5,6 +5,7 @@ import type { IconType } from 'react-icons/lib';
 import { baseButtonVariants } from '@/common/components/+vendor/BaseButton';
 import {
   BaseDrawerContent,
+  BaseDrawerDescription,
   BaseDrawerFooter,
   BaseDrawerHeader,
   BaseDrawerTitle,
@@ -48,6 +49,7 @@ export const GameListItemDrawerContent: FC<GameListItemDrawerContentProps> = ({
       <div className="mx-auto w-full max-w-sm overflow-hidden">
         <BaseDrawerHeader>
           <BaseDrawerTitle>{t('Game Details')}</BaseDrawerTitle>
+          <BaseDrawerDescription className="sr-only">{game.title}</BaseDrawerDescription>
         </BaseDrawerHeader>
 
         <div className="flex flex-col gap-4 p-4">


### PR DESCRIPTION
No functional changes.

Mobile drawer components are the source of dozens of errors in Sentry. The underlying vendor component is upset that a description isn't being used. This PR adds a description, but sets it to invisible.