### PR TITLE
fix(game): always show all achievements if user has completion/mastery

### DIFF
--- a/resources/views/pages-legacy/gameInfo.blade.php
+++ b/resources/views/pages-legacy/gameInfo.blade.php
@@ -916,7 +916,11 @@ if ($isFullyFeaturedGame) {
                 // Check if unlocked achievements should be hidden (for server-side rendering)
                 $hideUnlockedCookie = request()->cookie('hide_unlocked_achievements_games', '');
                 $hiddenGameIds = array_filter(array_map('intval', explode(',', $hideUnlockedCookie)));
-                $shouldHideUnlockedAchievements = in_array($gameID, $hiddenGameIds);
+
+                // Don't hide unlocked achievements if user has a completion or mastery.
+                $hasCompletionOrMastery = ($numEarnedCasual === $numAchievements) || ($numEarnedHardcore === $numAchievements);
+
+                $shouldHideUnlockedAchievements = !$hasCompletionOrMastery && in_array($gameID, $hiddenGameIds);
                 ?>
                     <x-game.achievements-list.root
                         :achievements="$achievementData"


### PR DESCRIPTION
Resolves a bug where if the user is persisting the "Hide unlocked achievements" filter and they complete/master the game, they no longer see the achievements list.