### PR TITLE
feat(messages): use UserHeading component on index page

### DIFF
--- a/app/Community/Actions/BuildMessageThreadIndexPagePropsAction.php
+++ b/app/Community/Actions/BuildMessageThreadIndexPagePropsAction.php
@@ -7,6 +7,7 @@ namespace App\Community\Actions;
 use App\Community\Data\MessageThreadData;
 use App\Community\Data\MessageThreadIndexPagePropsData;
 use App\Data\PaginatedData;
+use App\Data\UserData;
 use App\Models\MessageThread;
 use App\Models\User;
 use App\Policies\MessageThreadPolicy;
@@ -62,7 +63,7 @@ class BuildMessageThreadIndexPagePropsAction
                 items: MessageThreadData::fromCollection($paginatedMessageThreads->getCollection())
             ),
             unreadMessageCount: $inboxUser->UnreadMessageCount ?? 0,
-            senderUserDisplayName: $inboxUser->display_name,
+            senderUser: UserData::from($inboxUser),
             selectableInboxDisplayNames: $this->getAccessibleInboxes($me),
         );
 

--- a/app/Community/Actions/BuildMessageThreadShowPagePropsAction.php
+++ b/app/Community/Actions/BuildMessageThreadShowPagePropsAction.php
@@ -8,6 +8,7 @@ use App\Community\Data\MessageData;
 use App\Community\Data\MessageThreadData;
 use App\Community\Data\MessageThreadShowPagePropsData;
 use App\Data\PaginatedData;
+use App\Data\UserData;
 use App\Models\Message;
 use App\Models\MessageThread;
 use App\Models\MessageThreadParticipant;
@@ -83,7 +84,7 @@ class BuildMessageThreadShowPagePropsAction
             ),
             dynamicEntities: $dynamicEntities,
             canReply: $this->getCanReply($messageThread, $user),
-            senderUserDisplayName: $this->getSenderUserDisplayName($messageThread, $user),
+            senderUser: UserData::from($this->getSenderUser($messageThread, $user)),
         );
 
         return ['props' => $props, 'redirectToPage' => null];
@@ -103,7 +104,7 @@ class BuildMessageThreadShowPagePropsAction
         return $canReply;
     }
 
-    private function getSenderUserDisplayName(MessageThread $thread, User $user): string
+    private function getSenderUser(MessageThread $thread, User $user): User
     {
         $isUserParticipant = $thread->participants->contains('ID', $user->id);
         if (!$isUserParticipant) {
@@ -111,7 +112,7 @@ class BuildMessageThreadShowPagePropsAction
             $accessibleTeamIds = $policy->getAccessibleTeamIds($user);
 
             if (empty($accessibleTeamIds)) {
-                return $user->display_name;
+                return $user;
             }
 
             $foundTeamParticipant = $thread->participants()
@@ -119,13 +120,13 @@ class BuildMessageThreadShowPagePropsAction
                 ->first();
 
             if (!$foundTeamParticipant) {
-                return $user->display_name;
+                return $user;
             }
 
-            return User::firstWhere('ID', $foundTeamParticipant->id)->display_name;
+            return User::firstWhere('ID', $foundTeamParticipant->id);
         }
 
-        return $user->display_name;
+        return $user;
     }
 
     /**

--- a/app/Community/Controllers/MessageThreadController.php
+++ b/app/Community/Controllers/MessageThreadController.php
@@ -93,7 +93,7 @@ class MessageThreadController extends Controller
             templateKind: $request->input('templateKind')
                 ? MessageThreadTemplateKind::tryFrom($request->input('templateKind'))
                 : null,
-            senderUserDisplayName: $teamAccount?->display_name ?? $user->display_name,
+            senderUser: $teamAccount ? UserData::from($teamAccount) : UserData::from($user),
         ));
     }
 }

--- a/app/Community/Data/MessageThreadCreatePagePropsData.php
+++ b/app/Community/Data/MessageThreadCreatePagePropsData.php
@@ -17,7 +17,7 @@ class MessageThreadCreatePagePropsData extends Data
         public ?string $message,
         public ?string $subject,
         public ?MessageThreadTemplateKind $templateKind,
-        public string $senderUserDisplayName,
+        public UserData $senderUser,
     ) {
     }
 }

--- a/app/Community/Data/MessageThreadIndexPagePropsData.php
+++ b/app/Community/Data/MessageThreadIndexPagePropsData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Community\Data;
 
 use App\Data\PaginatedData;
+use App\Data\UserData;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
@@ -14,7 +15,7 @@ class MessageThreadIndexPagePropsData extends Data
     public function __construct(
         public PaginatedData $paginatedMessageThreads,
         public int $unreadMessageCount,
-        public string $senderUserDisplayName,
+        public UserData $senderUser,
         /** @var string[] */
         public array $selectableInboxDisplayNames,
     ) {

--- a/app/Community/Data/MessageThreadShowPagePropsData.php
+++ b/app/Community/Data/MessageThreadShowPagePropsData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Community\Data;
 
 use App\Data\PaginatedData;
+use App\Data\UserData;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
@@ -16,7 +17,7 @@ class MessageThreadShowPagePropsData extends Data
         public PaginatedData $paginatedMessages,
         public ShortcodeDynamicEntitiesData $dynamicEntities,
         public bool $canReply,
-        public string $senderUserDisplayName,
+        public UserData $senderUser,
     ) {
     }
 }

