### PR TITLE
feat(search): index comments, forum posts, and hubs

### DIFF
--- a/app/Helpers/database/user-permission.php
+++ b/app/Helpers/database/user-permission.php
@@ -2,6 +2,7 @@
 
 use App\Community\Enums\ArticleType;
 use App\Enums\Permissions;
+use App\Models\Comment;
 use App\Models\User;
 use App\Platform\Events\PlayerRankedStatusChanged;
 
@@ -174,6 +175,9 @@ function banAccountByUsername(string $username, int $permissions): void
     $user->Updated = now();
 
     $user->save();
+
+    $userComments = Comment::where('user_id', $user->id)->get();
+    $userComments->unsearchable();
 
     removeAvatar($username);
     $user->subscriptions()->delete();

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -86,6 +86,12 @@ class Comment extends BaseModel
             return false;
         }
 
+        // Don't index empty or extremely short comments (3 chars or less).
+        $trimmedPayload = trim($this->Payload);
+        if (empty($trimmedPayload) || mb_strlen($trimmedPayload) <= 3) {
+            return false;
+        }
+
         return true;
     }
 

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -13,10 +13,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Laravel\Scout\Searchable;
 
 class Comment extends BaseModel
 {
     use SoftDeletes;
+    use Searchable;
     /** @use HasFactory<CommentFactory> */
     use HasFactory;
 
@@ -49,6 +51,44 @@ class Comment extends BaseModel
         return CommentFactory::new();
     }
 
+    // == search
+
+    public function toSearchableArray(): array
+    {
+        return [
+            'id' => $this->ID,
+            'user_id' => $this->user_id,
+            'ArticleType' => $this->ArticleType,
+            'ArticleID' => $this->ArticleID,
+            'commentable_type' => $this->commentable_type,
+            'commentable_id' => $this->commentable_id,
+            'body' => $this->Payload, // this is fine, as of 2025-05-18, 99.88% of comments are <1KB
+            'created_at' => $this->Submitted,
+        ];
+    }
+
+    public function shouldBeSearchable(): bool
+    {
+        // Don't index deleted comments.
+        if ($this->deleted_at) {
+            return false;
+        }
+
+        // Don't index automated system comments.
+        if ($this->user_id === self::SYSTEM_USER_ID) {
+            return false;
+        }
+
+        // Don't index comments from banned users.
+        $this->loadMissing('userWithTrashed');
+        $user = $this->userWithTrashed;
+        if ($user->banned_at !== null) {
+            return false;
+        }
+
+        return true;
+    }
+
     // == accessors
 
     public function getEditLinkAttribute(): string
@@ -72,8 +112,6 @@ class Comment extends BaseModel
     {
         throw new Exception('Use derived comment model class in the comments() morphTo() relationship instead of ' . Comment::class . '. Add link attribute getters to the derived class. Use A dedicated controller for it and use the prepared actions.');
     }
-
-    // == accessors
 
     public function getIsAutomatedAttribute(): bool
     {

--- a/app/Models/GameSet.php
+++ b/app/Models/GameSet.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
+use Laravel\Scout\Searchable;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -27,6 +28,7 @@ class GameSet extends BaseModel
     use HasFactory;
 
     use PivotEventTrait;
+    use Searchable;
     use SoftDeletes;
 
     protected $table = 'game_sets';
@@ -186,6 +188,22 @@ class GameSet extends BaseModel
             ])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs();
+    }
+
+    // == search
+
+    public function toSearchableArray(): array
+    {
+        return [
+            'id' => (int) $this->id,
+            'title' => $this->title,
+            'games_count' => $this->games->count(),
+        ];
+    }
+
+    public function shouldBeSearchable(): bool
+    {
+        return $this->type === GameSetType::Hub;
     }
 
     // == constants

