### PR TITLE
chore: add horizon:watch command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
         "phpunit/phpunit": "^10.5",
         "predis/predis": "^2.0",
         "rector/rector": "^0.18.1",
+        "spatie/laravel-horizon-watcher": "^1.1",
         "spatie/laravel-ignition": "^2.4",
         "worksome/envy": "^1.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3af2e0c295a05b3aba69feb04c999efe",
+    "content-hash": "3ff91850a85a27bec1690238043ad921",
     "packages": [
         {
             "name": "amphp/amp",
@@ -18148,6 +18148,66 @@
             "time": "2024-07-25T11:06:04+00:00"
         },
         {
+            "name": "spatie/file-system-watcher",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/file-system-watcher.git",
+                "reference": "d9511ecbd266f190c4abce88516c3f231fcb6bfe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/file-system-watcher/zipball/d9511ecbd266f190c4abce88516c3f231fcb6bfe",
+                "reference": "d9511ecbd266f190c4abce88516c3f231fcb6bfe",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "symfony/process": "^5.2|^6.0|^7.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^1.22",
+                "phpunit/phpunit": "^9.5",
+                "spatie/ray": "^1.22",
+                "spatie/temporary-directory": "^2.0",
+                "vimeo/psalm": "^4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Watcher\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Watch changes in the file system using PHP",
+            "homepage": "https://github.com/spatie/file-system-watcher",
+            "keywords": [
+                "file-system-watcher",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/file-system-watcher/issues",
+                "source": "https://github.com/spatie/file-system-watcher/tree/1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-18T14:26:25+00:00"
+        },
+        {
             "name": "spatie/flare-client-php",
             "version": "1.8.0",
             "source": {
@@ -18298,6 +18358,76 @@
                 }
             ],
             "time": "2024-06-12T14:55:22+00:00"
+        },
+        {
+            "name": "spatie/laravel-horizon-watcher",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-horizon-watcher.git",
+                "reference": "cbebdaab800f9fd1bbb446223502466170d09363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-horizon-watcher/zipball/cbebdaab800f9fd1bbb446223502466170d09363",
+                "reference": "cbebdaab800f9fd1bbb446223502466170d09363",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
+                "php": "^8.1",
+                "spatie/file-system-watcher": "^1.1.1",
+                "spatie/laravel-package-tools": "^1.13.6"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.2",
+                "nunomaduro/collision": "^6.3.1|^8.0",
+                "orchestra/testbench": "^7.11|^8.0|^9.0|^10.0",
+                "pestphp/pest": "^1.22.1|^2.34|^3.7",
+                "pestphp/pest-plugin-laravel": "^1.3|^2.3|^3.1",
+                "phpunit/phpunit": "^9.5.26|^10.5|^11.5.3",
+                "spatie/laravel-ray": "^1.31"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "HorizonWatcher": "Spatie\\HorizonWatcher\\Facades\\HorizonWatcher"
+                    },
+                    "providers": [
+                        "Spatie\\HorizonWatcher\\HorizonWatcherServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\HorizonWatcher\\": "src",
+                    "Spatie\\HorizonWatcher\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Automatically restart Horizon when local PHP files change",
+            "homepage": "https://github.com/spatie/laravel-horizon-watcher",
+            "keywords": [
+                "laravel",
+                "laravel-horizon-watcher",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-horizon-watcher/issues",
+                "source": "https://github.com/spatie/laravel-horizon-watcher/tree/1.1.3"
+            },
+            "time": "2025-04-17T06:26:21+00:00"
         },
         {
             "name": "spatie/laravel-ignition",

--- a/config/horizon-watcher.php
+++ b/config/horizon-watcher.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    /*
+     * Horizon will be restarted when any PHP file inside these directories
+     * get created, updated or deleted. You can also specify other kinds
+     * of files here.
+     */
+    'paths' => [
+        app_path(),
+        config_path(),
+        database_path(),
+        resource_path('views'),
+        base_path('.env'),
+        base_path('composer.lock'),
+    ],
+
+    /*
+     * This command will be executed to start Horizon.
+     */
+    'command' => 'php artisan horizon',
+];


### PR DESCRIPTION
I just spent half an hour debugging something I was _sure_ I had fixed locally, but because I forgot to restart my local Horizon instance, my changes weren't working.

This PR adds a `horizon:watch` command that can be used like so:
```bash
sail artisan horizon:watch
```

Now, when local PHP files change, Horizon will automatically restart to get the latest changes:
```
   INFO  Starting Horizon, and restart when any file changes...


   INFO  Horizon started successfully.

   INFO  Change detected! Restarting horizon...


   INFO  Horizon started successfully.
```