### PR TITLE
feat(game): add Similar Games to React game pages

### DIFF
--- a/app/Platform/Actions/BuildGameShowPagePropsAction.php
+++ b/app/Platform/Actions/BuildGameShowPagePropsAction.php
@@ -61,11 +61,19 @@ class BuildGameShowPagePropsAction
             }
         }
 
+        $similarGames = $game
+            ->similarGamesList
+            ->filter(
+                fn ($game) => !str_contains($game->title, '[Subset')
+            )
+            ->sortBy('sort_title');
+
         return new GameShowPagePropsData(
             can: UserPermissionsData::fromUser($user, game: $game)->include(
                 'createGameForumTopic',
                 'manageGames',
             ),
+
             game: GameData::fromGame($game)->include(
                 'achievementsPublished',
                 'badgeUrl',
@@ -97,6 +105,16 @@ class BuildGameShowPagePropsAction
                 'system.nameShort',
                 'system',
             ),
+
+            similarGames: $similarGames->map(fn ($game) => GameData::fromGame($game)->include(
+                'achievementsPublished',
+                'badgeUrl',
+                'system.iconUrl',
+                'system.nameShort',
+                'pointsTotal',
+                'pointsWeighted',
+            ))->values()->all(),
+
             hubs: $game->hubs->map(fn ($hub) => GameSetData::from($hub))->all(),
             followedPlayerCompletions: $this->buildFollowedPlayerCompletionAction->execute($user, $game),
             playerAchievementChartBuckets: $this->buildGameAchievementDistributionAction->execute($game, $user),

--- a/app/Platform/Actions/BuildHubBreadcrumbsAction.php
+++ b/app/Platform/Actions/BuildHubBreadcrumbsAction.php
@@ -9,6 +9,7 @@ use App\Platform\Data\GameSetData;
 use App\Platform\Enums\GameSetType;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Spatie\LaravelData\Lazy;
 
 /**
  * Builds breadcrumb navigation paths for hub (game set) hierarchies.
@@ -167,6 +168,7 @@ class BuildHubBreadcrumbsAction
                 forumTopicId: null,
                 updatedAt: new Carbon($data['updated_at']),
                 gameId: 0,
+                game: Lazy::create(fn () => null),
                 hasMatureContent: false, // doesn't matter, this is just a breadcrumb
             ),
             $cachedData ?? [],

--- a/app/Platform/Controllers/GameController.php
+++ b/app/Platform/Controllers/GameController.php
@@ -96,8 +96,6 @@ class GameController extends Controller
         $game = $loadGameWithRelationsAction->execute($game, AchievementFlag::OfficialCore);
         $props = $buildGameShowPagePropsAction->execute($game, $user);
 
-        // dd(json_encode($props, JSON_PRETTY_PRINT));
-
         return Inertia::render('game/[game]', $props);
     }
 

--- a/app/Platform/Data/GameSetData.php
+++ b/app/Platform/Data/GameSetData.php
@@ -23,6 +23,7 @@ class GameSetData extends Data
         public int $linkCount,
         public Carbon $updatedAt,
         public Lazy|int|null $forumTopicId,
+        public Lazy|GameData $game,
         public Lazy|int|null $gameId,
         public Lazy|bool $hasMatureContent,
     ) {
@@ -42,6 +43,7 @@ class GameSetData extends Data
             linkCount: $gameSet->link_count ?? 0,
             updatedAt: $gameSet->updated_at,
             forumTopicId: Lazy::create(fn () => $gameSet->forum_topic_id),
+            game: Lazy::create(fn () => $gameSet->game),
             gameId: Lazy::create(fn () => $gameSet->game_id),
             hasMatureContent: Lazy::create(fn () => $gameSet->has_mature_content),
         );

--- a/app/Platform/Data/GameShowPagePropsData.php
+++ b/app/Platform/Data/GameShowPagePropsData.php
@@ -27,6 +27,8 @@ class GameShowPagePropsData extends Data
         public int $numCompatibleHashes,
         public int $numMasters,
         public int $numOpenTickets,
+        /** @var GameData[] */
+        public array $similarGames,
         public Collection $topAchievers,
         public ?PlayerGameData $playerGame,
         public ?PlayerGameProgressionAwardsData $playerGameProgressionAwards,

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -922,5 +922,6 @@
     "Find Related Games": "Find Related Games",
     "Memory": "Memory",
     "Guide": "Guide",
-    "Event Details": "Event Details"
+    "Event Details": "Event Details",
+    "Similar Games": "Similar Games"
 }

