### PR TITLE
fix(forums): 404 if the topic has no visible posts

### DIFF
--- a/app/Community/Actions/BuildShowForumTopicPagePropsAction.php
+++ b/app/Community/Actions/BuildShowForumTopicPagePropsAction.php
@@ -28,6 +28,8 @@ class BuildShowForumTopicPagePropsAction
             ->orderBy('created_at')
             ->paginate($perPage, ['*'], 'page', $currentPage);
 
+        abort_if($paginatedForumTopicComments->total() === 0, 404);
+
         $totalForumTopicComments = $paginatedForumTopicComments->total();
         $lastPage = (int) ceil($totalForumTopicComments / $perPage);
 


### PR DESCRIPTION
Resolves "Undefined array key 0" in the logs: https://retroachievements.org/log-viewer?file=1c5b31b8-laravel-2025-05-02.log&query=log-index%3A98

This is caused by forum topics being viewed where the single post is by someone who has unauthorized posting privileges, thus there are no posts to view.