### PR TITLE
feat(forums): only show 'last edited' label if updatedAt is >= 2 minutes after createdAt

### DIFF
--- a/resources/js/features/forums/components/ForumPostCard/ForumPostCardMeta/ForumPostCardTimestamps.test.tsx
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostCardMeta/ForumPostCardTimestamps.test.tsx
@@ -113,7 +113,7 @@ describe('Component: ForumPostCardTimestamps', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
-  it('given a comment was edited at least 5 minutes after the create date, shows both creation and edit times', () => {
+  it('given a comment was edited at least 2 minutes after the create date, shows both creation and edit times', () => {
     // ARRANGE
     vi.setSystemTime(dayjs.utc('2023-10-25').toDate());
 
@@ -134,7 +134,7 @@ describe('Component: ForumPostCardTimestamps', () => {
     expect(screen.getByText(/Oct 24, 2023/i)).toBeVisible();
   });
 
-  it('given a comment was not edited at least 5 minutes after the create date, shows both creation and edit times', () => {
+  it('given a comment was not edited at least 2 minutes after the create date, shows both creation and edit times', () => {
     // ARRANGE
     vi.setSystemTime(dayjs.utc('2023-10-25').toDate());
 

--- a/resources/js/features/forums/components/ForumPostCard/ForumPostCardMeta/ForumPostCardTimestamps.test.tsx
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostCardMeta/ForumPostCardTimestamps.test.tsx
@@ -113,12 +113,12 @@ describe('Component: ForumPostCardTimestamps', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
-  it('given a comment was edited, shows both creation and edit times', () => {
+  it('given a comment was edited at least 5 minutes after the create date, shows both creation and edit times', () => {
     // ARRANGE
     vi.setSystemTime(dayjs.utc('2023-10-25').toDate());
 
     const createdAt = dayjs.utc().subtract(2, 'days').toISOString();
-    const updatedAt = dayjs.utc().subtract(1, 'day').toISOString();
+    const updatedAt = dayjs.utc(createdAt).add(1, 'day').toISOString(); // !!
 
     render(
       <ForumPostCardTimestamps
@@ -132,6 +132,24 @@ describe('Component: ForumPostCardTimestamps', () => {
 
     expect(screen.getByText(/Oct 23, 2023/i)).toBeVisible();
     expect(screen.getByText(/Oct 24, 2023/i)).toBeVisible();
+  });
+
+  it('given a comment was not edited at least 5 minutes after the create date, shows both creation and edit times', () => {
+    // ARRANGE
+    vi.setSystemTime(dayjs.utc('2023-10-25').toDate());
+
+    const createdAt = dayjs.utc().subtract(2, 'days').toISOString();
+    const updatedAt = dayjs.utc(createdAt).add(1, 'second').toISOString(); // !!
+
+    render(
+      <ForumPostCardTimestamps
+        comment={createForumTopicComment({ id: 1, createdAt, updatedAt })}
+      />,
+      { pageProps: { auth: { user: createAuthenticatedUser() } } },
+    );
+
+    // ASSERT
+    expect(screen.queryByText(/edited/i)).not.toBeInTheDocument();
   });
 
   it('given a date is null, does not crash', () => {

--- a/resources/js/features/forums/components/ForumPostCard/ForumPostCardMeta/ForumPostCardTimestamps.tsx
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostCardMeta/ForumPostCardTimestamps.tsx
@@ -37,14 +37,14 @@ export const ForumPostCardTimestamps: FC<ForumPostCardTimestampsProps> = ({ comm
       : formatDate(date, 'lll');
   };
 
-  // Check if an edit was made at least 5 minutes after creation.
+  // Check if an edit was made at least 2 minutes after creation.
   // We won't show "last edited" labels for an edit that happens right
   // after a post is made, because it's usually to fix something like a
   // spelling mistake or typo.
   const hasReceivedSignificantEdit =
     comment.updatedAt &&
     comment.createdAt &&
-    dayjs.utc(comment.updatedAt).diff(dayjs.utc(comment.createdAt), 'minute') >= 5;
+    dayjs.utc(comment.updatedAt).diff(dayjs.utc(comment.createdAt), 'minute') >= 2;
 
   const createdLabel = formatTime(comment.createdAt);
   const editedLabel = hasReceivedSignificantEdit ? formatTime(comment.updatedAt) : null;

--- a/resources/js/features/forums/components/ForumPostCard/ForumPostCardMeta/ForumPostCardTimestamps.tsx
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostCardMeta/ForumPostCardTimestamps.tsx
@@ -37,9 +37,17 @@ export const ForumPostCardTimestamps: FC<ForumPostCardTimestampsProps> = ({ comm
       : formatDate(date, 'lll');
   };
 
+  // Check if an edit was made at least 5 minutes after creation.
+  // We won't show "last edited" labels for an edit that happens right
+  // after a post is made, because it's usually to fix something like a
+  // spelling mistake or typo.
+  const hasReceivedSignificantEdit =
+    comment.updatedAt &&
+    comment.createdAt &&
+    dayjs.utc(comment.updatedAt).diff(dayjs.utc(comment.createdAt), 'minute') >= 5;
+
   const createdLabel = formatTime(comment.createdAt);
-  const editedLabel =
-    comment.updatedAt !== comment.createdAt ? formatTime(comment.updatedAt) : null;
+  const editedLabel = hasReceivedSignificantEdit ? formatTime(comment.updatedAt) : null;
 
   const shouldShowCreatedTooltip =
     !auth?.user.preferences.prefersAbsoluteDates &&


### PR DESCRIPTION
This PR makes an adjustment to how this label is presented in the forums:
<img width="260" alt="Screenshot 2025-04-29 at 5 00 13 PM" src="https://github.com/user-attachments/assets/1cdb61a1-d4cb-4b28-93f4-492c71a2fb50" />

"last edited" will now no longer appear on a post if the edit is within 2 minutes of the post's creation date. This gives the poster a chance to fix any typos they may have made in their post without it being visibly marked as edited.