### PR TITLE
perf(BasePagination): prefetch on hover for desktop

### DIFF
--- a/resources/js/common/components/+vendor/BasePagination.tsx
+++ b/resources/js/common/components/+vendor/BasePagination.tsx
@@ -33,7 +33,7 @@ type BasePaginationLinkProps = {
   href: string;
   isActive?: boolean;
 } & Pick<BaseButtonProps, 'size'> &
-  ComponentProps<'a'> & { prefetch: InertiaLinkProps['prefetch'] };
+  ComponentProps<'a'> & { prefetch?: InertiaLinkProps['prefetch'] };
 
 const BasePaginationLink = ({
   className,

--- a/resources/js/common/components/+vendor/BasePagination.tsx
+++ b/resources/js/common/components/+vendor/BasePagination.tsx
@@ -4,7 +4,7 @@ import { LuChevronLeft, LuChevronRight, LuEllipsis } from 'react-icons/lu';
 
 import { cn } from '@/common/utils/cn';
 
-import { InertiaLink } from '../InertiaLink';
+import { InertiaLink, type InertiaLinkProps } from '../InertiaLink';
 import { type BaseButtonProps, baseButtonVariants } from './BaseButton';
 
 const BasePagination = ({ className, ...props }: ComponentProps<'nav'>) => (
@@ -33,13 +33,14 @@ type BasePaginationLinkProps = {
   href: string;
   isActive?: boolean;
 } & Pick<BaseButtonProps, 'size'> &
-  ComponentProps<'a'>;
+  ComponentProps<'a'> & { prefetch: InertiaLinkProps['prefetch'] };
 
 const BasePaginationLink = ({
   className,
   isActive,
-  size = 'icon',
   href,
+  prefetch = 'desktop-hover-only',
+  size = 'icon',
   ...props
 }: BasePaginationLinkProps) => (
   <InertiaLink
@@ -53,6 +54,7 @@ const BasePaginationLink = ({
       className,
     )}
     aria-disabled={props['aria-disabled']}
+    prefetch={prefetch}
   >
     {props.children}
   </InertiaLink>

--- a/resources/js/common/components/InertiaLink/InertiaLink.tsx
+++ b/resources/js/common/components/InertiaLink/InertiaLink.tsx
@@ -8,7 +8,7 @@ import { useInView } from 'react-intersection-observer';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import type { LinkPrefetchBehavior } from '@/common/models';
 
-type InertiaLinkProps = Omit<OriginalInertiaLinkProps, 'prefetch'> & {
+export type InertiaLinkProps = Omit<OriginalInertiaLinkProps, 'prefetch'> & {
   /**
    * Controls prefetch behavior:
    * - never: Default. Do not prefetch this link under any circumstance.


### PR DESCRIPTION
Improves the performance of the `FullPaginator` component wherever it's used, namely the forum, comment walls, and DMs. Now on hover for desktop devices only, the paginator prefetches the destination page, resulting in a moderately faster page transition.