### PR TITLE
feat(player_games): sync and write to `user_is_tracked`

### DIFF
--- a/app/Filament/Resources/UserResource/Pages/Edit.php
+++ b/app/Filament/Resources/UserResource/Pages/Edit.php
@@ -6,6 +6,7 @@ namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
 use App\Models\User;
+use App\Platform\Events\PlayerRankedStatusChanged;
 use Carbon\Carbon;
 use Filament\Resources\Pages\EditRecord;
 
@@ -26,6 +27,10 @@ class Edit extends EditRecord
 
         if ((bool) $record->Untracked !== $data['Untracked']) {
             $data['unranked_at'] = $data['Untracked'] ? Carbon::now() : null;
+
+            $record->playerGames()->update(['user_is_tracked' => !$data['Untracked']]);
+
+            PlayerRankedStatusChanged::dispatch($record, $data['Untracked']);
         }
 
         return $data;

--- a/app/Helpers/database/player-rank.php
+++ b/app/Helpers/database/player-rank.php
@@ -14,6 +14,8 @@ function SetUserUntrackedStatus(User $user, bool $isUntracked): void
     $user->unranked_at = $isUntracked ? now() : null;
     $user->save();
 
+    $user->playerGames()->update(['user_is_tracked' => !$isUntracked]);
+
     PlayerRankedStatusChanged::dispatch($user, $isUntracked);
 }
 

--- a/app/Models/PlayerGame.php
+++ b/app/Models/PlayerGame.php
@@ -22,6 +22,7 @@ class PlayerGame extends BasePivot
     protected $table = 'player_games';
 
     protected $casts = [
+        'user_is_tracked' => 'boolean',
         'last_played_at' => 'datetime',
         'beaten_at' => 'datetime',
         'beaten_hardcore_at' => 'datetime',

--- a/app/Platform/Actions/UpdatePlayerGameMetricsAction.php
+++ b/app/Platform/Actions/UpdatePlayerGameMetricsAction.php
@@ -29,6 +29,8 @@ class UpdatePlayerGameMetricsAction
             return;
         }
 
+        $playerGame->user_is_tracked = $user->unranked_at === null;
+
         $activityService = new PlayerGameActivityService();
         $activityService->initialize($playerGame->user, $playerGame->game, withSubsets: true);
 

--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -44,6 +44,7 @@ use App\Platform\Commands\SyncLeaderboardTopEntries;
 use App\Platform\Commands\SyncLegacyGameTags;
 use App\Platform\Commands\SyncMemoryNotes;
 use App\Platform\Commands\SyncPlayerBadges;
+use App\Platform\Commands\SyncPlayerGamesTrackedStatus;
 use App\Platform\Commands\SyncPlayerRichPresence;
 use App\Platform\Commands\SyncPlayerSession;
 use App\Platform\Commands\SyncTriggers;
@@ -135,6 +136,7 @@ class AppServiceProvider extends ServiceProvider
                 SyncLegacyGameTags::class,
                 SyncMemoryNotes::class,
                 SyncPlayerBadges::class,
+                SyncPlayerGamesTrackedStatus::class,
                 SyncPlayerRichPresence::class,
                 SyncPlayerSession::class,
                 SyncTriggers::class,

