### PR TITLE
chore(connect): remove multiset stuff from patch

### DIFF
--- a/app/Connect/Actions/BuildClientPatchDataAction.php
+++ b/app/Connect/Actions/BuildClientPatchDataAction.php
@@ -12,7 +12,6 @@ use App\Models\GameHash;
 use App\Models\PlayerGame;
 use App\Models\User;
 use App\Platform\Enums\AchievementFlag;
-use App\Platform\Enums\AchievementSetType;
 use App\Platform\Services\VirtualGameIdService;
 use Illuminate\Database\Eloquent\Collection;
 use InvalidArgumentException;
@@ -47,65 +46,34 @@ class BuildClientPatchDataAction
 
         // For legacy clients that don't provide a hash, just use the game directly.
         if (!$gameHash) {
-            return $this->buildPatchData($game, null, $user, $flag);
+            return $this->buildPatchData($game, $user, $flag);
         }
 
         // If the hash is not marked as compatible, and the current user is not flagged to
         // be testing the hash, return a dummy set that will inform the user.
-        if ($gameHash->compatibility !== GameHashCompatibility::Compatible
-                && $gameHash->compatibility_tester_id !== $user?->id) {
-            return $this->buildIncompatiblePatchData($game ?? $gameHash->game, $gameHash->compatibility, $user);
+        if (
+            $gameHash->compatibility !== GameHashCompatibility::Compatible
+            && $gameHash->compatibility_tester_id !== $user?->id
+        ) {
+            return $this->buildIncompatiblePatchData($game ?? $gameHash->game, $gameHash->compatibility);
         }
 
         $rootGameId = (new ResolveRootGameIdFromGameAndGameHashAction())->execute($gameHash, $game, $user);
         $rootGame = Game::find($rootGameId);
 
-        // If multiset is disabled or there's no user, just use the game directly.
-        if (!$user || $user->is_globally_opted_out_of_subsets) {
-            return $this->buildPatchData($rootGame, null, $user, $flag);
-        }
-
-        // Resolve sets once - we'll use this for building the full patch data.
-        $resolvedSets = (new ResolveAchievementSetsAction())->execute($gameHash, $user);
-        if ($resolvedSets->isEmpty()) {
-            return $this->buildPatchData($rootGame, null, $user, $flag);
-        }
-
-        // Get the core game from the first resolved set.
-        $coreSet = $resolvedSets->first();
-        $coreGame = Game::find($coreSet->game_id) ?? $rootGame;
-
-        $richPresencePatch = $coreGame->RichPresencePatch;
-
-        // For specialty/exclusive sets, we use:
-        // - The root game's ID and achievements (already determined by ResolveRootGameIdFromGameAndGameHashAction).
-        // - The core game's title and image.
-        // - The root game's RP if present, otherwise fall back to core game's RP.
-        if ($rootGameId === $gameHash->game->id) {
-            $richPresencePatch = $gameHash->game->RichPresencePatch ?: $richPresencePatch;
-
-            return $this->buildPatchData($rootGame, $resolvedSets, $user, $flag, $richPresencePatch, $coreGame);
-        }
-
-        // For all other cases (including bonus sets), we use the core game's data.
-        return $this->buildPatchData($coreGame, $resolvedSets, $user, $flag, $richPresencePatch);
+        // This endpoint assumes multiset is not in use. Just use the game directly.
+        return $this->buildPatchData($rootGame, $user, $flag);
     }
 
     /**
      * @param Game $game The game to build root-level data for
-     * @param Collection<int, GameAchievementSet>|null $resolvedSets The sets to send to the client/emulator
      * @param User|null $user The current user requesting the patch data (for player count calculations)
      * @param AchievementFlag|null $flag Optional flag to filter the achievements by (eg: only official achievements)
-     * @param string|null $richPresencePatch The RP patch code that the client should use
-     * @param Game|null $titleGame Optional game to use for title and image (for specialty/exclusive sets)
      */
     private function buildPatchData(
         Game $game,
-        ?Collection $resolvedSets,
         ?User $user,
         ?AchievementFlag $flag,
-        ?string $richPresencePatch = null,
-        ?Game $titleGame = null
     ): array {
         $gamePlayerCount = $this->calculateGamePlayerCount($game, $user);
 
@@ -114,88 +82,14 @@ class BuildClientPatchDataAction
             ->with('achievementSet.achievements.developer')
             ->first();
 
-        // Don't fetch the games in the loop if we have sets. Grab them all in a single query.
-        $sets = [];
-        if ($resolvedSets?->isNotEmpty()) {
-            $coreGameIds = $resolvedSets->pluck('core_game_id')->unique();
-            $achievementSetIds = $resolvedSets->pluck('achievement_set_id')->unique();
-
-            // Preload all games.
-            $games = Game::whereIn('ID', $coreGameIds)->get()->keyBy('ID');
-
-            // Preload all GameAchievementSet entities we'll need.
-            $gameAchievementSets = GameAchievementSet::where(function ($query) use ($game, $achievementSetIds) {
-                $query->where('game_id', $game->id)->whereIn('achievement_set_id', $achievementSetIds);
-            })->orWhere(function ($query) use ($resolvedSets) {
-                $query
-                    ->whereIn('game_id', $resolvedSets->pluck('game_id'))
-                    ->whereIn('achievement_set_id', $resolvedSets->pluck('achievement_set_id'));
-            })->get();
-
-            foreach ($resolvedSets as $resolvedSet) {
-                // We don't want to include sets in the list that are duplicative
-                // with the root-level data in the response (for achievements & leaderboards).
-                if ($resolvedSet->game_id === $game->id && $resolvedSet->type === AchievementSetType::Core) {
-                    continue;
-                }
-
-                // For specialty/exclusive sets, instead of looking up how this game's
-                // achievement set is attached, look up how the resolved set's achievement
-                // set is attached to its parent.
-                $setAttachment = $gameAchievementSets->first(function ($attachment) use ($resolvedSet) {
-                    return
-                        $attachment->game_id === $resolvedSet->game_id
-                        && $attachment->achievement_set_id === $resolvedSet->achievement_set_id
-                    ;
-                });
-
-                // Get the achievement set for the current game.
-                $gameAchievementSet = $gameAchievementSets->first(function ($attachment) use ($game, $resolvedSet) {
-                    return
-                        $attachment->game_id === $game->id
-                        && $attachment->achievement_set_id === $resolvedSet->achievement_set_id
-                    ;
-                });
-
-                // Skip if this is a specialty/exclusive set that we're directly loading a hash for.
-                if (
-                    $setAttachment
-                    && in_array($setAttachment->type, [AchievementSetType::Specialty, AchievementSetType::Exclusive])
-                    && $gameAchievementSet !== null
-                ) {
-                    continue;
-                }
-
-                // Get the achievements for this set. If there are no published
-                // achievements, we won't bother sending the set to the client.
-                $achievements = $this->buildAchievementsData($resolvedSet, $gamePlayerCount, $flag);
-                if (empty($achievements)) {
-                    continue;
-                }
-
-                $setGame = $games[$resolvedSet->core_game_id];
-                $sets[] = [
-                    'GameID' => $setGame->id,
-                    'GameAchievementSetID' => $resolvedSet->id,
-                    'SetTitle' => $resolvedSet->title,
-                    'Type' => $resolvedSet->type->value,
-                    'ImageIcon' => $setGame->ImageIcon,
-                    'ImageIconURL' => media_asset($setGame->ImageIcon),
-                    'Achievements' => $achievements,
-                    'Leaderboards' => $this->buildLeaderboardsData($setGame),
-                ];
-            }
-        }
-
         return [
             'Success' => true,
             'PatchData' => [
-                ...$this->buildBaseGameData($game, $richPresencePatch, $titleGame),
+                ...$this->buildBaseGameData($game),
                 'Achievements' => $coreAchievementSet
                     ? $this->buildAchievementsData($coreAchievementSet, $gamePlayerCount, $flag)
                     : [],
                 'Leaderboards' => $this->buildLeaderboardsData($game),
-                ...(!empty($sets) ? ['Sets' => $sets] : []),
             ],
         ];
     }
