### PR TITLE
test(GameSuggestionEngine): remediate ci flake

### DIFF
--- a/tests/Feature/Platform/Services/GameSuggestions/GameSuggestionEngineTest.php
+++ b/tests/Feature/Platform/Services/GameSuggestions/GameSuggestionEngineTest.php
@@ -108,6 +108,9 @@ class GameSuggestionEngineTest extends TestCase
 
         // Act
         $engine = new GameSuggestionEngine($user);
+        $engine->dangerouslySetFixedStrategyForTesting(
+            new WantToPlayStrategy($user)
+        );
         $suggestions = $engine->selectSuggestions(limit: 5); // we'll ask for 5 but expect fewer
 
         // Assert


### PR DESCRIPTION
One test case in this file is still missing a call to `dangerouslySetFixedStrategyForTesting()`, which is causing it to frequently fail in CI.