### PR TITLE
feat(api): cap API_GetClaims to 1000 results

### DIFF
--- a/public/API/API_GetClaims.php
+++ b/public/API/API_GetClaims.php
@@ -55,7 +55,7 @@ if ($claimKind === $droppedClaims) {
     $claimFilter = ClaimFilters::AllActiveClaims;
 }
 
-$claimsResults = getFilteredClaims(claimFilter: $claimFilter)->take(1000);
+$claimsResults = getFilteredClaims(claimFilter: $claimFilter, limit: 1000);
 
 if ($claimKind === $expiredClaims) {
     $onlyFullyExpired = $claimsResults->filter(function ($claim) {

--- a/tests/Feature/Api/V1/AchievementSetClaimTest.php
+++ b/tests/Feature/Api/V1/AchievementSetClaimTest.php
@@ -56,28 +56,24 @@ class AchievementSetClaimTest extends TestCase
         $this->get($this->apiUrl('GetClaims', ['k' => '1']))
             ->assertSuccessful()
             ->assertJson([
-                'Count' => 1,
-                'Total' => 1,
-                'Results' => [
-                    [
-                        'ClaimType' => ClaimType::Primary,
-                        'ConsoleName' => $system->Name,
-                        'Created' => $claim->Created->__toString(),
-                        'DoneTime' => $claim->Finished->__toString(),
-                        'Extension' => 0,
-                        'GameID' => $game->ID,
-                        'GameIcon' => '/Images/000001.png',
-                        'GameTitle' => $game->Title,
-                        'ID' => $claim->ID,
-                        'MinutesLeft' => Carbon::now()->diffInMinutes($claim->Finished),
-                        'SetType' => ClaimSetType::NewSet,
-                        'Special' => ClaimSpecial::None,
-                        'Status' => ClaimStatus::Complete,
-                        'Updated' => $claim->Updated->__toString(),
-                        'User' => $user->User,
-                        'ULID' => $user->ulid,
-                        'UserIsJrDev' => 0,
-                    ],
+                [
+                    'ClaimType' => ClaimType::Primary,
+                    'ConsoleName' => $system->Name,
+                    'Created' => $claim->Created->__toString(),
+                    'DoneTime' => $claim->Finished->__toString(),
+                    'Extension' => 0,
+                    'GameID' => $game->ID,
+                    'GameIcon' => '/Images/000001.png',
+                    'GameTitle' => $game->Title,
+                    'ID' => $claim->ID,
+                    'MinutesLeft' => Carbon::now()->diffInMinutes($claim->Finished),
+                    'SetType' => ClaimSetType::NewSet,
+                    'Special' => ClaimSpecial::None,
+                    'Status' => ClaimStatus::Complete,
+                    'Updated' => $claim->Updated->__toString(),
+                    'User' => $user->User,
+                    'ULID' => $user->ulid,
+                    'UserIsJrDev' => 0,
                 ],
             ]);
     }
@@ -103,28 +99,24 @@ class AchievementSetClaimTest extends TestCase
         $this->get($this->apiUrl('GetClaims', ['k' => '2']))
             ->assertSuccessful()
             ->assertJson([
-                'Count' => 1,
-                'Total' => 1,
-                'Results' => [
-                    [
-                        'ClaimType' => ClaimType::Primary,
-                        'ConsoleName' => $system->Name,
-                        'Created' => $claim->Created->__toString(),
-                        'DoneTime' => $claim->Finished->__toString(),
-                        'Extension' => 0,
-                        'GameID' => $game->ID,
-                        'GameIcon' => '/Images/000001.png',
-                        'GameTitle' => $game->Title,
-                        'ID' => $claim->ID,
-                        'MinutesLeft' => Carbon::now()->diffInMinutes($claim->Finished),
-                        'SetType' => ClaimSetType::NewSet,
-                        'Special' => ClaimSpecial::None,
-                        'Status' => ClaimStatus::Dropped,
-                        'Updated' => $claim->Updated->__toString(),
-                        'User' => $user->User,
-                        'ULID' => $user->ulid,
-                        'UserIsJrDev' => 1,
-                    ],
+                [
+                    'ClaimType' => ClaimType::Primary,
+                    'ConsoleName' => $system->Name,
+                    'Created' => $claim->Created->__toString(),
+                    'DoneTime' => $claim->Finished->__toString(),
+                    'Extension' => 0,
+                    'GameID' => $game->ID,
+                    'GameIcon' => '/Images/000001.png',
+                    'GameTitle' => $game->Title,
+                    'ID' => $claim->ID,
+                    'MinutesLeft' => Carbon::now()->diffInMinutes($claim->Finished),
+                    'SetType' => ClaimSetType::NewSet,
+                    'Special' => ClaimSpecial::None,
+                    'Status' => ClaimStatus::Dropped,
+                    'Updated' => $claim->Updated->__toString(),
+                    'User' => $user->User,
+                    'ULID' => $user->ulid,
+                    'UserIsJrDev' => 1,
                 ],
             ]);
     }
@@ -143,10 +135,7 @@ class AchievementSetClaimTest extends TestCase
         $response = $this->get($this->apiUrl('GetClaims', ['k' => '3']))
             ->assertSuccessful();
 
-        $responseData = $response->json();
-        $this->assertEquals(1, $responseData['Count']);
-        $this->assertEquals(1, $responseData['Total']);
-        $this->assertCount(1, $responseData['Results']);
+        $this->assertCount(1, $response->json());
     }
 
     public function testGetUserClaims(): void

--- a/tests/Feature/Api/V1/AchievementSetClaimTest.php
+++ b/tests/Feature/Api/V1/AchievementSetClaimTest.php
@@ -56,24 +56,28 @@ class AchievementSetClaimTest extends TestCase
         $this->get($this->apiUrl('GetClaims', ['k' => '1']))
             ->assertSuccessful()
             ->assertJson([
-                [
-                    'ClaimType' => ClaimType::Primary,
-                    'ConsoleName' => $system->Name,
-                    'Created' => $claim->Created->__toString(),
-                    'DoneTime' => $claim->Finished->__toString(),
-                    'Extension' => 0,
-                    'GameID' => $game->ID,
-                    'GameIcon' => '/Images/000001.png',
-                    'GameTitle' => $game->Title,
-                    'ID' => $claim->ID,
-                    'MinutesLeft' => Carbon::now()->diffInMinutes($claim->Finished),
-                    'SetType' => ClaimSetType::NewSet,
-                    'Special' => ClaimSpecial::None,
-                    'Status' => ClaimStatus::Complete,
-                    'Updated' => $claim->Updated->__toString(),
-                    'User' => $user->User,
-                    'ULID' => $user->ulid,
-                    'UserIsJrDev' => 0,
+                'Count' => 1,
+                'Total' => 1,
+                'Results' => [
+                    [
+                        'ClaimType' => ClaimType::Primary,
+                        'ConsoleName' => $system->Name,
+                        'Created' => $claim->Created->__toString(),
+                        'DoneTime' => $claim->Finished->__toString(),
+                        'Extension' => 0,
+                        'GameID' => $game->ID,
+                        'GameIcon' => '/Images/000001.png',
+                        'GameTitle' => $game->Title,
+                        'ID' => $claim->ID,
+                        'MinutesLeft' => Carbon::now()->diffInMinutes($claim->Finished),
+                        'SetType' => ClaimSetType::NewSet,
+                        'Special' => ClaimSpecial::None,
+                        'Status' => ClaimStatus::Complete,
+                        'Updated' => $claim->Updated->__toString(),
+                        'User' => $user->User,
+                        'ULID' => $user->ulid,
+                        'UserIsJrDev' => 0,
+                    ],
                 ],
             ]);
     }
@@ -99,24 +103,28 @@ class AchievementSetClaimTest extends TestCase
         $this->get($this->apiUrl('GetClaims', ['k' => '2']))
             ->assertSuccessful()
             ->assertJson([
-                [
-                    'ClaimType' => ClaimType::Primary,
-                    'ConsoleName' => $system->Name,
-                    'Created' => $claim->Created->__toString(),
-                    'DoneTime' => $claim->Finished->__toString(),
-                    'Extension' => 0,
-                    'GameID' => $game->ID,
-                    'GameIcon' => '/Images/000001.png',
-                    'GameTitle' => $game->Title,
-                    'ID' => $claim->ID,
-                    'MinutesLeft' => Carbon::now()->diffInMinutes($claim->Finished),
-                    'SetType' => ClaimSetType::NewSet,
-                    'Special' => ClaimSpecial::None,
-                    'Status' => ClaimStatus::Dropped,
-                    'Updated' => $claim->Updated->__toString(),
-                    'User' => $user->User,
-                    'ULID' => $user->ulid,
-                    'UserIsJrDev' => 1,
+                'Count' => 1,
+                'Total' => 1,
+                'Results' => [
+                    [
+                        'ClaimType' => ClaimType::Primary,
+                        'ConsoleName' => $system->Name,
+                        'Created' => $claim->Created->__toString(),
+                        'DoneTime' => $claim->Finished->__toString(),
+                        'Extension' => 0,
+                        'GameID' => $game->ID,
+                        'GameIcon' => '/Images/000001.png',
+                        'GameTitle' => $game->Title,
+                        'ID' => $claim->ID,
+                        'MinutesLeft' => Carbon::now()->diffInMinutes($claim->Finished),
+                        'SetType' => ClaimSetType::NewSet,
+                        'Special' => ClaimSpecial::None,
+                        'Status' => ClaimStatus::Dropped,
+                        'Updated' => $claim->Updated->__toString(),
+                        'User' => $user->User,
+                        'ULID' => $user->ulid,
+                        'UserIsJrDev' => 1,
+                    ],
                 ],
             ]);
     }
@@ -135,7 +143,10 @@ class AchievementSetClaimTest extends TestCase
         $response = $this->get($this->apiUrl('GetClaims', ['k' => '3']))
             ->assertSuccessful();
 
-        $this->assertCount(1, $response->json());
+        $responseData = $response->json();
+        $this->assertEquals(1, $responseData['Count']);
+        $this->assertEquals(1, $responseData['Total']);
+        $this->assertCount(1, $responseData['Results']);
     }
 
     public function testGetUserClaims(): void


### PR DESCRIPTION
API_GetClaims was implemented without pagination, and is now returning over a 4MB response (and growing) by default in prod.

There is an existing comment that reads:
> returns information about 1000 max set claims

This PR enforces this cap, which reduces the payload size to roughly 390KB.