--- a/resources/js/features/games/components/+show-sidebar/GameShowSidebarRoot.tsx
+++ b/resources/js/features/games/components/+show-sidebar/GameShowSidebarRoot.tsx
@@ -8,6 +8,7 @@ import { PlayableTopPlayers } from '@/common/components/PlayableTopPlayers';
 import { usePageProps } from '@/common/hooks/usePageProps';
 
 import { GameSidebarFullWidthButtons } from '../GameSidebarFullWidthButtons';
+import { SimilarGamesList } from '../SimilarGamesList';
 
 export const GameShowSidebarRoot: FC = () => {
   const {
@@ -17,6 +18,7 @@ export const GameShowSidebarRoot: FC = () => {
     playerAchievementChartBuckets,
     playerGame,
     numMasters,
+    similarGames,
     topAchievers,
   } = usePageProps<App.Platform.Data.GameShowPageProps>();
 
@@ -30,6 +32,7 @@ export const GameShowSidebarRoot: FC = () => {
     <div data-testid="sidebar" className="flex flex-col gap-6">
       <PlayableBoxArtImage src={game.imageBoxArtUrl} />
       <GameSidebarFullWidthButtons game={game} />
+      <SimilarGamesList similarGames={similarGames} />
       <PlayableHubsList hubs={hubs} />
       <PlayableCompareProgress
         followedPlayerCompletions={followedPlayerCompletions}

--- a/resources/js/features/games/components/+show/GameShowMainRoot.tsx
+++ b/resources/js/features/games/components/+show/GameShowMainRoot.tsx
@@ -13,7 +13,9 @@ import { PrimaryMetadataChip } from '../PrimaryMetadataChip';
 import { ReleasedAtChip } from '../ReleasedAtChip';
 
 export const GameShowMainRoot: FC = () => {
-  const { game, hubs } = usePageProps<App.Platform.Data.GameShowPageProps>();
+  const { game, hubs, similarGames } = usePageProps<App.Platform.Data.GameShowPageProps>();
+
+  console.log(similarGames);
 
   const { t } = useTranslation();
 

--- a/resources/js/features/games/components/SimilarGamesList/SimilarGamesList.test.tsx
+++ b/resources/js/features/games/components/SimilarGamesList/SimilarGamesList.test.tsx
@@ -1,0 +1,96 @@
+import { createAuthenticatedUser } from '@/common/models';
+import { render, screen } from '@/test';
+import { createGame, createSystem } from '@/test/factories';
+
+import { SimilarGamesList } from './SimilarGamesList';
+
+describe('Component: SimilarGamesList', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const system = createSystem();
+    const similarGames = [createGame({ system })];
+
+    const { container } = render(<SimilarGamesList similarGames={similarGames} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser(),
+        },
+      },
+    });
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given no similar games, renders nothing', () => {
+    // ARRANGE
+    render(<SimilarGamesList similarGames={[]} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser(),
+        },
+      },
+    });
+
+    // ASSERT
+    expect(screen.queryByText(/similar games/i)).not.toBeInTheDocument();
+  });
+
+  it('given null for similar games, renders nothing', () => {
+    // ARRANGE
+    render(<SimilarGamesList similarGames={null as any} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser(),
+        },
+      },
+    });
+
+    // ASSERT
+    expect(screen.queryByText(/similar games/i)).not.toBeInTheDocument();
+  });
+
+  it('given similar games, renders the correct heading', () => {
+    // ARRANGE
+    const system = createSystem();
+    const similarGames = [createGame({ system })];
+    render(<SimilarGamesList similarGames={similarGames} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser(),
+        },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText(/similar games/i)).toBeVisible();
+  });
+
+  it('given similar games, renders a list item for each game', () => {
+    // ARRANGE
+    const system = createSystem();
+    const similarGames = [
+      createGame({ system, id: 1, title: 'Game One' }),
+      createGame({ system, id: 2, title: 'Game Two' }),
+      createGame({ system, id: 3, title: 'Game Three' }),
+    ];
+
+    render(<SimilarGamesList similarGames={similarGames} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser(),
+        },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByTestId('similar-games-list')).toBeVisible();
+
+    expect(screen.getAllByText('Game One')[0]).toBeVisible();
+    expect(screen.getAllByText('Game Two')[0]).toBeVisible();
+    expect(screen.getAllByText('Game Three')[0]).toBeVisible();
+
+    const listItems = screen.getAllByRole('listitem');
+    expect(listItems).toHaveLength(3);
+  });
+});

