### PR TITLE
feat(game): add type indicators to React game pages

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -922,5 +922,8 @@
     "Find Related Games": "Find Related Games",
     "Memory": "Memory",
     "Guide": "Guide",
-    "Event Details": "Event Details"
+    "Event Details": "Event Details",
+    "Progression": "Progression",
+    "Win Condition": "Win Condition",
+    "Missable": "Missable"
 }

--- a/resources/js/common/components/AchievementsListItem/AchievementTypeIndicator/AchievementTypeIndicator.test.tsx
+++ b/resources/js/common/components/AchievementsListItem/AchievementTypeIndicator/AchievementTypeIndicator.test.tsx
@@ -1,0 +1,52 @@
+import userEvent from '@testing-library/user-event';
+
+import { render, screen, waitFor } from '@/test';
+
+import { AchievementTypeIndicator } from './AchievementTypeIndicator';
+
+describe('Component: AchievementTypeIndicator', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const { container } = render(<AchievementTypeIndicator type="missable" />);
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given the type is missable, renders the missable icon with correct label', () => {
+    // ARRANGE
+    render(<AchievementTypeIndicator type="missable" />);
+
+    // ASSERT
+    expect(screen.getByLabelText(/missable/i)).toBeVisible();
+  });
+
+  it('given the type is progression, renders the progression icon with correct label', () => {
+    // ARRANGE
+    render(<AchievementTypeIndicator type="progression" />);
+
+    // ASSERT
+    expect(screen.getByLabelText(/progression/i)).toBeVisible();
+  });
+
+  it('given the type is win_condition, renders the win condition icon with correct label', () => {
+    // ARRANGE
+    render(<AchievementTypeIndicator type="win_condition" />);
+
+    // ASSERT
+    expect(screen.getByLabelText(/win condition/i)).toBeVisible();
+  });
+
+  it('renders a tooltip with the appropriate label when hovered', async () => {
+    // ARRANGE
+    render(<AchievementTypeIndicator type="missable" />);
+
+    // ACT
+    await userEvent.hover(screen.getByLabelText(/missable/i));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip', { name: /missable/i })).toBeVisible();
+    });
+  });
+});

--- a/resources/js/common/components/AchievementsListItem/AchievementTypeIndicator/AchievementTypeIndicator.tsx
+++ b/resources/js/common/components/AchievementsListItem/AchievementTypeIndicator/AchievementTypeIndicator.tsx
@@ -1,0 +1,48 @@
+import type { FC, ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/common/utils/cn';
+import type { TranslatedString } from '@/types/i18next';
+
+import { BaseTooltip, BaseTooltipContent, BaseTooltipTrigger } from '../../+vendor/BaseTooltip';
+import { RaMissable } from '../../RaMissable';
+import { RaProgression } from '../../RaProgression';
+import { RaWinCondition } from '../../RaWinCondition';
+
+interface AchievementTypeIndicatorProps {
+  type: NonNullable<App.Platform.Data.Achievement['type']>;
+}
+
+export const AchievementTypeIndicator: FC<AchievementTypeIndicatorProps> = ({ type }) => {
+  const { t } = useTranslation();
+
+  const typeMetaMap: Record<
+    AchievementTypeIndicatorProps['type'],
+    { label: TranslatedString; icon: ReactNode }
+  > = {
+    missable: { icon: <RaMissable className="size-[18px]" />, label: t('Missable') },
+    progression: { icon: <RaProgression className="size-[18px]" />, label: t('Progression') },
+    win_condition: { icon: <RaWinCondition className="size-[18px]" />, label: t('Win Condition') },
+  };
+
+  const { icon, label } = typeMetaMap[type];
+
+  return (
+    <BaseTooltip>
+      <BaseTooltipTrigger asChild>
+        <div
+          className={cn(
+            'group flex items-center rounded-full border bg-embed p-1',
+            'text-neutral-200 light:border-neutral-300 light:bg-neutral-50 light:text-neutral-500',
+
+            type === 'missable' ? 'border-dashed border-stone-500' : 'border-transparent',
+          )}
+        >
+          <div aria-label={label}>{icon}</div>
+        </div>
+      </BaseTooltipTrigger>
+
+      <BaseTooltipContent>{label}</BaseTooltipContent>
+    </BaseTooltip>
+  );
+};

--- a/resources/js/common/components/AchievementsListItem/AchievementTypeIndicator/index.ts
+++ b/resources/js/common/components/AchievementsListItem/AchievementTypeIndicator/index.ts
@@ -1,0 +1,1 @@
+export * from './AchievementTypeIndicator';

--- a/resources/js/common/components/AchievementsListItem/AchievementsListItem.test.tsx
+++ b/resources/js/common/components/AchievementsListItem/AchievementsListItem.test.tsx
@@ -154,4 +154,25 @@ describe('Component: AchievementsListItem', () => {
     await __UNSAFE_VERY_DANGEROUS_SLEEP(100); // let any animations finish up
     expect(screen.queryByText(/100/i)).not.toBeInTheDocument();
   });
+
+  it('given an achievement has a type, displays a type indicator', async () => {
+    // ARRANGE
+    const achievement = createAchievement({
+      type: 'progression',
+    });
+
+    render(
+      <AchievementsListItem
+        achievement={achievement}
+        index={0}
+        isLargeList={false}
+        playersTotal={null}
+      />,
+    );
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByLabelText(/progression/i)).toBeVisible();
+    });
+  });
 });

