### PR TITLE
fix(manage): perm-gate assign maintainer table action

### DIFF
--- a/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
@@ -174,7 +174,8 @@ class AchievementsRelationManager extends RelationManager
                                 ->body('Successfully assigned maintainer to selected achievement.')
                                 ->success()
                                 ->send();
-                        }),
+                        })
+                        ->visible(fn () => $user->can('assignMaintainer', Achievement::class)),
 
                     Tables\Actions\DeleteAction::make(),
                 ]),


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195377993416714/1368665461146910861

Hides the "Assign Maintainer" individual row action for users who do not have the permission to assign maintainers.