### PR TITLE
perf: split new actions across several queues

### DIFF
--- a/app/Platform/Actions/ResetPlayerProgressAction.php
+++ b/app/Platform/Actions/ResetPlayerProgressAction.php
@@ -155,7 +155,7 @@ class ResetPlayerProgressAction
 
             // if all achievements for a game were reset, the user is no longer considered a
             // player of the game. will be a no-op if they still have achievements for the game.
-            dispatch(new UpdateGamePlayerCountJob($affectedGameID));
+            dispatch(new UpdateGamePlayerCountJob($affectedGameID))->onQueue('game-player-count');
         }
 
         dispatch(new UpdatePlayerBeatenGamesStatsJob($user->id));

--- a/app/Platform/Actions/UpdateGameMetricsForGamesPlayedByUserAction.php
+++ b/app/Platform/Actions/UpdateGameMetricsForGamesPlayedByUserAction.php
@@ -32,7 +32,7 @@ class UpdateGameMetricsForGamesPlayedByUserAction
                         fn (PlayerGame $playerGame) => new UpdateGamePlayerCountJob($playerGame->game_id)
                     )
                 )
-                    ->onQueue('game-metrics')
+                    ->onQueue('game-player-count')
                     ->name('player-played-games ' . $user->id . ' ' . $page)
                     ->allowFailures()
                     ->finally(function (Batch $batch) {

--- a/app/Platform/Actions/UpdatePlayerGameMetricsAction.php
+++ b/app/Platform/Actions/UpdatePlayerGameMetricsAction.php
@@ -183,7 +183,7 @@ class UpdatePlayerGameMetricsAction
         }
 
         foreach ($newPlayerGameIds as $gameId) {
-            dispatch(new UpdateGamePlayerCountJob($gameId))->onQueue('game-metrics');
+            dispatch(new UpdateGamePlayerCountJob($gameId))->onQueue('game-player-count');
         }
 
         app()->make(RevalidateAchievementSetBadgeEligibilityAction::class)->execute($playerGame);

--- a/app/Platform/Commands/UpdateGameBeatenMetrics.php
+++ b/app/Platform/Commands/UpdateGameBeatenMetrics.php
@@ -53,7 +53,7 @@ class UpdateGameBeatenMetrics extends Command
         $query->chunk(100, function ($games) use (&$processed, $progressBar) {
             foreach ($games as $game) {
                 if ($this->argument('gameIds') === null) {
-                    dispatch(new UpdateGameBeatenMetricsJob($game->id))->onQueue('game-metrics');
+                    dispatch(new UpdateGameBeatenMetricsJob($game->id))->onQueue('game-beaten-metrics');
                 } else {
                     $this->updateGameBeatenMetrics->execute($game);
                 }

--- a/app/Platform/Listeners/DispatchUpdateAchievementMetricsJob.php
+++ b/app/Platform/Listeners/DispatchUpdateAchievementMetricsJob.php
@@ -29,7 +29,7 @@ class DispatchUpdateAchievementMetricsJob implements ShouldQueue
 
         if ($achievement instanceof Achievement) {
             dispatch(new UpdateAchievementMetricsJob($achievement->id))
-                ->onQueue('game-metrics');
+                ->onQueue('achievement-metrics');
         }
     }
 }

--- a/app/Platform/Listeners/DispatchUpdateGameBeatenMetricsJob.php
+++ b/app/Platform/Listeners/DispatchUpdateGameBeatenMetricsJob.php
@@ -40,7 +40,7 @@ class DispatchUpdateGameBeatenMetricsJob implements ShouldQueue
 
         if ($game instanceof Game) {
             dispatch(new UpdateGameBeatenMetricsJob($game->id))
-                ->onQueue('game-metrics');
+                ->onQueue('game-beaten-metrics');
         }
     }
 }

--- a/app/Platform/Listeners/DispatchUpdateGamePlayerCountJob.php
+++ b/app/Platform/Listeners/DispatchUpdateGamePlayerCountJob.php
@@ -39,12 +39,12 @@ class DispatchUpdateGamePlayerCountJob implements ShouldQueue
 
         if ($game instanceof Game) {
             dispatch(new UpdateGamePlayerCountJob($game->id))
-                ->onQueue('game-metrics');
+                ->onQueue('game-player-count');
         }
 
         if ($originalGame instanceof Game) {
             dispatch(new UpdateGamePlayerCountJob($originalGame->id))
-                ->onQueue('game-metrics');
+                ->onQueue('game-player-count');
         }
     }
 }

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -191,9 +191,11 @@ return [
         'supervisor-1' => [
             'connection' => 'redis',
             'queue' => [
+                'achievement-metrics',
                 'default',
                 'developer-metrics',
                 'game-metrics',
+                'game-player-count',
                 'player-achievements',
                 'player-beaten-games-stats',
                 'player-game-metrics',
@@ -216,6 +218,7 @@ return [
         'supervisor-2' => [
             'connection' => 'redis',
             'queue' => [
+                'game-beaten-metrics',
                 'game-player-games',
                 'player-game-metrics-batch',
             ],


### PR DESCRIPTION
Implements https://github.com/RetroAchievements/RAWeb/pull/3578#discussion_r2117794872.

Puts the long-running stuff in supervisor-2. Other things go into supervisor-1.