### PR TITLE
fix(BaseSelectAsync): disable native autocomplete

### DIFF
--- a/resources/js/common/components/+vendor/BaseSelectAsync.tsx
+++ b/resources/js/common/components/+vendor/BaseSelectAsync.tsx
@@ -144,6 +144,7 @@ export function BaseSelectAsync<T>({
               value={localSearchTerm}
               onChange={(e) => setLocalSearchTerm(e.target.value)}
               className="flex-1 rounded-b-none border-none pl-8 focus-visible:ring-0"
+              autoComplete="off"
             />
             {query.isFetching && (
               <div className="absolute right-2 top-1/2 flex -translate-y-1/2 transform items-center">


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1152683553348407409/1366396241541595146.

Password managers are unhappy with the BaseSelectAsync component.

There should be no functional changes other than disabling certain password managers from trying to inject stuff into the field.