### PR TITLE
fix: use `sort_title` on the Completion Progress page

### DIFF
--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -362,7 +362,7 @@ function getUsersCompletedGamesAndMax(string $user): array
     $minAchievementsForCompletion = 5;
 
     $query = "SELECT gd.ID AS GameID, c.Name AS ConsoleName, c.ID AS ConsoleID,
-            gd.ImageIcon, gd.Title, gd.achievements_published as MaxPossible,
+            gd.ImageIcon, gd.Title, gd.sort_title as SortTitle, gd.achievements_published as MaxPossible,
             pg.first_unlock_at AS FirstWonDate, pg.last_unlock_at AS MostRecentWonDate,
             pg.achievements_unlocked AS NumAwarded, pg.achievements_unlocked_hardcore AS NumAwardedHC, " .
             floatDivisionStatement('pg.achievements_unlocked', 'gd.achievements_published') . " AS PctWon, " .

--- a/app/Platform/Services/PlayerCompletionProgressPageService.php
+++ b/app/Platform/Services/PlayerCompletionProgressPageService.php
@@ -151,19 +151,13 @@ class PlayerCompletionProgressPageService
 
         if ($sortOrder === 'game_title') {
             usort($filteredAndJoinedGamesList, function ($a, $b) {
-                $titleA = $this->removeGameTitlePrefix($a['Title']);
-                $titleB = $this->removeGameTitlePrefix($b['Title']);
-
-                return strcmp($titleA, $titleB);
+                return strcmp($a['SortTitle'], $b['SortTitle']);
             });
         }
 
         if ($sortOrder === '-game_title') {
             usort($filteredAndJoinedGamesList, function ($a, $b) {
-                $titleA = $this->removeGameTitlePrefix($a['Title']);
-                $titleB = $this->removeGameTitlePrefix($b['Title']);
-
-                return strcmp($titleB, $titleA);
+                return strcmp($b['SortTitle'], $a['SortTitle']);
             });
         }
 
@@ -346,17 +340,5 @@ class PlayerCompletionProgressPageService
         $allAvailableConsoleIds = array_filter($allAvailableConsoleIds, fn ($value) => !is_null($value));
 
         return $allAvailableConsoleIds;
-    }
-
-    private function removeGameTitlePrefix(string $gameTitle): string
-    {
-        if (substr($gameTitle, 0, 1) === '~') {
-            $endOfPrefixPos = strpos($gameTitle, '~', 1);
-            if ($endOfPrefixPos !== false) {
-                $gameTitle = substr($gameTitle, $endOfPrefixPos + 1);
-            }
-        }
-
-        return trim($gameTitle);
     }
 }


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1373056387227324447.

The game datatables are using `sort_title`, but the Completion Progress page still sorts games via `Title`. This PR fixes the inconsistency.