### PR TITLE
chore: silence SSR errors caused by Google Translate

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -49,6 +49,13 @@ class Handler extends ExceptionHandler
      */
     public function report(Throwable $e): void
     {
+        // Filter out React errors caused by Google Translate modifying the DOM during SSR.
+        if ($e instanceof \Inertia\Ssr\SsrException
+            && preg_match('/React does not recognize|Invalid attribute name/', $e->getMessage())
+        ) {
+            return;
+        }
+
         parent::report($e);
     }
 


### PR DESCRIPTION
Google Translate is modifying the DOM during SSR, which causes initial page hydration to fail for some users, particularly those using the German language.

True errors of this nature would cause our `tsc` job to fail.

This is a related bug filed in Chromium about this issue: https://issues.chromium.org/issues/41407169

These errors are making a lot of noise in our logs, and there is nothing we can do to fix them without degrading UI performance for all users.

![Screenshot 2025-04-24 at 5 56 41 PM](https://github.com/user-attachments/assets/64a40f29-0608-4367-aa68-83ca06bc6860)
