### PR TITLE
fix(useHydrateShortcodeDynamicEntities): sync atoms with page props

### DIFF
--- a/resources/js/common/hooks/useHydrateShortcodeDynamicEntities.test.ts
+++ b/resources/js/common/hooks/useHydrateShortcodeDynamicEntities.test.ts
@@ -23,7 +23,7 @@ vi.mock('jotai/utils', async () => {
 describe('Hook: useHydrateShortcodeDynamicEntities', () => {
   it('renders without crashing', () => {
     // ARRANGE
-    const dynamicEntities = {
+    const initialDynamicEntities = {
       achievements: [],
       games: [],
       hubs: [],
@@ -33,7 +33,21 @@ describe('Hook: useHydrateShortcodeDynamicEntities', () => {
     };
 
     // ACT
-    const { result } = renderHook(() => useHydrateShortcodeDynamicEntities(dynamicEntities));
+    const { result } = renderHook(
+      () => useHydrateShortcodeDynamicEntities(initialDynamicEntities),
+      {
+        pageProps: {
+          dynamicEntities: {
+            achievements: [],
+            games: [],
+            hubs: [],
+            events: [],
+            tickets: [],
+            users: [],
+          },
+        },
+      },
+    );
 
     // ASSERT
     expect(result).toBeTruthy();
@@ -52,7 +66,18 @@ describe('Hook: useHydrateShortcodeDynamicEntities', () => {
     };
 
     // ACT
-    renderHook(() => useHydrateShortcodeDynamicEntities(dynamicEntities as any));
+    renderHook(() => useHydrateShortcodeDynamicEntities(dynamicEntities as any), {
+      pageProps: {
+        dynamicEntities: {
+          achievements: [],
+          games: [],
+          hubs: [],
+          events: [],
+          tickets: [],
+          users: [],
+        },
+      },
+    });
 
     // ASSERT
     expect(mockUseHydrateAtoms).toHaveBeenCalledWith([

--- a/resources/js/common/hooks/useHydrateShortcodeDynamicEntities.ts
+++ b/resources/js/common/hooks/useHydrateShortcodeDynamicEntities.ts
@@ -1,4 +1,6 @@
+import { useSetAtom } from 'jotai';
 import { useHydrateAtoms } from 'jotai/utils';
+import { useEffect } from 'react';
 
 import {
   persistedAchievementsAtom,
@@ -7,16 +9,43 @@ import {
   persistedTicketsAtom,
   persistedUsersAtom,
 } from '../state/shortcode.atoms';
+import { usePageProps } from './usePageProps';
 
 export function useHydrateShortcodeDynamicEntities(
-  dynamicEntities: App.Community.Data.ShortcodeDynamicEntities,
+  initialDynamicEntities: App.Community.Data.ShortcodeDynamicEntities,
 ) {
+  const { dynamicEntities: propsDynamicEntities } = usePageProps<{
+    dynamicEntities: App.Community.Data.ShortcodeDynamicEntities;
+  }>();
+
+  // Always call useHydrateAtoms during SSR.
   useHydrateAtoms([
-    [persistedAchievementsAtom, dynamicEntities.achievements],
-    [persistedGamesAtom, dynamicEntities.games],
-    [persistedHubsAtom, dynamicEntities.hubs],
-    [persistedTicketsAtom, dynamicEntities.tickets],
-    [persistedUsersAtom, dynamicEntities.users],
-    //
+    [persistedAchievementsAtom, initialDynamicEntities.achievements],
+    [persistedGamesAtom, initialDynamicEntities.games],
+    [persistedHubsAtom, initialDynamicEntities.hubs],
+    [persistedTicketsAtom, initialDynamicEntities.tickets],
+    [persistedUsersAtom, initialDynamicEntities.users],
+  ]);
+
+  // These setters are only used for client-side updates.
+  const setPersistedAchievements = useSetAtom(persistedAchievementsAtom);
+  const setPersistedGames = useSetAtom(persistedGamesAtom);
+  const setPersistedHubs = useSetAtom(persistedHubsAtom);
+  const setPersistedTickets = useSetAtom(persistedTicketsAtom);
+  const setPersistedUsers = useSetAtom(persistedUsersAtom);
+
+  useEffect(() => {
+    setPersistedAchievements(propsDynamicEntities.achievements);
+    setPersistedGames(propsDynamicEntities.games);
+    setPersistedHubs(propsDynamicEntities.hubs);
+    setPersistedTickets(propsDynamicEntities.tickets);
+    setPersistedUsers(propsDynamicEntities.users);
+  }, [
+    propsDynamicEntities,
+    setPersistedAchievements,
+    setPersistedGames,
+    setPersistedHubs,
+    setPersistedTickets,
+    setPersistedUsers,
   ]);
 }

--- a/resources/js/features/messages/components/CreateMessageReplyForm/CreateMessageReplyForm.test.tsx
+++ b/resources/js/features/messages/components/CreateMessageReplyForm/CreateMessageReplyForm.test.tsx
@@ -1,3 +1,4 @@
+import { router } from '@inertiajs/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 
@@ -94,6 +95,8 @@ describe('Component: CreateMessageReplyForm', () => {
     const paginatedMessages = createPaginatedData([], { lastPage: 5 });
     const mockOnPreview = vi.fn();
 
+    vi.spyOn(router, 'visit').mockImplementationOnce(vi.fn());
+
     vi.spyOn(axios, 'post').mockResolvedValueOnce({ data: {} });
 
     render(<CreateMessageReplyForm onPreview={mockOnPreview} />, {
@@ -112,7 +115,7 @@ describe('Component: CreateMessageReplyForm', () => {
       expect(screen.getByText(/submitted/i)).toBeVisible();
     });
 
-    // vitest is very unhappy when it hits the setTimeout() for window.location.assign().
+    // vitest is very unhappy when it hits the setTimeout() for router.visit().
     await __UNSAFE_VERY_DANGEROUS_SLEEP(1100);
   });
 

--- a/resources/js/features/messages/components/CreateMessageReplyForm/useCreateMessageReplyForm.ts
+++ b/resources/js/features/messages/components/CreateMessageReplyForm/useCreateMessageReplyForm.ts
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { router } from '@inertiajs/react';
 import { useMutation } from '@tanstack/react-query';
 import axios, { type AxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
@@ -41,14 +42,15 @@ export function useCreateMessageReplyForm() {
     await toastMessage.promise(mutation.mutateAsync(formValues), {
       loading: t('Submitting...'),
       success: () => {
-        setTimeout(() => {
-          window.location.assign(
-            route('message-thread.show', {
-              messageThread: messageThread.id,
-              _query: { page: paginatedMessages.lastPage },
-            }),
-          );
-        }, 1000);
+        router.visit(
+          route('message-thread.show', {
+            messageThread: messageThread.id,
+            _query: { page: paginatedMessages.lastPage },
+          }),
+          {
+            preserveScroll: true,
+          },
+        );
 
         return t('Submitted!');
       },


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1017568867574362283/1364950721526497361 and https://discord.com/channels/310192285306454017/1364989244963295283.

On pagination while viewing a forum topic, if a dynamic shortcode entity is on the destination page and it's also not on the current page, it will not render until a browser hard refresh.

**Root Cause**
Atoms are being used to manage global state on the page. On a client-side navigation, the atoms need to be resynced with props from the Laravel controller, otherwise the global state becomes stale.