### PR TITLE
use event route for event awards

### DIFF
--- a/app/Helpers/render/site-award.php
+++ b/app/Helpers/render/site-award.php
@@ -263,7 +263,7 @@ function RenderAward(array $award, int $imageSize, string $ownerUsername, bool $
             }
 
             echo avatar('event', $event->id,
-                link: route('game.show', $event->legacyGame->id),
+                link: route('event.show', $event->id),
                 tooltip: "<div class='p-2 max-w-[320px] text-pretty'><span>$tooltip</span><p class='italic'>{$awardDate}</p></div>",
                 iconUrl: media_asset($image),
                 iconSize: $imageSize,


### PR DESCRIPTION
Updates the awards on the user profile page to link directly to the event page instead of going through the game page.