### PR TITLE
perf: add throttling to player game metrics job execution

### DIFF
--- a/app/Platform/Jobs/UpdatePlayerGameMetricsJob.php
+++ b/app/Platform/Jobs/UpdatePlayerGameMetricsJob.php
@@ -50,6 +50,13 @@ class UpdatePlayerGameMetricsJob implements ShouldQueue, ShouldBeUniqueUntilProc
 
     public function handle(): void
     {
+        // PHPUnit implodes if it encounters the Redis facade.
+        if (app()->environment('testing')) {
+            $this->processJob();
+
+            return;
+        }
+
         /**
          * This action is very prone to causing CPU spikes and high
          * DB load in production if it's left to run wild on its own.

--- a/app/Platform/Jobs/UpdatePlayerGameMetricsJob.php
+++ b/app/Platform/Jobs/UpdatePlayerGameMetricsJob.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Redis;
 
 class UpdatePlayerGameMetricsJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
 {
@@ -48,6 +49,24 @@ class UpdatePlayerGameMetricsJob implements ShouldQueue, ShouldBeUniqueUntilProc
     }
 
     public function handle(): void
+    {
+        /**
+         * This action is very prone to causing CPU spikes and high
+         * DB load in production if it's left to run wild on its own.
+         * We'll cap the number of jobs that can be executed per second
+         * to keep load at a reasonable level.
+         */
+        Redis::throttle('player-game-metrics')
+            ->allow(30) // 30 jobs ...
+            ->every(1)  // ... per second
+            ->then(function () {
+                $this->processJob();
+            }, function () {
+                $this->release(1);
+            });
+    }
+
+    private function processJob(): void
     {
         if ($this->batch()?->cancelled()) {
             return;


### PR DESCRIPTION
This PR:
* Adds throttling to `UpdatePlayerGameMetricsJob`. Now, only 30 jobs can be executed per second.
* Resolves an N+1 query problem in `PlayerGameActivityService`.

This should hopefully mitigate the high CPU spikes we see from `player-game-metrics-batch`. You can test the change by running Horizon and then changing any achievement's point values - throughput should be more limited than usual.

These jobs are not really time-sensitive, and I'd rather them finish a little slower than come close to taking down prod every weekend.

If we still see large CPU spikes, we can lower throughput from 30, to 25, to 20, if that's ultimately what it takes.

There really isn't any low-hanging fruit for performance optimization in the actions themselves. The CPU spikes are mainly just a result of so much computational work happening in this pipeline. We should be judicious moving forward about adding more to these specific actions; ideally new work gets split off into its own queues, which Horizon can then intelligently balance processes against.