### PR TITLE
chore: revert #3509

### DIFF
--- a/app/Helpers/database/player-game.php
+++ b/app/Helpers/database/player-game.php
@@ -380,13 +380,6 @@ function getUsersCompletedGamesAndMax(string $user): array
 
 function getGameRecentPlayers(int $gameID, int $maximum_results = 10): array
 {
-    // For multiple reasons (MySQL specific query details + legacyDbFetch),
-    // this function explodes while under test.
-    // For now, while under test, return an empty array.
-    if (app()->environment('testing')) {
-        return [];
-    }
-
     $retval = [];
 
     // determine the most recent session for each user who has played the game

--- a/app/Platform/Actions/ResumePlayerSessionAction.php
+++ b/app/Platform/Actions/ResumePlayerSessionAction.php
@@ -15,9 +15,7 @@ use App\Platform\Enums\AchievementSetType;
 use App\Platform\Events\PlayerSessionResumed;
 use App\Platform\Events\PlayerSessionStarted;
 use App\Platform\Jobs\UpdatePlayerGameMetricsJob;
-use App\Support\Cache\CacheKey;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Cache;
 
 class ResumePlayerSessionAction
 {
@@ -110,9 +108,6 @@ class ResumePlayerSessionAction
 
             $playerSession->save(['touch' => true]);
 
-            // Regenerate the recent players cache so it's primed on the next game page load.
-            $this->regenerateRecentPlayersCache($game->id);
-
             PlayerSessionResumed::dispatch($user, $game, $presence);
 
             return $playerSession;
@@ -143,9 +138,6 @@ class ResumePlayerSessionAction
         ]);
 
         $user->playerSessions()->save($playerSession);
-
-        // Regenerate the recent players cache so it's primed on the next game page load.
-        $this->regenerateRecentPlayersCache($game->id);
 
         PlayerSessionStarted::dispatch($user, $game, $presence);
 
@@ -193,30 +185,5 @@ class ResumePlayerSessionAction
                 $playerAchievementSet->save();
             }
         }
-    }
-
-    /**
-     * Invalidate and pre-warm the recent players cache for a game.
-     *
-     * When a player starts/pings for a game session, we:
-     * 1. Remove the existing cached data.
-     * 2. Pre-warm the cache with fresh data that includes the current player.
-     *
-     * This ensures the game page shows current data without causing a
-     * cache miss for the next visitor.
-     */
-    private function regenerateRecentPlayersCache(int $gameId): void
-    {
-        $cacheKey = CacheKey::buildGameRecentPlayersCacheKey($gameId);
-
-        // Before we do anything, delete the existing cache entry.
-        Cache::forget($cacheKey);
-
-        // Now, pre-warm the cache with fresh data (player list including the current player).
-        Cache::put(
-            $cacheKey,
-            getGameRecentPlayers($gameId, 10),
-            7 * 24 * 60 * 60, // 1 week
-        );
     }
 }

--- a/app/Support/Cache/CacheKey.php
+++ b/app/Support/Cache/CacheKey.php
@@ -13,11 +13,6 @@ class CacheKey
         return self::buildNormalizedCacheKey("game", $gameId, "card-data");
     }
 
-    public static function buildGameRecentPlayersCacheKey(int $gameId): string
-    {
-        return self::buildNormalizedCacheKey("game", $gameId, 'recent-players', [10]); // 10 players cached
-    }
-
     public static function buildUserLastLoginCacheKey(string $username): string
     {
         return self::buildNormalizedUserCacheKey($username, "last-login");

--- a/resources/views/pages-legacy/gameInfo.blade.php
+++ b/resources/views/pages-legacy/gameInfo.blade.php
@@ -21,7 +21,6 @@ use App\Platform\Enums\AchievementType;
 use App\Platform\Enums\GameSetType;
 use App\Platform\Enums\ImageType;
 use App\Platform\Enums\UnlockMode;
-use App\Support\Cache\CacheKey;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Gate;
 
@@ -930,19 +929,7 @@ if ($isFullyFeaturedGame) {
         echo "</div>";
 
         if ($isFullyFeaturedGame) {
-            /**
-             * Cache data for up to 1 week.
-             * The cache is automatically invalidated when a player 
-             * starts the game or pings the server with an ongoing session.
-             */
-            $recentPlayerData = Cache::remember(
-                CacheKey::buildGameRecentPlayersCacheKey($gameID),
-                7 * 24 * 60 * 60, // 1 week
-                function () use ($gameID) {
-                    return getGameRecentPlayers($gameID, 10);
-                }
-            );
-
+            $recentPlayerData = getGameRecentPlayers($gameID, 10);
             if (!empty($recentPlayerData)) {
                 echo "<div class='mt-6 mb-8'>";
                 ?>


### PR DESCRIPTION
Reverts the game page recent players cache changes (never deployed to prod).

I've confirmed this has negative performance impacts when dealing with games with millions of sessions, such as Final Fantasy XI. Notably, it causes `ResumePlayerSessionAction` to take multiple seconds to finish.