### PR TITLE
fix achievement metrics not updating when resetting single achievement

### DIFF
--- a/app/Platform/Actions/UpdatePlayerGameMetricsAction.php
+++ b/app/Platform/Actions/UpdatePlayerGameMetricsAction.php
@@ -129,7 +129,7 @@ class UpdatePlayerGameMetricsAction
             // similarly, if they went fro non-zero unlocks to zero unlocks, they're no longer considered a
             // player for the set. in both cases, we need to update the game player count
             if (($playerAchievementSet->achievements_unlocked > 0 && $playerAchievementSet->getOriginal('achievements_unlocked') < 1)
-                || ($playerAchievementSet->achievements_unlocked_hardcore > 0 && $playerAchievementSet->getOriginal('achievements_unlocked_hardcore') > 0)
+                || ($playerAchievementSet->achievements_unlocked_hardcore > 0 && $playerAchievementSet->getOriginal('achievements_unlocked_hardcore') < 1)
                 || ($playerAchievementSet->achievements_unlocked < 1 && $playerAchievementSet->getOriginal('achievements_unlocked') > 0)
                 || ($playerAchievementSet->achievements_unlocked_hardcore < 1 && $playerAchievementSet->getOriginal('achievements_unlocked_hardcore') > 0)) {
                 $possiblePlayerCountChangeGameIds[] = $gameAchievementSet->game_id;


### PR DESCRIPTION
Also eliminates the UpdatePlayerCount call when a single achievement is reset and relies on the UpdatePlayerGames action detecting the number of unlocks going to zero. This also handles the case where the number of unlocks go to zero through demoting all achievements a player has earned.