@@ -262,22 +156,15 @@ class BuildClientPatchDataAction
     /**
      * Builds the basic game information needed by emulators.
      */
-    private function buildBaseGameData(
-        Game $game,
-        ?string $richPresencePatch,
-        ?Game $titleGame,
-    ): array {
-        // If a title game is provided, use its title and image.
-        $titleGame = $titleGame ?? $game;
-
+    private function buildBaseGameData(Game $game): array
+    {
         return [
             'ID' => $game->id,
-            'ParentID' => $titleGame->id,
-            'Title' => $titleGame->title,
-            'ImageIcon' => $titleGame->ImageIcon,
-            'RichPresencePatch' => $richPresencePatch ?? $game->RichPresencePatch,
+            'Title' => $game->title,
+            'ImageIcon' => $game->ImageIcon,
+            'RichPresencePatch' => $game->RichPresencePatch,
             'ConsoleID' => $game->ConsoleID,
-            'ImageIconURL' => media_asset($titleGame->ImageIcon),
+            'ImageIconURL' => media_asset($game->ImageIcon),
         ];
     }
 
@@ -340,12 +227,10 @@ class BuildClientPatchDataAction
 
     /**
      * @param Game $game The game to build root-level data for
-     * @param User|null $user The current user requesting the patch data (to support future testing role)
      */
     private function buildIncompatiblePatchData(
         Game $game,
         GameHashCompatibility $gameHashCompatibility,
-        ?User $user,
     ): array {
         $seeSupportedGameFiles = 'See the Supported Game Files page for this game to find a compatible version.';
 

--- a/app/Connect/Actions/BuildIncompatiblePatchDataAction.php
+++ b/app/Connect/Actions/BuildIncompatiblePatchDataAction.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Connect\Actions;
+
+use App\Enums\GameHashCompatibility;
+use App\Models\Game;
+use App\Platform\Services\VirtualGameIdService;
+
+class BuildIncompatiblePatchDataAction
+{
+    public function execute(Game $game, GameHashCompatibility $gameHashCompatibility): array
+    {
+        $seeSupportedGameFiles = 'See the Supported Game Files page for this game to find a compatible version.';
+
+        return [
+            'Success' => true,
+            'PatchData' => [
+                'ID' => VirtualGameIdService::encodeVirtualGameId($game->id, $gameHashCompatibility),
+                'Title' => 'Unsupported Game Version',
+                'ConsoleID' => $game->ConsoleID,
+                'ImageIcon' => $game->ImageIcon,
+                'ImageIconURL' => media_asset($game->ImageIcon),
+                'Achievements' => [
+                    (new CreateWarningAchievementAction())->execute(
+                        title: 'Unsupported Game Version',
+                        description: match ($gameHashCompatibility) {
+                            GameHashCompatibility::Incompatible => "This version of the game is known to not work with the defined achievements. {$seeSupportedGameFiles}",
+                            GameHashCompatibility::Untested => "This version of the game has not been tested to see if it works with the defined achievements. {$seeSupportedGameFiles}",
+                            GameHashCompatibility::PatchRequired => "This version of the game requires a patch to support achievements. {$seeSupportedGameFiles}",
+                            default => $seeSupportedGameFiles,
+                        }),
+                ],
+                'Leaderboards' => [],
+            ],
+        ];
+    }
+}

--- a/tests/Feature/Connect/Actions/BuildClientPatchDataActionTest.php
+++ b/tests/Feature/Connect/Actions/BuildClientPatchDataActionTest.php
@@ -7,17 +7,13 @@ namespace Tests\Feature\Connect\Actions;
 use App\Connect\Actions\BuildClientPatchDataAction;
 use App\Models\Achievement;
 use App\Models\Game;
-use App\Models\GameAchievementSet;
 use App\Models\GameHash;
 use App\Models\Leaderboard;
 use App\Models\PlayerGame;
 use App\Models\System;
 use App\Models\User;
-use App\Models\UserGameAchievementSetPreference;
-use App\Platform\Actions\AssociateAchievementSetToGameAction;
 use App\Platform\Actions\UpsertGameCoreAchievementSetFromLegacyFlagsAction;
 use App\Platform\Enums\AchievementFlag;
-use App\Platform\Enums\AchievementSetType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use InvalidArgumentException;
 use Tests\TestCase;
@@ -26,12 +22,8 @@ class BuildClientPatchDataActionTest extends TestCase
 {
     use RefreshDatabase;
 
-    public const OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED = 8439;
-    public const OPT_IN_TO_ALL_SUBSETS_PREF_DISABLED = 270583;
-
     private System $system;
     private UpsertGameCoreAchievementSetFromLegacyFlagsAction $upsertGameCoreSetAction;
-    private AssociateAchievementSetToGameAction $associateAchievementSetToGameAction;
 
     protected function setUp(): void
     {
@@ -40,7 +32,6 @@ class BuildClientPatchDataActionTest extends TestCase
         $this->system = System::factory()->create(['ID' => 1, 'Name' => 'NES/Famicom']);
 
         $this->upsertGameCoreSetAction = new UpsertGameCoreAchievementSetFromLegacyFlagsAction();
-        $this->associateAchievementSetToGameAction = new AssociateAchievementSetToGameAction();
     }
 
     /**
@@ -73,7 +64,6 @@ class BuildClientPatchDataActionTest extends TestCase
     private function assertBaseGameData(array $patchData, Game $game): void
     {
         $this->assertEquals($game->id, $patchData['ID']);
-        $this->assertEquals($game->id, $patchData['ParentID']);
         $this->assertEquals($game->title, $patchData['Title']);
         $this->assertEquals($game->ConsoleID, $patchData['ConsoleID']);
         $this->assertEquals($game->ImageIcon, $patchData['ImageIcon']);
@@ -292,394 +282,6 @@ class BuildClientPatchDataActionTest extends TestCase
         }
     }
 
-    public function testItIncludesMultisetDataWhenUsingGameHash(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements($this->system, 'Dragon Quest III', publishedCount: 2);
-        $bonusGame = $this->createGameWithAchievements($this->system, 'Dragon Quest III [Subset - Gold Medals]', publishedCount: 1);
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($bonusGame);
-        $this->associateAchievementSetToGameAction->execute($baseGame, $bonusGame, AchievementSetType::Bonus, 'Bonus');
-
-        $gameHash = GameHash::factory()->create(['game_id' => $baseGame->id]);
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(gameHash: $gameHash, user: $user);
-
-        // Assert
-        $this->assertTrue($result['Success']);
-        $this->assertArrayHasKey('Sets', $result['PatchData']);
-        $this->assertCount(1, $result['PatchData']['Sets']);
-
-        // ... verify the base data includes ParentID ...
-        $this->assertEquals($baseGame->id, $result['PatchData']['ID']);
-        $this->assertEquals($baseGame->id, $result['PatchData']['ParentID']);
-
-        // ... verify the core set is at the root level ...
-        $this->assertCount(2, $result['PatchData']['Achievements']);
-
-        // ... verify the bonus set is in the sets level ...
-        $bonusSet = $result['PatchData']['Sets'][0];
-        $this->assertEquals(AchievementSetType::Bonus->value, $bonusSet['Type']);
-        $this->assertEquals($bonusGame->id, $bonusSet['GameID']); // Each set includes the game ID
-        $this->assertCount(1, $bonusSet['Achievements']);
-    }
-
-    public function testItOmitsMultisetDataWhenUsingGameDirectlyLikeLegacyClients(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements($this->system, 'Dragon Quest III', publishedCount: 2);
-        $bonusGame = $this->createGameWithAchievements($this->system, 'Dragon Quest III [Subset - Gold Medals]', publishedCount: 1);
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($bonusGame);
-        $this->associateAchievementSetToGameAction->execute($baseGame, $bonusGame, AchievementSetType::Bonus, 'Bonus');
-
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(
-            game: $baseGame,
-            gameHash: null, // !!
-            user: $user
-        );
-
-        // Assert
-        $this->assertTrue($result['Success']);
-        $this->assertArrayNotHasKey('Sets', $result['PatchData']);
-    }
-
-    /**
-     * If the user is globally opted out of subsets and they load a bonus subset
-     * game's hash, then it's like the user is still living in the pre-multiset
-     * world. The only set that resolves is the set for the subset game.
-     */
-    public function testGloballyOptedOutOfSubsetsAndLoadedSubsetHash(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements($this->system, 'Dragon Quest III', publishedCount: 1);
-        $bonusGame = $this->createGameWithAchievements($this->system, 'Dragon Quest III [Subset - Bonus]', publishedCount: 2);
-        $bonusGame2 = $this->createGameWithAchievements($this->system, 'Dragon Quest III [Subset - Bonus 2]', publishedCount: 3);
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($bonusGame);
-        $this->upsertGameCoreSetAction->execute($bonusGame2);
-
-        $this->associateAchievementSetToGameAction->execute($baseGame, $bonusGame, AchievementSetType::Bonus, 'Bonus');
-        $this->associateAchievementSetToGameAction->execute($baseGame, $bonusGame2, AchievementSetType::Bonus, 'Bonus 2');
-
-        $bonusGameHash = GameHash::factory()->create(['game_id' => $bonusGame->id]);
-
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_DISABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(
-            gameHash: $bonusGameHash,
-            user: $user
-        );
-
-        // Assert
-        $this->assertTrue($result['Success']);
-
-        $this->assertEquals(2, $result['PatchData']['ID']);
-        $this->assertEquals('Dragon Quest III [Subset - Bonus]', $result['PatchData']['Title']);
-        $this->assertCount(2, $result['PatchData']['Achievements']);
-
-        $this->assertArrayNotHasKey('Sets', $result['PatchData']);
-    }
-
-    /**
-     * If the user has multiset enabled, they load a bonus subset game's hash, but are locally
-     * opted out of that subset, then we treat it like they loaded a core game hash. They'll
-     * receive the core set and any other bonus sets, but not the set they've opted out of.
-     */
-    public function testLocallyOptedOutOfSubsetsAndLoadedOptedOutSubsetHash(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III',
-            publishedCount: 1,
-            imagePath: '/Images/000001.png',
-            richPresencePatch: 'Foo',
-        );
-        $bonusGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III [Subset - Bonus]',
-            publishedCount: 2,
-            imagePath: '/Images/000002.png',
-            richPresencePatch: 'Bar',
-        );
-        $bonusGame2 = $this->createGameWithAchievements($this->system, 'Dragon Quest III [Subset - Bonus 2]', publishedCount: 3);
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($bonusGame);
-        $this->upsertGameCoreSetAction->execute($bonusGame2);
-
-        $this->associateAchievementSetToGameAction->execute($baseGame, $bonusGame, AchievementSetType::Bonus, 'Bonus'); // !!
-        $this->associateAchievementSetToGameAction->execute($baseGame, $bonusGame2, AchievementSetType::Bonus, 'Bonus 2');
-
-        $bonusGameHash = GameHash::factory()->create(['game_id' => $bonusGame->id]);
-
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // They're going to load a hash for $bonusGame, but they're also locally opted out of
-        // $bonusGame's achievement set.
-        $optOutSet = GameAchievementSet::firstWhere('title', 'Bonus'); // !!
-        UserGameAchievementSetPreference::factory()->create([
-            'user_id' => $user->id,
-            'game_achievement_set_id' => GameAchievementSet::whereGameId($baseGame->id)
-                ->whereType(AchievementSetType::Bonus)
-                ->whereAchievementSetId($optOutSet->achievement_set_id)
-                ->first()
-                ->id,
-            'opted_in' => false,
-        ]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(
-            gameHash: $bonusGameHash,
-            user: $user
-        );
-
-        // Assert
-        $this->assertTrue($result['Success']);
-
-        $this->assertEquals($baseGame->id, $result['PatchData']['ID']);
-        $this->assertEquals($baseGame->title, $result['PatchData']['Title']);
-        $this->assertEquals($baseGame->ImageIcon, $result['PatchData']['ImageIcon']);
-        $this->assertCount(1, $result['PatchData']['Achievements']);
-
-        $this->assertEquals($baseGame->RichPresencePatch, $result['PatchData']['RichPresencePatch']);
-
-        $this->assertCount(1, $result['PatchData']['Sets']);
-
-        $this->assertEquals('bonus', $result['PatchData']['Sets'][0]['Type']);
-        $this->assertEquals('Bonus 2', $result['PatchData']['Sets'][0]['SetTitle']);
-        $this->assertCount(3, $result['PatchData']['Sets'][0]['Achievements']);
-    }
-
-    public function testItPrioritizesSpecialtySetRichPresenceScript(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III',
-            publishedCount: 1,
-            imagePath: '/Images/000001.png',
-            richPresencePatch: 'Foo',
-        );
-        $specialtyGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III [Subset - Special]',
-            publishedCount: 2,
-            imagePath: '/Images/000002.png',
-            richPresencePatch: 'Bar',
-        );
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($specialtyGame);
-        $this->associateAchievementSetToGameAction->execute($baseGame, $specialtyGame, AchievementSetType::Specialty, 'Special');
-
-        $specialtyGameHash = GameHash::factory()->create(['game_id' => $specialtyGame->id]);
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(gameHash: $specialtyGameHash, user: $user);
-
-        // Assert
-        $this->assertTrue($result['Success']);
-        $this->assertEquals($specialtyGame->id, $result['PatchData']['ID']); // ... use subset game's ID ...
-        $this->assertEquals($specialtyGame->RichPresencePatch, $result['PatchData']['RichPresencePatch']); // ... and specialty RP.
-    }
-
-    public function testItPrioritizesExclusiveSetRichPresenceScript(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III',
-            publishedCount: 1,
-            richPresencePatch: 'Foo',
-        );
-        $exclusiveGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III [Subset - Exclusive]',
-            publishedCount: 2,
-            richPresencePatch: 'Bar',
-        );
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($exclusiveGame);
-        $this->associateAchievementSetToGameAction->execute($baseGame, $exclusiveGame, AchievementSetType::Exclusive, 'Exclusive');
-
-        $exclusiveGameHash = GameHash::factory()->create(['game_id' => $exclusiveGame->id]);
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(gameHash: $exclusiveGameHash, user: $user);
-
-        // Assert
-        $this->assertTrue($result['Success']);
-        $this->assertEquals($exclusiveGame->id, $result['PatchData']['ID']); // ... use subset game's ID ...
-        $this->assertEquals($exclusiveGame->RichPresencePatch, $result['PatchData']['RichPresencePatch']); // ... but exclusive RP.
-    }
-
-    public function testItFallsBackToCoreSetRichPresenceScript(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III',
-            publishedCount: 1,
-            imagePath: '/Images/000001.png',
-            richPresencePatch: 'Foo',
-        );
-        $specialtyGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III [Subset - Special]',
-            publishedCount: 2,
-            imagePath: '/Images/000002.png',
-        );
-
-        $specialtyGame->RichPresencePatch = ""; // !!
-        $specialtyGame->save();
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($specialtyGame);
-        $this->associateAchievementSetToGameAction->execute($baseGame, $specialtyGame, AchievementSetType::Specialty, 'Special');
-
-        $specialtyGameHash = GameHash::factory()->create(['game_id' => $specialtyGame->id]);
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(gameHash: $specialtyGameHash, user: $user);
-
-        // Assert
-        $this->assertTrue($result['Success']);
-        $this->assertEquals($baseGame->RichPresencePatch, $result['PatchData']['RichPresencePatch']);
-    }
-
-    public function testItUsesCoreGameRichPresenceForBonusSet(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III',
-            publishedCount: 1,
-            richPresencePatch: 'Foo',
-        );
-        $bonusGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III [Subset - Bonus]',
-            publishedCount: 2,
-            richPresencePatch: 'Bar',
-        );
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($bonusGame);
-        $this->associateAchievementSetToGameAction->execute($baseGame, $bonusGame, AchievementSetType::Bonus, 'Bonus');
-
-        $bonusGameHash = GameHash::factory()->create(['game_id' => $bonusGame->id]);
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(gameHash: $bonusGameHash, user: $user);
-
-        // Assert
-        $this->assertTrue($result['Success']);
-        $this->assertEquals($baseGame->RichPresencePatch, $result['PatchData']['RichPresencePatch']);
-    }
-
-    public function testItResolvesRootDataCorrectlyForSpecialtySet(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III',
-            publishedCount: 3,
-            richPresencePatch: 'Foo',
-        );
-        $specialtyGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III [Subset - Special]',
-            publishedCount: 2,
-            richPresencePatch: 'Bar',
-        );
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($specialtyGame);
-        $this->associateAchievementSetToGameAction->execute($baseGame, $specialtyGame, AchievementSetType::Specialty, 'Special');
-
-        $specialtyGameHash = GameHash::factory()->create(['game_id' => $specialtyGame->id]);
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(gameHash: $specialtyGameHash, user: $user);
-
-        // Assert
-        $this->assertTrue($result['Success']);
-
-        // ... title and image should be from the base game ...
-        $this->assertEquals($baseGame->title, $result['PatchData']['Title']);
-        $this->assertEquals($baseGame->ImageIcon, $result['PatchData']['ImageIcon']);
-
-        // ... id should be from the subset but ParentID should point to the base game ...
-        $this->assertEquals($specialtyGame->id, $result['PatchData']['ID']);
-        $this->assertEquals($baseGame->id, $result['PatchData']['ParentID']);
-        $this->assertCount(2, $result['PatchData']['Achievements']); // the subset game's achievements
-
-        // ... RP should be from the specialty game ...
-        $this->assertEquals($specialtyGame->RichPresencePatch, $result['PatchData']['RichPresencePatch']);
-    }
-
-    public function testItResolvesRootDataCorrectlyForExclusiveSet(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III',
-            publishedCount: 3,
-            richPresencePatch: 'Foo',
-        );
-        $exclusiveGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III [Subset - Exclusive]',
-            publishedCount: 2,
-            richPresencePatch: 'Bar',
-        );
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($exclusiveGame);
-        $this->associateAchievementSetToGameAction->execute($baseGame, $exclusiveGame, AchievementSetType::Exclusive, 'Exclusive');
-
-        $exclusiveGameHash = GameHash::factory()->create(['game_id' => $exclusiveGame->id]);
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(gameHash: $exclusiveGameHash, user: $user);
-
-        // Assert
-        $this->assertTrue($result['Success']);
-
-        // ... title and image should be from the base game ...
-        $this->assertEquals($baseGame->title, $result['PatchData']['Title']);
-        $this->assertEquals($baseGame->ImageIcon, $result['PatchData']['ImageIcon']);
-
-        // ... id should be from the subset but ParentID should point to the base game ...
-        $this->assertEquals($exclusiveGame->id, $result['PatchData']['ID']);
-        $this->assertEquals($baseGame->id, $result['PatchData']['ParentID']);
-        $this->assertCount(2, $result['PatchData']['Achievements']); // the subset game's achievements
-
-        // ... RP should be from the exclusive game ...
-        $this->assertEquals($exclusiveGame->RichPresencePatch, $result['PatchData']['RichPresencePatch']);
-
-        // ... sets should not be present, as it is duplicative ...
-        $this->assertArrayNotHasKey('Sets', $result['PatchData']);
-    }
-
     public function testItHandlesGameWithNoAchievementSets(): void
     {
         // Arrange
@@ -691,7 +293,7 @@ class BuildClientPatchDataActionTest extends TestCase
         );
 
         $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
