### PR TITLE
fix(code-notes): don't show soft-deleted notes in the php ui

### DIFF
--- a/app/Helpers/database/code-note.php
+++ b/app/Helpers/database/code-note.php
@@ -1,10 +1,14 @@
 <?php
 
+use App\Models\MemoryNote;
 use App\Models\User;
 
 function loadCodeNotes(int $gameId): array
 {
-    $codeNotes = App\Models\MemoryNote::with('user')
+    $codeNotes = MemoryNote::query()
+        ->with(['user' => function ($query) {
+            $query->withTrashed();
+        }])
         ->where('game_id', $gameId)
         ->orderBy('address')
         ->get()


### PR DESCRIPTION
Soft deleted code notes are appearing in the legacy PHP UI (http://localhost:64000/codenotes.php?g=1) due to the legacy SQL query not considering the `deleted_at` field.