### PR TITLE
fix(ForumTopicCommentData): decode the body field

### DIFF
--- a/app/Data/ForumTopicCommentData.php
+++ b/app/Data/ForumTopicCommentData.php
@@ -29,7 +29,7 @@ class ForumTopicCommentData extends Data
     {
         return new self(
             id: $comment->id,
-            body: $comment->body,
+            body: html_entity_decode($comment->body),
             createdAt: $comment->created_at,
             updatedAt: $comment->updated_at,
             user: UserData::from($comment->user),


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1364953100397449268.

We have thousands of comments with various encoded characters in the DB. The React UI does no decoding.

This approach of decoding characters in the DTO seems safest of all for visually displaying things correctly in the UI. It covers all possible encoded characters and mitigates any data corruption risks (ie: `updated_at`).