### PR TITLE
fix(downloads): store popularity metrics in the db instead of redis

### DIFF
--- a/app/Console/Commands/CacheMostPopularSystems.php
+++ b/app/Console/Commands/CacheMostPopularSystems.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\DownloadsPopularityMetric;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 class CacheMostPopularSystems extends Command
@@ -50,7 +50,11 @@ class CacheMostPopularSystems extends Command
         // Extract just the system IDs in order.
         $topSystemIds = array_map(fn ($row) => (int) $row->system_id, $results);
 
-        Cache::put('top-systems', $topSystemIds, now()->addMonth());
+        // Store the ordered IDs in the database.
+        DownloadsPopularityMetric::updateOrCreate(
+            ['key' => 'top-systems'],
+            ['ordered_ids' => $topSystemIds]
+        );
 
         $this->newLine();
         $this->info("Done.");

--- a/app/Models/DownloadsPopularityMetric.php
+++ b/app/Models/DownloadsPopularityMetric.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Support\Database\Eloquent\BaseModel;
+
+class DownloadsPopularityMetric extends BaseModel
+{
+    protected $table = 'downloads_popularity_metrics';
+
+    protected $fillable = [
+        'key',
+        'ordered_ids',
+    ];
+
+    protected $casts = [
+        'ordered_ids' => 'array',
+    ];
+}

--- a/database/migrations/2025_05_02_000000_create_downloads_popularity_metrics_table.php
+++ b/database/migrations/2025_05_02_000000_create_downloads_popularity_metrics_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::create('downloads_popularity_metrics', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique(); // eg: 'top-systems', 'popular-emulators-for-system:0', 'popular-emulators-for-system:1'
+            $table->json('ordered_ids'); // JSON array of IDs in order of popularity.
+            $table->timestamps(); // so we can track when recalculations occur.
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('downloads_popularity_metrics');
+    }
+};


### PR DESCRIPTION
Currently, the downloads page uses persisted data in Redis for the system & emulator popularity metrics. However, this is being blown away on every prod deploy by our deployment script.

This PR moves the data to being stored in a lightweight table called `downloads_popularity_metrics`.