### PR TITLE
fix TotalTruePoints calculation when updating single achievement

### DIFF
--- a/app/Platform/Actions/UpdateAchievementMetricsAction.php
+++ b/app/Platform/Actions/UpdateAchievementMetricsAction.php
@@ -109,7 +109,7 @@ class UpdateAchievementMetricsAction
             $this->performBulkUpdate($bulkUpdates);
         }
 
-        $game->TotalTruePoints = $achievements->sum('TrueRatio');
+        $game->TotalTruePoints = $game->achievements()->published()->sum('TrueRatio');
         if ($game->isDirty()) {
             $game->saveQuietly();
 


### PR DESCRIPTION
fixes https://discord.com/channels/310192285306454017/453242743292952578/1378419636567281696