### PR TITLE
fix(EventResource): remediate crash that happens on search

### DIFF
--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -255,7 +255,9 @@ class EventResource extends Resource
                 Tables\Columns\TextColumn::make('id')
                     ->label('ID')
                     ->sortable()
-                    ->searchable(),
+                    ->searchable(query: function (Builder $query, string $search): Builder {
+                        return $query->where('events.id', 'like', "%{$search}%");
+                    }),
 
                 Tables\Columns\TextColumn::make('legacyGame.title')
                     ->label('Title')


### PR DESCRIPTION
This PR resolves a server error which occurs on http://localhost:64000/manage/events when any search is made on the page.

Easily reproducible with a URL like https://retroachievements.org/manage/events?tableSearch=asdf.