### PR TITLE
feat(MessageThreadPolicy): allow moderators to access RAdmin

### DIFF
--- a/app/Policies/MessageThreadPolicy.php
+++ b/app/Policies/MessageThreadPolicy.php
@@ -140,18 +140,15 @@ class MessageThreadPolicy
      */
     public function getAccessibleTeamInboxes(User $user): array
     {
-        // Get all roles this user has.
-        $userRoles = collect($user->roles()->pluck('name')->toArray());
-        
-        // Filter the inbox map to only include roles the user has.
-        $accessibleInboxes = collect(static::ROLE_INBOX_MAP)
-            ->filter(function ($inboxName, $role) use ($userRoles) {
-                return $userRoles->contains($role);
-            })
-            ->values()
-            ->unique()
-            ->toArray();
-            
+        $userRoles = $user->roles()->pluck('name')->toArray();
+        $accessibleInboxes = [];
+
+        foreach (static::INBOX_ROLES_MAP as $inboxDisplayName => $roles) {
+            if (count(array_intersect($userRoles, $roles)) > 0) {
+                $accessibleInboxes[] = $inboxDisplayName;
+            }
+        }
+
         return $accessibleInboxes;
     }
 }

--- a/app/Policies/MessageThreadPolicy.php
+++ b/app/Policies/MessageThreadPolicy.php
@@ -15,16 +15,16 @@ class MessageThreadPolicy
     use HandlesAuthorization;
 
     /**
-     * Role => display_name
+     * Inbox display_name => [Roles]
      */
-    protected const ROLE_INBOX_MAP = [
-        Role::ADMINISTRATOR => 'RAdmin',
-        Role::DEV_COMPLIANCE => 'DevCompliance',
-        Role::QUALITY_ASSURANCE => 'QATeam',
-        Role::ARTIST => 'RAArtTeam',
-        Role::CHEAT_INVESTIGATOR => 'RACheats',
-        Role::WRITER => 'WritingTeam',
-        Role::EVENT_MANAGER => 'RAEvents',
+    protected const INBOX_ROLES_MAP = [
+        'DevCompliance' => [Role::DEV_COMPLIANCE],
+        'QATeam' => [Role::QUALITY_ASSURANCE],
+        'RAArtTeam' => [Role::ARTIST],
+        'RACheats' => [Role::CHEAT_INVESTIGATOR],
+        'RAdmin' => [Role::ADMINISTRATOR, Role::MODERATOR],
+        'RAEvents' => [Role::EVENT_MANAGER],
+        'WritingTeam' => [Role::WRITER],
     ];
 
     public function manage(User $user): bool
@@ -58,9 +58,12 @@ class MessageThreadPolicy
         if ($user && $teamAccount) {
             $teamDisplayName = $teamAccount->display_name;
 
-            foreach (static::ROLE_INBOX_MAP as $role => $inboxDisplayName) {
-                if ($inboxDisplayName === $teamDisplayName && $user->hasRole($role)) {
-                    return true;
+            if (isset(static::INBOX_ROLES_MAP[$teamDisplayName])) {
+                $allowedRoles = static::INBOX_ROLES_MAP[$teamDisplayName];
+                foreach ($allowedRoles as $role) {
+                    if ($user->hasRole($role)) {
+                        return true;
+                    }
                 }
             }
 
@@ -77,9 +80,12 @@ class MessageThreadPolicy
         if ($teamAccount) {
             $teamDisplayName = $teamAccount->display_name;
 
-            foreach (static::ROLE_INBOX_MAP as $role => $inboxDisplayName) {
-                if ($inboxDisplayName === $teamDisplayName && $user->hasRole($role)) {
-                    return true;
+            if (isset(static::INBOX_ROLES_MAP[$teamDisplayName])) {
+                $allowedRoles = static::INBOX_ROLES_MAP[$teamDisplayName];
+                foreach ($allowedRoles as $role) {
+                    if ($user->hasRole($role)) {
+                        return true;
+                    }
                 }
             }
 
@@ -136,9 +142,13 @@ class MessageThreadPolicy
     {
         $accessibleInboxes = [];
 
-        foreach (static::ROLE_INBOX_MAP as $role => $inboxDisplayName) {
-            if ($user->hasRole($role)) {
-                $accessibleInboxes[] = $inboxDisplayName;
+        foreach (static::INBOX_ROLES_MAP as $inboxDisplayName => $roles) {
+            foreach ($roles as $role) {
+                if ($user->hasRole($role)) {
+                    $accessibleInboxes[] = $inboxDisplayName;
+
+                    break;
+                }
             }
         }
 

--- a/app/Policies/MessageThreadPolicy.php
+++ b/app/Policies/MessageThreadPolicy.php
@@ -140,18 +140,18 @@ class MessageThreadPolicy
      */
     public function getAccessibleTeamInboxes(User $user): array
     {
-        $accessibleInboxes = [];
-
-        foreach (static::INBOX_ROLES_MAP as $inboxDisplayName => $roles) {
-            foreach ($roles as $role) {
-                if ($user->hasRole($role)) {
-                    $accessibleInboxes[] = $inboxDisplayName;
-
-                    break;
-                }
-            }
-        }
-
+        // Get all roles this user has.
+        $userRoles = collect($user->roles()->pluck('name')->toArray());
+        
+        // Filter the inbox map to only include roles the user has.
+        $accessibleInboxes = collect(static::ROLE_INBOX_MAP)
+            ->filter(function ($inboxName, $role) use ($userRoles) {
+                return $userRoles->contains($role);
+            })
+            ->values()
+            ->unique()
+            ->toArray();
+            
         return $accessibleInboxes;
     }
 }


### PR DESCRIPTION
This PR allows users with `Role::MODERATOR` to change their inbox to the RAdmin inbox.

Additionally, `ROLE_INBOX_MAP` has been flipped so the key is now the inbox `display_name`, and the value is a list of allowed roles.