### PR TITLE
allow junior developers with writer role to update leaderboard titles for non-claimed games

### DIFF
--- a/app/Filament/Resources/LeaderboardResource.php
+++ b/app/Filament/Resources/LeaderboardResource.php
@@ -23,6 +23,7 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 
 class LeaderboardResource extends Resource
 {
@@ -114,6 +115,9 @@ class LeaderboardResource extends Resource
 
     public static function form(Form $form): Form
     {
+        /** @var User $user */
+        $user = Auth::user();
+
         return $form
             ->schema([
                 Forms\Components\Section::make('Primary Details')
@@ -123,15 +127,18 @@ class LeaderboardResource extends Resource
                         Forms\Components\TextInput::make('Title')
                             ->required()
                             ->minLength(2)
-                            ->maxLength(255),
+                            ->maxLength(255)
+                            ->disabled(!$user->can('updateField', [$form->model, 'Title'])),
 
                         Forms\Components\TextInput::make('Description')
-                            ->maxLength(255),
+                            ->maxLength(255)
+                            ->disabled(!$user->can('updateField', [$form->model, 'Description'])),
 
                         Forms\Components\TextInput::make('DisplayOrder')
                             ->numeric()
                             ->helperText("If set to less than 0, the leaderboard will be invisible to regular players.")
-                            ->required(),
+                            ->required()
+                            ->disabled(!$user->can('updateField', [$form->model, 'DisplayOrder'])),
                     ]),
 
                 Forms\Components\Section::make('Rules')
@@ -144,12 +151,14 @@ class LeaderboardResource extends Resource
                                     ->mapWithKeys(fn ($format) => [$format => ValueFormat::toString($format)])
                                     ->toArray()
                             )
-                            ->required(),
+                            ->required()
+                            ->disabled(!$user->can('updateField', [$form->model, 'Format'])),
 
                         Forms\Components\Toggle::make('LowerIsBetter')
                             ->label('Lower Is Better')
                             ->inline(false)
-                            ->helperText('Useful for speedrun leaderboards and similar scenarios.'),
+                            ->helperText('Useful for speedrun leaderboards and similar scenarios.')
+                            ->disabled(!$user->can('updateField', [$form->model, 'LowerIsBetter'])),
                     ]),
             ]);
     }

--- a/app/Policies/LeaderboardPolicy.php
+++ b/app/Policies/LeaderboardPolicy.php
@@ -45,13 +45,74 @@ class LeaderboardPolicy
 
     public function update(User $user, Leaderboard $leaderboard): bool
     {
+        $canEditAnyLeaderboard = $user->hasAnyRole([
+            /*
+             * developers can upload/edit any leaderboard
+             */
+            Role::DEVELOPER,
+
+            /*
+             * writers may update leaderboard title and description if the respective leaderboard are open for editing
+             */
+            Role::WRITER,
+        ]);
+
+        if ($canEditAnyLeaderboard) {
+            return true;
+        }
+
+        // Junior Developers have additional specific criteria that must be satisfied
+        // before they are allowed to edit leaderboard fields.
         if ($user->hasRole(Role::DEVELOPER_JUNIOR)) {
             return $user->is($leaderboard->developer);
         }
 
-        return $user->hasAnyRole([
-            Role::DEVELOPER,
-        ]);
+        return false;
+    }
+
+    public function updateField(User $user, ?Leaderboard $leaderboard, string $fieldName): bool
+    {
+        $roleFieldPermissions = [
+            Role::DEVELOPER_JUNIOR => ['Title', 'Description', 'Format', 'LowerIsBetter', 'DisplayOrder'],
+            Role::DEVELOPER => ['Title', 'Description', 'Format', 'LowerIsBetter', 'DisplayOrder'],
+            Role::WRITER => ['Title', 'Description'],
+        ];
+
+        // Root can edit everything.
+        if ($user->hasRole(Role::ROOT)) {
+            return true;
+        }
+
+        $userRoles = $user->getRoleNames();
+
+        // Aggregate the allowed fields for all roles the user has.
+        $allowedFieldsForUser = collect($roleFieldPermissions)
+            ->filter(function ($fields, $role) use ($userRoles, $user, $leaderboard) {
+                if (!$userRoles->contains($role)) {
+                    return false;
+                }
+
+                // Junior Developers have additional specific criteria that must be satisfied
+                // before they are allowed to edit leaderboard fields.
+                if ($role === Role::DEVELOPER_JUNIOR) {
+                    return isset($leaderboard) && $this->juniorDeveloperCanUpdate($user, $leaderboard);
+                }
+
+                return true;
+            })
+            ->collapse()
+            ->unique()
+            ->all();
+
+        // If any of the user's roles allow updating the specified field, return true.
+        // Otherwise, they can't edit the field.
+        return in_array($fieldName, $allowedFieldsForUser, true);
+    }
+
+    private function juniorDeveloperCanUpdate(User $user, Leaderboard $leaderboard): bool
+    {
+        // If the user has a DEVELOPER_JUNIOR role, they need to have a claim on the game
+        return $user->hasActiveClaimOnGameId($leaderboard->game->id);
     }
 
     public function delete(User $user, Leaderboard $leaderboard): bool

--- a/resources/views/pages-legacy/leaderboardinfo.blade.php
+++ b/resources/views/pages-legacy/leaderboardinfo.blade.php
@@ -102,6 +102,12 @@ $pageTitle = "$lbTitle in $gameTitle ($consoleName)";
         echo "</small>";
         echo "</p>";
 
+        if ($userModel && $userModel->can('update', $leaderboard)) {
+            echo '<a class="btn mb-1" href="' . route('filament.admin.resources.leaderboards.edit', ['record' => $leaderboard->id]) . '">Manage</a>';
+        } elseif ($userModel && $userModel->can('manage', $leaderboard)) {
+            echo '<a class="btn mb-1" href="' . route('filament.admin.resources.leaderboards.view', ['record' => $leaderboard->id]) . '">Manage</a>';
+        }
+
         if (isset($user) && $permissions >= Permissions::JuniorDeveloper) {
             echo "<div>";
             echo "<button class='btn' id='devboxbutton' onclick=\"toggleExpander('devboxbutton', 'devboxcontent');\">Dev ▼</button>";


### PR DESCRIPTION
fixes https://discord.com/channels/310192285306454017/1376448588871106560/1379668587815633068

similar issue as #3561, but for leaderboards.

also added a manage button directly on the leaderboard page (#3559 for achievements) and hooked up the field-level permissions in the leaderboard management page.