### PR TITLE
Split UpdateGameMetricsAction into multiple actions

### DIFF
--- a/app/Platform/Actions/ResetPlayerProgressAction.php
+++ b/app/Platform/Actions/ResetPlayerProgressAction.php
@@ -10,7 +10,6 @@ use App\Platform\Enums\AchievementFlag;
 use App\Platform\Enums\UnlockMode;
 use App\Platform\Events\PlayerBadgeLost;
 use App\Platform\Jobs\UpdateDeveloperContributionYieldJob;
-use App\Platform\Jobs\UpdateGameMetricsJob;
 use App\Platform\Jobs\UpdatePlayerBeatenGamesStatsJob;
 use App\Platform\Jobs\UpdatePlayerGameMetricsJob;
 use Illuminate\Support\Facades\DB;
@@ -153,7 +152,7 @@ class ResetPlayerProgressAction
                 dispatch(new UpdatePlayerGameMetricsJob($user->id, $affectedGameID));
             } else {
                 // update the game metrics directly
-                dispatch(new UpdateGameMetricsJob($affectedGameID));
+                dispatch(new UpdateGamePlayerCountJob($affectedGameID));
             }
         }
 

--- a/app/Platform/Actions/ResetPlayerProgressAction.php
+++ b/app/Platform/Actions/ResetPlayerProgressAction.php
@@ -10,6 +10,7 @@ use App\Platform\Enums\AchievementFlag;
 use App\Platform\Enums\UnlockMode;
 use App\Platform\Events\PlayerBadgeLost;
 use App\Platform\Jobs\UpdateDeveloperContributionYieldJob;
+use App\Platform\Jobs\UpdateGamePlayerCountJob;
 use App\Platform\Jobs\UpdatePlayerBeatenGamesStatsJob;
 use App\Platform\Jobs\UpdatePlayerGameMetricsJob;
 use Illuminate\Support\Facades\DB;

--- a/app/Platform/Actions/ResetPlayerProgressAction.php
+++ b/app/Platform/Actions/ResetPlayerProgressAction.php
@@ -151,10 +151,11 @@ class ResetPlayerProgressAction
             if (!$isFullReset) {
                 // update the player game metrics, which will cascade into the game metrics
                 dispatch(new UpdatePlayerGameMetricsJob($user->id, $affectedGameID));
-            } else {
-                // update the game metrics directly
-                dispatch(new UpdateGamePlayerCountJob($affectedGameID));
             }
+
+            // if all achievements for a game were reset, the user is no longer considered a
+            // player of the game. will be a no-op if they still have achievements for the game.
+            dispatch(new UpdateGamePlayerCountJob($affectedGameID));
         }
 
         dispatch(new UpdatePlayerBeatenGamesStatsJob($user->id));

--- a/app/Platform/Actions/UnlockPlayerAchievementAction.php
+++ b/app/Platform/Actions/UnlockPlayerAchievementAction.php
@@ -97,15 +97,6 @@ class UnlockPlayerAchievementAction
 
         // commit the unlock
         if ($achievement->is_published) {
-            // if it's the first unlock for the player in this game, update the player count for the game
-            $unlockedAchievementCount = $user->playerGames()
-                ->where('game_id', $achievement->GameID)
-                ->value('achievements_unlocked');
-            if ($unlockedAchievementCount === 0) {
-                dispatch(new UpdateGamePlayerCountJob($originalGame->id))
-                    ->onQueue('game-metrics');
-            }
-
             $unlock->save();
 
             // Check if this achievement is currently maintained by someone other than the author.

--- a/app/Platform/Actions/UnlockPlayerAchievementAction.php
+++ b/app/Platform/Actions/UnlockPlayerAchievementAction.php
@@ -97,6 +97,15 @@ class UnlockPlayerAchievementAction
 
         // commit the unlock
         if ($achievement->is_published) {
+            // if it's the first unlock for the player in this game, update the player count for the game
+            $unlockedAchievementCount = $user->playerGames()
+                ->where('game_id', $achievement->GameID)
+                ->value('achievements_unlocked');
+            if ($unlockedAchievementCount === 0) {
+                dispatch(new UpdateGamePlayerCountJob($originalGame->id))
+                    ->onQueue('game-metrics');
+            }
+
             $unlock->save();
 
             // Check if this achievement is currently maintained by someone other than the author.

--- a/app/Platform/Actions/UpdateAchievementMetricsAction.php
+++ b/app/Platform/Actions/UpdateAchievementMetricsAction.php
@@ -76,6 +76,14 @@ class UpdateAchievementMetricsAction
         if ($game->isDirty()) {
             $game->saveQuietly();
 
+            // copy the new weighted points to the achievement set
+            $coreGameAchievementSet = $game->gameAchievementSets()->core()->first();
+            if ($coreGameAchievementSet) {
+                $coreSet = $coreGameAchievementSet->achievementSet;
+                $coreSet->points_weighted = $game->TotalTruePoints;
+                $coreSet->save();
+            }
+
             $searchIndexingService->queueGameForIndexing($game->id);
         }
     }

--- a/app/Platform/Actions/UpdateAchievementMetricsAction.php
+++ b/app/Platform/Actions/UpdateAchievementMetricsAction.php
@@ -71,5 +71,12 @@ class UpdateAchievementMetricsAction
             $achievement->saveQuietly();
             $searchIndexingService->queueAchievementForIndexing($achievement->ID);
         }
+
+        $game->TotalTruePoints = $achievements->sum('TrueRatio');
+        if ($game->isDirty()) {
+            $game->saveQuietly();
+
+            $searchIndexingService->queueGameForIndexing($game->id);
+        }
     }
 }

--- a/app/Platform/Actions/UpdateAchievementMetricsAction.php
+++ b/app/Platform/Actions/UpdateAchievementMetricsAction.php
@@ -7,10 +7,8 @@ namespace App\Platform\Actions;
 use App\Models\Achievement;
 use App\Models\Game;
 use App\Models\PlayerAchievement;
-use App\Platform\Jobs\UpdateGamePlayerGamesJob;
 use App\Platform\Services\SearchIndexingService;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Log;
 
 class UpdateAchievementMetricsAction
 {
@@ -19,7 +17,9 @@ class UpdateAchievementMetricsAction
         $this->update($achievement->game, collect([$achievement]));
     }
 
