### PR TITLE
fix(UpdateDeveloperContributionYieldAction): duplicate the flags param

### DIFF
--- a/app/Platform/Actions/UpdateDeveloperContributionYieldAction.php
+++ b/app/Platform/Actions/UpdateDeveloperContributionYieldAction.php
@@ -111,7 +111,7 @@ class UpdateDeveloperContributionYieldAction
             JOIN player_achievements pa ON pa.id = amu.player_achievement_id
             JOIN Achievements a ON a.ID = amu.achievement_id
             WHERE amu.maintainer_id = :user_id3
-                AND a.Flags = :flags
+                AND a.Flags = :flags2
             ORDER BY unlock_date
             LIMIT :limit OFFSET :offset
         SQL;
@@ -121,6 +121,7 @@ class UpdateDeveloperContributionYieldAction
             'user_id2' => $user->id,
             'user_id3' => $user->id,
             'flags' => AchievementFlag::OfficialCore->value,
+            'flags2' => AchievementFlag::OfficialCore->value,
             'limit' => $limit,
             'offset' => $offset,
         ]);


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/3605.

The `:flags` param is used twice, which is causing the query exception. Similar to `user_id`, it needs to be duplicated across uniquely-named params.