### PR TITLE
chore(player_games): add `user_is_tracked` field

### DIFF
--- a/database/migrations/2025_05_30_000000_update_player_games_table.php
+++ b/database/migrations/2025_05_30_000000_update_player_games_table.php
@@ -10,7 +10,7 @@ return new class() extends Migration {
     public function up(): void
     {
         Schema::table('player_games', function (Blueprint $table) {
-            $table->boolean('user_is_tracked')->after('game_id')->nullable()->index();
+            $table->boolean('user_is_tracked')->after('user_id')->nullable()->index();
         });
 
         Schema::table('player_games', function (Blueprint $table) {

--- a/database/migrations/2025_05_30_000000_update_player_games_table.php
+++ b/database/migrations/2025_05_30_000000_update_player_games_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('player_games', function (Blueprint $table) {
+            $table->boolean('user_is_tracked')->after('game_id')->nullable()->index();
+        });
+
+        Schema::table('player_games', function (Blueprint $table) {
+            $table->index(['game_id', 'user_is_tracked', 'achievements_unlocked'], 'idx_game_tracked_unlocked');
+            $table->index(['game_id', 'user_is_tracked', 'achievements_unlocked_hardcore'], 'idx_game_tracked_unlocked_hardcore');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_games', function (Blueprint $table) {
+            $table->dropIndex('idx_game_tracked_unlocked_hardcore');
+            $table->dropIndex('idx_game_tracked_unlocked');
+            $table->dropIndex(['user_is_tracked']);
+            $table->dropColumn('user_is_tracked');
+        });
+    }
+};


### PR DESCRIPTION
This is **the first of 3 PRs that will need to be deployed independently** to speed up `UpdateGameMetricsAction`.

**The Plan:**
* PR+Deployment 1/3: Add the `player_games.user_is_tracked` field. It starts off as being nullable.
* PR+Deployment 2/3: Sync and write to the field. Don't read from it yet. https://github.com/RetroAchievements/RAWeb/pull/3575
* PR+Deployment 3/3: Make the field non-nullable, remove the `UserAccounts` join from `UpdateGameMetricsAction`.

Ideally we can get all three of these done within the next 24 hours.

---

This PR adds and indexes a single column onto the `player_games` table: `user_is_tracked`.

The goal here is to remove the expensive join in `UpdateGameMetricsAction` onto `UserAccounts` to dramatically improve the performance of that action.

This PR is intended to be deployed in isolation. It includes only a migration - no logic for writing to the column. The migration takes approximately 1 minute to run.
