### PR TITLE
perf(UpdateAchievementMetricsAction): bulk write

### DIFF
--- a/app/Models/Achievement.php
+++ b/app/Models/Achievement.php
@@ -110,6 +110,8 @@ class Achievement extends BaseModel implements HasVersionedTrigger
         'GameID' => 'integer',
         'Points' => 'integer',
         'TrueRatio' => 'integer',
+        'unlock_percentage' => 'double',
+        'unlock_hardcore_percentage' => 'double',
     ];
 
     protected $visible = [

--- a/app/Platform/Actions/UpdateAchievementMetricsAction.php
+++ b/app/Platform/Actions/UpdateAchievementMetricsAction.php
@@ -77,8 +77,10 @@ class UpdateAchievementMetricsAction
                 + $achievement->points * (($playersHardcoreCalc / $unlocksHardcoreCalc) * $weight)
             );
 
-            $unlockPercentage = $playersTotal ? $unlocksCount / $playersTotal : 0;
-            $unlockHardcorePercentage = $playersHardcore ? $unlocksHardcoreCount / $playersHardcore : 0;
+            // Round percentages to 9 decimal places to match the exact database column precision (decimal(10,9)).
+            // This prevents unnecessary updates due to precision differences in PHP.
+            $unlockPercentage = round($playersTotal ? $unlocksCount / $playersTotal : 0, 9);
+            $unlockHardcorePercentage = round($playersHardcore ? $unlocksHardcoreCount / $playersHardcore : 0, 9);
 
             // We'll optimistically set attributes on the model to leverage Laravel's dirty checking.
             // This doesn't necessarily mean we'll be doing a save for the model, though.

--- a/app/Platform/Actions/UpdateAchievementMetricsAction.php
+++ b/app/Platform/Actions/UpdateAchievementMetricsAction.php
@@ -9,6 +9,7 @@ use App\Models\Game;
 use App\Models\PlayerAchievement;
 use App\Platform\Services\SearchIndexingService;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 class UpdateAchievementMetricsAction
 {
@@ -22,6 +23,11 @@ class UpdateAchievementMetricsAction
      */
     public function update(Game $game, Collection $achievements): void
     {
+        // Bail early if there are no achievements to update.
+        if ($achievements->isEmpty()) {
+            return;
+        }
+
         // NOTE if game has a parent game it contains the parent game's players metrics
         $playersTotal = $game->players_total;
         $playersHardcore = $game->players_hardcore;
@@ -50,6 +56,15 @@ class UpdateAchievementMetricsAction
 
         $searchIndexingService = app()->make(SearchIndexingService::class);
 
+        /**
+         * In Horizon, each write requires an entire network round trip to the DB.
+         * If there are hundreds of achievements to update, and each achievement
+         * round trip takes 1-5ms, this could add up to additional second(s) of
+         * processing time in the job just from pure network overhead. To mitigate
+         * this, we'll do a single bulk update.
+         */
+        $bulkUpdates = [];
+
         foreach ($achievements as $achievement) {
             $unlocksCount = $unlockCounts[$achievement->ID] ?? 0;
             $unlocksHardcoreCount = $hardcoreUnlockCounts[$achievement->ID] ?? 0;
@@ -62,14 +77,23 @@ class UpdateAchievementMetricsAction
                 + $achievement->points * (($playersHardcoreCalc / $unlocksHardcoreCalc) * $weight)
             );
 
-            $achievement->unlocks_total = $unlocksCount;
-            $achievement->unlocks_hardcore_total = $unlocksHardcoreCount;
-            $achievement->unlock_percentage = $playersTotal ? $unlocksCount / $playersTotal : 0;
-            $achievement->unlock_hardcore_percentage = $playersHardcore ? $unlocksHardcoreCount / $playersHardcore : 0;
+            $bulkUpdates[] = [
+                'ID' => $achievement->ID,
+                'unlocks_total' => $unlocksCount,
+                'unlocks_hardcore_total' => $unlocksHardcoreCount,
+                'unlock_percentage' => $playersTotal ? $unlocksCount / $playersTotal : 0,
+                'unlock_hardcore_percentage' => $playersHardcore ? $unlocksHardcoreCount / $playersHardcore : 0,
+                'TrueRatio' => $pointsWeighted,
+            ];
+
+            // Also update the model instance for the sum calculation later.
             $achievement->TrueRatio = $pointsWeighted;
 
-            $achievement->saveQuietly();
             $searchIndexingService->queueAchievementForIndexing($achievement->ID);
+        }
+
+        if (!empty($bulkUpdates)) {
+            $this->performBulkUpdate($bulkUpdates);
         }
 
         $game->TotalTruePoints = $achievements->sum('TrueRatio');
@@ -86,5 +110,73 @@ class UpdateAchievementMetricsAction
 
             $searchIndexingService->queueGameForIndexing($game->id);
         }
