### PR TITLE
fix note deletion from client

### DIFF
--- a/app/Connect/Actions/SubmitCodeNoteAction.php
+++ b/app/Connect/Actions/SubmitCodeNoteAction.php
@@ -29,7 +29,7 @@ class SubmitCodeNoteAction extends BaseAuthenticatedApiAction
 
     protected function initialize(Request $request): ?array
     {
-        if (!$request->has(['g', 'm', 'n'])) {
+        if (!$request->has(['g', 'm'])) {
             return $this->missingParameters();
         }
 

--- a/tests/Feature/Connect/GetCodeNotesTest.php
+++ b/tests/Feature/Connect/GetCodeNotesTest.php
@@ -128,6 +128,28 @@ class GetCodeNotesTest extends TestCase
             ]);
 
         // ----------------------------
+        // user name still returned for deleted user
+        $otherUser->delete();
+        $this->post('dorequest.php', $this->apiParams('codenotes2', [
+            'g' => $game->ID,
+        ]))
+            ->assertExactJson([
+                'Success' => true,
+                'CodeNotes' => [
+                    [
+                        'User' => $otherUser->display_name,
+                        'Address' => '0x000bed',
+                        'Note' => 'Useful?',
+                    ],
+                    [
+                        'User' => $this->user->display_name,
+                        'Address' => '0x001235',
+                        'Note' => 'This is another note',
+                    ],
+                ],
+            ]);
+
+        // ----------------------------
         // unauthenticated
         $this->post('dorequest.php', $this->apiParams('codenotes2', [
             'g' => $game->ID,

--- a/tests/Feature/Connect/SubmitCodeNoteTest.php
+++ b/tests/Feature/Connect/SubmitCodeNoteTest.php
@@ -148,6 +148,17 @@ class SubmitCodeNoteTest extends TestCase
         $this->assertTrue($newNote->trashed());
         $this->assertEquals('This "note" is $pec!al', $newNote->body);
 
+        // ----------------------------
+        // delete deleted note
+        $this->post('dorequest.php', $this->apiParams('submitcodenote', [
+            'g' => $game->ID,
+            'm' => 0x1235,
+        ]))
+            ->assertExactJson(['Success' => true]);
+
+        $newNote->refresh();
+        $this->assertTrue($newNote->trashed());
+        $this->assertEquals('This "note" is $pec!al', $newNote->body);
     }
 
     public function testSubmitCodeNoteJuniorDeveloper(): void

--- a/tests/Feature/Connect/SubmitCodeNoteTest.php
+++ b/tests/Feature/Connect/SubmitCodeNoteTest.php
@@ -79,7 +79,7 @@ class SubmitCodeNoteTest extends TestCase
         $this->assertEquals('This is a new note', $note->body);
 
         // ----------------------------
-        // delete note
+        // delete note by setting to empty
         $this->post('dorequest.php', $this->apiParams('submitcodenote', [
             'g' => $game->ID,
             'm' => 0x1234,
@@ -134,6 +134,18 @@ class SubmitCodeNoteTest extends TestCase
         $game->refresh();
         $newNote = $game->memoryNotes->where('address', 0x1235)->first();
         $this->assertNotNull($newNote);
+        $this->assertEquals('This "note" is $pec!al', $newNote->body);
+
+        // ----------------------------
+        // delete note by setting to null
+        $this->post('dorequest.php', $this->apiParams('submitcodenote', [
+            'g' => $game->ID,
+            'm' => 0x1235,
+        ]))
+            ->assertExactJson(['Success' => true]);
+
+        $newNote->refresh();
+        $this->assertTrue($newNote->trashed());
         $this->assertEquals('This "note" is $pec!al', $newNote->body);
 
     }


### PR DESCRIPTION
Fixes first part of https://discord.com/channels/310192285306454017/310195377993416714/1367961651156095067 (ability to delete code notes from DLL). I believe the second part (them magically reappearing when deleted from the site) is handled by #3486.