### PR TITLE
perf(WriteUserActivity): use saveQuietly

### DIFF
--- a/app/Community/Listeners/WriteUserActivity.php
+++ b/app/Community/Listeners/WriteUserActivity.php
@@ -115,7 +115,7 @@ class WriteUserActivity
             * update last activity timestamp regardless of whether an activity was stored as some might have been suppressed
             */
             $user->LastLogin = Carbon::now();
-            $user->save();
+            $user->saveQuietly();
         }
     }
 }


### PR DESCRIPTION
There's one more source that's dispatching massive amounts of Meilisearch jobs. `WriteUserActivity` needs to use `->saveQuietly()` instead of `->save()`.