### PR TITLE
feat(manage): add guidelines doc url to game release form

### DIFF
--- a/app/Filament/Resources/GameResource/RelationManagers/ReleasesRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/ReleasesRelationManager.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\HtmlString;
 
 class ReleasesRelationManager extends RelationManager
 {
@@ -43,6 +44,11 @@ class ReleasesRelationManager extends RelationManager
     {
         return $form
             ->schema([
+                Forms\Components\Placeholder::make('guidelines')
+                    ->hiddenLabel()
+                    ->columnSpan(2)
+                    ->content(new HtmlString('🔴 For detailed guidelines, see the <a href="https://docs.retroachievements.org/guidelines/content/game-info-and-hub-guidelines.html#regional-titles" target="_blank" class="underline">documentation</a>.')),
+
                 Forms\Components\TextInput::make('title')
                     ->required()
                     ->maxLength(80)


### PR DESCRIPTION
Adds a URL which links to the changes introduced in https://github.com/RetroAchievements/docs/pull/249.

![Screenshot 2025-05-23 at 7 09 21 PM](https://github.com/user-attachments/assets/cf7151cc-bdb9-42fe-9a32-dd4d68346fe6)
