### PR TITLE
Add "gives site award" flag to events

### DIFF
--- a/app/Community/Enums/AwardType.php
+++ b/app/Community/Enums/AwardType.php
@@ -55,6 +55,7 @@ abstract class AwardType
             AwardType::PatreonSupporter => 'Patreon Supporter',
             AwardType::CertifiedLegend => 'Certified Legend',
             AwardType::GameBeaten => 'Game Beaten',
+            AwardType::Event => 'Event',
             default => 'Invalid or deprecated award type',
         };
     }

--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -52,42 +52,49 @@ class EventResource extends Resource
                     ->label('')
                     ->size(config('media.icon.lg.width')),
 
-                Infolists\Components\Section::make('Primary Details')
-                    ->icon('heroicon-m-key')
-                    ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
-                    ->schema([
-                        Infolists\Components\TextEntry::make('legacyGame.title')
-                            ->label('Title'),
+                Infolists\Components\Split::make([
+                    Infolists\Components\Section::make('Primary Details')
+                        ->icon('heroicon-m-key')
+                        ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
+                        ->schema([
+                            Infolists\Components\TextEntry::make('legacyGame.title')
+                                ->label('Title'),
 
+                            Infolists\Components\TextEntry::make('permalink')
+                                ->formatStateUsing(fn () => 'Here')
+                                ->url(fn (Event $record): string => $record->getPermalinkAttribute())
+                                ->extraAttributes(['class' => 'underline'])
+                                ->openUrlInNewTab(),
+
+                            Infolists\Components\TextEntry::make('legacyGame.forumTopic.id')
+                                ->label('Forum Topic ID')
+                                ->url(fn (?int $state) => $state ? route('forum-topic.show', ['topic' => $state]) : null)
+                                ->placeholder('none')
+                                ->extraAttributes(function (Event $event): array {
+                                    if ($event->legacyGame->forumTopic?->id) {
+                                        return ['class' => 'underline'];
+                                    }
+
+                                    return [];
+                                }),
+
+                            Infolists\Components\TextEntry::make('active_from')
+                                ->label('Active From')
+                                ->date(),
+
+                            Infolists\Components\TextEntry::make('active_through')
+                            ->label('Active Through')
+                            ->date(),
+                        ]),
+                    Infolists\Components\Section::make([
                         Infolists\Components\TextEntry::make('id')
                             ->label('ID'),
 
-                        Infolists\Components\TextEntry::make('permalink')
-                            ->formatStateUsing(fn () => 'Here')
-                            ->url(fn (Event $record): string => $record->getPermalinkAttribute())
-                            ->extraAttributes(['class' => 'underline'])
-                            ->openUrlInNewTab(),
+                        Infolists\Components\IconEntry::make('gives_site_award')
+                            ->boolean(),
 
-                        Infolists\Components\TextEntry::make('legacyGame.forumTopic.id')
-                            ->label('Forum Topic ID')
-                            ->url(fn (?int $state) => $state ? route('forum-topic.show', ['topic' => $state]) : null)
-                            ->placeholder('none')
-                            ->extraAttributes(function (Event $event): array {
-                                if ($event->legacyGame->forumTopic?->id) {
-                                    return ['class' => 'underline'];
-                                }
-
-                                return [];
-                            }),
-
-                        Infolists\Components\TextEntry::make('active_from')
-                            ->label('Active From')
-                            ->date(),
-
-                        Infolists\Components\TextEntry::make('active_through')
-                        ->label('Active Through')
-                        ->date(),
-                    ]),
+                        ])->grow(false),
+                    ])->from('md'),
 
                 Infolists\Components\Section::make('Metrics')
                     ->icon('heroicon-s-arrow-trending-up')
