### PR TITLE
fix(game): remediate issue with client-side unlocked achievements filter

### DIFF
--- a/resources/js/tall-stack/alpine/toggleAchievementRowsComponent/toggleAchievementRowsComponent.ts
+++ b/resources/js/tall-stack/alpine/toggleAchievementRowsComponent/toggleAchievementRowsComponent.ts
@@ -79,6 +79,18 @@ export function toggleAchievementRowsComponent(
     isUsingOnlyShowMissables: false,
 
     init(): void {
+      // Check if all achievements are unlocked.
+      const allRows = document.querySelectorAll<HTMLLIElement>('#set-achievements-list > li');
+      const unlockedRows = document.querySelectorAll<HTMLLIElement>(
+        '#set-achievements-list > li.unlocked-row',
+      );
+
+      // If all achievements are unlocked, disable the hide unlocked filter.
+      if (allRows.length > 0 && allRows.length === unlockedRows.length) {
+        this.isUsingHideUnlockedAchievements = false;
+        toggleGameInHiddenList(false);
+      }
+
       // Respect whatever the initial state from the server is.
       if (this.isUsingHideUnlockedAchievements) {
         this.updateRowsVisibility();


### PR DESCRIPTION
Supplemental to https://github.com/RetroAchievements/RAWeb/pull/3580.

3580 fixes the server render, but the client render needs to be fixed too.