--- a/resources/js/features/messages/components/+create/MessagesCreateRoot.test.tsx
+++ b/resources/js/features/messages/components/+create/MessagesCreateRoot.test.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event';
 
 import { createAuthenticatedUser } from '@/common/models';
 import { render, screen, waitFor } from '@/test';
+import { createUser } from '@/test/factories';
 
 import { MessagesCreateRoot } from './MessagesCreateRoot';
 
@@ -48,7 +49,7 @@ describe('Component: MessagesCreateRoot', () => {
     render(<MessagesCreateRoot />, {
       pageProps: {
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) },
-        senderUserDisplayName: 'Scott',
+        senderUser: createUser({ displayName: 'Scott' }),
       },
     });
 
@@ -63,7 +64,7 @@ describe('Component: MessagesCreateRoot', () => {
     render(<MessagesCreateRoot />, {
       pageProps: {
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) },
-        senderUserDisplayName: 'RAdmin',
+        senderUser: createUser({ displayName: 'RAdmin' }),
       },
     });
 

--- a/resources/js/features/messages/components/+create/MessagesCreateRoot.tsx
+++ b/resources/js/features/messages/components/+create/MessagesCreateRoot.tsx
@@ -9,8 +9,7 @@ import { MessagePreviewContent } from '../MessagePreviewContent';
 import { MessagesBreadcrumbs } from '../MessagesBreadcrumbs';
 
 export const MessagesCreateRoot: FC = () => {
-  const { auth, senderUserDisplayName } =
-    usePageProps<App.Community.Data.MessageThreadCreatePageProps>();
+  const { auth, senderUser } = usePageProps<App.Community.Data.MessageThreadCreatePageProps>();
 
   const { t } = useTranslation();
 
@@ -20,12 +19,12 @@ export const MessagesCreateRoot: FC = () => {
     return null;
   }
 
-  const isDelegating = auth.user.displayName !== senderUserDisplayName;
+  const isDelegating = auth.user.displayName !== senderUser?.displayName;
 
   return (
     <div className="flex flex-col gap-4">
       <MessagesBreadcrumbs
-        delegatedUserDisplayName={isDelegating ? senderUserDisplayName : undefined}
+        delegatedUserDisplayName={isDelegating ? senderUser?.displayName : undefined}
         t_currentPageLabel={t('Start new message thread')}
       />
 

--- a/resources/js/features/messages/components/+index/MessagesIndexRoot.test.tsx
+++ b/resources/js/features/messages/components/+index/MessagesIndexRoot.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import { createAuthenticatedUser } from '@/common/models';
 import { render, screen } from '@/test';
-import { createMessageThread, createPaginatedData } from '@/test/factories';
+import { createMessageThread, createPaginatedData, createUser } from '@/test/factories';
 
 import { MessagesIndexRoot } from './MessagesIndexRoot';
 
@@ -82,7 +82,7 @@ describe('Component: MessagesIndexRoot', () => {
         paginatedMessageThreads: createPaginatedData([]),
         unreadMessageCount: 0,
         selectableInboxDisplayNames: ['Scott'],
-        senderUserDisplayName: 'Scott',
+        senderUser: createUser({ displayName: 'Scott' }),
       },
     });
 
@@ -156,7 +156,7 @@ describe('Component: MessagesIndexRoot', () => {
             },
           },
         ),
