### PR TITLE
fix(globalRanking): remediate stable username leak on followed users ranking

### DIFF
--- a/app/Helpers/render/ranking.php
+++ b/app/Helpers/render/ranking.php
@@ -250,7 +250,7 @@ function getGlobalRankingData(
     }
 
     return legacyDbFetchAll("
-        SELECT User,
+        SELECT User, DisplayName,
             COALESCE(MAX(AchievementCount), 0) AS AchievementCount,
             COALESCE(MAX(Points), 0) AS Points,
             COALESCE(MAX(RetroPoints), 0) AS RetroPoints,
@@ -260,6 +260,7 @@ function getGlobalRankingData(
         (
             (
                 SELECT ua.User AS User,
+                    ua.display_name AS DisplayName,
                     ua.ID as user_id,
                     SUM($achCount) AS AchievementCount,
                     SUM($achPoints) as Points,
@@ -277,6 +278,7 @@ function getGlobalRankingData(
             UNION
             (
                 SELECT ua.User AS User,
+                    ua.display_name AS DisplayName,
                     ua.ID AS user_id,
                     NULL AS AchievementCount,
                     NULL AS Points,

--- a/resources/views/pages-legacy/globalRanking.blade.php
+++ b/resources/views/pages-legacy/globalRanking.blade.php
@@ -283,7 +283,7 @@ $unlockMode = match ($sort % 10) {
 
             // If viewing the daily leaderboard then link the total achievements obtained to the users history page for the day
             if ($type == 0) {
-                echo "<td class='text-right'><a href='historyexamine.php?d=$dateUnix&u=" . $dataPoint['User'] . "'>" . localized_number($dataPoint['AchievementCount']) . "</a></td>";
+                echo "<td class='text-right'><a href='historyexamine.php?d=$dateUnix&u=" . $dataPoint['DisplayName'] . "'>" . localized_number($dataPoint['AchievementCount']) . "</a></td>";
             } else {
                 echo "<td class='text-right'>" . localized_number($dataPoint['AchievementCount'] ?? 0) . "</td>";
             }
@@ -345,7 +345,7 @@ $unlockMode = match ($sort % 10) {
 
                 // If viewing the daily leaderboard then link the total achievements obtained to the users history page for the day
                 if ($type == 0) {
-                    echo "<td class='text-right'><a href='historyexamine.php?d=$dateUnix&u=" . $userData[0]['User'] . "'>" . $userData[0]['AchievementCount'] . "</a></td>";
+                    echo "<td class='text-right'><a href='historyexamine.php?d=$dateUnix&u=" . $userData[0]['DisplayName'] . "'>" . $userData[0]['AchievementCount'] . "</a></td>";
                 } else {
                     echo "<td class='text-right'>" . localized_number($userData[0]['AchievementCount']) . "</a></td>";
                 }


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1380323238747443320.

**How to reproduce this issue:**
Navigate to a URL like http://localhost:64000/globalRanking.php?s=5&t=0&d=2025-04-19&f=1.
Hover over the count for "Hardcore Achievements":

![Screenshot 2025-06-06 at 6 17 18 PM](https://github.com/user-attachments/assets/c42c7bd2-96a3-4971-b430-99b7f51324f8)

This specific URL is leaking stable usernames.

Rather than alter everywhere in the massive query where the stable username is used and risk a breakage, for the sake of simplicity I added a `DisplayName` field for each user in the response.