+        $user = User::factory()->create();
 
         // Act
         $result = (new BuildClientPatchDataAction())->execute(gameHash: $gameHash, user: $user);
@@ -702,45 +304,6 @@ class BuildClientPatchDataActionTest extends TestCase
         $this->assertEmpty($result['PatchData']['Sets'] ?? []);
         $this->assertEquals($game->id, $result['PatchData']['ID']);
         $this->assertEquals($game->RichPresencePatch, $result['PatchData']['RichPresencePatch']);
-    }
-
-    public function testItHandlesSubsetWithNoCoreGame(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III',
-            publishedCount: 0,
-            unpublishedCount: 0,
-            richPresencePatch: 'Foo',
-        );
-        $subsetGame = $this->createGameWithAchievements(
-            $this->system,
-            'Dragon Quest III [Subset - Gold Medals]',
-            publishedCount: 2,
-            richPresencePatch: 'Bar',
-        );
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($subsetGame);
-        $this->associateAchievementSetToGameAction->execute($baseGame, $subsetGame, AchievementSetType::Specialty, 'Gold Medals');
-
-        $subsetGameHash = GameHash::factory()->create(['game_id' => $subsetGame->id]);
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(gameHash: $subsetGameHash, user: $user);
-
-        // Assert
-        $this->assertTrue($result['Success']);
-
-        $this->assertEquals($subsetGame->id, $result['PatchData']['ID']);
-        $this->assertEquals($subsetGame->RichPresencePatch, $result['PatchData']['RichPresencePatch']);
-
-        $this->assertCount(2, $result['PatchData']['Achievements']);
-
-        // no achievements for the base game and user loaded a subset hash. therefore, no sets.
-        $this->assertArrayNotHasKey('Sets', $result['PatchData']);
     }
 
     public function testItBuildsPatchDataWithGameHashAndNullUser(): void