@@ -113,21 +120,29 @@ class EventResource extends Resource
 
         return $form
             ->schema([
-                Forms\Components\Section::make()
-                    ->relationship('legacyGame')
-                    ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
-                    ->schema([
-                        Forms\Components\TextInput::make('Title')
-                            ->label('Title')
-                            ->unique(ignoreRecord: true)
-                            ->required()
-                            ->minLength(2)
-                            ->maxLength(80),
+                Forms\Components\Split::make([
+                    Forms\Components\Section::make()
+                        ->relationship('legacyGame')
+                        ->columns(2)
+                        ->schema([
+                            Forms\Components\TextInput::make('Title')
+                                ->label('Title')
+                                ->unique(ignoreRecord: true)
+                                ->required()
+                                ->minLength(2)
+                                ->maxLength(80),
 
-                        Forms\Components\TextInput::make('ForumTopicID')
-                            ->label('Forum Topic ID')
-                            ->numeric()
-                            ->rules([new ExistsInForumTopics()]),
+                            Forms\Components\TextInput::make('ForumTopicID')
+                                ->label('Forum Topic ID')
+                                ->numeric()
+                                ->rules([new ExistsInForumTopics()]),
+                        ]),
+
+                    Forms\Components\Section::make()
+                        ->grow(false)
+                        ->schema([
+                            Forms\Components\Toggle::make('gives_site_award'),
+                        ]),
                     ]),
 
                 Forms\Components\Section::make()

--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -52,49 +52,45 @@ class EventResource extends Resource
                     ->label('')
                     ->size(config('media.icon.lg.width')),
 
-                Infolists\Components\Split::make([
-                    Infolists\Components\Section::make('Primary Details')
-                        ->icon('heroicon-m-key')
-                        ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
-                        ->schema([
-                            Infolists\Components\TextEntry::make('legacyGame.title')
-                                ->label('Title'),
-
-                            Infolists\Components\TextEntry::make('permalink')
-                                ->formatStateUsing(fn () => 'Here')
-                                ->url(fn (Event $record): string => $record->getPermalinkAttribute())
-                                ->extraAttributes(['class' => 'underline'])
-                                ->openUrlInNewTab(),
-
-                            Infolists\Components\TextEntry::make('legacyGame.forumTopic.id')
-                                ->label('Forum Topic ID')
-                                ->url(fn (?int $state) => $state ? route('forum-topic.show', ['topic' => $state]) : null)
-                                ->placeholder('none')
-                                ->extraAttributes(function (Event $event): array {
-                                    if ($event->legacyGame->forumTopic?->id) {
-                                        return ['class' => 'underline'];
-                                    }
-
-                                    return [];
-                                }),
-
-                            Infolists\Components\TextEntry::make('active_from')
-                                ->label('Active From')
-                                ->date(),
-
-                            Infolists\Components\TextEntry::make('active_through')
-                            ->label('Active Through')
-                            ->date(),
-                        ]),
-                    Infolists\Components\Section::make([
+                Infolists\Components\Section::make('Primary Details')
+                    ->icon('heroicon-m-key')
+                    ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
+                    ->schema([
                         Infolists\Components\TextEntry::make('id')
                             ->label('ID'),
 
+                        Infolists\Components\TextEntry::make('legacyGame.title')
+                            ->label('Title'),
+
+                        Infolists\Components\TextEntry::make('permalink')
+                            ->formatStateUsing(fn () => 'Here')
+                            ->url(fn (Event $record): string => $record->getPermalinkAttribute())
+                            ->extraAttributes(['class' => 'underline'])
+                            ->openUrlInNewTab(),
+
+                        Infolists\Components\TextEntry::make('legacyGame.forumTopic.id')
+                            ->label('Forum Topic ID')
+                            ->url(fn (?int $state) => $state ? route('forum-topic.show', ['topic' => $state]) : null)
+                            ->placeholder('none')
+                            ->extraAttributes(function (Event $event): array {
+                                if ($event->legacyGame->forumTopic?->id) {
+                                    return ['class' => 'underline'];
+                                }
+
+                                return [];
+                            }),
+
+                        Infolists\Components\TextEntry::make('active_from')
+                            ->label('Active From')
+                            ->date(),
+
+                        Infolists\Components\TextEntry::make('active_through')
+                        ->label('Active Through')
+                        ->date(),
+
                         Infolists\Components\IconEntry::make('gives_site_award')
                             ->boolean(),
-
-                    ])->grow(false),
-                ])->from('md'),
+                    ]),
 
                 Infolists\Components\Section::make('Metrics')
                     ->icon('heroicon-s-arrow-trending-up')
@@ -120,30 +116,22 @@ class EventResource extends Resource
 
         return $form
             ->schema([
-                Forms\Components\Split::make([
-                    Forms\Components\Section::make()
-                        ->relationship('legacyGame')
-                        ->columns(2)
-                        ->schema([
-                            Forms\Components\TextInput::make('Title')
-                                ->label('Title')
-                                ->unique(ignoreRecord: true)
-                                ->required()
-                                ->minLength(2)
-                                ->maxLength(80),
+                Forms\Components\Section::make()
+                    ->relationship('legacyGame')
+                    ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
+                    ->schema([
+                        Forms\Components\TextInput::make('Title')
+                            ->label('Title')
+                            ->unique(ignoreRecord: true)
+                            ->required()
+                            ->minLength(2)
+                            ->maxLength(80),
 
-                            Forms\Components\TextInput::make('ForumTopicID')
-                                ->label('Forum Topic ID')
-                                ->numeric()
-                                ->rules([new ExistsInForumTopics()]),
-                        ]),
-
-                    Forms\Components\Section::make()
-                        ->grow(false)
-                        ->schema([
-                            Forms\Components\Toggle::make('gives_site_award'),
-                        ]),
-                ]),
+                        Forms\Components\TextInput::make('ForumTopicID')
+                            ->label('Forum Topic ID')
+                            ->numeric()
+                            ->rules([new ExistsInForumTopics()]),
+                    ]),
 
                 Forms\Components\Section::make()
                     ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
@@ -157,6 +145,8 @@ class EventResource extends Resource
                             ->label('Active Through')
                             ->native(false)
                             ->date(),
+
+                        Forms\Components\Toggle::make('gives_site_award'),
                     ]),
 
                 Forms\Components\Section::make('Achievements')

--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -85,8 +85,8 @@ class EventResource extends Resource
                             ->date(),
 
                         Infolists\Components\TextEntry::make('active_through')
-                        ->label('Active Through')
-                        ->date(),
+                            ->label('Active Through')
+                            ->date(),
 
                         Infolists\Components\IconEntry::make('gives_site_award')
                             ->boolean(),
@@ -146,7 +146,8 @@ class EventResource extends Resource
                             ->native(false)
                             ->date(),
 
-                        Forms\Components\Toggle::make('gives_site_award'),
+                        Forms\Components\Toggle::make('gives_site_award')
+                            ->inline(false),
                     ]),
 
                 Forms\Components\Section::make('Achievements')

--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -56,11 +56,11 @@ class EventResource extends Resource
                     ->icon('heroicon-m-key')
                     ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])
                     ->schema([
-                        Infolists\Components\TextEntry::make('id')
-                            ->label('ID'),
-
                         Infolists\Components\TextEntry::make('legacyGame.title')
                             ->label('Title'),
+
+                        Infolists\Components\TextEntry::make('id')
+                            ->label('ID'),
 
                         Infolists\Components\TextEntry::make('permalink')
                             ->formatStateUsing(fn () => 'Here')

--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -93,8 +93,8 @@ class EventResource extends Resource
                         Infolists\Components\IconEntry::make('gives_site_award')
                             ->boolean(),
 
-                        ])->grow(false),
-                    ])->from('md'),
+                    ])->grow(false),
+                ])->from('md'),
 
                 Infolists\Components\Section::make('Metrics')
                     ->icon('heroicon-s-arrow-trending-up')