+    }
+
+    /**
+     * In Horizon, each write requires an entire network round trip to the DB.
+     * If there are hundreds of achievements to update, and each achievement
+     * round trip takes 1-5ms, this could add up to additional second(s) of
+     * processing time in the job just from pure network overhead. To mitigate
+     * this, we'll do a single bulk update.
+     */
+    private function performBulkUpdate(array $bulkUpdates): void
+    {
+        // Build a bulk UPDATE query using CASE statements to update all achievements in a single DB statement.
+
+        /*
+         * The final query will look like this:
+         *
+         * UPDATE Achievements
+         * SET
+         *   unlocks_total = CASE ID
+         *     WHEN X THEN Y
+         *   END,
+         *   unlocks_hardcore_total = CASE ID
+         *     WHEN X THEN Y
+         *   END,
+         *   unlock_percentage = CASE ID
+         *     WHEN X THEN Y
+         *   END,
+         *   unlock_hardcore_percentage = CASE ID
+         *     WHEN X THEN Y
+         *   END,
+         *   TrueRatio = CASE ID
+         *     WHEN X THEN Y
+         *   END,
+         *   Updated = '...'
+         * WHERE ID IN ( ... )
+         */
+        $ids = array_column($bulkUpdates, 'ID');
+        $cases = [
+            'unlocks_total' => 'CASE ID',
+            'unlocks_hardcore_total' => 'CASE ID',
+            'unlock_percentage' => 'CASE ID',
+            'unlock_hardcore_percentage' => 'CASE ID',
+            'TrueRatio' => 'CASE ID',
+        ];
+
+        foreach ($bulkUpdates as $update) {
+            $cases['unlocks_total'] .= " WHEN {$update['ID']} THEN {$update['unlocks_total']}";
+            $cases['unlocks_hardcore_total'] .= " WHEN {$update['ID']} THEN {$update['unlocks_hardcore_total']}";
+            $cases['unlock_percentage'] .= " WHEN {$update['ID']} THEN {$update['unlock_percentage']}";
+            $cases['unlock_hardcore_percentage'] .= " WHEN {$update['ID']} THEN {$update['unlock_hardcore_percentage']}";
+            $cases['TrueRatio'] .= " WHEN {$update['ID']} THEN {$update['TrueRatio']}";
+        }
+
+        foreach ($cases as &$case) {
+            $case .= ' END';
+        }
+
+        // Use DB to bypass model events.
+        DB::table('Achievements')
+            ->whereIn('ID', $ids)
+            ->update([
+                'unlocks_total' => DB::raw($cases['unlocks_total']),
+                'unlocks_hardcore_total' => DB::raw($cases['unlocks_hardcore_total']),
+                'unlock_percentage' => DB::raw($cases['unlock_percentage']),
+                'unlock_hardcore_percentage' => DB::raw($cases['unlock_hardcore_percentage']),
+                'TrueRatio' => DB::raw($cases['TrueRatio']),
+                'Updated' => now(),
+            ]);
     }
 }


### PR DESCRIPTION
Reimplements https://github.com/RetroAchievements/RAWeb/pull/3572.

* We're no longer using `DB::statement()` with bindings.
* We're no longer doing dirty checking with `syncOriginal()`.

The only intent here is to lift `$achievement->saveQuietly();` to a single bulk write to mitigate network overhead between Horizon and the DB.