@@ -780,56 +343,5 @@ class BuildClientPatchDataActionTest extends TestCase
         $this->assertCount(6, $result['PatchData']['Achievements']);
 
         $this->assertNull($result['PatchData']['RichPresencePatch']);
-    }
-
-    public function testItResolvesSetTypesForBaseGameHashesCorrectly(): void
-    {
-        // Arrange
-        $baseGame = $this->createGameWithAchievements($this->system, 'Multi-Set Game', publishedCount: 2);
-        $bonusSet = $this->createGameWithAchievements($this->system, 'Multi-Set Game [Subset - Bonus]', publishedCount: 1);
-        $bonusSet2 = $this->createGameWithAchievements($this->system, 'Multi-Set Game [Subset - Bonus 2]', publishedCount: 1);
-        $specialtySet = $this->createGameWithAchievements($this->system, 'Multi-Set Game [Subset - Specialty]', publishedCount: 1);
-
-        $this->upsertGameCoreSetAction->execute($baseGame);
-        $this->upsertGameCoreSetAction->execute($bonusSet);
-        $this->upsertGameCoreSetAction->execute($bonusSet2);
-        $this->upsertGameCoreSetAction->execute($specialtySet);
-
-        $this->associateAchievementSetToGameAction->execute($baseGame, $bonusSet, AchievementSetType::Bonus, 'Bonus');
-        $this->associateAchievementSetToGameAction->execute($baseGame, $bonusSet2, AchievementSetType::Bonus, 'Bonus 2');
-        $this->associateAchievementSetToGameAction->execute($baseGame, $specialtySet, AchievementSetType::Specialty, 'Specialty');
-
-        $baseGameHash = GameHash::factory()->create(['game_id' => $baseGame->id]); // !!
-        $user = User::factory()->create(['websitePrefs' => self::OPT_IN_TO_ALL_SUBSETS_PREF_ENABLED]);
-
-        // Act
-        $result = (new BuildClientPatchDataAction())->execute(gameHash: $baseGameHash, user: $user);
-
-        // Assert
-        $this->assertTrue($result['Success']);
-        $this->assertArrayHasKey('Sets', $result['PatchData']);
-        $this->assertCount(2, $result['PatchData']['Sets']); // only bonus sets, core is at the root level
-
-        // ... verify the ID and ParentID match for root game ...
-        $this->assertEquals($baseGame->id, $result['PatchData']['ID']);
-        $this->assertEquals($baseGame->id, $result['PatchData']['ParentID']);
-
-        // ... verify core is at the root level ...
-        $this->assertCount(2, $result['PatchData']['Achievements']);
-
-        // ... verify each set has a GameID field ...
-        foreach ($result['PatchData']['Sets'] as $set) {
-            $this->assertArrayHasKey('GameID', $set);
-        }
-
-        // ... verify the bonus set GameIDs ...
-        $setGameIds = array_column($result['PatchData']['Sets'], 'GameID');
-        $this->assertContains($bonusSet->id, $setGameIds);
-        $this->assertContains($bonusSet2->id, $setGameIds);
-
-        $setTypes = array_column($result['PatchData']['Sets'], 'Type');
-        $this->assertContains(AchievementSetType::Bonus->value, $setTypes);
-        $this->assertNotContains(AchievementSetType::Core->value, $setTypes);
-        $this->assertNotContains(AchievementSetType::Specialty->value, $setTypes);
     }
 }

