### PR TITLE
perf(forums): client-side navigate on reply and edit

### DIFF
--- a/resources/js/features/forums/hooks/useUpsertPostForm.ts
+++ b/resources/js/features/forums/hooks/useUpsertPostForm.ts
@@ -64,7 +64,7 @@ export function useUpsertPostForm(
           return t('Updated.');
         }
 
-        window.location.assign(
+        router.visit(
           route('forum-topic.show', {
             topic: targetTopic!.id,
             _query: { comment: data.commentId },


### PR DESCRIPTION
Swaps a leftover `window.location.assign()` with a `router.visit()`. This slightly improves page load speed on edit and submit.

To test this PR, just reply to a forum topic.