@@ -143,7 +143,7 @@ class EventResource extends Resource
                         ->schema([
                             Forms\Components\Toggle::make('gives_site_award'),
                         ]),
-                    ]),
+                ]),
 
                 Forms\Components\Section::make()
                     ->columns(['md' => 2, 'xl' => 3, '2xl' => 4])

--- a/app/Filament/Resources/HubResource.php
+++ b/app/Filament/Resources/HubResource.php
@@ -123,6 +123,7 @@ class HubResource extends Resource
 
                         Forms\Components\Toggle::make('has_mature_content')
                             ->label('Has Mature Content')
+                            ->inline(false)
                             ->helperText('CAUTION: If this is enabled, players will get a warning when opening any game in the hub!')
                             ->default(false)
                             ->visible(fn ($record) => $user->can('toggleHasMatureContent', $record)),

--- a/app/Helpers/database/site-award.php
+++ b/app/Helpers/database/site-award.php
@@ -84,7 +84,7 @@ function getUsersSiteAwards(?User $user): array
                 ))
         UNION
         -- event awards
-        SELECT " . unixTimestampStatement('saw.AwardDate', 'AwardedAt') . ", saw.AwardType, saw.user_id, saw.AwardData, saw.AwardDataExtra, saw.DisplayOrder, gd.Title, " . System::Events . ", NULL, NULL, NULL
+        SELECT " . unixTimestampStatement('saw.AwardDate', 'AwardedAt') . ", saw.AwardType, saw.user_id, saw.AwardData, saw.AwardDataExtra, saw.DisplayOrder, gd.Title, " . System::Events . ", 'Events', NULL, e.image_asset_path
             FROM SiteAwards AS saw
             LEFT JOIN events e ON e.id = saw.AwardData
             LEFT JOIN GameData gd ON gd.id = e.legacy_game_id

--- a/app/Helpers/render/site-award.php
+++ b/app/Helpers/render/site-award.php
@@ -3,7 +3,6 @@
 use App\Community\Enums\AwardType;
 use App\Models\Event;
 use App\Models\EventAward;
-use App\Models\GameSet;
 use App\Models\PlayerBadge;
 
 function SeparateAwards(array $userAwards): array

--- a/app/Helpers/render/site-award.php
+++ b/app/Helpers/render/site-award.php
@@ -20,34 +20,20 @@ function SeparateAwards(array $userAwards): array
         }
     }
 
