### PR TITLE
fix(messages): show event shortcodes in message threads correctly

### DIFF
--- a/app/Community/Actions/BuildMessageThreadShowPagePropsAction.php
+++ b/app/Community/Actions/BuildMessageThreadShowPagePropsAction.php
@@ -55,6 +55,7 @@ class BuildMessageThreadShowPagePropsAction
             ticketIds: $entities['ticketIds'],
             achievementIds: $entities['achievementIds'],
             gameIds: $entities['gameIds'],
+            eventIds: $entities['eventIds'],
             hubIds: $entities['hubIds'],
         );
 


### PR DESCRIPTION
Applies the fix from https://github.com/RetroAchievements/RAWeb/pull/3453 to message threads as well. `[event]` shortcodes are currently rendering in previews, but not submitted messages.