--- a/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
+++ b/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
@@ -45,7 +45,7 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
 
   return (
     <motion.li
-      className="flex w-full gap-x-3 px-2 py-3 odd:bg-[rgba(50,50,50,0.4)] light:odd:bg-neutral-100 md:py-1"
+      className="flex w-full gap-x-3.5 px-2 py-3 odd:bg-[rgba(50,50,50,0.4)] light:odd:bg-neutral-100 md:gap-x-3 md:py-1"
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 10 }}
@@ -56,7 +56,7 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
           : Math.min(index * 0.015, 0.2), // Cap at 200ms for small lists
       }}
     >
-      <div className="flex flex-col gap-y-1 self-center">
+      <div className="flex flex-col gap-y-1 md:mt-1">
         <AchievementAvatar
           {...achievement}
           showLabel={false}
@@ -66,12 +66,12 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
         />
       </div>
 
-      <div className="mt-1 grid w-full gap-x-5 gap-y-1.5 leading-4 md:grid-cols-6">
+      <div className="grid w-full gap-x-5 gap-y-1.5 leading-4 md:grid-cols-6">
         {/* Title and description area */}
         <div className="md:col-span-4">
           <div className="mb-0.5 flex justify-between gap-x-2">
             {/* Title */}
-            <div className="-mt-2 mb-0.5 md:mt-0">
+            <div className="-mt-1 mb-0.5 md:mt-0">
               <span className="mr-2">
                 <a href={route('achievement.show', { achievement })} className="font-medium">
                   {title}
@@ -119,7 +119,7 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
 
         {/* Progress bar and stats area */}
         {playersTotal !== null ? (
-          <div className="md:col-span-2 md:flex md:flex-col-reverse md:justify-end md:gap-y-1 md:pt-1">
+          <div className="mt-1 md:col-span-2 md:flex md:flex-col-reverse md:justify-end md:gap-y-1 md:pt-1">
             {/* Meta chips (Desktop) */}
             {type ? (
               <div className="hidden items-center justify-end gap-x-1 md:flex">

--- a/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
+++ b/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
@@ -10,6 +10,7 @@ import { formatPercentage } from '@/common/utils/l10n/formatPercentage';
 import { AchievementDateMeta } from './AchievementDateMeta';
 import { AchievementGameTitle } from './AchievementGameTitle';
 import { AchievementPoints } from './AchievementPoints';
+import { AchievementTypeIndicator } from './AchievementTypeIndicator';
 import { ProgressBarMetaText } from './ProgressBarMetaText';
 
 interface AchievementsListItemProps {
@@ -35,7 +36,7 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const { title, description, game } = achievement;
+  const { description, game, title, type } = achievement;
 
   const unlockPercentage = achievement.unlockPercentage ? Number(achievement.unlockPercentage) : 0;
 
@@ -96,11 +97,13 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
             </div>
 
             {/* Meta chips (Mobile) */}
-            {/* <div className="-mt-1.5 flex items-center gap-x-1 md:hidden">
-              <div className="-mt-1.5">
-
+            {type ? (
+              <div className="-mt-1.5 flex items-center gap-x-1 md:hidden">
+                <div className="-mt-1.5">
+                  <AchievementTypeIndicator type={type} />
+                </div>
               </div>
-            </div> */}
+            ) : null}
           </div>
 
           {/* Description */}
@@ -117,8 +120,12 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
         {/* Progress bar and stats area */}
         {playersTotal !== null ? (
           <div className="md:col-span-2 md:flex md:flex-col-reverse md:justify-end md:gap-y-1 md:pt-1">
-            {/* Meta chips */}
-            {/* <div className="hidden items-center justify-end gap-x-1 md:flex"></div> */}
+            {/* Meta chips (Desktop) */}
+            {type ? (
+              <div className="hidden items-center justify-end gap-x-1 md:flex">
+                <AchievementTypeIndicator type={type} />
+              </div>
+            ) : null}
 
             <p className="-mt-1.5 hidden text-center text-2xs md:block">
               {t('{{percentage}} unlock rate', {


### PR DESCRIPTION
This PR adds type indicators to achievement rows on the React game pages.

There are two subtle behavior changes to keep in mind:
* The text animation has been replaced with `BaseTooltip`. This is so we can put other things in the rows (such as comment counts) without being design-constrained.
* The "[m]" invisible text on missable icons has been retired.

The beaten game credit dialog is not implemented yet.

![Screenshot 2025-05-09 at 6 14 00 PM](https://github.com/user-attachments/assets/a94aabdb-b6bd-4fc1-bc8e-fa8b9e82e131)

![Screenshot 2025-05-09 at 6 14 03 PM](https://github.com/user-attachments/assets/1d379c78-f207-4341-9ac0-72f16c282b7d)