--- a/app/Models/GameSet.php
+++ b/app/Models/GameSet.php
@@ -194,10 +194,12 @@ class GameSet extends BaseModel
 
     public function toSearchableArray(): array
     {
+        $this->loadCount('games');
+
         return [
             'id' => (int) $this->id,
             'title' => $this->title,
-            'games_count' => $this->games->count(),
+            'games_count' => $this->games_count,
         ];
     }
 

--- a/app/Platform/Actions/UpdateGameAchievementsMetricsAction.php
+++ b/app/Platform/Actions/UpdateGameAchievementsMetricsAction.php
@@ -68,11 +68,11 @@ class UpdateGameAchievementsMetricsAction
             $achievement->unlock_percentage = $playersTotal ? $unlocksCount / $playersTotal : 0;
             $achievement->unlock_hardcore_percentage = $playersHardcore ? $unlocksHardcoreCount / $playersHardcore : 0;
             $achievement->TrueRatio = $pointsWeighted;
-            $achievement->save();
+            $achievement->saveQuietly();
         }
 
         $game->TotalTruePoints = $pointsWeightedTotal;
-        $game->save();
+        $game->saveQuietly();
 
         // TODO GameAchievementSetMetricsUpdated::dispatch($game);
     }

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -200,7 +200,6 @@ return [
                 'player-metrics',
                 'player-points-stats',
                 'player-sessions',
-                'scout',
             ],
             'balance' => 'auto',
             'autoScalingStrategy' => 'size',
@@ -228,6 +227,20 @@ return [
             'memory' => 128,
             'tries' => 1,
             'timeout' => 600, // NOTE timeout should always be at least several seconds shorter than the queue config's retry_after configuration value
+            'nice' => 0,
+        ],
+        'supervisor-3' => [
+            'connection' => 'redis',
+            'queue' => [
+                'scout',
+            ],
+            'balance' => 'simple',
+            'processes' => 1, // Fixed at exactly 1 process.
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 128,
+            'tries' => 1,
+            'timeout' => 300, // NOTE timeout should always be at least several seconds shorter than the queue config's retry_after configuration value.
             'nice' => 0,
         ],
     ],

--- a/config/scout.php
+++ b/config/scout.php
@@ -151,8 +151,8 @@ return [
                     'created_at',
                     'user_id',
                 ],
-                'sortableAttributes' => ['created_at'],
                 'searchableAttributes' => ['body'],