-    /** @var Collection<int, Achievement> $achievements */
+    /**
+     * @param Collection<int, Achievement> $achievements
+     */
     public function update(Game $game, Collection $achievements): void
     {
         // NOTE if game has a parent game it contains the parent game's players metrics

--- a/app/Platform/Actions/UpdateAchievementMetricsAction.php
+++ b/app/Platform/Actions/UpdateAchievementMetricsAction.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Actions;
+
+use App\Models\Achievement;
+use App\Models\Game;
+use App\Models\PlayerAchievement;
+use App\Platform\Jobs\UpdateGamePlayerGamesJob;
+use App\Platform\Services\SearchIndexingService;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+class UpdateAchievementMetricsAction
+{
+    public function execute(Achievement $achievement): void
+    {
+        $this->update($achievement->game, collect([$achievement]));
+    }
+
+    /** @var Collection<int, Achievement> $achievements */
+    public function update(Game $game, Collection $achievements): void
+    {
+        // NOTE if game has a parent game it contains the parent game's players metrics
+        $playersTotal = $game->players_total;
+        $playersHardcore = $game->players_hardcore;
+        $playersHardcoreCalc = $playersHardcore ?: 1;
+
+        // Get both total and hardcore counts in a single query.
+        $achievementIds = $achievements->pluck('ID')->all();
+        $unlockStats = PlayerAchievement::query()
+            ->whereIn('player_achievements.achievement_id', $achievementIds)
+            ->whereHas('user', function ($query) { $query->tracked(); })
+            ->groupBy('player_achievements.achievement_id')
+            ->selectRaw('
+                player_achievements.achievement_id,
+                COUNT(*) as total_unlocks,
+                SUM(CASE WHEN unlocked_hardcore_at IS NOT NULL THEN 1 ELSE 0 END) as hardcore_unlocks
+            ')
+            ->get();
+
+        // Convert to lookup arrays for faster read access.
+        $unlockCounts = [];
+        $hardcoreUnlockCounts = [];
+        foreach ($unlockStats as $stat) {
+            $unlockCounts[$stat->achievement_id] = $stat->total_unlocks;
+            $hardcoreUnlockCounts[$stat->achievement_id] = $stat->hardcore_unlocks;
+        }
+
+        $searchIndexingService = app()->make(SearchIndexingService::class);
+
+        foreach ($achievements as $achievement) {
+            $unlocksCount = $unlockCounts[$achievement->ID] ?? 0;
+            $unlocksHardcoreCount = $hardcoreUnlockCounts[$achievement->ID] ?? 0;
+
+            // force all unachieved to be 1
+            $unlocksHardcoreCalc = $unlocksHardcoreCount ?: 1;
+            $weight = 0.4;
+            $pointsWeighted = (int) (
+                $achievement->points * (1 - $weight)
+                + $achievement->points * (($playersHardcoreCalc / $unlocksHardcoreCalc) * $weight)
+            );
+
+            $achievement->unlocks_total = $unlocksCount;
+            $achievement->unlocks_hardcore_total = $unlocksHardcoreCount;
+            $achievement->unlock_percentage = $playersTotal ? $unlocksCount / $playersTotal : 0;
+            $achievement->unlock_hardcore_percentage = $playersHardcore ? $unlocksHardcoreCount / $playersHardcore : 0;
+            $achievement->TrueRatio = $pointsWeighted;
+
+            $achievement->saveQuietly();
+            $searchIndexingService->queueAchievementForIndexing($achievement->ID);
+        }
+    }
+}

--- a/app/Platform/Actions/UpdateGameAchievementsMetricsAction.php
+++ b/app/Platform/Actions/UpdateGameAchievementsMetricsAction.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Platform\Actions;
 
 use App\Models\Game;
-use App\Models\PlayerAchievement;
-use App\Platform\Actions\UpdateAchievementMetricsAction;
 use App\Platform\Services\SearchIndexingService;
 
 class UpdateGameAchievementsMetricsAction

--- a/app/Platform/Actions/UpdateGameAchievementsMetricsAction.php
+++ b/app/Platform/Actions/UpdateGameAchievementsMetricsAction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Platform\Actions;
 
 use App\Models\Game;
-use App\Platform\Services\SearchIndexingService;
 
 class UpdateGameAchievementsMetricsAction
 {
@@ -21,14 +20,6 @@ class UpdateGameAchievementsMetricsAction
 
         $action = new UpdateAchievementMetricsAction();
         $action->update($game, $achievements);
-
-        $game->TotalTruePoints = $achievements->sum('TrueRatio');
-        if ($game->isDirty()) {
-            $game->saveQuietly();
-
-            $searchIndexingService = app()->make(SearchIndexingService::class);
-            $searchIndexingService->queueGameForIndexing($game->id);
-        }
 
         // TODO GameAchievementSetMetricsUpdated::dispatch($game);
     }

--- a/app/Platform/Actions/UpdateGameAchievementsMetricsAction.php
+++ b/app/Platform/Actions/UpdateGameAchievementsMetricsAction.php
@@ -6,6 +6,7 @@ namespace App\Platform\Actions;
 
 use App\Models\Game;
 use App\Models\PlayerAchievement;
+use App\Platform\Actions\UpdateAchievementMetricsAction;
 use App\Platform\Services\SearchIndexingService;
 
 class UpdateGameAchievementsMetricsAction
@@ -14,71 +15,22 @@ class UpdateGameAchievementsMetricsAction
     {
         // TODO refactor to do this for each achievement set
 
-        // NOTE if game has a parent game it contains the parent game's players metrics
-        $playersTotal = $game->players_total;
-        $playersHardcore = $game->players_hardcore;
-
         // force all unachieved to be 1
-        $playersHardcoreCalc = $playersHardcore ?: 1;
-        $pointsWeightedTotal = 0;
         $achievements = $game->achievements()->published()->get();
         if ($achievements->isEmpty()) {
             return;
         }
 
-        $achievementIds = $achievements->pluck('ID')->all();
+        $action = new UpdateAchievementMetricsAction();
+        $action->update($game, $achievements);
 
-        // Get both total and hardcore counts in a single query.
-        $unlockStats = PlayerAchievement::query()
-            ->whereIn('player_achievements.achievement_id', $achievementIds)
-            ->whereHas('user', function ($query) { $query->tracked(); })
-            ->groupBy('player_achievements.achievement_id')
-            ->selectRaw('
-                player_achievements.achievement_id,
-                COUNT(*) as total_unlocks,
-                SUM(CASE WHEN unlocked_hardcore_at IS NOT NULL THEN 1 ELSE 0 END) as hardcore_unlocks
-            ')
-            ->get();
+        $game->TotalTruePoints = $achievements->sum('TrueRatio');
+        if ($game->isDirty()) {
+            $game->saveQuietly();
 
-        // Convert to lookup arrays for faster read access.
-        $unlockCounts = [];
-        $hardcoreUnlockCounts = [];
-        foreach ($unlockStats as $stat) {
-            $unlockCounts[$stat->achievement_id] = $stat->total_unlocks;
-            $hardcoreUnlockCounts[$stat->achievement_id] = $stat->hardcore_unlocks;
+            $searchIndexingService = app()->make(SearchIndexingService::class);
+            $searchIndexingService->queueGameForIndexing($game->id);
         }
-
-        $searchIndexingService = app()->make(SearchIndexingService::class);
-
-        $pointsWeightedTotal = 0;
-
-        foreach ($achievements as $achievement) {
-            $unlocksCount = $unlockCounts[$achievement->ID] ?? 0;
-            $unlocksHardcoreCount = $hardcoreUnlockCounts[$achievement->ID] ?? 0;
-
-            // force all unachieved to be 1
-            $unlocksHardcoreCalc = $unlocksHardcoreCount ?: 1;
-            $weight = 0.4;
-            $pointsWeighted = (int) (
-                $achievement->points * (1 - $weight)
-                + $achievement->points * (($playersHardcoreCalc / $unlocksHardcoreCalc) * $weight)
-            );
-            $pointsWeightedTotal += $pointsWeighted;
-
-            $achievement->unlocks_total = $unlocksCount;
-            $achievement->unlocks_hardcore_total = $unlocksHardcoreCount;
-            $achievement->unlock_percentage = $playersTotal ? $unlocksCount / $playersTotal : 0;
-            $achievement->unlock_hardcore_percentage = $playersHardcore ? $unlocksHardcoreCount / $playersHardcore : 0;
-            $achievement->TrueRatio = $pointsWeighted;
-
-            $achievement->saveQuietly();
-            $searchIndexingService->queueAchievementForIndexing($achievement->ID);
-        }
-
-        $game->TotalTruePoints = $pointsWeightedTotal;
-
-        $game->saveQuietly();
-        $searchIndexingService->queueGameForIndexing($game->id);
 
         // TODO GameAchievementSetMetricsUpdated::dispatch($game);
     }

--- a/app/Platform/Actions/UpdateGameBeatenMetricsAction.php
+++ b/app/Platform/Actions/UpdateGameBeatenMetricsAction.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Actions;
+
+use App\Models\Game;
+use App\Models\GameAchievementSet;
+use App\Models\PlayerAchievementSet;
+use App\Models\PlayerGame;
+use App\Platform\Jobs\UpdateGameMetricsJob;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
+
+class UpdateGameBeatenMetricsAction
+{
+    public function execute(Game $game): void
+    {
+        // get median time to beat
+        $query = PlayerGame::where('game_id', $game->id)
+            ->whereNotNull('time_to_beat')->whereNull('time_to_beat_hardcore');
+        [$game->times_beaten, $game->median_time_to_beat] = $this->getMedian($query, 'time_to_beat');
+
+        $query = PlayerGame::where('game_id', $game->id)
+            ->whereNotNull('time_to_beat_hardcore');
+        [$game->times_beaten_hardcore, $game->median_time_to_beat_hardcore] =
+             $this->getMedian($query, 'time_to_beat_hardcore');
+
+        $game->saveQuietly();
+
+        // get median time to complete for each associated set
+        $gameAchievementSets = GameAchievementSet::where('game_id', $game->id)
+            ->with('achievementSet')
+            ->get();
+
+        foreach ($gameAchievementSets as $gameAchievementSet) {
+            $achievementSet = $gameAchievementSet->achievementSet;
+
+            // NOTE: this only finds masters of the current set. it ignores users who may
+            //       have previously mastered it before a revision
+            $query = PlayerAchievementSet::where('achievement_set_id', $achievementSet->id)
+                ->where('achievements_unlocked', '=', $achievementSet->achievements_published)
+                ->where('achievements_unlocked_hardcore', '!=', $achievementSet->achievements_published);
+            [$achievementSet->times_completed, $achievementSet->median_time_to_complete] =
+                $this->getMedian($query, 'time_taken');
+
+            $query = PlayerAchievementSet::where('achievement_set_id', $achievementSet->id)
+                ->where('achievements_unlocked_hardcore', '=', $achievementSet->achievements_published);
+            [$achievementSet->times_completed_hardcore, $achievementSet->median_time_to_complete_hardcore] =
+                $this->getMedian($query, 'time_taken_hardcore');
+
+            $achievementSet->save();
+        }
+    }
+
+    /**
+     * @param Builder<PlayerGame>|Builder<PlayerAchievementSet> $query
+     */
+    private function getMedian(Builder $query, string $field): array
+    {
+        $count = $query->count();
+        if ($count === 0) {
+            return [0, null];
+        }
+
+        $query->select($field)->orderBy($field);
+
+        if (($count % 2) == 1) {
+            // odd. just get the middle item
+            $query->offset((int) ($count / 2))->limit(1);
+            $median = $query->value($field);
+        } else {
+            // even. get the two items in the middle and average them together
+            $query->offset((int) ($count / 2) - 1)->limit(2);
+            $values = $query->pluck($field)->toArray();
+            $median = ($values[0] + $values[1]) / 2;
+        }
+
+        return [$count, $median];
+    }
+}

--- a/app/Platform/Actions/UpdateGameBeatenMetricsAction.php
+++ b/app/Platform/Actions/UpdateGameBeatenMetricsAction.php
@@ -8,9 +8,7 @@ use App\Models\Game;
 use App\Models\GameAchievementSet;
 use App\Models\PlayerAchievementSet;
 use App\Models\PlayerGame;
-use App\Platform\Jobs\UpdateGameMetricsJob;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Log;
 
 class UpdateGameBeatenMetricsAction
 {

--- a/app/Platform/Actions/UpdateGameMetricsAction.php
+++ b/app/Platform/Actions/UpdateGameMetricsAction.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace App\Platform\Actions;
 
 use App\Models\Game;
-use App\Models\GameAchievementSet;
-use App\Models\PlayerAchievementSet;
-use App\Models\PlayerGame;
 use App\Platform\Events\GameMetricsUpdated;
 use App\Platform\Jobs\UpdateGamePlayerGamesJob;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
 
+// Game metrics managed by this action are related to published achievements and their definitions
+// For player-related metrics, see UpdateGamePlayerCountAction and UpdateGameBeatenMetricsAction.
 class UpdateGameMetricsAction
 {
     public function execute(Game $game): void
@@ -20,22 +18,10 @@ class UpdateGameMetricsAction
         $game->achievements_published = $game->achievements()->published()->count();
         $game->achievements_unpublished = $game->achievements()->unpublished()->count();
 
-        // update achievements version by changed hash
-        // if ($game->attributes['achievements_total']) {
-        //     $game->attributes['achievements_version_hash'] = md5($publishedAchievements->implode('trigger'));
-        //     if ($game->isDirty('achievements_version_hash')) {
-        //         $game->attributes['achievements_version'] = $game->achievements_version + 1;
-        //     }
-        // }
-
         $game->points_total = $game->achievements()->published()->sum('points');
         // NOTE $game->TotalTruePoints are updated separately
 
         $achievementSetVersionChanged = false;
-        $achievementsPublishedChange = 0;
-        $pointsTotalChange = 0;
-        $playersTotalChange = 0;
-        $playersHardcoreChange = 0;
         if ($game->achievements_published || $game->achievements_unpublished) {
             $versionHashFields = ['ID', 'MemAddr', 'type', 'Points'];
             $achievementSetVersionHashPayload = $game->achievements()->published()
@@ -46,38 +32,20 @@ class UpdateGameMetricsAction
             $game->achievement_set_version_hash = hash('sha256', $achievementSetVersionHashPayload);
 
             $achievementSetVersionChanged = $game->isDirty('achievement_set_version_hash');
-            $achievementsPublishedChange = $game->achievements_published - $game->getOriginal('achievements_published');
-            $pointsTotalChange = $game->points_total - $game->getOriginal('points_total');
-            $playersTotalChange = $game->players_total - $game->getOriginal('players_total');
-            $playersHardcoreChange = $game->players_hardcore - $game->getOriginal('players_hardcore');
         }
-        $pointsWeightedBeforeUpdate = $game->TotalTruePoints;
 
         $game->saveQuietly();
 
-        app()->make(UpdateGameAchievementsMetricsAction::class)
-            ->execute($game);
-
-        app()->make(UpsertGameCoreAchievementSetFromLegacyFlagsAction::class)
-            ->execute($game);
-
-        $game->refresh();
-
-        $pointsWeightedChange = $game->TotalTruePoints - $pointsWeightedBeforeUpdate;
-
         GameMetricsUpdated::dispatch($game);
-
-        // TODO dispatch events for achievement set and game metrics changes
-        $tmp = $achievementsPublishedChange;
-        $tmp = $pointsTotalChange;
-        $tmp = $pointsWeightedChange;
-        $tmp = $playersTotalChange;
-        $tmp = $playersHardcoreChange;
 
         if ($achievementSetVersionChanged) {
             Log::info("Hash change detected for game [" . $game->id . "]. Queueing all outdated player games.");
             dispatch(new UpdateGamePlayerGamesJob($game->id))
                 ->onQueue('game-player-games');
+
+            // one or more achievements was added/removed/modified. sync to achievement set
+            app()->make(UpsertGameCoreAchievementSetFromLegacyFlagsAction::class)
+                ->execute($game);
         }
     }
 }

--- a/app/Platform/Actions/UpdateGameMetricsAction.php
+++ b/app/Platform/Actions/UpdateGameMetricsAction.php
@@ -31,29 +31,6 @@ class UpdateGameMetricsAction
         $game->points_total = $game->achievements()->published()->sum('points');
         // NOTE $game->TotalTruePoints are updated separately
 
-        $parentGame = $game->parentGame();
-        if ($parentGame) {
-            // NOTE: This assumes everyone who plays a child set also plays the parent set.
-            //       These counts should technically be the union of users from both sets.
-            if ($parentGame->players_total > 0) {
-                $game->players_total = $parentGame->players_total;
-                $game->players_hardcore = $parentGame->players_hardcore;
-            } else {
-                $parentGame = null;
-            }
-        }
-
-        if (!$parentGame) {
-            $game->players_total = $game->playerGames()
-                ->where('achievements_unlocked', '>', 0)
-                ->whereHas('user', function ($query) { $query->tracked(); })
-                ->count();
-            $game->players_hardcore = $game->playerGames()
-                ->where('achievements_unlocked_hardcore', '>', 0)
-                ->whereHas('user', function ($query) { $query->tracked(); })
-                ->count();
-        }
-
         $achievementSetVersionChanged = false;
         $achievementsPublishedChange = 0;
         $pointsTotalChange = 0;

--- a/app/Platform/Actions/UpdateGameMetricsAction.php
+++ b/app/Platform/Actions/UpdateGameMetricsAction.php
@@ -53,41 +53,7 @@ class UpdateGameMetricsAction
         }
         $pointsWeightedBeforeUpdate = $game->TotalTruePoints;
 
-        // get median time to beat
-        $query = PlayerGame::where('game_id', $game->id)
-            ->whereNotNull('time_to_beat')->whereNull('time_to_beat_hardcore');
-        [$game->times_beaten, $game->median_time_to_beat] = $this->getMedian($query, 'time_to_beat');
-
-        $query = PlayerGame::where('game_id', $game->id)
-            ->whereNotNull('time_to_beat_hardcore');
-        [$game->times_beaten_hardcore, $game->median_time_to_beat_hardcore] =
-             $this->getMedian($query, 'time_to_beat_hardcore');
-
         $game->saveQuietly();
-
-        // get median time to complete for each associated set
-        $gameAchievementSets = GameAchievementSet::where('game_id', $game->id)
-            ->with('achievementSet')
-            ->get();
-
-        foreach ($gameAchievementSets as $gameAchievementSet) {
-            $achievementSet = $gameAchievementSet->achievementSet;
-
-            // NOTE: this only finds masters of the current set. it ignores users who may
-            //       have previously mastered it before a revision
-            $query = PlayerAchievementSet::where('achievement_set_id', $achievementSet->id)
-                ->where('achievements_unlocked', '=', $achievementSet->achievements_published)
-                ->where('achievements_unlocked_hardcore', '!=', $achievementSet->achievements_published);
-            [$achievementSet->times_completed, $achievementSet->median_time_to_complete] =
-                $this->getMedian($query, 'time_taken');
-
-            $query = PlayerAchievementSet::where('achievement_set_id', $achievementSet->id)
-                ->where('achievements_unlocked_hardcore', '=', $achievementSet->achievements_published);
-            [$achievementSet->times_completed_hardcore, $achievementSet->median_time_to_complete_hardcore] =
-                $this->getMedian($query, 'time_taken_hardcore');
-
-            $achievementSet->save();
-        }
 
         app()->make(UpdateGameAchievementsMetricsAction::class)
             ->execute($game);
@@ -113,31 +79,5 @@ class UpdateGameMetricsAction
             dispatch(new UpdateGamePlayerGamesJob($game->id))
                 ->onQueue('game-player-games');
         }
-    }
-
-    /**
-     * @param Builder<PlayerGame>|Builder<PlayerAchievementSet> $query
-     */
-    private function getMedian(Builder $query, string $field): array
-    {
-        $count = $query->count();
-        if ($count === 0) {
-            return [0, null];
-        }
-
-        $query->select($field)->orderBy($field);
-
-        if (($count % 2) == 1) {
-            // odd. just get the middle item
-            $query->offset((int) ($count / 2))->limit(1);
-            $median = $query->value($field);
-        } else {
-            // even. get the two items in the middle and average them together
-            $query->offset((int) ($count / 2) - 1)->limit(2);
-            $values = $query->pluck($field)->toArray();
-            $median = ($values[0] + $values[1]) / 2;
-        }
-
-        return [$count, $median];
     }
 }

