### PR TITLE
perf(search): limit the scout queue to 1 process

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -200,7 +200,6 @@ return [
                 'player-metrics',
                 'player-points-stats',
                 'player-sessions',
-                'scout',
             ],
             'balance' => 'auto',
             'autoScalingStrategy' => 'size',
@@ -228,6 +227,20 @@ return [
             'memory' => 128,
             'tries' => 1,
             'timeout' => 600, // NOTE timeout should always be at least several seconds shorter than the queue config's retry_after configuration value
+            'nice' => 0,
+        ],
+        'supervisor-3' => [
+            'connection' => 'redis',
+            'queue' => [
+                'scout',
+            ],
+            'balance' => 'simple',
+            'processes' => 1, // Fixed at exactly 1 process.
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 128,
+            'tries' => 1,
+            'timeout' => 300, // NOTE timeout should always be at least several seconds shorter than the queue config's retry_after configuration value.
             'nice' => 0,
         ],
     ],


### PR DESCRIPTION
At least for the time being, the Scout queue is the lowest priority thing we have being provisioned by Horizon.

I don't see any reason for it to need more than a single process, but right now it can consume 2-4 depending on load. These search index synchronizations are not time-critical.