### PR TITLE
fix(search): remediate forum link 404

### DIFF
--- a/app/Helpers/database/search.php
+++ b/app/Helpers/database/search.php
@@ -103,7 +103,7 @@ function performSearch(
         $counts[] = "SELECT COUNT(*) AS Count FROM forum_topic_comments WHERE body LIKE '%$searchQuery%'";
         $parts[] = "
         SELECT " . SearchType::Forum . " AS Type, ua.User AS ID,
-               CONCAT( '/forums/topic/', ftc.forum_topic_id, '&comment=', ftc.id, '#', ftc.id ) AS Target,
+               CONCAT( '/forums/topic/', ftc.forum_topic_id, '?comment=', ftc.id, '#', ftc.id ) AS Target,
                CASE WHEN CHAR_LENGTH(ftc.body) <= 64 THEN ftc.body ELSE
                CONCAT( '...', MID( ftc.body, GREATEST( LOCATE('$searchQuery', ftc.body)-25, 1), 60 ), '...' ) END AS Title
         FROM forum_topic_comments AS ftc


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1364959420232241232.

Currently, "Forum Topic" search results send the user to a 404 when they click on them.

This is because the URLs are malformed due to a typo. The first query param starts with a `&` instead of a `?`.