--- a/resources/js/features/games/components/SimilarGamesList/SimilarGamesList.tsx
+++ b/resources/js/features/games/components/SimilarGamesList/SimilarGamesList.tsx
@@ -1,0 +1,35 @@
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { SimilarGamesListItem } from './SimilarGamesListItem';
+
+interface SimilarGamesListProps {
+  similarGames: App.Platform.Data.Game[];
+}
+
+export const SimilarGamesList: FC<SimilarGamesListProps> = ({ similarGames }) => {
+  const { t } = useTranslation();
+
+  if (!similarGames?.length) {
+    return null;
+  }
+
+  return (
+    <div data-testid="similar-games-list">
+      <h2 className="mb-0 border-0 text-lg font-semibold">{t('Similar Games')}</h2>
+
+      <div className="rounded-lg bg-embed p-1 light:border light:border-neutral-200 light:bg-white">
+        <ul className="zebra-list overflow-hidden rounded-lg">
+          {similarGames.map((similarGame) => (
+            <li
+              key={`similar-games-list-item-${similarGame.id}`}
+              className="w-full p-2 first:rounded-t-lg last:rounded-b-lg"
+            >
+              <SimilarGamesListItem game={similarGame} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/SimilarGamesListItem.test.tsx
+++ b/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/SimilarGamesListItem.test.tsx
@@ -1,0 +1,133 @@
+import { createAuthenticatedUser } from '@/common/models';
+import { render, screen } from '@/test';
+import { createGame, createSystem, createZiggyProps } from '@/test/factories';
+
+import { SimilarGamesListItem } from './SimilarGamesListItem';
+
+describe('Component: SimilarGamesListItem', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const system = createSystem({ name: 'Test System' });
+    const game = createGame({ system });
+    const { container } = render(<SimilarGamesListItem game={game} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser({ displayName: 'TestUser' }),
+        },
+        ziggy: createZiggyProps({}),
+      },
+    });
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given a game with achievements, displays the achievement count and points', () => {
+    // ARRANGE
+    const system = createSystem();
+    const game = createGame({
+      system,
+      achievementsPublished: 15,
+      pointsTotal: 7500,
+    });
+
+    render(<SimilarGamesListItem game={game} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser({ displayName: 'TestUser' }),
+        },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText('15')).toBeVisible();
+    expect(screen.getByText('7,500 points')).toBeVisible();
+  });
+
+  it('given a game with no achievements, displays the achievement count with muted styling', () => {
+    // ARRANGE
+    const system = createSystem();
+    const game = createGame({
+      system,
+      achievementsPublished: 0,
+      pointsTotal: 0,
+    });
+
+    render(<SimilarGamesListItem game={game} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser({ displayName: 'TestUser' }),
+        },
+      },
+    });
+
+    // ASSERT
+    const achievementElement = screen.getByText('0');
+    expect(achievementElement).toBeVisible();
+
+    const achievementContainer = achievementElement.closest('p');
+    expect(achievementContainer).toHaveClass('text-neutral-600');
+
+    const pointsElement = screen.getByText('0 points');
+    expect(pointsElement).toBeVisible();
+    expect(pointsElement).toHaveClass('text-neutral-600');
+  });
+
+  it('given a game with a system, displays the system chip', () => {
+    // ARRANGE
+    const system = createSystem({ name: 'PlayStation', nameShort: 'PS1' });
+    const game = createGame({ system });
+
+    render(<SimilarGamesListItem game={game} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser({ displayName: 'TestUser' }),
+        },
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByText(/ps1/i)).toBeVisible();
+  });
+
+  it('given a game without a system, does not display a system chip', () => {
+    // ARRANGE
+    const game = createGame({ system: undefined });
+
+    render(<SimilarGamesListItem game={game} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser(),
+        },
+      },
+    });
+
+    // ASSERT
+    expect(screen.queryByText(/system/i)).not.toBeInTheDocument();
+  });
+
+  it('given a game, renders the game badge with correct attributes', () => {
+    // ARRANGE
+    const game = createGame({
+      title: 'Elden Ring',
+      badgeUrl: 'https://example.com/elden-ring.png',
+    });
+
+    render(<SimilarGamesListItem game={game} />, {
+      pageProps: {
+        auth: {
+          user: createAuthenticatedUser(),
+        },
+      },
+    });
+
+    // ASSERT
+    const imageElement = screen.getByAltText('Elden Ring');
+    expect(imageElement).toBeVisible();
+    expect(imageElement).toHaveAttribute('src', 'https://example.com/elden-ring.png');
+    expect(imageElement).toHaveAttribute('width', '36');
+    expect(imageElement).toHaveAttribute('height', '36');
+    expect(imageElement).toHaveAttribute('loading', 'lazy');
+    expect(imageElement).toHaveAttribute('decoding', 'async');
+  });
+});

