### PR TITLE
ensure players_total gets intialized

### DIFF
--- a/app/Connect/Actions/SubmitGameTitleAction.php
+++ b/app/Connect/Actions/SubmitGameTitleAction.php
@@ -98,7 +98,14 @@ class SubmitGameTitleAction extends BaseAuthenticatedApiAction
                 $game = $release->game;
             } else {
                 // no title match, it's a new game
-                $game = Game::create(['Title' => $this->gameTitle, 'ConsoleID' => $this->systemId]);
+                $game = new Game(['Title' => $this->gameTitle, 'ConsoleID' => $this->systemId]);
+                // these properties are not fillable, so have to be set manually
+                $game->players_total = 0;
+                $game->players_hardcore = 0;
+                $game->points_total = 0;
+                $game->achievements_published = 0;
+                $game->achievements_unpublished = 0;
+                $game->save();
 
                 // Create the initial canonical title in game_releases.
                 $game->releases()->create([

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -20,7 +20,7 @@ function getGameData(int $gameID): ?array
     return !$game ? null : array_merge($game->toArray(), [
         'ConsoleID' => $game->system->ID,
         'ConsoleName' => $game->system->Name,
-        'NumDistinctPlayers' => $game->players_total,
+        'NumDistinctPlayers' => $game->players_total ?? 0,
     ]);
 }
 


### PR DESCRIPTION
also initializes other nullable counts that were previously being set to 0 (I assume this has to be the result of #3558, but I can't find anything explicitly setting the values to 0 [there](https://github.com/RetroAchievements/RAWeb/pull/3558/files#diff-6689b0b689dabb410c1e2cd5db0c475fa05e5d538d56b13e66251f5064a214dcL693-L709)).

these should probably be made not nullable with a default of 0.