--- a/app/Platform/Commands/SyncPlayerGamesTrackedStatus.php
+++ b/app/Platform/Commands/SyncPlayerGamesTrackedStatus.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class SyncPlayerGamesTrackedStatus extends Command
+{
+    protected $signature = 'ra:sync:player-games-tracked-status';
+    protected $description = 'Sync user_is_tracked field for all player_games records based on UserAccounts.unranked_at and Deleted status';
+
+    public function handle(): void
+    {
+        $this->info('Starting sync of player_games tracked status...');
+
+        $total = DB::table('player_games')->count();
+        $this->info("Found {$total} player_games records to process.");
+
+        if ($total === 0) {
+            $this->info('No records to process.');
+
+            return;
+        }
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        // Use the DB facade for performance reasons.
+        DB::table('player_games')->orderBy('id')->chunk(5000, function ($playerGames) use ($bar) {
+            // Collect all user IDs from this chunk.
+            $userIds = $playerGames->pluck('user_id')->unique();
+
+            // Get all user tracked statuses in one query.
+            // Use the DB facade for performance reasons.
+            $users = DB::table('UserAccounts')
+                ->whereIn('ID', $userIds)
+                ->select('ID', 'unranked_at', 'Deleted')
+                ->get()
+                ->keyBy('ID');
+
+            // Build batch update data.
+            $trackedIds = [];
+            $untrackedIds = [];
+
+            foreach ($playerGames as $playerGame) {
+                if (isset($users[$playerGame->user_id])) {
+                    $user = $users[$playerGame->user_id];
+                    $isTracked = $user->unranked_at === null && $user->Deleted === null;
+
+                    if ($isTracked) {
+                        $trackedIds[] = $playerGame->id;
+                    } else {
+                        $untrackedIds[] = $playerGame->id;
+                    }
+                }
+                $bar->advance();
+            }
+
+            // Batch update tracked records.
+            // Use the DB facade for performance reasons.
+            if (!empty($trackedIds)) {
+                DB::table('player_games')
+                    ->whereIn('id', $trackedIds)
+                    ->update(['user_is_tracked' => 1]);
+            }
+
+            // Batch update untracked records.
+            // Use the DB facade for performance reasons.
+            if (!empty($untrackedIds)) {
+                DB::table('player_games')
+                    ->whereIn('id', $untrackedIds)
+                    ->update(['user_is_tracked' => 0]);
+            }
+        });
+
+        $bar->finish();
+        $this->newLine(2);
+
+        $this->info('Done syncing player_games tracked status.');
+    }
+}

--- a/database/migrations/2025_05_30_000000_update_player_games_table.php
+++ b/database/migrations/2025_05_30_000000_update_player_games_table.php
@@ -10,7 +10,7 @@ return new class() extends Migration {
     public function up(): void
     {
         Schema::table('player_games', function (Blueprint $table) {
-            $table->boolean('user_is_tracked')->after('game_id')->nullable()->index();
+            $table->boolean('user_is_tracked')->after('user_id')->nullable()->index();
         });
 
         Schema::table('player_games', function (Blueprint $table) {

--- a/database/migrations/2025_05_30_000000_update_player_games_table.php
+++ b/database/migrations/2025_05_30_000000_update_player_games_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('player_games', function (Blueprint $table) {
+            $table->boolean('user_is_tracked')->after('game_id')->nullable()->index();
+        });
+
+        Schema::table('player_games', function (Blueprint $table) {
+            $table->index(['game_id', 'user_is_tracked', 'achievements_unlocked'], 'idx_game_tracked_unlocked');
+            $table->index(['game_id', 'user_is_tracked', 'achievements_unlocked_hardcore'], 'idx_game_tracked_unlocked_hardcore');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('player_games', function (Blueprint $table) {
+            $table->dropIndex('idx_game_tracked_unlocked_hardcore');
+            $table->dropIndex('idx_game_tracked_unlocked');
+            $table->dropIndex(['user_is_tracked']);
+            $table->dropColumn('user_is_tracked');
+        });
+    }
+};


### PR DESCRIPTION
Stacked on https://github.com/RetroAchievements/RAWeb/pull/3574.

This is **the second of 3 PRs that will need to be deployed independently** to speed up `UpdateGameMetricsAction`.

**The Plan:**
* PR+Deployment 1/3: Add the `player_games.user_is_tracked` field. It starts off as being nullable. https://github.com/RetroAchievements/RAWeb/pull/3574
* PR+Deployment 2/3: Sync and write to the field. Don't read from it yet.
* PR+Deployment 3/3: Make the field non-nullable, remove the `UserAccounts` join from `UpdateGameMetricsAction`. https://github.com/RetroAchievements/RAWeb/pull/3576

Ideally we can get all three of these done within the next 24 hours.

---

This PR adds writes and a sync command for `player_games.user_is_tracked`.

```bash
# this takes 1-2 hours
sail artisan ra:sync:player-games-tracked-status
```

This PR's changes should also be an independent deploy.
