### PR TITLE
feat: set up dedicated inbox for code review team

### DIFF
--- a/app/Policies/MessageThreadPolicy.php
+++ b/app/Policies/MessageThreadPolicy.php
@@ -18,6 +18,7 @@ class MessageThreadPolicy
      * Inbox display_name => [Roles]
      */
     protected const INBOX_ROLES_MAP = [
+        'CodeReviewTeam' => [Role::CODE_REVIEWER],
         'DevCompliance' => [Role::DEV_COMPLIANCE],
         'QATeam' => [Role::QUALITY_ASSURANCE],
         'RAArtTeam' => [Role::ARTIST],

--- a/config/services.php
+++ b/config/services.php
@@ -36,6 +36,10 @@ return [
             'sentry' => env('DISCORD_WEBHOOK_MOD_SENTRY'),
         ],
         'inbox_webhook' => [
+            'CodeReviewTeam' => [
+                'url' => env('DISCORD_WEBHOOK_CODEREVIEWERS'),
+                'is_forum' => true,
+            ],
             'DevCompliance' => [
                 'url' => env('DISCORD_WEBHOOK_DEVCOMPLIANCE'),
                 'is_forum' => true,


### PR DESCRIPTION
This PR sets up a dedicated inbox for the new code review team account (you will probably need to create an account locally with username "CodeReviewTeam").

Tested and verified working at https://discord.com/channels/310192285306454017/1375934438520786974. Prod env has already been configured.