### PR TITLE
perf(ResumePlayerSessionAction): bulk update player_achievement_sets

### DIFF
--- a/app/Platform/Actions/ResumePlayerSessionAction.php
+++ b/app/Platform/Actions/ResumePlayerSessionAction.php
@@ -174,6 +174,7 @@ class ResumePlayerSessionAction
 
         if (!empty($activeAchievementSets)) {
             $baseQuery = PlayerAchievementSet::query()
+                ->where('user_id', $playerGame->user_id)
                 ->whereIn('achievement_set_id', $activeAchievementSets)
                 ->whereHas('achievementSet', function ($query) {
                     $query->whereNotNull('achievements_first_published_at');


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1374919660058837063.

Changes these updates from O(N) to O(1). Each increment operation is atomic at the database level, with updates happening in bulk.

Additionally, adds a `user_id` filter.