--- a/tests/Feature/Connect/PatchDataTest.php
+++ b/tests/Feature/Connect/PatchDataTest.php
@@ -169,7 +169,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -201,7 +200,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -237,7 +235,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -280,7 +277,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game2->ID,
-                    'ParentID' => $game2->ID,
                     'Title' => $game2->Title,
                     'ConsoleID' => $game2->ConsoleID,
                     'ImageIcon' => $game2->ImageIcon,
@@ -337,7 +333,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -365,7 +360,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -420,7 +414,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -446,7 +439,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -472,7 +464,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -497,7 +488,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -533,7 +523,6 @@ class PatchDataTest extends TestCase
                 'Success' => true,
                 'PatchData' => [
                     'ID' => $game->ID,
-                    'ParentID' => $game->ID,
                     'Title' => $game->Title,
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
@@ -738,7 +727,6 @@ class PatchDataTest extends TestCase
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
                     'ImageIconURL' => media_asset($game->ImageIcon),
-                    'ParentID' => 1,
                     'RichPresencePatch' => $game->RichPresencePatch,
                     'Achievements' => [
                         $this->getAchievementPatchData($achievement1), // DisplayOrder: 1
@@ -765,7 +753,6 @@ class PatchDataTest extends TestCase
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
                     'ImageIconURL' => media_asset($game->ImageIcon),
-                    'ParentID' => 1,
                     'RichPresencePatch' => $game->RichPresencePatch,
                     'Achievements' => [
                         $this->getAchievementPatchData($achievement1), // DisplayOrder: 1
@@ -788,7 +775,6 @@ class PatchDataTest extends TestCase
                     'ConsoleID' => $game->ConsoleID,
                     'ImageIcon' => $game->ImageIcon,
                     'ImageIconURL' => media_asset($game->ImageIcon),
-                    'ParentID' => 1,
                     'RichPresencePatch' => $game->RichPresencePatch,
                     'Achievements' => [
                         $this->getAchievementPatchData($achievement1), // DisplayOrder: 1


### PR DESCRIPTION
Going to do this as two separate PRs.

This PR removes multiset functionality from `patch`. A follow-up PR will add it to `patch2`.