### PR TITLE
fix(tickets): exclude 'inactive' dev tickets that have active maintainers

### DIFF
--- a/app/Platform/Services/TicketListService.php
+++ b/app/Platform/Services/TicketListService.php
@@ -245,9 +245,11 @@ class TicketListService
 
             case 'inactive':
                 $tickets->whereHas('achievement', function ($query) {
-                    $query->whereHas('developer', function ($query2) {
-                        $query2->where('Permissions', '<', Permissions::JuniorDeveloper);
-                    });
+                    $query
+                        ->whereDoesntHave('activeMaintainer')
+                        ->whereHas('developer', function ($query2) {
+                            $query2->where('Permissions', '<', Permissions::JuniorDeveloper);
+                        });
                 });
                 break;
         }


### PR DESCRIPTION
Fixes https://discord.com/channels/310192285306454017/1370868969531117600.

Currently, if a ticket has an inactive developer but an active maintainer, it's still appearing when filtering tickets by inactive devs.

With this branch's changes, those tickets will be excluded when using the filter.