-    if (!empty($awardEventIds)) {
-        $awardEventGameIds = array_merge($awardEventGameIds,
-            Event::whereIn('id', $awardEventIds)->pluck('legacy_game_id')->toArray()
+    if (!empty($awardEventGameIds)) {
+        $awardEventIds = array_merge($awardEventIds,
+            Event::whereIn('legacy_game_id', $awardEventIds)->select('id')->pluck('id')->toArray()
         );
     }
 
     $devEventIds = [];
-    $devEventGameIds = [];
-    if (!empty($awardEventGameIds)) {
-        $awardEventGameIds = array_unique($awardEventGameIds);
-
-        // Get all dev event game IDs in a single optimized query.
-        $devEventGameIds = GameSet::query()
-            ->whereHas('games', fn ($q) => $q->whereIn('game_id', $awardEventGameIds))
-            ->where(fn ($q) => $q->where('id', GameSet::DeveloperEventsHubId)
-                    ->orWhere('title', 'LIKE', '[Dev Events - %')
-            )
-            ->with(['games' => fn ($q) => $q->select('GameData.ID')])
-            ->get()
-            ->pluck('games.*.ID')
-            ->flatten()
-            ->unique()
-            ->values()
-            ->all();
-
-        if (!empty($awardEventIds)) {
-            $devEventIds = Event::whereIn('legacy_game_id', $devEventGameIds)->pluck('id')->toArray();
-        }
+    if (!empty($awardEventIds)) {
+        $devEventIds = Event::query()
+            ->whereIn('id', $awardEventIds)
+            ->where('gives_site_award', true)
+            ->select('id')
+            ->pluck('id')
+            ->toArray();
     }
 
     $gameAwards = []; // Mastery awards that aren't Events.
@@ -59,9 +45,7 @@ function SeparateAwards(array $userAwards): array
         $id = (int) $award['AwardData'];
 
         if (AwardType::isGame($type)) {
-            if (in_array($id, $devEventGameIds)) {
-                $siteAwards[] = $award;
-            } elseif ($award['ConsoleName'] === 'Events') {
+            if ($award['ConsoleName'] === 'Events') {
                 $eventAwards[] = $award;
             } elseif ($award['AwardType'] !== AwardType::GameBeaten) {
                 $gameAwards[] = $award;

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -68,6 +68,7 @@ class Event extends BaseModel
                 'image_asset_path',
                 'active_from',
                 'active_until',
+                'gives_site_award',
             ])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs();

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -36,11 +36,13 @@ class Event extends BaseModel
         'active_from',
         'active_until',
         'active_through',
+        'gives_site_award',
     ];
 
     protected $casts = [
         'active_from' => 'date',
         'active_until' => 'date',
+        'gives_site_award' => 'boolean',
     ];
 
     protected $appends = [

--- a/database/migrations/2025_05_18_000000_update_events_table.php
+++ b/database/migrations/2025_05_18_000000_update_events_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->boolean('gives_site_award')->default(0)->after('active_until');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn(['gives_site_award']);
+        });
+    }
+};

--- a/public/API/API_GetUserAwards.php
+++ b/public/API/API_GetUserAwards.php
@@ -69,7 +69,17 @@ foreach ($userAwards as $userAward) {
 
 foreach ($userAwards as &$userAward) {
     $userAward['AwardedAt'] = Carbon::createFromTimestampUTC($userAward['AwardedAt'])->toIso8601String();
-    $userAward['AwardType'] = AwardType::toString((int) $userAward['AwardType']);
+
+    $awardType = (int) $userAward['AwardType'];
+    $userAward['AwardType'] = AwardType::toString($awardType);
+    if ($awardType === AwardType::Event) {
+        foreach ($siteAwards as $siteAward) {
+            if ($siteAward['AwardData'] === $userAward['AwardData']) {
+                $userAward['AwardType'] = 'Site Event';
+                break;
+            }
+        }
+    }
 
     // A user's hidden awards are not exposed to scrapers on their profile,
     // so we should not expose them via the API either.

--- a/tests/Feature/Connect/SubmitCodeNoteTest.php
+++ b/tests/Feature/Connect/SubmitCodeNoteTest.php
@@ -272,5 +272,6 @@ class SubmitCodeNoteTest extends TestCase
 
         $note->refresh();
         $this->assertEquals('This is an overwritten note', $note->body);
+        $this->assertNull($note->deleted_at);
     }
 }


### PR DESCRIPTION
Instead of trying to derive it from the hubs it belongs to.

Also addresses https://github.com/RetroAchievements/RAWeb/discussions/3148#discussioncomment-11996185.
Site Awards will have `'AwardType'='Site Event'` and other events will have `'AwardType'='Event'`.

Does not address #3135, which deals with specific Site Awards not backed with an actual event record.

----

Query to initialize field:
```
UPDATE events SET gives_site_award=1 WHERE legacy_game_id
    IN (SELECT game_id FROM game_set_games WHERE game_set_id IN (5, 3483, 5491, 25648));
```