### PR TITLE
pass unlockPercentage to checklist

### DIFF
--- a/app/Community/Actions/BuildAchievementChecklistAction.php
+++ b/app/Community/Actions/BuildAchievementChecklistAction.php
@@ -77,6 +77,7 @@ class BuildAchievementChecklistAction
                         'unlocksTotal',
                         'unlocksHardcoreTotal',
                         'unlockHardcorePercentage',
+                        'unlockPercentage',
                         'game.badgeUrl',
                         'game.playersTotal',
                         'game.system.nameShort',

--- a/tests/Feature/Community/Actions/BuildAchievementChecklistActionTest.php
+++ b/tests/Feature/Community/Actions/BuildAchievementChecklistActionTest.php
@@ -242,6 +242,7 @@ class BuildAchievementChecklistActionTest extends TestCase
             'unlockedHardcoreAt' => $hardcoreUnlock ? $hardcoreUnlock->format('c') : null,
             'unlocksTotal' => $achievement->unlocks_total,
             'unlocksHardcoreTotal' => $achievement->unlocks_hardcore_total,
+            'unlockPercentage' => $achievement->unlock_percentage,
             'unlockHardcorePercentage' => $achievement->unlock_hardcore_percentage,
             'game' => [
                 'id' => $achievement->game->id,


### PR DESCRIPTION
fixes https://discord.com/channels/310192285306454017/1017568867574362283/1376830899114737755

[#3442](https://github.com/RetroAchievements/RAWeb/pull/3442/files#diff-a49bc33a4f857f839f04006eb0a5037bea913f0973c79b904ec4c516a6fe3bd1L38-L40) changed the widget to use `unlockPercentage` instead of `unlockHardcorePercentage` for the unlock rate, and the checklist wasn't passing it.