### PR TITLE
fix toolbox on achievement inspector page

### DIFF
--- a/resources/views/pages-legacy/achievementinspector.blade.php
+++ b/resources/views/pages-legacy/achievementinspector.blade.php
@@ -260,7 +260,7 @@ if ($gameIDSpecified) {
         <x-developer.inspector-toolbox
             :canHaveBeatenTypes="$canHaveBeatenTypes"
             :gameId="$gameID"
-            :isManagingCoreAchievements="$flag === AchievementFlag::OfficialCore->value"
+            :isManagingCoreAchievements="$flag === AchievementFlag::OfficialCore"
             :modificationLevel="$modificationLevel"
         />
     </div>


### PR DESCRIPTION
Fixes an issue where "Demote Selected" and "View Unofficial Achievements" weren't being shown when going to the "Manage Core Achievements" page for a game.