### PR TITLE
fix(report-issue): remove generic Message QATeam button

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -156,7 +156,6 @@
     "Hide": "Hide",
     "Hide missable achievement indicators": "Hide missable achievement indicators",
     "Hub organizational questions.": "Hub organizational questions.",
-    "I have an issue with this achievement that is not described above.": "I have an issue with this achievement that is not described above.",
     "I met the requirements, but the achievement did not trigger.": "I met the requirements, but the achievement did not trigger.",
     "I receive a private message": "I receive a private message",
     "I unlocked this achievement without meeting the requirements, and then I reset it.": "I unlocked this achievement without meeting the requirements, and then I reset it.",

--- a/resources/js/features/achievements/components/ReportIssueMainRoot/ReportIssueMainRoot.test.tsx
+++ b/resources/js/features/achievements/components/ReportIssueMainRoot/ReportIssueMainRoot.test.tsx
@@ -292,8 +292,7 @@ describe('Component: ReportIssueMainRoot', () => {
     expect(screen.getByRole('link', { name: /report to writingteam/i })).toBeVisible();
 
     expect(screen.getByText(/achievement type/i)).toBeVisible();
-    expect(screen.getByText(/that is not described above/i)).toBeVisible();
-    expect(screen.getAllByRole('link', { name: /qateam/i }).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByRole('link', { name: /qateam/i }).length).toEqual(1);
 
     expect(screen.getByText(/unwelcome concept/i)).toBeVisible();
     expect(screen.getByRole('link', { name: /report to devcompliance/i })).toBeVisible();

--- a/resources/js/features/achievements/components/ReportIssueMainRoot/ReportIssueMainRoot.tsx
+++ b/resources/js/features/achievements/components/ReportIssueMainRoot/ReportIssueMainRoot.tsx
@@ -60,16 +60,6 @@ export const ReportIssueMainRoot: FC = memo(() => {
         >
           {t('There is a spelling or grammatical error in the title or description.')}
         </ReportIssueOptionItem>
-
-        <ReportIssueOptionItem
-          t_buttonText={t('Message QATeam')}
-          href={route('message-thread.create', {
-            to: 'QATeam',
-            ...buildStructuredMessage(achievement, 'achievement-issue'),
-          })}
-        >
-          {t('I have an issue with this achievement that is not described above.')}
-        </ReportIssueOptionItem>
       </ul>
     </div>
   );


### PR DESCRIPTION
At the request of the team: https://discord.com/channels/476211979464343552/1360729249929101535/1360803113275097222

Only the en_US.json string needs to be removed - it'll naturally propagate through Crowdin to the other files.