### PR TITLE
feat(search): index events

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Laravel\Scout\Searchable;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -27,6 +28,8 @@ class Event extends BaseModel
     }
 
     use HasSelfHealingUrls;
+
+    use Searchable;
 
     protected $table = 'events';
 
@@ -72,6 +75,24 @@ class Event extends BaseModel
             ])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs();
+    }
+
+    // == search
+
+    public function toSearchableArray(): array
+    {
+        $this->load('legacyGame');
+
+        return [
+            'id' => (int) $this->id,
+            'title' => $this->legacyGame->title,
+            'players_total' => $this->legacyGame->players_total,
+        ];
+    }
+
+    public function shouldBeSearchable(): bool
+    {
+        return true;
     }
 
     // == accessors

--- a/config/scout.php
+++ b/config/scout.php
@@ -2,6 +2,7 @@
 
 use App\Models\Achievement;
 use App\Models\Comment;
+use App\Models\Event;
 use App\Models\ForumTopicComment;
 use App\Models\Game;
 use App\Models\GameSet;
@@ -174,6 +175,21 @@ return [
                 ],
                 'searchableAttributes' => ['body'],
                 'sortableAttributes' => ['created_at'],
+            ],
+
+            Event::class => [
+                'filterableAttributes' => ['title', 'players_total'],
+                'rankingRules' => [
+                    'words',
+                    'typo',
+                    'attribute',
+                    'unlocks_total:desc',
+                    'proximity',
+                    'exactness',
+                    'sort',
+                ],
+                'searchableAttributes' => ['title', 'id'],
+                'sortableAttributes' => ['id', 'title', 'players_total'],
             ],
 
             ForumTopicComment::class => [

--- a/resources/views/pages/demo/scout.blade.php
+++ b/resources/views/pages/demo/scout.blade.php
@@ -1,5 +1,6 @@
 @use('App\Models\Achievement')
 @use('App\Models\Comment')
+@use('App\Models\Event')
 @use('App\Models\ForumTopicComment')
 @use('App\Models\Game')
 @use('App\Models\GameSet')
@@ -17,7 +18,8 @@
     $commentSearch = request()->query('comment_search');
     $gameSetSearch = request()->query('game_set_search');
     $forumCommentSearch = request()->query('forum_comment_search');
-    
+    $eventSearch = request()->query('event_search');
+
     // Search using the terms (default or provided).
     $games = !empty($gameSearch)
         ? Game::search($gameSearch)->get()
@@ -41,6 +43,10 @@
         
     $forumComments = !empty($forumCommentSearch) 
         ? ForumTopicComment::search($forumCommentSearch)->take(20)->get() 
+        : collect();
+
+    $events = !empty($eventSearch)
+        ? Event::search($eventSearch)->take(10)->get()
         : collect();
 @endphp
 
@@ -118,6 +124,18 @@
                     class="rounded border px-2 py-1 w-full"
                 >
             </div>
+
+            <div>
+                <label for="forum_comment_search" class="block text-sm mb-1">Event Search</label>
+                <input 
+                    type="text" 
+                    id="event_search"
+                    name="event_search" 
+                    value="{{ $eventSearch }}" 
+                    placeholder="Search events"
+                    class="rounded border px-2 py-1 w-full"
+                >
+            </div>
             
             <div class="flex items-end">
                 <button 
@@ -181,6 +199,15 @@
                     @dump($forumComments->toArray())
                 @else
                     <p class="text-gray-500">{{ $forumCommentSearch ? 'No forum comment results found' : 'Enter a search term to find forum comments' }}</p>
+                @endif
+            </div>
+
+            <div>
+                <h2 class="text-lg font-bold mb-2">Events ({{ $events->count() }})</h2>
+                @if ($events->isNotEmpty())
+                    @dump($events->toArray())
+                @else
+                    <p class="text-gray-500">{{ $events ? 'No event results found' : 'Enter a search term to find events' }}</p>
                 @endif
             </div>
         </div>


### PR DESCRIPTION
This PR adds basic Scout/Meilisearch indexing for events.
```bash
sail artisan horizon

sail artisan scout:sync-index-settings
sail artisan scout:import "App\Models\Event"
```

Events are now searchable on the http://localhost:64000/demo/scout demo page. The event titles are not obvious in the naive `@dump` results, as they live in the `legacyGame` relationship.