+                'sortableAttributes' => ['created_at'],
             ],
 
             ForumTopicComment::class => [
@@ -161,8 +161,8 @@ return [
                     'author_id',
                     'created_at',
                 ],
-                'sortableAttributes' => ['created_at'],
                 'searchableAttributes' => ['body'],
+                'sortableAttributes' => ['created_at'],
             ],
 
             Game::class => [

--- a/config/scout.php
+++ b/config/scout.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Models\Comment;
+use App\Models\ForumTopicComment;
 use App\Models\Game;
+use App\Models\GameSet;
 use App\Models\User;
 
 return [
@@ -139,10 +142,39 @@ return [
         'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
         'key' => env('MEILISEARCH_KEY'),
         'index-settings' => [
+            Comment::class => [
+                'filterableAttributes' => [
+                    'ArticleID',
+                    'ArticleType',
+                    'commentable_id',
+                    'commentable_type',
+                    'created_at',
+                    'user_id',
+                ],
+                'sortableAttributes' => ['created_at'],
+                'searchableAttributes' => ['body'],
+            ],
+
+            ForumTopicComment::class => [
+                'filterableAttributes' => [
+                    'forum_topic_id',
+                    'author_id',
+                    'created_at',
+                ],
+                'sortableAttributes' => ['created_at'],
+                'searchableAttributes' => ['body'],
+            ],
+
             Game::class => [
                 'filterableAttributes' => ['id', 'title'],
                 'searchableAttributes' => ['title', 'id'],
                 'sortableAttributes' => ['id', 'title'],
+            ],
+
+            GameSet::class => [
+                'filterableAttributes' => ['id', 'games_count', 'title'],
+                'searchableAttributes' => ['title', 'id'],
+                'sortableAttributes' => ['id', 'games_count', 'title'],
             ],
 
             User::class => [

--- a/resources/views/pages/demo/scout.blade.php
+++ b/resources/views/pages/demo/scout.blade.php
@@ -1,23 +1,46 @@
+@use('App\Models\Comment')
+@use('App\Models\ForumTopicComment')
 @use('App\Models\Game')
+@use('App\Models\GameSet')
 @use('App\Models\User')
 @use('Illuminate\Support\Facades\Auth')
 
 @php
     $me = Auth::user();
-    abort_if(!$me || !$me->can('manage', \App\Models\User::class), 404);
+    abort_if(!$me || !$me->hasRole(\App\Models\Role::ADMINISTRATOR), 404);
 
-    // Get search terms from query params or use defaults.
-    $gameSearch = request()->query('game_search', 'poke');
-    $userSearch = request()->query('user_search', 'scott');
+    // Get search terms from query params.
+    $gameSearch = request()->query('game_search');
+    $userSearch = request()->query('user_search');
+    $commentSearch = request()->query('comment_search');
+    $gameSetSearch = request()->query('game_set_search');
+    $forumCommentSearch = request()->query('forum_comment_search');
     
     // Search using the terms (default or provided).
-    $games = Game::search($gameSearch)->get();
-    $users = User::search($userSearch)->get();
+    $games = !empty($gameSearch)
+        ? Game::search($gameSearch)->get()
+        : collect();
+
+    $users = !empty($userSearch)
+        ? User::search($userSearch)->get()
+        : collect();
+    
+    $comments = !empty($commentSearch) 
+        ? Comment::search($commentSearch)->take(20)->get() 
+        : collect();
+        
+    $gameSets = !empty($gameSetSearch) 
+        ? GameSet::search($gameSetSearch)->get() 
+        : collect();
+        
+    $forumComments = !empty($forumCommentSearch) 
+        ? ForumTopicComment::search($forumCommentSearch)->take(20)->get() 
+        : collect();
 @endphp
 
 <x-app-layout>
     <div class="flex flex-col gap-6">
-        <form method="GET" action="" class="flex gap-4 mb-4">
+        <form method="GET" action="" class="grid grid-cols-3 gap-4 mb-4">
             <div>
                 <label for="game_search" class="block text-sm mb-1">Game Search</label>
                 <input 
@@ -26,7 +49,7 @@
                     name="game_search" 
                     value="{{ $gameSearch }}" 
                     placeholder="Search games"
-                    class="rounded border px-2 py-1"
+                    class="rounded border px-2 py-1 w-full"
                 >
             </div>
             
@@ -38,22 +61,101 @@
                     name="user_search" 
                     value="{{ $userSearch }}" 
                     placeholder="Search users"
-                    class="rounded border px-2 py-1"
+                    class="rounded border px-2 py-1 w-full"
                 >
             </div>
             
-            <button 
-                type="submit" 
-                class="bg-blue-500 text-white px-4 py-1 rounded self-end"
-            >
-                Search
-            </button>
+            <div>
+                <label for="comment_search" class="block text-sm mb-1">Comment Search</label>
+                <input 
+                    type="text" 
+                    id="comment_search"
+                    name="comment_search" 
+                    value="{{ $commentSearch }}" 
+                    placeholder="Search comments"
+                    class="rounded border px-2 py-1 w-full"
+                >
+            </div>
+            
+            <div>
+                <label for="game_set_search" class="block text-sm mb-1">Game Set Search</label>
+                <input 
+                    type="text" 
+                    id="game_set_search"
+                    name="game_set_search" 
+                    value="{{ $gameSetSearch }}" 
+                    placeholder="Search game sets"
+                    class="rounded border px-2 py-1 w-full"
+                >
+            </div>
+            
+            <div>
+                <label for="forum_comment_search" class="block text-sm mb-1">Forum Comment Search</label>
+                <input 
+                    type="text" 
+                    id="forum_comment_search"
+                    name="forum_comment_search" 
+                    value="{{ $forumCommentSearch }}" 
+                    placeholder="Search forum comments"
+                    class="rounded border px-2 py-1 w-full"
+                >
+            </div>
+            
+            <div class="flex items-end">
+                <button 
+                    type="submit" 
+                    class="btn"
+                >
+                    Search
+                </button>
+            </div>
         </form>
         
-        <p>Games</p>
-        @dump($games->toArray())
+        <div class="space-y-8">
+            <div>
+                <h2 class="text-lg font-bold mb-2">Games ({{ $games->count() }})</h2>
+                @if($games->isNotEmpty())
+                    @dump($games->toArray())
+                @else
+                    <p class="text-gray-500">{{ $commentSearch ? 'No game results found' : 'Enter a search term to find games' }}</p>
+                @endif
+            </div>
 
-        <p class="mt-8">Users</p>
-        @dump($users->toArray())
+            <div>
+                <h2 class="text-lg font-bold mb-2">Users ({{ $users->count() }})</h2>
+                @if($users->isNotEmpty())
+                    @dump($users->toArray())
+                @else
+                    <p class="text-gray-500">{{ $commentSearch ? 'No user results found' : 'Enter a search term to find users' }}</p>
+                @endif
+            </div>
+            
+            <div>
+                <h2 class="text-lg font-bold mb-2">Comments ({{ $comments->count() }})</h2>
+                @if($comments->isNotEmpty())
+                    @dump($comments->toArray())
+                @else
+                    <p class="text-gray-500">{{ $commentSearch ? 'No comment results found' : 'Enter a search term to find comments' }}</p>
+                @endif
+            </div>
+            
+            <div>
+                <h2 class="text-lg font-bold mb-2">Game Sets ({{ $gameSets->count() }})</h2>
+                @if($gameSets->isNotEmpty())
+                    @dump($gameSets->toArray())
+                @else
+                    <p class="text-gray-500">{{ $gameSetSearch ? 'No game set results found' : 'Enter a search term to find game sets' }}</p>
+                @endif
+            </div>
+            
+            <div>
+                <h2 class="text-lg font-bold mb-2">Forum Comments ({{ $forumComments->count() }})</h2>
+                @if($forumComments->isNotEmpty())
+                    @dump($forumComments->toArray())
+                @else
+                    <p class="text-gray-500">{{ $forumCommentSearch ? 'No forum comment results found' : 'Enter a search term to find forum comments' }}</p>
+                @endif
+            </div>
+        </div>
     </div>
 </x-app-layout>


### PR DESCRIPTION
This PR adds the `Searchable` trait to `Comment`, `ForumTopicComment`, and `GameSet`.

Additionally, the demo page has been enhanced so you can search for these things:
![Screenshot 2025-05-18 at 12 00 56 PM](https://github.com/user-attachments/assets/2933f108-cfbe-4703-a8d5-740770594ede)

**How to test this PR:**
```bash
sail artisan horizon # be sure to restart your horizon instance if one is already running

sail artisan scout:sync-index-settings
sail artisan scout:import "App\Models\GameSet"
sail artisan scout:import "App\Models\ForumTopicComment"

# this will probably take anywhere from 15-30 minutes
sail artisan scout:import "App\Models\Comment"
```

**Things to note:**
* Comments left by banned users are not searchable. Forum posts are still searchable from banned users.
* When a user is banned, their comments are marked as unsearchable. There is no treatment for unbanning a user (should there be?).
* A few `->saveQuietly()` invocations have been added to `UpdateGameAchievementsMetricsAction`. One affects games, the other affects achievements. Achievements are not indexed yet, but they will be in a subsequent PR.