--- a/app/Platform/Actions/UpdateGameMetricsForGamesPlayedByUserAction.php
+++ b/app/Platform/Actions/UpdateGameMetricsForGamesPlayedByUserAction.php
@@ -6,7 +6,7 @@ namespace App\Platform\Actions;
 
 use App\Models\PlayerGame;
 use App\Models\User;
-use App\Platform\Jobs\UpdateGameMetricsJob;
+use App\Platform\Jobs\UpdateGamePlayerCountJob;
 use App\Platform\Services\GameTopAchieversService;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\BatchRepository;
@@ -22,12 +22,14 @@ class UpdateGameMetricsForGamesPlayedByUserAction
             return;
         }
 
+        // when a player becomes unranked (or re-ranked), we have to recalculate player
+        // counts for every game they've played.
         $user->playerGames()
             ->chunkById(1000, function (Collection $chunk, $page) use ($user) {
                 // map and dispatch this chunk as a batch of jobs
                 Bus::batch(
                     $chunk->map(
-                        fn (PlayerGame $playerGame) => new UpdateGameMetricsJob($playerGame->game_id)
+                        fn (PlayerGame $playerGame) => new UpdateGamePlayerCountJob($playerGame->game_id)
                     )
                 )
                     ->onQueue('game-metrics')

--- a/app/Platform/Actions/UpdateGamePlayerCountAction.php
+++ b/app/Platform/Actions/UpdateGamePlayerCountAction.php
@@ -5,13 +5,8 @@ declare(strict_types=1);
 namespace App\Platform\Actions;
 
 use App\Models\Game;
-use App\Models\GameAchievementSet;
-use App\Models\PlayerAchievementSet;
-use App\Models\PlayerGame;
-use App\Platform\Jobs\UpdateGameMetricsJob;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Log;
 
+// Recalculates the number of players for a game.
 class UpdateGamePlayerCountAction
 {
     public function execute(Game $game): void
@@ -42,8 +37,9 @@ class UpdateGamePlayerCountAction
         if ($game->isDirty()) {
             $game->saveQuietly();
 
-            dispatch(new UpdateGameMetricsJob($game->id))
-                ->onQueue('game-metrics');
+            // if the player count changed, update unlock percentages and weighted points for all achievements in the set
+            app()->make(UpdateGameAchievementsMetricsAction::class)
+                ->execute($game);
         }
     }
 }

--- a/app/Platform/Actions/UpdateGamePlayerCountAction.php
+++ b/app/Platform/Actions/UpdateGamePlayerCountAction.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Actions;
+
+use App\Models\Game;
+use App\Models\GameAchievementSet;
+use App\Models\PlayerAchievementSet;
+use App\Models\PlayerGame;
+use App\Platform\Jobs\UpdateGameMetricsJob;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
+
+class UpdateGamePlayerCountAction
+{
+    public function execute(Game $game): void
+    {
+        $parentGame = $game->parentGame();
+        if ($parentGame) {
+            // NOTE: This assumes everyone who plays a child set also plays the parent set.
+            //       These counts should technically be the union of users from both sets.
+            if ($parentGame->players_total > 0) {
+                $game->players_total = $parentGame->players_total;
+                $game->players_hardcore = $parentGame->players_hardcore;
+            } else {
+                $parentGame = null;
+            }
+        }
+
+        if (!$parentGame) {
+            $game->players_total = $game->playerGames()
+                ->where('achievements_unlocked', '>', 0)
+                ->whereHas('user', function ($query) { $query->tracked(); })
+                ->count();
+            $game->players_hardcore = $game->playerGames()
+                ->where('achievements_unlocked_hardcore', '>', 0)
+                ->whereHas('user', function ($query) { $query->tracked(); })
+                ->count();
+        }
+
+        if ($game->isDirty()) {
+            $game->saveQuietly();
+
+            dispatch(new UpdateGameMetricsJob($game->id))
+                ->onQueue('game-metrics');
+        }
+    }
+}

--- a/app/Platform/Actions/UpdateGamePlayerCountAction.php
+++ b/app/Platform/Actions/UpdateGamePlayerCountAction.php
@@ -37,6 +37,15 @@ class UpdateGamePlayerCountAction
         if ($game->isDirty()) {
             $game->saveQuietly();
 
+            // copy the new player counts to the achievement set
+            $coreGameAchievementSet = $game->gameAchievementSets()->core()->first();
+            if ($coreGameAchievementSet) {
+                $coreSet = $coreGameAchievementSet->achievementSet;
+                $coreSet->players_hardcore = $game->players_hardcore;
+                $coreSet->players_total = $game->players_total;
+                $coreSet->save();
+            }
+
             // if the player count changed, update unlock percentages and weighted points for all achievements in the set
             app()->make(UpdateGameAchievementsMetricsAction::class)
                 ->execute($game);

--- a/app/Platform/Actions/UpdatePlayerGameMetricsAction.php
+++ b/app/Platform/Actions/UpdatePlayerGameMetricsAction.php
@@ -14,6 +14,7 @@ use App\Platform\Enums\AchievementFlag;
 use App\Platform\Enums\AchievementSetType;
 use App\Platform\Enums\AchievementType;
 use App\Platform\Events\PlayerGameMetricsUpdated;
+use App\Platform\Jobs\UpdateGamePlayerCountJob;
 use App\Platform\Services\PlayerGameActivityService;
 use ErrorException;
 use Illuminate\Support\Collection;

--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -52,6 +52,7 @@ use App\Platform\Commands\UnlockPlayerAchievement;
 use App\Platform\Commands\UpdateAwardsStaticData;
 use App\Platform\Commands\UpdateDeveloperContributionYield;
 use App\Platform\Commands\UpdateGameAchievementsMetrics;
+use App\Platform\Commands\UpdateGameBeatenMetrics;
 use App\Platform\Commands\UpdateGameMetrics;
 use App\Platform\Commands\UpdateGamePlayerCount;
 use App\Platform\Commands\UpdateGamePlayerGames;
@@ -80,8 +81,9 @@ class AppServiceProvider extends ServiceProvider
             $this->commands([
                 // Games
                 TrimGameMetadata::class,
-                UpdateGameMetrics::class,
                 UpdateGameAchievementsMetrics::class,
+                UpdateGameBeatenMetrics::class,
+                UpdateGameMetrics::class,
                 UpdateGamePlayerCount::class,
                 UpdateGamePlayerGames::class,
                 VerifyAchievementSetIntegrity::class,

--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -53,6 +53,7 @@ use App\Platform\Commands\UpdateAwardsStaticData;
 use App\Platform\Commands\UpdateDeveloperContributionYield;
 use App\Platform\Commands\UpdateGameAchievementsMetrics;
 use App\Platform\Commands\UpdateGameMetrics;
+use App\Platform\Commands\UpdateGamePlayerCount;
 use App\Platform\Commands\UpdateGamePlayerGames;
 use App\Platform\Commands\UpdateLeaderboardMetrics;
 use App\Platform\Commands\UpdatePlayerBeatenGamesStats;
@@ -81,6 +82,7 @@ class AppServiceProvider extends ServiceProvider
                 TrimGameMetadata::class,
                 UpdateGameMetrics::class,
                 UpdateGameAchievementsMetrics::class,
+                UpdateGamePlayerCount::class,
                 UpdateGamePlayerGames::class,
                 VerifyAchievementSetIntegrity::class,
                 WriteGameSortTitles::class,

--- a/app/Platform/Commands/UpdateGamePlayerCount.php
+++ b/app/Platform/Commands/UpdateGamePlayerCount.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Commands;
+
+use App\Models\Game;
+use App\Platform\Actions\UpdateGamePlayerCountAction;
+use App\Platform\Jobs\UpdateGamePlayerCountJob;
+use Illuminate\Console\Command;
+
+class UpdateGamePlayerCount extends Command
+{
+    protected $signature = 'ra:platform:game:update-player-count
+                            {gameIds? : Optional comma-separated list of game IDs}';
+    protected $description = "Update player count metrics for all games or a comma-separated list of game IDs";
+
+    public function __construct(
+        private readonly UpdateGamePlayerCountAction $updateGamePlayerCount
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): void
+    {
+        $query = Game::query();
+
+        $gameIds = null;
+        if ($this->argument('gameIds')) {
+            $gameIds = collect(explode(',', $this->argument('gameIds')))->map(fn ($id) => (int) $id);
+            $query->whereIn('id', $gameIds);
+        }
+
+        $totalGames = $query->count();
+
+        if ($totalGames === 0) {
+            $this->info('No games found.');
+
+            return;
+        }
+
+        if ($this->argument('gameIds') !== null) {
+            $this->info("Processing {$totalGames} games...");
+        } else {
+            $this->info("Dispatching jobs for {$totalGames} games...");
+        }
+
+        $progressBar = $this->output->createProgressBar($totalGames);
+        $progressBar->start();
+
+        $processed = 0;
+
+        $query->chunk(100, function ($games) use (&$processed, $progressBar) {
+            foreach ($games as $game) {
+                $this->updateGamePlayerCount->execute($game);
+
+                $processed++;
+                $progressBar->advance();
+            }
+        });
+
+        $progressBar->finish();
+        $this->newLine(2);
+
+        if ($this->argument('gameIds')) {
+            $this->info("Processed {$totalGames} games successfully.");
+        } else {
+            $this->info("Dispatched {$totalGames} jobs successfully.");
+        }
+    }
+}

--- a/app/Platform/Commands/UpdateGamePlayerCount.php
+++ b/app/Platform/Commands/UpdateGamePlayerCount.php
@@ -6,7 +6,6 @@ namespace App\Platform\Commands;
 
 use App\Models\Game;
 use App\Platform\Actions\UpdateGamePlayerCountAction;
-use App\Platform\Jobs\UpdateGamePlayerCountJob;
 use Illuminate\Console\Command;
 
 class UpdateGamePlayerCount extends Command

--- a/app/Platform/EventServiceProvider.php
+++ b/app/Platform/EventServiceProvider.php
@@ -47,15 +47,18 @@ class EventServiceProvider extends ServiceProvider
             DispatchUpdateGameMetricsJob::class, // dispatches GameMetricsUpdated
         ],
         AchievementMoved::class => [
+            DispatchUpdateGamePlayerCountJob::class,
             DispatchUpdateGameMetricsJob::class, // dispatches GameMetricsUpdated
         ],
         AchievementPublished::class => [
+            DispatchUpdateGamePlayerCountJob::class,
             DispatchUpdateGameMetricsJob::class, // dispatches GameMetricsUpdated
             DispatchUpdateDeveloperContributionYieldJob::class, // dispatches UpdateDeveloperContributionYield
             UpdateTotalGamesCount::class,
             // TODO Notify player/developer when moved to AchievementSetPublished event
         ],
         AchievementUnpublished::class => [
+            DispatchUpdateGamePlayerCountJob::class,
             DispatchUpdateGameMetricsJob::class, // dispatches GameMetricsUpdated
             DispatchUpdateDeveloperContributionYieldJob::class, // dispatches UpdateDeveloperContributionYield
             UpdateTotalGamesCount::class,

--- a/app/Platform/EventServiceProvider.php
+++ b/app/Platform/EventServiceProvider.php
@@ -70,6 +70,7 @@ class EventServiceProvider extends ServiceProvider
         AchievementPointsChanged::class => [
             DispatchUpdateGameMetricsJob::class,
             DispatchUpdateDeveloperContributionYieldJob::class, // dispatches UpdateDeveloperContributionYield
+            DispatchUpdateAchievementMetricsJob::class,
         ],
         AchievementTypeChanged::class => [
             DispatchUpdateGameMetricsJob::class,

--- a/app/Platform/EventServiceProvider.php
+++ b/app/Platform/EventServiceProvider.php
@@ -27,9 +27,12 @@ use App\Platform\Events\PlayerMetricsUpdated;
 use App\Platform\Events\PlayerPointsStatsUpdated;
 use App\Platform\Events\PlayerRankedStatusChanged;
 use App\Platform\Events\PlayerSessionHeartbeat;
+use App\Platform\Listeners\DispatchUpdateAchievementMetricsJob;
 use App\Platform\Listeners\DispatchUpdateDeveloperContributionYieldJob;
+use App\Platform\Listeners\DispatchUpdateGameBeatenMetricsJob;
 use App\Platform\Listeners\DispatchUpdateGameMetricsForGamesPlayedByUserJob;
 use App\Platform\Listeners\DispatchUpdateGameMetricsJob;
+use App\Platform\Listeners\DispatchUpdateGamePlayerCountJob;
 use App\Platform\Listeners\DispatchUpdatePlayerBeatenGamesStatsJob;
 use App\Platform\Listeners\DispatchUpdatePlayerGameMetricsJob;
 use App\Platform\Listeners\DispatchUpdatePlayerMetricsJob;
@@ -79,12 +82,14 @@ class EventServiceProvider extends ServiceProvider
         PlayerAchievementLocked::class => [
             DispatchUpdatePlayerGameMetricsJob::class, // dispatches PlayerGameMetricsUpdated
             DispatchUpdateDeveloperContributionYieldJob::class, // dispatches UpdateDeveloperContributionYield
+            DispatchUpdateAchievementMetricsJob::class,
         ],
         PlayerAchievementUnlocked::class => [
             // dispatches PlayerGameAttached
             // NOTE ResumePlayerSessionAction is executed synchronously during PlayerAchievementUnlockAction
             DispatchUpdatePlayerGameMetricsJob::class, // dispatches PlayerGameMetricsUpdated
             DispatchUpdateDeveloperContributionYieldJob::class, // dispatches UpdateDeveloperContributionYield
+            DispatchUpdateAchievementMetricsJob::class,
         ],
         PlayerBadgeAwarded::class => [
             // TODO Notify player

--- a/app/Platform/EventServiceProvider.php
+++ b/app/Platform/EventServiceProvider.php
@@ -74,9 +74,10 @@ class EventServiceProvider extends ServiceProvider
         GameMetricsUpdated::class => [
         ],
         GamePlayerGameMetricsUpdated::class => [
-            DispatchUpdateGameMetricsJob::class, // dispatches GameMetricsUpdated
+            DispatchUpdateGamePlayerCountJob::class,
         ],
         PlayerAchievementLocked::class => [
+            DispatchUpdatePlayerGameMetricsJob::class, // dispatches PlayerGameMetricsUpdated
             DispatchUpdateDeveloperContributionYieldJob::class, // dispatches UpdateDeveloperContributionYield
         ],
         PlayerAchievementUnlocked::class => [
@@ -87,10 +88,12 @@ class EventServiceProvider extends ServiceProvider
         ],
         PlayerBadgeAwarded::class => [
             // TODO Notify player
+            DispatchUpdateGameBeatenMetricsJob::class,
             DispatchUpdatePlayerBeatenGamesStatsJob::class, // dispatches PlayerBeatenGamesStatsUpdated
         ],
         PlayerBadgeLost::class => [
             // TODO Notify player
+            DispatchUpdateGameBeatenMetricsJob::class,
             DispatchUpdatePlayerBeatenGamesStatsJob::class, // dispatches PlayerBeatenGamesStatsUpdated
         ],
         PlayerGameAttached::class => [
@@ -108,7 +111,6 @@ class EventServiceProvider extends ServiceProvider
         ],
         PlayerGameMetricsUpdated::class => [
             DispatchUpdatePlayerMetricsJob::class, // dispatches PlayerMetricsUpdated
-            DispatchUpdateGameMetricsJob::class, // dispatches GameMetricsUpdated
         ],
         PlayerMetricsUpdated::class => [
             DispatchUpdatePlayerPointsStatsJob::class, // dispatches PlayerPointsStatsUpdated

--- a/app/Platform/EventServiceProvider.php
+++ b/app/Platform/EventServiceProvider.php
@@ -80,16 +80,16 @@ class EventServiceProvider extends ServiceProvider
             DispatchUpdateGamePlayerCountJob::class,
         ],
         PlayerAchievementLocked::class => [
+            DispatchUpdateAchievementMetricsJob::class,
             DispatchUpdatePlayerGameMetricsJob::class, // dispatches PlayerGameMetricsUpdated
             DispatchUpdateDeveloperContributionYieldJob::class, // dispatches UpdateDeveloperContributionYield
-            DispatchUpdateAchievementMetricsJob::class,
         ],
         PlayerAchievementUnlocked::class => [
             // dispatches PlayerGameAttached
             // NOTE ResumePlayerSessionAction is executed synchronously during PlayerAchievementUnlockAction
+            DispatchUpdateAchievementMetricsJob::class,
             DispatchUpdatePlayerGameMetricsJob::class, // dispatches PlayerGameMetricsUpdated
             DispatchUpdateDeveloperContributionYieldJob::class, // dispatches UpdateDeveloperContributionYield
-            DispatchUpdateAchievementMetricsJob::class,
         ],
         PlayerBadgeAwarded::class => [
             // TODO Notify player

--- a/app/Platform/Jobs/UpdateAchievementMetricsJob.php
+++ b/app/Platform/Jobs/UpdateAchievementMetricsJob.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Platform\Jobs;
+
+use App\Models\Achievement;
+use App\Platform\Actions\UpdateAchievementMetricsAction;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateAchievementMetricsJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use Batchable;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        private readonly int $achievementId,
+    ) {
+    }
+
+    public int $uniqueFor = 3600;
+
+    public function uniqueId(): string
+    {
+        return config('queue.default') === 'sync' ? '' : $this->gameId;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return [
+            Achievement::class . ':' . $this->achievementId,
+        ];
+    }
+
+    public function handle(): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
+        app()->make(UpdateAchievementMetricsAction::class)
+            ->execute(Achievement::findOrFail($this->achievementId));
+    }
+}

--- a/app/Platform/Jobs/UpdateAchievementMetricsJob.php
+++ b/app/Platform/Jobs/UpdateAchievementMetricsJob.php
@@ -29,7 +29,7 @@ class UpdateAchievementMetricsJob implements ShouldQueue, ShouldBeUniqueUntilPro
 
     public function uniqueId(): string
     {
-        return config('queue.default') === 'sync' ? '' : $this->gameId;
+        return config('queue.default') === 'sync' ? '' : $this->achievementId;
     }
 
     /**

--- a/app/Platform/Jobs/UpdateGameBeatenMetricsJob.php
+++ b/app/Platform/Jobs/UpdateGameBeatenMetricsJob.php
@@ -4,7 +4,6 @@ namespace App\Platform\Jobs;
 
 use App\Models\Game;
 use App\Platform\Actions\UpdateGameBeatenMetricsAction;
-use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/app/Platform/Jobs/UpdateGameBeatenMetricsJob.php
+++ b/app/Platform/Jobs/UpdateGameBeatenMetricsJob.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Platform\Jobs;
+
+use App\Models\Game;
+use App\Platform\Actions\UpdateGameBeatenMetricsAction;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateGameBeatenMetricsJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        private readonly int $gameId,
+    ) {
+    }
+
+    public int $uniqueFor = 3600;
+
+    public function uniqueId(): string
+    {
+        return config('queue.default') === 'sync' ? '' : $this->gameId;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return [
+            Game::class . ':' . $this->gameId,
+        ];
+    }
+
+    public function handle(): void
+    {
+        app()->make(UpdateGameBeatenMetricsAction::class)
+            ->execute(Game::findOrFail($this->gameId));
+    }
+}

--- a/app/Platform/Jobs/UpdateGamePlayerCountJob.php
+++ b/app/Platform/Jobs/UpdateGamePlayerCountJob.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\SerializesModels;
 
 class UpdateGamePlayerCountJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
 {
+    use Batchable;
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
@@ -43,6 +44,10 @@ class UpdateGamePlayerCountJob implements ShouldQueue, ShouldBeUniqueUntilProces
 
     public function handle(): void
     {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
         app()->make(UpdateGamePlayerCountAction::class)
             ->execute(Game::findOrFail($this->gameId));
     }

--- a/app/Platform/Jobs/UpdateGamePlayerCountJob.php
+++ b/app/Platform/Jobs/UpdateGamePlayerCountJob.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Platform\Jobs;
+
+use App\Models\Game;
+use App\Platform\Actions\UpdateGamePlayerCountAction;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateGamePlayerCountJob implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        private readonly int $gameId,
+    ) {
+    }
+
+    public int $uniqueFor = 3600;
+
+    public function uniqueId(): string
+    {
+        return config('queue.default') === 'sync' ? '' : $this->gameId;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return [
+            Game::class . ':' . $this->gameId,
+        ];
+    }
+
+    public function handle(): void
+    {
+        app()->make(UpdateGamePlayerCountAction::class)
+            ->execute(Game::findOrFail($this->gameId));
+    }
+}

--- a/app/Platform/Listeners/DispatchUpdateAchievementMetricsJob.php
+++ b/app/Platform/Listeners/DispatchUpdateAchievementMetricsJob.php
@@ -3,6 +3,7 @@
 namespace App\Platform\Listeners;
 
 use App\Models\Achievement;
+use App\Platform\Events\AchievementPointsChanged;
 use App\Platform\Events\PlayerAchievementLocked;
 use App\Platform\Events\PlayerAchievementUnlocked;
 use App\Platform\Jobs\UpdateAchievementMetricsJob;
@@ -19,6 +20,9 @@ class DispatchUpdateAchievementMetricsJob implements ShouldQueue
                 $achievement = $event->achievement;
                 break;
             case PlayerAchievementUnlocked::class:
+                $achievement = $event->achievement;
+                break;
+            case AchievementPointsChanged::class:
                 $achievement = $event->achievement;
                 break;
         }

--- a/app/Platform/Listeners/DispatchUpdateAchievementMetricsJob.php
+++ b/app/Platform/Listeners/DispatchUpdateAchievementMetricsJob.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Platform\Listeners;
+
+use App\Models\Achievement;
+use App\Platform\Events\PlayerAchievementLocked;
+use App\Platform\Events\PlayerAchievementUnlocked;
+use App\Platform\Jobs\UpdateAchievementMetricsJob;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DispatchUpdateAchievementMetricsJob implements ShouldQueue
+{
+    public function handle(object $event): void
+    {
+        $achievement = null;
+
+        switch ($event::class) {
+            case PlayerAchievementLocked::class:
+                $achievement = $event->achievement;
+                break;
+            case PlayerAchievementUnlocked::class:
+                $achievement = $event->achievement;
+                break;
+        }
+
+        if ($achievement instanceof Achievement) {
+            dispatch(new UpdateAchievementMetricsJob($achievement->id))
+                ->onQueue('game-metrics');
+        }
+    }
+}

--- a/app/Platform/Listeners/DispatchUpdateGameBeatenMetricsJob.php
+++ b/app/Platform/Listeners/DispatchUpdateGameBeatenMetricsJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Platform\Listeners;
+
+use App\Models\Game;
+use App\Platform\Events\PlayerBadgeAwarded;
+use App\Platform\Events\PlayerBadgeLost;
+use App\Platform\Jobs\UpdateGameBeatenMetricsJob;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DispatchUpdateGameBeatenMetricsJob implements ShouldQueue
+{
+    public function handle(object $event): void
+    {
+        $game = null;
+
+        switch ($event::class) {
+            case PlayerBadgeAwarded::class:
+                // this probably should watch for PlayerGameBeaten and PlayerGameCompleted,
+                // but it's easier to just watch for the badge being awarded, which
+                // complements the behavior of watching for the badge disappearing.
+                switch ($event->playerBadge->AwardType) {
+                    case AwardType::GameBeaten:
+                    case AwardType::Mastery:
+                        $game = Game::find($event->playerBadge->AwardData);
+                        break;
+                }
+                break;
+
+            case PlayerBadgeLost::class:
+                switch ($event->awardType) {
+                    case AwardType::GameBeaten:
+                    case AwardType::Mastery:
+                        $game = Game::find($event->awardData);
+                        break;
+                }
+                break;
+        }
+
+        if ($game instanceof Game) {
+            dispatch(new UpdateGameBeatenMetricsJob($game->id))
+                ->onQueue('game-metrics');
+        }
+    }
+}

--- a/app/Platform/Listeners/DispatchUpdateGameBeatenMetricsJob.php
+++ b/app/Platform/Listeners/DispatchUpdateGameBeatenMetricsJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Platform\Listeners;
 
+use App\Community\Enums\AwardType;
 use App\Models\Game;
 use App\Platform\Events\PlayerBadgeAwarded;
 use App\Platform\Events\PlayerBadgeLost;

--- a/app/Platform/Listeners/DispatchUpdateGameMetricsJob.php
+++ b/app/Platform/Listeners/DispatchUpdateGameMetricsJob.php
@@ -9,8 +9,6 @@ use App\Platform\Events\AchievementPointsChanged;
 use App\Platform\Events\AchievementPublished;
 use App\Platform\Events\AchievementTypeChanged;
 use App\Platform\Events\AchievementUnpublished;
-use App\Platform\Events\GamePlayerGameMetricsUpdated;
-use App\Platform\Events\PlayerGameMetricsUpdated;
 use App\Platform\Jobs\UpdateGameMetricsJob;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
@@ -47,12 +45,6 @@ class DispatchUpdateGameMetricsJob implements ShouldQueue
                 $achievement = $event->achievement;
                 $game = $achievement->game;
                 $originalGame = $event->originalGame;
-                break;
-            case GamePlayerGameMetricsUpdated::class:
-                $game = $event->game;
-                break;
-            case PlayerGameMetricsUpdated::class:
-                $game = $event->game;
                 break;
         }
 

--- a/app/Platform/Listeners/DispatchUpdateGamePlayerCountJob.php
+++ b/app/Platform/Listeners/DispatchUpdateGamePlayerCountJob.php
@@ -3,14 +3,10 @@
 namespace App\Platform\Listeners;
 
 use App\Models\Game;
-use App\Platform\Events\AchievementCreated;
 use App\Platform\Events\AchievementMoved;
-use App\Platform\Events\AchievementPointsChanged;
 use App\Platform\Events\AchievementPublished;
-use App\Platform\Events\AchievementTypeChanged;
 use App\Platform\Events\AchievementUnpublished;
 use App\Platform\Events\GamePlayerGameMetricsUpdated;
-use App\Platform\Events\PlayerGameMetricsUpdated;
 use App\Platform\Jobs\UpdateGamePlayerCountJob;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
@@ -35,6 +31,9 @@ class DispatchUpdateGamePlayerCountJob implements ShouldQueue
                 $achievement = $event->achievement;
                 $game = $achievement->game;
                 $originalGame = $event->originalGame;
+                break;
+            case GamePlayerGameMetricsUpdated::class:
+                $game = $event->game;
                 break;
         }
 

--- a/app/Platform/Listeners/DispatchUpdateGamePlayerCountJob.php
+++ b/app/Platform/Listeners/DispatchUpdateGamePlayerCountJob.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Platform\Listeners;
+
+use App\Models\Game;
+use App\Platform\Events\AchievementCreated;
+use App\Platform\Events\AchievementMoved;
+use App\Platform\Events\AchievementPointsChanged;
+use App\Platform\Events\AchievementPublished;
+use App\Platform\Events\AchievementTypeChanged;
+use App\Platform\Events\AchievementUnpublished;
+use App\Platform\Events\GamePlayerGameMetricsUpdated;
+use App\Platform\Events\PlayerGameMetricsUpdated;
+use App\Platform\Jobs\UpdateGamePlayerCountJob;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DispatchUpdateGamePlayerCountJob implements ShouldQueue
+{
+    public function handle(object $event): void
+    {
+        $achievement = null;
+        $game = null;
+        $originalGame = null;
+
+        switch ($event::class) {
+            case AchievementPublished::class:
+                $achievement = $event->achievement;
+                $game = $achievement->game;
+                break;
+            case AchievementUnpublished::class:
+                $achievement = $event->achievement;
+                $game = $achievement->game;
+                break;
+            case AchievementMoved::class:
+                $achievement = $event->achievement;
+                $game = $achievement->game;
+                $originalGame = $event->originalGame;
+                break;
+        }
+
+        if ($game instanceof Game) {
+            dispatch(new UpdateGamePlayerCountJob($game->id))
+                ->onQueue('game-metrics');
+        }
+
+        if ($originalGame instanceof Game) {
+            dispatch(new UpdateGamePlayerCountJob($originalGame->id))
+                ->onQueue('game-metrics');
+        }
+    }
+}

--- a/app/Platform/Services/PlayerGameActivityService.php
+++ b/app/Platform/Services/PlayerGameActivityService.php
@@ -498,8 +498,15 @@ class PlayerGameActivityService
         }
         $achievementsPublishedAt = $achievementSet->achievements_first_published_at;
 
-        $metrics['achievementPlaytimeSoftcore'] = $this->calculatePlaytime($achievementsPublishedAt, $metrics['lastUnlockTimeSoftcore'], UnlockMode::Softcore);
-        $metrics['achievementPlaytimeHardcore'] = $this->calculatePlaytime($achievementsPublishedAt, $metrics['lastUnlockTimeHardcore'], UnlockMode::Hardcore);
+        if ($achievementsPublishedAt) {
+            $metrics['achievementPlaytimeSoftcore'] = $this->calculatePlaytime($achievementsPublishedAt, $metrics['lastUnlockTimeSoftcore'], UnlockMode::Softcore);
+            $metrics['achievementPlaytimeHardcore'] = $this->calculatePlaytime($achievementsPublishedAt, $metrics['lastUnlockTimeHardcore'], UnlockMode::Hardcore);
+        } else {
+            // don't count any playtime if achievements haven't been published yet
+            $metrics['achievementPlaytimeSoftcore'] = 0;
+            $metrics['achievementPlaytimeHardcore'] = 0;
+        }
+
         $metrics['devTime'] = $this->calculatePlaytime(null, $achievementsPublishedAt, UnlockMode::Softcore);
 
         return $metrics;

--- a/tests/Feature/Api/V1/UserSummaryTest.php
+++ b/tests/Feature/Api/V1/UserSummaryTest.php
@@ -132,6 +132,7 @@ class UserSummaryTest extends TestCase
             'region' => GameReleaseRegion::NorthAmerica,
             'is_canonical_game_title' => true,
         ]);
+        $game->refresh(); // pick up released_at sync'd from GameRelease
 
         $publishedAchievements = $game->achievements;
         (new UpdateGameMetricsAction())->execute($game);

--- a/tests/Feature/Platform/Actions/ResetPlayerProgressActionTest.php
+++ b/tests/Feature/Platform/Actions/ResetPlayerProgressActionTest.php
@@ -125,7 +125,7 @@ class ResetPlayerProgressActionTest extends TestCase
         $achievement = Achievement::factory()->published()->create(['GameID' => $game->id, 'Points' => 5, 'TrueRatio' => 7, 'user_id' => $user->id]);
 
         $this->addHardcoreUnlock($user, $achievement);
-        $achievement->refresh();
+        $achievement->refresh(); // achievement unlock may adjust weighted points
 
         $this->assertHasSoftcoreUnlock($user, $achievement);
         $this->assertHasHardcoreUnlock($user, $achievement);


### PR DESCRIPTION
* `UpdateGameMetricsAction` now only updates metadata about the game (number of achievements, number of points, hash of all published achievements).
  - It's called whenever an achievement is modified (promoted/demoted/points changed)
  - Calculating the hash is probably a lot less expensive than scanning millions of rows in the database, but it's still something that we don't need to be doing as frequently as we were.
  - Whenever the hash changes, the set is synced to the core achievement set for the game. Doing a sync (even if the only change was the unlock percentage) was the third most expensive part of calling `UpdateGameMetricsAction`. That was largely improved by #3573.
* `UpdateGamePlayerCountAction` updates the number of players for the game.
  - It's called when a player unlocks their first achievement for a game or resets their progress, when achievements are promoted/demoted, or when a player who has played the game is unranked/re-ranked.
  - This was previously the most expensive part of calling `UpdateGameMetricsAction`.
* `UpdateGameBeatenMetricsAction` updates the median time to beat metrics for a game.
  - It's called when a player earns or loses a SiteAward for mastering or beating a game (beaten awards are not shown on the profile page, but are tracked in the database).
  - This was the second most expensive part of calling `UpdateGameMetricsAction`.
* `UpdateAchievementMetricsAction` updates the unlock count, unlock percentage, and weighted points for an achievement.
  - It's called when an achievement is locked/unlocked or its points change.
  - It's also called for all achievements of a game when the game's player count changes.
  - This was the fourth most expensive part of calling `UpdateGameMetricsAction`.
  - Because I've separated this code from `UpdateGameAchievementsMetricsAction`, this will conflict with #3572, but it should be straightforward to port those changes to the new location.
  
This does not attempt to optimize any of the code/queries being used. It's trying to minimize the amount of code/queries that have to be executed in response to a player unlocking an achievement.

In the existing codebase, unlocking any achievement triggers the `UpdateGameMetricsAction` (presumably to update the player count for the set), and that does all of the things listed above every time it's called.

With this PR, unlocking an achievement should only call `UpdateAchievementMetricsAction` for the single achievement being unlocked.

If it's the player's first achievement for a set, it will also call `UpdateGamePlayerCountAction`, which will call `UpdateAchievementMetricsAction` for all achievements in the set. That will be the most expensive call for any unlock, and is still going to be faster than the previous implementation because it's not recalculating the beaten metrics or the achievement_set_version_hash.

If the unlock results in the player being awarded a beaten or mastery badge, it will also call `UpdateGameBeatenMetricsAction`.

NOTE: I have only tested loading a game that I've previously played. I want to also test loading a game that I've never played before and earning at least one achievement in that game. I also want to reset a progression achievement in a game I've previously beaten and re-earn it. I believe those tests will cover all the important use cases. I just haven't had time to do it yet.