### PR TITLE
feat(forums): animate the spoiler button

### DIFF
--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeSpoiler/ShortcodeSpoiler.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeSpoiler/ShortcodeSpoiler.tsx
@@ -1,5 +1,11 @@
-import type { FC, ReactNode } from 'react';
+import { AnimatePresence } from 'motion/react';
+import * as m from 'motion/react-m';
+import { type FC, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LuChevronDown } from 'react-icons/lu';
+
+import { useAnimatedCollapse } from '@/common/hooks/useAnimatedCollapse';
+import { cn } from '@/common/utils/cn';
 
 import { stripLeadingWhitespaceFromChildren } from '../../../utils/shortcodes/stripLeadingWhitespaceFromChildren';
 import { BaseButton } from '../../+vendor/BaseButton';
@@ -16,15 +22,46 @@ interface ShortcodeSpoilerProps {
 export const ShortcodeSpoiler: FC<ShortcodeSpoilerProps> = ({ children }) => {
   const { t } = useTranslation();
 
+  const { contentHeight, contentRef, isOpen, setIsOpen } = useAnimatedCollapse();
+
   return (
-    <BaseCollapsible>
+    <BaseCollapsible open={isOpen} onOpenChange={setIsOpen}>
       <BaseCollapsibleTrigger asChild>
-        <BaseButton size="sm">{t('Spoiler')}</BaseButton>
+        <BaseButton
+          size="sm"
+          className={cn(isOpen ? 'rounded-b-none border-transparent bg-embed' : null)}
+        >
+          {t('Spoiler')}
+
+          <LuChevronDown
+            className={cn(
+              'ml-1 size-4 transition-transform duration-300',
+              isOpen ? 'rotate-180' : 'rotate-0',
+            )}
+          />
+        </BaseButton>
       </BaseCollapsibleTrigger>
 
-      <BaseCollapsibleContent className="rounded border border-dashed border-text-muted px-3 py-2">
-        {stripLeadingWhitespaceFromChildren(children)}
-      </BaseCollapsibleContent>
+      <AnimatePresence initial={false}>
+        {isOpen ? (
+          <BaseCollapsibleContent forceMount asChild>
+            <m.div
+              initial={{ height: 0 }}
+              animate={{ height: contentHeight }}
+              exit={{ height: 0 }}
+              transition={{
+                duration: 0.3,
+                ease: [0.4, 0, 0.2, 1], // Custom easing curve for natural motion.
+              }}
+              className="overflow-hidden"
+            >
+              <div ref={contentRef} className="rounded-b-lg rounded-tr-lg bg-embed px-3 py-2">
+                {stripLeadingWhitespaceFromChildren(children)}
+              </div>
+            </m.div>
+          </BaseCollapsibleContent>
+        ) : null}
+      </AnimatePresence>
     </BaseCollapsible>
   );
 };

--- a/resources/js/common/hooks/useAnimatedCollapse.ts
+++ b/resources/js/common/hooks/useAnimatedCollapse.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useAnimatedCollapse() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState(0);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setContentHeight(contentRef.current.offsetHeight);
+    }
+  }, [isOpen]);
+
+  return {
+    contentHeight,
+    contentRef,
+    isOpen,
+    setIsOpen,
+  };
+}

--- a/resources/js/features/forums/components/TopicOptions/TopicOptions.tsx
+++ b/resources/js/features/forums/components/TopicOptions/TopicOptions.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence } from 'motion/react';
 import * as m from 'motion/react-m';
-import { type FC, useEffect, useRef, useState } from 'react';
+import { type FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LuChevronDown } from 'react-icons/lu';
 
@@ -10,6 +10,7 @@ import {
   BaseCollapsibleContent,
   BaseCollapsibleTrigger,
 } from '@/common/components/+vendor/BaseCollapsible';
+import { useAnimatedCollapse } from '@/common/hooks/useAnimatedCollapse';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import { cn } from '@/common/utils/cn';
 
@@ -22,16 +23,7 @@ export const TopicOptions: FC = () => {
 
   const { t } = useTranslation();
 
-  const [isOpen, setIsOpen] = useState(false);
-
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [contentHeight, setContentHeight] = useState(0);
-
-  useEffect(() => {
-    if (contentRef.current) {
-      setContentHeight(contentRef.current.offsetHeight);
-    }
-  }, [isOpen]);
+  const { contentHeight, contentRef, isOpen, setIsOpen } = useAnimatedCollapse();
 
   return (
     <BaseCollapsible open={isOpen} onOpenChange={setIsOpen}>

--- a/resources/js/features/games/components/HashesMainRoot/OtherHashesSection.tsx
+++ b/resources/js/features/games/components/HashesMainRoot/OtherHashesSection.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence } from 'motion/react';
 import * as m from 'motion/react-m';
-import { type FC, memo, useEffect, useRef, useState } from 'react';
+import { type FC, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LuChevronDown } from 'react-icons/lu';
 
@@ -10,6 +10,7 @@ import {
   BaseCollapsibleContent,
   BaseCollapsibleTrigger,
 } from '@/common/components/+vendor/BaseCollapsible';
+import { useAnimatedCollapse } from '@/common/hooks/useAnimatedCollapse';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import { cn } from '@/common/utils/cn';
 
@@ -23,15 +24,8 @@ export const OtherHashesSection: FC = memo(() => {
     incompatibleHashes?.length || untestedHashes?.length || patchRequiredHashes?.length;
 
   const { t } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [contentHeight, setContentHeight] = useState(0);
 
-  useEffect(() => {
-    if (contentRef.current) {
-      setContentHeight(contentRef.current.offsetHeight);
-    }
-  }, [isOpen]);
+  const { contentHeight, contentRef, isOpen, setIsOpen } = useAnimatedCollapse();
 
   if (!hasOtherHashes) return null;
 


### PR DESCRIPTION
This PR:
* Extracts animated collapse orchestration into a reusable hook.
* Animates the `[spoiler]` shortcode collapse.


https://github.com/user-attachments/assets/928025f9-d26f-4a4b-82c6-02b615c8e98e