--- a/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/SimilarGamesListItem.tsx
+++ b/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/SimilarGamesListItem.tsx
@@ -72,9 +72,7 @@ export const SimilarGamesListItem: FC<SimilarGamesListItemProps> = ({ game }) =>
         <p
           className={cn(
             'flex items-center gap-1 text-2xs',
-            game.achievementsPublished === 0
-              ? 'text-neutral-600 light:text-neutral-400'
-              : 'text-neutral-300 light:text-neutral-700',
+            game.achievementsPublished === 0 ? 'text-neutral-600 light:text-neutral-400' : null,
           )}
         >
           {t('{{val, number}} points', {

--- a/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/SimilarGamesListItem.tsx
+++ b/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/SimilarGamesListItem.tsx
@@ -1,0 +1,84 @@
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FaTrophy } from 'react-icons/fa';
+import { route } from 'ziggy-js';
+
+import { GameTitle } from '@/common/components/GameTitle';
+import { InertiaLink } from '@/common/components/InertiaLink';
+import { SystemChip } from '@/common/components/SystemChip';
+import { useCardTooltip } from '@/common/hooks/useCardTooltip';
+import { usePageProps } from '@/common/hooks/usePageProps';
+import { cn } from '@/common/utils/cn';
+
+interface SimilarGamesListItemProps {
+  game: App.Platform.Data.Game;
+}
+
+export const SimilarGamesListItem: FC<SimilarGamesListItemProps> = ({ game }) => {
+  const { auth } = usePageProps();
+
+  const { t } = useTranslation();
+
+  const { cardTooltipProps } = useCardTooltip({
+    dynamicType: 'game',
+    dynamicId: game.id,
+    dynamicContext: auth?.user.displayName,
+  });
+
+  return (
+    <div className="flex w-full items-center justify-between gap-2">
+      <div className="relative flex items-center gap-x-2">
+        {/* Keep the image and game title in a single tooltipped container. Do not tooltip the system name. */}
+        <InertiaLink href={route('game2.show', { game: game.id })} {...cardTooltipProps}>
+          <img
+            src={game.badgeUrl}
+            alt={game.title}
+            width={36}
+            height={36}
+            className="h-9 w-9"
+            loading="lazy"
+            decoding="async"
+          />
+
+          <p className="absolute left-7 top-0 mb-0.5 line-clamp-1 pl-4 text-xs font-medium">
+            <GameTitle title={game.title} />
+          </p>
+        </InertiaLink>
+
+        <div>
+          {/* Provide invisible space to slide the system underneath. */}
+          <p className="invisible mb-0.5 line-clamp-1 max-w-fit text-xs font-medium">
+            <GameTitle title={game.title} />
+          </p>
+
+          <div className="flex items-center gap-1">
+            {game.system ? <SystemChip {...game.system} /> : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-end whitespace-nowrap">
+        <p
+          className={cn(
+            'flex items-center gap-1 text-xs',
+            game.achievementsPublished === 0 ? 'text-neutral-600' : 'text-neutral-300',
+          )}
+        >
+          <FaTrophy /> {game.achievementsPublished}
+        </p>
+
+        <p
+          className={cn(
+            'flex items-center gap-1 text-2xs',
+            game.achievementsPublished === 0 ? 'text-neutral-600' : null,
+          )}
+        >
+          {t('{{val, number}} points', {
+            val: game.pointsTotal,
+            count: game.pointsTotal,
+          })}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/SimilarGamesListItem.tsx
+++ b/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/SimilarGamesListItem.tsx
@@ -61,7 +61,9 @@ export const SimilarGamesListItem: FC<SimilarGamesListItemProps> = ({ game }) =>
         <p
           className={cn(
             'flex items-center gap-1 text-xs',
-            game.achievementsPublished === 0 ? 'text-neutral-600' : 'text-neutral-300',
+            game.achievementsPublished === 0
+              ? 'text-neutral-600 light:text-neutral-400'
+              : 'text-neutral-300 light:text-neutral-700',
           )}
         >
           <FaTrophy /> {game.achievementsPublished}
@@ -70,7 +72,9 @@ export const SimilarGamesListItem: FC<SimilarGamesListItemProps> = ({ game }) =>
         <p
           className={cn(
             'flex items-center gap-1 text-2xs',
-            game.achievementsPublished === 0 ? 'text-neutral-600' : null,
+            game.achievementsPublished === 0
+              ? 'text-neutral-600 light:text-neutral-400'
+              : 'text-neutral-300 light:text-neutral-700',
           )}
         >
           {t('{{val, number}} points', {

--- a/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/index.ts
+++ b/resources/js/features/games/components/SimilarGamesList/SimilarGamesListItem/index.ts
@@ -1,0 +1,1 @@
+export * from './SimilarGamesListItem';

--- a/resources/js/features/games/components/SimilarGamesList/index.ts
+++ b/resources/js/features/games/components/SimilarGamesList/index.ts
@@ -1,0 +1,1 @@
+export * from './SimilarGamesList';

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -660,6 +660,7 @@ declare namespace App.Platform.Data {
     linkCount: number;
     updatedAt: string;
     forumTopicId?: number | null;
+    game?: App.Platform.Data.Game;
     gameId?: number | null;
     hasMatureContent?: boolean;
   };
@@ -672,6 +673,7 @@ declare namespace App.Platform.Data {
     numCompatibleHashes: number;
     numMasters: number;
     numOpenTickets: number;
+    similarGames: Array<App.Platform.Data.Game>;
     topAchievers: Array<App.Platform.Data.GameTopAchiever>;
     playerGame: App.Platform.Data.PlayerGame | null;
     playerGameProgressionAwards: App.Platform.Data.PlayerGameProgressionAwards | null;


### PR DESCRIPTION
This PR adds a Similar Games component to React game pages:
![Screenshot 2025-05-08 at 7 58 17 PM](https://github.com/user-attachments/assets/c3435711-03ee-4ddb-970d-bbc3bb0009dc)

Some subtle nuances to note:
* Games are sorted server-side by `sort_title`.
* Rather than show RetroPoints, which tends to confuse new users, the achievement count is shown instead. The achievement icon is the same one from the navbar.