### PR TITLE
feat(game): persist the 'Hide unlocked achievements' checkbox

### DIFF
--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -24,6 +24,7 @@ class EncryptCookies extends Middleware
         'datatable_view_preference_playlist',
         'datatable_view_preference_suggest',
         'datatable_view_preference_system_games',
+        'hide_unlocked_achievements_games',
         'prefers_hidden_user_completed_sets',
         'prefers_hidden_user_profile_stats',
         'prefers_seeing_saved_hidden_rows_when_reordering',

--- a/resources/js/tall-stack/alpine/toggleAchievementRowsComponent/toggleAchievementRowsComponent.ts
+++ b/resources/js/tall-stack/alpine/toggleAchievementRowsComponent/toggleAchievementRowsComponent.ts
@@ -1,8 +1,89 @@
-export function toggleAchievementRowsComponent() {
+export function toggleAchievementRowsComponent(
+  gameId?: number | null,
+  initialHideUnlocked = false,
+) {
+  const COOKIE_NAME = 'hide_unlocked_achievements_games';
+  /**
+   * Don't store more than this count of game IDs.
+   * We want to keep the cookie size small.
+   */
+  const MAX_GAME_IDS = 10;
+
+  // Get the list of game IDs from cookie.
+  function getHiddenGameIds(): number[] {
+    const cookieValue = window.getCookie(COOKIE_NAME);
+    if (!cookieValue) {
+      return [];
+    }
+
+    try {
+      const gameIds = cookieValue
+        .split(',')
+        .map((id) => parseInt(id, 10))
+        .filter((id) => !isNaN(id));
+
+      return gameIds;
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Save the list of game IDs to a the cookie.
+   */
+  function saveHiddenGameIds(gameIds: number[]): void {
+    // Keep only the most recent MAX_GAME_IDS.
+    const trimmedIds = gameIds.slice(-MAX_GAME_IDS);
+    window.setCookie(COOKIE_NAME, trimmedIds.join(','));
+  }
+
+  /**
+   * Check if the current game's unlocked achievements should be hidden.
+   */
+  function isGameHidden(): boolean {
+    if (!gameId) {
+      return false;
+    }
+
+    const hiddenGameIds = getHiddenGameIds();
+
+    return hiddenGameIds.includes(gameId);
+  }
+
+  /**
+   * Toggle the current game in the hidden game IDs list.
+   */
+  function toggleGameInHiddenList(shouldHide: boolean): void {
+    if (!gameId) {
+      return;
+    }
+
+    let hiddenGameIds = getHiddenGameIds();
+
+    if (shouldHide) {
+      // Add the game ID if it's not already present.
+      if (!hiddenGameIds.includes(gameId)) {
+        hiddenGameIds.push(gameId);
+      }
+    } else {
+      // Remove the game ID from the list.
+      hiddenGameIds = hiddenGameIds.filter((id) => id !== gameId);
+    }
+
+    saveHiddenGameIds(hiddenGameIds);
+  }
+
   return {
-    isUsingHideUnlockedAchievements: false,
+    isUsingHideUnlockedAchievements: initialHideUnlocked || isGameHidden(),
     isUsingHideInactiveAchievements: false,
     isUsingOnlyShowMissables: false,
+
+    init(): void {
+      // Respect whatever the initial state from the server is.
+      if (this.isUsingHideUnlockedAchievements) {
+        this.updateRowsVisibility();
+      }
+    },
 
     updateRowsVisibility(): void {
       const allRows = document.querySelectorAll<HTMLLIElement>('#set-achievements-list > li');
@@ -28,6 +109,7 @@ export function toggleAchievementRowsComponent() {
 
     toggleUnlockedRows(): void {
       this.isUsingHideUnlockedAchievements = !this.isUsingHideUnlockedAchievements;
+      toggleGameInHiddenList(this.isUsingHideUnlockedAchievements);
       this.updateRowsVisibility();
     },
 

--- a/resources/views/components/game/achievements-list-filters.blade.php
+++ b/resources/views/components/game/achievements-list-filters.blade.php
@@ -4,9 +4,11 @@ use App\Enums\UserPreference;
 ?>
 
 @props([
-    'canShowHideUnlockedAchievements' => false,
     'canShowHideInactiveAchievements' => false,
+    'canShowHideUnlockedAchievements' => false,
+    'gameId' => null,
     'numMissableAchievements' => 0,
+    'shouldHideUnlocked' => false,
 ])
 
 <?php
@@ -19,9 +21,9 @@ if ($isMissableFilterAllowed) {
 }
 ?>
 
-<div x-data="toggleAchievementRowsComponent()" class="flex gap-x-4 sm:flex-col md:flex-row lg:flex-col xl:flex-row">
+<div x-data="toggleAchievementRowsComponent({{ $gameId }}, {{ $shouldHideUnlocked ? 'true' : 'false' }})" x-init="init()" class="flex gap-x-4 sm:flex-col md:flex-row lg:flex-col xl:flex-row">
     @if ($isMissableFilterAllowed)
-        <label class="flex items-center gap-x-1 select-none transition lg:active:scale-95 cursor-pointer">
+        <label class="flex items-center gap-x-1 select-none cursor-pointer">
             <input
                 type="checkbox"
                 autocomplete="off"
@@ -34,12 +36,14 @@ if ($isMissableFilterAllowed) {
     @endif
 
     @if ($canShowHideUnlockedAchievements)
-        <label class="flex items-center gap-x-1 select-none transition lg:active:scale-95 cursor-pointer">
+        <label class="flex items-center gap-x-1 select-none cursor-pointer">
             <input
                 type="checkbox"
                 autocomplete="off"
                 class="cursor-pointer"
+                :checked="isUsingHideUnlockedAchievements"
                 @change="toggleUnlockedRows"
+                @if ($shouldHideUnlocked) checked @endif
             >
                 Hide unlocked achievements
             </input>
@@ -47,7 +51,7 @@ if ($isMissableFilterAllowed) {
     @endif
 
     @if ($canShowHideInactiveAchievements)
-        <label class="flex items-center gap-x-1 select-none transition lg:active:scale-95 cursor-pointer">
+        <label class="flex items-center gap-x-1 select-none cursor-pointer">
             <input
                 type="checkbox"
                 autocomplete="off"

--- a/resources/views/components/game/achievements-list/achievements-list-item.blade.php
+++ b/resources/views/components/game/achievements-list/achievements-list-item.blade.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
     'isCreditDialogEnabled' => true,
     'isUnlocked' => false,
     'isUnlockedHardcore' => false,
+    'shouldHideUnlocked' => false,
     'showAuthorName' => false,
     'totalPlayerCount' => 0,
     'useMinimalLayout' => false,
@@ -44,7 +45,7 @@ $renderedAchievementAvatar = achievementAvatar(
 );
 ?>
 
-<li class="flex gap-x-3 odd:bg-[rgba(50,50,50,0.4)] light:odd:bg-neutral-200  px-2 py-3 md:py-1 w-full {{ $isUnlocked ? 'unlocked-row' : '' }} {{ $achievement['type'] === 'missable' ? 'missable-row' : '' }}">
+<li class="flex gap-x-3 odd:bg-[rgba(50,50,50,0.4)] light:odd:bg-neutral-200  px-2 py-3 md:py-1 w-full {{ $isUnlocked ? 'unlocked-row' : '' }} {{ $achievement['type'] === 'missable' ? 'missable-row' : '' }} {{ ($shouldHideUnlocked && $isUnlocked) ? 'hidden' : '' }}">
     <div class="flex flex-col gap-y-1">
         {!! $renderedAchievementAvatar !!}
     </div>

--- a/resources/views/components/game/achievements-list/root.blade.php
+++ b/resources/views/components/game/achievements-list/root.blade.php
@@ -1,10 +1,11 @@
 @props([
     'achievements' => [],
     'beatenGameCreditDialogContext' => 's:|h:',
-    'totalPlayerCount' => 0,
     'isCreditDialogEnabled' => true,
-    'showAuthorNames' => false,
     'separateUnlockedAchievements' => true,
+    'shouldHideUnlocked' => false,
+    'showAuthorNames' => false,
+    'totalPlayerCount' => 0,
 ])
 
 <?php
@@ -29,6 +30,7 @@ if ($separateUnlockedAchievements) {
                 :achievement="$achievement"
                 :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
                 :isCreditDialogEnabled="$isCreditDialogEnabled"
+                :shouldHideUnlocked="$shouldHideUnlocked"
                 :showAuthorName="$showAuthorNames"
                 :totalPlayerCount="$totalPlayerCount"
             />
@@ -39,6 +41,7 @@ if ($separateUnlockedAchievements) {
                 :achievement="$achievement"
                 :beatenGameCreditDialogContext="$beatenGameCreditDialogContext"
                 :isCreditDialogEnabled="$isCreditDialogEnabled"
+                :shouldHideUnlocked="$shouldHideUnlocked"
                 :showAuthorName="$showAuthorNames"
                 :totalPlayerCount="$totalPlayerCount"
             />

--- a/resources/views/pages-legacy/gameInfo.blade.php
+++ b/resources/views/pages-legacy/gameInfo.blade.php
@@ -887,10 +887,17 @@ if ($isFullyFeaturedGame) {
 
                 $hasCompletionOrMastery = ($numEarnedCasual === $numAchievements) || ($numEarnedHardcore === $numAchievements);
                 $canShowHideUnlockedAchievements = $user && ($numEarnedCasual > 0 || $numEarnedHardcore > 0) && !$hasCompletionOrMastery;
+                
+                // Check if the user wants this game's unlocked achievements to be hidden by default.
+                $hideUnlockedCookie = request()->cookie('hide_unlocked_achievements_games', '');
+                $hiddenGameIds = array_filter(array_map('intval', explode(',', $hideUnlockedCookie)));
+                $shouldHideUnlocked = in_array($gameID, $hiddenGameIds);
                 ?>
                     <x-game.achievements-list-filters
                         :canShowHideUnlockedAchievements="$canShowHideUnlockedAchievements"
                         :numMissableAchievements="$gameMetaBindings['numMissableAchievements']"
+                        :gameId="$gameID"
+                        :shouldHideUnlocked="$shouldHideUnlocked"
                     />
                 <?php
                 RenderGameSort($gameModel->ConsoleID, $flagParam?->value, $officialFlag->value, $gameID, $sortBy, canSortByType: $isGameBeatable);
@@ -906,6 +913,10 @@ if ($isFullyFeaturedGame) {
 
         if ($isFullyFeaturedGame || $isEventGame) {
             if (isset($achievementData)) {
+                // Check if unlocked achievements should be hidden (for server-side rendering)
+                $hideUnlockedCookie = request()->cookie('hide_unlocked_achievements_games', '');
+                $hiddenGameIds = array_filter(array_map('intval', explode(',', $hideUnlockedCookie)));
+                $shouldHideUnlockedAchievements = in_array($gameID, $hiddenGameIds);
                 ?>
                     <x-game.achievements-list.root
                         :achievements="$achievementData"
@@ -914,6 +925,7 @@ if ($isFullyFeaturedGame) {
                         :showAuthorNames="!$isOfficial && isset($user) && $permissions >= Permissions::JuniorDeveloper"
                         :totalPlayerCount="$numDistinctPlayers"
                         :separateUnlockedAchievements="!$isEventGame"
+                        :shouldHideUnlocked="$shouldHideUnlockedAchievements"
                     />
                 <?php
             }


### PR DESCRIPTION
This PR makes an enhancement to this checkbox filter on legacy/Blade game pages:
![Screenshot 2025-05-24 at 3 57 08 PM](https://github.com/user-attachments/assets/f0d38f31-87ef-4e75-a439-d8f5a3e4445f)

Now, the user's filter preference is stored in a cookie and respected by the page when they navigate/refresh the page, which is very common when the filter is active (especially page refreshes).

The persistence is aware of what game ID is being persisted. Up to 10 game IDs are held in the cookie at a time in a FIFO approach.

**How it works:**
A new cookie, `hide_unlocked_achievements_games` has been added to _EncryptCookies.php_.

On server-side rendering, PHP reads the cookie value in _gameInfo.blade.php_ and checks if the current game ID is in the cookie's list of game IDs. If it is, it's passed down to the achievement list to do the initial filtering before JS loads.

On the client, the Alpine.js component handles setting and updating the user's cookie value. The cookie value is an array of IDs, up to 10 maximum, that are stored in a first-in first-out approach. In other words, upon storing the 11th ID, whatever the 1st ID value is gets expunged from the array. This is necessary in order to keep the cookie size at a minimum.