### PR TITLE
feat: make some light mode accessibility impovements

### DIFF
--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -74,7 +74,7 @@ a:hover {
   --box-shadow-color: rgb(22, 22, 22, .3);
   /*--box-bg-color:rgb(248, 248, 248);*/
   /*--bg-color: rgb(255, 255, 255);*/
-  --embed-color:  rgb(240, 240, 240);
+  --embed-color:  rgb(241, 241, 241);
   --embed-highlight-color: rgb(230, 230, 230);
   --heading-color: rgb(50, 50, 50);
   --link-hover-color: rgb(0, 0, 0);
@@ -109,6 +109,12 @@ a:hover {
   --heading-color: rgb(44, 151, 250);
   --link-color: rgb(204, 153, 0); /*#CC9900*/
   --text-color: rgb(44, 151, 250); /*#2C97FA*/
+}
+[data-theme=""][data-scheme="light"],
+[data-theme=""][data-scheme="system"] {
+  --heading-color: #404040; /* neutral-700 */;
+  --link-color: rgb(168, 126, 0);
+  --text-color: #404040; /* neutral-700 */
 }
 
 [data-theme="slate"] {

--- a/resources/css/utilities.css
+++ b/resources/css/utilities.css
@@ -15,7 +15,7 @@
   }
   [data-scheme='light'] .zebra-list > *:nth-child(odd),
   [data-scheme='system'] .zebra-list > *:nth-child(odd) {
-    @apply bg-[rgba(80,80,80,0.09)];
+    @apply bg-[rgba(80,80,80,0.08)];
   }
   .zebra-list > *:hover:not(.no-hover) {
     @apply outline-[rgba(128,128,128,0.3)] bg-[rgba(128,128,128,0.2)];

--- a/resources/js/common/components/+vendor/BaseChart.tsx
+++ b/resources/js/common/components/+vendor/BaseChart.tsx
@@ -53,6 +53,7 @@ const BaseChartContainer = React.forwardRef<
           "[&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-neutral-600/50",
           "[&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border",
           '[&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-zinc-800',
+          '[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-zinc-200',
           "[&_.recharts-reference-line_[stroke='#ccc']]:stroke-border",
           'flex justify-center text-xs',
           "[&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none",

--- a/resources/js/common/components/+vendor/BaseSeparator.tsx
+++ b/resources/js/common/components/+vendor/BaseSeparator.tsx
@@ -14,7 +14,7 @@ const BaseSeparator = React.forwardRef<
     decorative={decorative}
     orientation={orientation}
     className={cn(
-      'shrink-0 bg-neutral-700',
+      'shrink-0 bg-neutral-700 light:bg-white',
       orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
       className,
     )}

--- a/resources/js/features/events/components/AchievementDistribution/AchievementDistribution.tsx
+++ b/resources/js/features/events/components/AchievementDistribution/AchievementDistribution.tsx
@@ -38,7 +38,7 @@ export const AchievementDistribution: FC<AchievementDistributionProps> = ({
     <div data-testid="achievement-distribution">
       <h2 className="mb-0 border-0 text-lg font-semibold">{t('Achievement Distribution')}</h2>
 
-      <div className="flex flex-col gap-3 rounded-lg bg-embed p-3">
+      <div className="flex flex-col gap-3 rounded-lg bg-embed p-3 light:border light:border-neutral-200 light:bg-white">
         <BaseChartContainer config={chartConfig} className="h-[260px] w-full">
           <BarChart accessibilityLayer data={buckets}>
             <CartesianGrid vertical={false} />

--- a/resources/js/features/events/components/AchievementSet/AchievementDateMeta/AchievementDateMeta.tsx
+++ b/resources/js/features/events/components/AchievementSet/AchievementDateMeta/AchievementDateMeta.tsx
@@ -56,7 +56,7 @@ export const AchievementDateMeta: FC<AchievementDateMetaProps> = ({
       className={cn('gap-x-2 text-[0.63rem] text-neutral-400/70 light:text-neutral-500', className)}
     >
       {isActive && activeThrough ? (
-        <p className="text-green-400">
+        <p className="text-green-400 light:text-green-600">
           {t('Active through {{date}}', { date: formatDate(activeThrough, 'll') })}
         </p>
       ) : null}

--- a/resources/js/features/events/components/AchievementSet/AchievementsListItem/AchievementsListItem.tsx
+++ b/resources/js/features/events/components/AchievementSet/AchievementsListItem/AchievementsListItem.tsx
@@ -44,7 +44,7 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
 
   return (
     <motion.li
-      className="flex w-full gap-x-3 px-2 py-3 odd:bg-[rgba(50,50,50,0.4)] light:odd:bg-neutral-200 md:py-1"
+      className="flex w-full gap-x-3 px-2 py-3 odd:bg-[rgba(50,50,50,0.4)] light:odd:bg-neutral-100 md:py-1"
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 10 }}

--- a/resources/js/features/events/components/CompareProgress/CompareProgress.tsx
+++ b/resources/js/features/events/components/CompareProgress/CompareProgress.tsx
@@ -45,7 +45,7 @@ export const CompareProgress: FC<CompareProgressProps> = ({ followedPlayerComple
     <div data-testid="compare-progress">
       <h2 className="mb-0 border-0 text-lg font-semibold">{t('Compare Progress')}</h2>
 
-      <div className="flex flex-col gap-3 rounded-lg bg-embed p-3">
+      <div className="flex flex-col gap-3 rounded-lg bg-embed p-3 light:border light:border-neutral-200 light:bg-white">
         <div className="flex flex-col">
           {canShowPlayerCompletions ? (
             <PopulatedPlayerCompletions

--- a/resources/js/features/events/components/EventAwardTiers/AwardTierItem.tsx
+++ b/resources/js/features/events/components/EventAwardTiers/AwardTierItem.tsx
@@ -35,8 +35,8 @@ export const AwardTierItem: FC<AwardTierItemProps> = ({ event, eventAward, hasVi
       className={cn(
         'group rounded-lg p-1 light:bg-white',
         eventAward.earnedAt
-          ? 'bg-zinc-700/50 light:border light:border-yellow-500'
-          : 'bg-zinc-800/50',
+          ? 'bg-zinc-700/50 light:border light:border-yellow-500 light:bg-white'
+          : 'bg-zinc-800/50 light:bg-zinc-100',
       )}
     >
       <div className="relative flex items-center gap-3">
@@ -85,7 +85,7 @@ export const AwardTierItem: FC<AwardTierItemProps> = ({ event, eventAward, hasVi
               <BaseTooltipTrigger>
                 <div
                   data-testid="award-earned-checkmark"
-                  className="mr-1 flex size-6 items-center justify-center rounded-full bg-embed light:text-neutral-700"
+                  className="mr-1 flex size-6 items-center justify-center rounded-full bg-embed light:bg-neutral-200 light:text-neutral-700"
                 >
                   <LuCheck className="size-4" />
                 </div>

--- a/resources/js/features/events/components/EventAwardTiers/EventAwardTiers.tsx
+++ b/resources/js/features/events/components/EventAwardTiers/EventAwardTiers.tsx
@@ -33,7 +33,7 @@ export const EventAwardTiers: FC<EventAwardTiersProps> = ({ event, numMasters })
     <div data-testid="award-tiers">
       <h2 className="mb-0 border-0 text-lg font-semibold">{t('Award Tiers')}</h2>
 
-      <div className="rounded-lg bg-embed p-2">
+      <div className="rounded-lg bg-embed p-2 light:border light:border-neutral-200 light:bg-white">
         <div className="flex flex-col gap-3">
           {sortedByPoints.map((eventAward) => (
             <AwardTierItem

--- a/resources/js/features/events/components/EventMainMedia/EventMainMedia.tsx
+++ b/resources/js/features/events/components/EventMainMedia/EventMainMedia.tsx
@@ -22,7 +22,7 @@ export const EventMainMedia: FC<EventMainMediaProps> = ({ imageIngameUrl, imageT
     <div
       className={cn(
         'flex w-full items-center justify-around',
-        'border border-embed-highlight bg-zinc-900/50 light:bg-embed',
+        'border border-embed-highlight bg-zinc-900/50 light:bg-neutral-50',
         'gap-x-5 gap-y-1',
         'xl:mx-0 xl:min-h-[180px] xl:w-full xl:rounded-lg xl:px-4 xl:py-2',
       )}

--- a/resources/js/features/events/components/EventProgress/EventProgress.tsx
+++ b/resources/js/features/events/components/EventProgress/EventProgress.tsx
@@ -47,7 +47,7 @@ export const EventProgress: FC<EventProgressProps> = ({ event, playerGame }) => 
         <Glow isMastered={isMastered} />
       ) : null}
 
-      <div className="relative border border-embed-highlight bg-embed px-5 pb-5 pt-3.5 light:bg-white lg:rounded">
+      <div className="relative border border-embed-highlight bg-embed px-5 pb-5 pt-3.5 light:border-neutral-200 light:bg-white lg:rounded">
         <div className="mb-2">
           <p className="sr-only">{t('Your Progress')}</p>
 

--- a/resources/js/features/events/components/EventProgress/Glow/Glow.tsx
+++ b/resources/js/features/events/components/EventProgress/Glow/Glow.tsx
@@ -16,10 +16,12 @@ export const Glow: FC<GlowProps> = ({ isMastered }) => {
         'bg-gradient-to-tr',
         'motion-safe:animate-tilt',
 
-        isMastered ? 'inset-[7px]' : 'inset-[5px]',
-        isMastered ? 'group-hover:inset-[5px]' : 'group-hover:inset-[3px]',
+        isMastered ? 'inset-[7px] light:inset-[12px]' : 'inset-[5px] light:inset-[12px]',
         isMastered
-          ? 'from-yellow-400 to-amber-400 light:from-yellow-700 light:to-amber-700'
+          ? 'group-hover:inset-[5px] light:group-hover:inset-[12px]'
+          : 'group-hover:inset-[3px] light:group-hover:inset-[12px]',
+        isMastered
+          ? 'from-yellow-400 to-amber-400'
           : 'from-zinc-400 to-slate-500 light:from-zinc-600 light:to-slate-700',
       ])}
     />

--- a/resources/js/features/events/components/HubsList/HubsList.tsx
+++ b/resources/js/features/events/components/HubsList/HubsList.tsx
@@ -19,7 +19,7 @@ export const HubsList: FC<HubsListProps> = ({ hubs }) => {
     <div data-testid="hubs-list">
       <h2 className="mb-0 border-0 text-lg font-semibold">{t('Hubs')}</h2>
 
-      <div className="rounded-lg bg-embed p-1">
+      <div className="rounded-lg bg-embed p-1 light:border light:border-neutral-200 light:bg-white">
         <ul className="zebra-list overflow-hidden rounded-lg">
           {hubs.map((hub) => (
             <li

--- a/resources/js/features/events/components/TopEventPlayers/TopEventPlayers.tsx
+++ b/resources/js/features/events/components/TopEventPlayers/TopEventPlayers.tsx
@@ -41,8 +41,8 @@ export const TopEventPlayers: FC<TopEventParticipantsProps> = ({ event, numMaste
         {listKind === 'most-points-earned' ? t('Most Points Earned') : null}
       </h2>
 
-      <div className="flex flex-col gap-2 rounded-lg bg-embed p-2">
-        <BaseTable className="table-highlight overflow-hidden rounded-lg outline outline-1 outline-neutral-800">
+      <div className="flex flex-col gap-2 rounded-lg bg-embed p-2 light:border light:border-neutral-200 light:bg-white">
+        <BaseTable className="table-highlight overflow-hidden rounded-lg outline outline-1 outline-neutral-800 light:outline-white">
           <BaseTableHeader className="border-neutral-800">
             <BaseTableRow className="do-not-highlight text-menu-link">
               <BaseTableCell className="text-right">{'#'}</BaseTableCell>


### PR DESCRIPTION
This PR makes some light mode a11y improvements. The bulk of changes are on the events page, however the default palette is affected (in light mode) on the entire site.

The default palette changes for light mode are:
* The embed color is ever so slightly brighter.
* The heading and text colors are now neutral-700 instead of blue.
* The link color has been darkened.

This isn't a silver bullet; light mode still suffers from major issues all over the place. However, this remediates some text on the site being completely unreadable while in the mode.

It is worth noting that currently the light mode usage rate on the site is <1%. Though the typography changes might be drastic, they aren't going to impact very many people.

**Before**
![Screenshot 2025-04-10 at 8 50 37 PM](https://github.com/user-attachments/assets/35f5b42f-26c5-4b51-a1c3-640dfba23013)

![Screenshot 2025-04-10 at 8 50 31 PM](https://github.com/user-attachments/assets/5e84cc41-3939-4f64-ab14-437ef28cbc93)


**After**
![Screenshot 2025-04-10 at 8 52 22 PM](https://github.com/user-attachments/assets/ae2a880b-7601-4236-8fe3-5fca30eadc4a)


![Screenshot 2025-04-10 at 8 49 11 PM](https://github.com/user-attachments/assets/be279262-17d4-4317-8590-c66040de6a8b)
