### PR TITLE
perf(UpsertGameCoreAchievementSetFromLegacyFlagsAction): batch sync

### DIFF
--- a/app/Models/AchievementSetAchievement.php
+++ b/app/Models/AchievementSetAchievement.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Support\Database\Eloquent\BasePivot;
+
+class AchievementSetAchievement extends BasePivot
+{
+    protected $table = 'achievement_set_achievements';
+
+    protected $fillable = [
+        'achievement_set_id',
+        'achievement_id',
+        'order_column',
+        'created_at',
+        'updated_at',
+    ];
+}


### PR DESCRIPTION
This PR tackles another cause of N+1 writes in `UpdateGameMetricsAction`. Eloquent ORM's `sync()` kicks off an individual query for every entity to be synced.

Now, they're all rolled up into an `->upsert()`.