-        senderUserDisplayName: 'Scott',
+        senderUser: createUser({ displayName: 'Scott' }),
         unreadMessageCount: 0,
         selectableInboxDisplayNames: [],
       },
@@ -192,7 +192,7 @@ describe('Component: MessagesIndexRoot', () => {
             },
           },
         ),
-        senderUserDisplayName: 'RAdmin',
+        senderUser: createUser({ displayName: 'RAdmin' }),
         unreadMessageCount: 0,
         selectableInboxDisplayNames: [],
       },

--- a/resources/js/features/messages/components/+index/MessagesIndexRoot.tsx
+++ b/resources/js/features/messages/components/+index/MessagesIndexRoot.tsx
@@ -7,6 +7,7 @@ import { route } from 'ziggy-js';
 import { baseButtonVariants } from '@/common/components/+vendor/BaseButton';
 import { FullPaginator } from '@/common/components/FullPaginator';
 import { InertiaLink } from '@/common/components/InertiaLink';
+import { UserHeading } from '@/common/components/UserHeading';
 import { usePageProps } from '@/common/hooks/usePageProps';
 
 import { ChangeInboxButton } from '../ChangeInboxButton';
@@ -19,7 +20,7 @@ export const MessagesIndexRoot: FC = memo(() => {
     auth,
     paginatedMessageThreads,
     selectableInboxDisplayNames,
-    senderUserDisplayName,
+    senderUser,
     unreadMessageCount,
   } = usePageProps<App.Community.Data.MessageThreadIndexPageProps>();
 
@@ -29,13 +30,13 @@ export const MessagesIndexRoot: FC = memo(() => {
     return null;
   }
 
-  const isDelegating = auth.user.displayName !== senderUserDisplayName;
+  const isDelegating = auth.user.displayName !== senderUser?.displayName;
 
   const handlePageSelectValueChange = (newPageValue: number) => {
     router.visit(
       isDelegating
         ? route('message-thread.user.index', {
-            user: senderUserDisplayName,
+            user: senderUser?.displayName,
             _query: { page: newPageValue },
           })
         : route('message-thread.index', {
@@ -51,18 +52,18 @@ export const MessagesIndexRoot: FC = memo(() => {
           shouldShowInboxLinkCrumb={false}
           t_currentPageLabel={
             isDelegating
-              ? t("{{username}}'s Inbox", { username: senderUserDisplayName })
+              ? t("{{username}}'s Inbox", { username: senderUser?.displayName })
               : t('Your Inbox')
           }
         />
-        <h1 className="text-h3 w-full self-end sm:mt-2.5 sm:!text-[2.0em]">
+        <UserHeading user={senderUser ?? auth.user} wrapperClassName="!mb-1">
           {t('Messages Inbox')}
-        </h1>
+        </UserHeading>
 
         <p>
           {isDelegating
             ? t('delegatedUnreadMessages', {
-                username: senderUserDisplayName,
+                username: senderUser?.displayName,
                 unreadCount: unreadMessageCount,
                 threadCount: paginatedMessageThreads.total,
               })
@@ -78,7 +79,7 @@ export const MessagesIndexRoot: FC = memo(() => {
           <InertiaLink
             href={
               isDelegating
-                ? route('message-thread.user.create', { user: senderUserDisplayName })
+                ? route('message-thread.user.create', { user: senderUser?.displayName })
                 : route('message-thread.create')
             }
             className={baseButtonVariants({ size: 'sm' })}

--- a/resources/js/features/messages/components/+show/MessagesShowRoot.test.tsx
+++ b/resources/js/features/messages/components/+show/MessagesShowRoot.test.tsx
@@ -4,7 +4,12 @@ import { route } from 'ziggy-js';
 
 import { createAuthenticatedUser } from '@/common/models';
 import { render, screen, waitFor } from '@/test';
-import { createMessage, createMessageThread, createPaginatedData } from '@/test/factories';
+import {
+  createMessage,
+  createMessageThread,
+  createPaginatedData,
+  createUser,
+} from '@/test/factories';
 
 import { MessagesShowRoot } from './MessagesShowRoot';
 
@@ -168,7 +173,7 @@ describe('Component: MessagesShowRoot', () => {
         messageThread,
         paginatedMessages,
         canReply: true,
-        senderUserDisplayName: 'Scott',
+        senderUser: createUser({ displayName: 'Scott' }),
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) },
       },
     });
@@ -195,7 +200,7 @@ describe('Component: MessagesShowRoot', () => {
         messageThread,
         paginatedMessages,
         canReply: true,
-        senderUserDisplayName: 'RAdmin',
+        senderUser: createUser({ displayName: 'RAdmin' }),
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) },
       },
     });

--- a/resources/js/features/messages/components/+show/MessagesShowRoot.tsx
+++ b/resources/js/features/messages/components/+show/MessagesShowRoot.tsx
@@ -17,7 +17,7 @@ import { MessagesBreadcrumbs } from '../MessagesBreadcrumbs';
 import { ReadableMessageCard } from '../ReadableMessageCard';
 
 export const MessagesShowRoot: FC = () => {
-  const { auth, canReply, messageThread, paginatedMessages, senderUserDisplayName } =
+  const { auth, canReply, messageThread, paginatedMessages, senderUser } =
     usePageProps<App.Community.Data.MessageThreadShowPageProps>();
 
   const { t } = useTranslation();
@@ -30,7 +30,7 @@ export const MessagesShowRoot: FC = () => {
     return null;
   }
 
-  const isDelegating = auth.user.displayName !== senderUserDisplayName;
+  const isDelegating = auth.user.displayName !== senderUser?.displayName;
 
   const handleDeleteClick = async () => {
     if (!confirm(t('Are you sure you want to delete this message thread?'))) {
@@ -45,7 +45,7 @@ export const MessagesShowRoot: FC = () => {
 
     router.visit(
       isDelegating
-        ? route('message-thread.user.index', { user: senderUserDisplayName })
+        ? route('message-thread.user.index', { user: senderUser.displayName })
         : route('message-thread.index'),
     );
   };
@@ -63,7 +63,7 @@ export const MessagesShowRoot: FC = () => {
     <div className="flex flex-col gap-4">
       <div>
         <MessagesBreadcrumbs
-          delegatedUserDisplayName={isDelegating ? senderUserDisplayName : undefined}
+          delegatedUserDisplayName={isDelegating ? senderUser?.displayName : undefined}
           t_currentPageLabel={messageThread.title as TranslatedString}
         />
         <h1 className="text-h3 w-full self-end sm:mt-2.5 sm:!text-[2.0em]">

--- a/resources/js/features/messages/components/ChangeInboxButton/ChangeInboxButton.test.tsx
+++ b/resources/js/features/messages/components/ChangeInboxButton/ChangeInboxButton.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import { createAuthenticatedUser } from '@/common/models';
 import { render, screen } from '@/test';
+import { createUser } from '@/test/factories';
 
 import { ChangeInboxButton } from './ChangeInboxButton';
 
@@ -13,7 +14,7 @@ describe('Component: ChangeInboxButton', () => {
       pageProps: {
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) },
         selectableInboxDisplayNames: ['Scott', 'RAdmin'],
-        senderUserDisplayName: 'Scott',
+        senderUser: createUser({ displayName: 'Scott' }),
       },
     });
 
@@ -27,7 +28,7 @@ describe('Component: ChangeInboxButton', () => {
       pageProps: {
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) },
         selectableInboxDisplayNames: ['Scott', 'RAdmin'],
-        senderUserDisplayName: 'Scott',
+        senderUser: createUser({ displayName: 'Scott' }),
       },
     });
 
@@ -46,7 +47,7 @@ describe('Component: ChangeInboxButton', () => {
       pageProps: {
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) },
         selectableInboxDisplayNames: ['Scott', 'RAdmin'],
-        senderUserDisplayName: 'Scott', // !! currently in Scott's inbox, not RAdmin's
+        senderUser: createUser({ displayName: 'Scott' }), // !! currently in Scott's inbox, not RAdmin's
       },
     });
 
@@ -68,7 +69,7 @@ describe('Component: ChangeInboxButton', () => {
       pageProps: {
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) },
         selectableInboxDisplayNames: ['Scott', 'RAdmin'],
-        senderUserDisplayName: 'RAdmin', // !! currently in RAdmin's inbox, not Scott's
+        senderUser: createUser({ displayName: 'RAdmin' }), // !! currently in RAdmin's inbox, not Scott's
       },
     });
 

--- a/resources/js/features/messages/components/ChangeInboxButton/ChangeInboxButton.tsx
+++ b/resources/js/features/messages/components/ChangeInboxButton/ChangeInboxButton.tsx
@@ -20,12 +20,12 @@ import { BaseSelectNative } from '@/common/components/+vendor/BaseSelectNative';
 import { usePageProps } from '@/common/hooks/usePageProps';
 
 export const ChangeInboxButton: FC = () => {
-  const { auth, selectableInboxDisplayNames, senderUserDisplayName } =
+  const { auth, selectableInboxDisplayNames, senderUser } =
     usePageProps<App.Community.Data.MessageThreadIndexPageProps>();
 
   const { t } = useTranslation();
 
-  const [selectedDisplayName, setSelectedDisplayName] = useState(senderUserDisplayName);
+  const [selectedDisplayName, setSelectedDisplayName] = useState(senderUser?.displayName);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/resources/js/features/messages/components/CreateMessageReplyForm/CreateMessageReplyForm.tsx
+++ b/resources/js/features/messages/components/CreateMessageReplyForm/CreateMessageReplyForm.tsx
@@ -22,8 +22,7 @@ interface CreateMessageReplyFormProps {
 }
 
 export const CreateMessageReplyForm: FC<CreateMessageReplyFormProps> = ({ onPreview }) => {
-  const { auth, senderUserDisplayName } =
-    usePageProps<App.Community.Data.MessageThreadShowPageProps>();
+  const { auth, senderUser } = usePageProps<App.Community.Data.MessageThreadShowPageProps>();
 
   const { t } = useTranslation();
 
@@ -71,9 +70,9 @@ export const CreateMessageReplyForm: FC<CreateMessageReplyFormProps> = ({ onPrev
               </BaseButton>
 
               <BaseButton type="submit" disabled={!form.formState.isValid || mutation.isPending}>
-                {auth!.user.displayName === senderUserDisplayName
+                {auth!.user.displayName === senderUser?.displayName
                   ? t('Submit')
-                  : t('Submit (as {{username}})', { username: senderUserDisplayName })}
+                  : t('Submit (as {{username}})', { username: senderUser?.displayName })}
               </BaseButton>
             </div>
           </div>

--- a/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.test.tsx
+++ b/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.test.tsx
@@ -41,7 +41,7 @@ describe('Component: CreateMessageThreadForm', () => {
         subject: null,
         templateKind: null,
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) }, // !!
-        senderUserDisplayName: 'Scott', // !!
+        senderUser: createUser({ displayName: 'Scott' }), // !!
       },
     });
 
@@ -57,7 +57,7 @@ describe('Component: CreateMessageThreadForm', () => {
         subject: null,
         templateKind: null,
         auth: { user: createAuthenticatedUser({ displayName: 'Scott' }) }, // !!
-        senderUserDisplayName: 'RAdmin', // !!
+        senderUser: createUser({ displayName: 'RAdmin' }), // !!
       },
     });
 

--- a/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.tsx
+++ b/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.tsx
@@ -25,7 +25,7 @@ interface CreateMessageThreadFormProps {
 }
 
 export const CreateMessageThreadForm: FC<CreateMessageThreadFormProps> = ({ onPreview }) => {
-  const { auth, message, subject, templateKind, senderUserDisplayName, toUser } =
+  const { auth, message, subject, templateKind, senderUser, toUser } =
     usePageProps<App.Community.Data.MessageThreadCreatePageProps>();
 
   const { t } = useTranslation();
@@ -36,7 +36,7 @@ export const CreateMessageThreadForm: FC<CreateMessageThreadFormProps> = ({ onPr
       body: message ?? '',
       recipient: toUser?.displayName,
     },
-    senderUserDisplayName,
+    senderUser?.displayName,
   );
   const [body] = form.watch(['body']);
 
@@ -143,9 +143,9 @@ export const CreateMessageThreadForm: FC<CreateMessageThreadFormProps> = ({ onPr
               </BaseButton>
 
               <BaseButton type="submit" disabled={!form.formState.isValid || mutation.isPending}>
-                {auth!.user.displayName === senderUserDisplayName
+                {auth!.user.displayName === senderUser?.displayName
                   ? t('Submit')
-                  : t('Submit (as {{username}})', { username: senderUserDisplayName })}
+                  : t('Submit (as {{username}})', { username: senderUser?.displayName })}
               </BaseButton>
             </div>
           </div>

--- a/resources/js/features/messages/components/MessagesTable/MessagesTableRow.test.tsx
+++ b/resources/js/features/messages/components/MessagesTable/MessagesTableRow.test.tsx
@@ -136,7 +136,7 @@ describe('Component: MessagesTableRow', () => {
     render(<MessagesTableRow messageThread={thread} />, {
       pageProps: {
         auth: { user: authUser },
-        senderUserDisplayName: firstParticipant.displayName,
+        senderUser: createUser({ displayName: firstParticipant.displayName }),
       },
     });
 
@@ -154,7 +154,7 @@ describe('Component: MessagesTableRow', () => {
     render(<MessagesTableRow messageThread={thread} />, {
       pageProps: {
         auth: { user: createAuthenticatedUser() },
-        senderUserDisplayName: 'Same Name',
+        senderUser: createUser({ displayName: 'Same Name' }),
       },
     });
 

--- a/resources/js/features/messages/components/MessagesTable/MessagesTableRow.tsx
+++ b/resources/js/features/messages/components/MessagesTable/MessagesTableRow.tsx
@@ -15,15 +15,14 @@ interface MessagesTableRowProps {
 }
 
 export const MessagesTableRow: FC<MessagesTableRowProps> = ({ messageThread }) => {
-  const { auth, senderUserDisplayName } =
-    usePageProps<App.Community.Data.MessageThreadIndexPageProps>();
+  const { auth, senderUser } = usePageProps<App.Community.Data.MessageThreadIndexPageProps>();
 
   const { t } = useTranslation();
 
   // Find who we're chatting with in order to populate the "With" column.
   const otherParticipant =
     (messageThread.participants?.find(
-      (p) => p.displayName !== senderUserDisplayName,
+      (p) => p.displayName !== senderUser?.displayName,
     ) as App.Data.User) ?? messageThread.participants?.[0];
 
   return (

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -80,7 +80,7 @@ declare namespace App.Community.Data {
     message: string | null;
     subject: string | null;
     templateKind: App.Community.Enums.MessageThreadTemplateKind | null;
-    senderUserDisplayName: string;
+    senderUser: App.Data.User;
   };
   export type MessageThread = {
     id: number;
@@ -94,7 +94,7 @@ declare namespace App.Community.Data {
   export type MessageThreadIndexPageProps<TItems = App.Community.Data.MessageThread> = {
     paginatedMessageThreads: App.Data.PaginatedData<TItems>;
     unreadMessageCount: number;
-    senderUserDisplayName: string;
+    senderUser: App.Data.User;
     selectableInboxDisplayNames: Array<string>;
   };
   export type MessageThreadShowPageProps<TItems = App.Community.Data.Message> = {
@@ -102,7 +102,7 @@ declare namespace App.Community.Data {
     paginatedMessages: App.Data.PaginatedData<TItems>;
     dynamicEntities: App.Community.Data.ShortcodeDynamicEntities;
     canReply: boolean;
-    senderUserDisplayName: string;
+    senderUser: App.Data.User;
   };
   export type RecentLeaderboardEntry = {
     leaderboard: App.Platform.Data.Leaderboard;


### PR DESCRIPTION
This PR makes a small change to the messages index pages (`/messages` and `/messages/{user}`).

Now, `<UserHeading />` is used for the H1, so the user avatar displays for the currently-selected inbox:
![Screenshot 2025-05-22 at 8 02 52 PM](https://github.com/user-attachments/assets/fee694eb-b012-4ded-a569-9cc693e2ad84)

This makes it a little more obvious which inbox is currently active for the user, assuming they have multiple available.