### PR TITLE
Show real beat/master times (when available)

### DIFF
--- a/app/Helpers/system-icon.php
+++ b/app/Helpers/system-icon.php
@@ -4,22 +4,27 @@ declare(strict_types=1);
 
 use App\Models\System;
 
-function getSystemIconUrl(int|System $system): string
+function getSystemIconUrl(int|string|System $system): string
 {
     $fallBackConsoleIcon = asset("assets/images/system/unknown.png");
 
-    if (is_int($system)) {
-        if ($system < 1) {
-            return $fallBackConsoleIcon;
-        }
+    if (is_string($system)) {
+        $shortName = $system;
+    } else {
+        if (is_int($system)) {
+            if ($system < 1) {
+                return $fallBackConsoleIcon;
+            }
 
-        $system = System::find($system);
-        if (!$system) {
-            return $fallBackConsoleIcon;
+            $system = System::find($system);
+            if (!$system) {
+                return $fallBackConsoleIcon;
+            }
         }
+        $shortName = $system->name_short ?? '';
     }
 
-    $cleanSystemShortName = Str::lower(str_replace("/", "", $system->name_short ?? ''));
+    $cleanSystemShortName = Str::lower(str_replace("/", "", $shortName));
     $iconName = Str::kebab($cleanSystemShortName);
     $iconPath = public_path("assets/images/system/$iconName.png");
     $iconUrl = file_exists($iconPath) ? asset("assets/images/system/$iconName.png") : $fallBackConsoleIcon;

--- a/app/Platform/Actions/GetAwardTimeTakenAction.php
+++ b/app/Platform/Actions/GetAwardTimeTakenAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Actions;
+
+use App\Models\GameAchievementSet;
+use App\Models\PlayerAchievementSet;
+use App\Models\PlayerGame;
+use App\Platform\Enums\AchievementSetType;
+
+class GetAwardTimeTakenAction
+{
+    public function execute(int $userId, array $gameIds, string $awardKind): array
+    {
+        $result = [];
+
+        if ($awardKind === 'mastered' || $awardKind === 'completed') {
+            $coreAchievementSetIds = GameAchievementSet::query()
+                ->whereIn('game_id', $gameIds)
+                ->where('type', AchievementSetType::Core)
+                ->pluck('game_id', 'achievement_set_id')
+                ->toArray();
+            if (!empty($coreAchievementSetIds)) {
+                $playerAchievementSets = PlayerAchievementSet::query()
+                    ->whereIn('achievement_set_id', array_keys($coreAchievementSetIds))
+                    ->where('user_id', $userId)
+                    ->select(['achievement_set_id', 'time_taken', 'time_taken_hardcore'])
+                    ->get();
+                foreach ($playerAchievementSets as $playerAchievementSet) {
+                    $gameId = $coreAchievementSetIds[$playerAchievementSet->achievement_set_id];
+                    $result[$gameId] = ($awardKind === 'mastered') ?
+                        $playerAchievementSet->time_taken_hardcore :
+                        $playerAchievementSet->time_taken;
+                }
+            }
+        } elseif ($awardKind !== null) {
+            $playerGames = PlayerGame::query()
+                ->whereIn('game_id', $gameIds)
+                ->where('user_id', $userId)
+                ->select(['game_id', 'time_to_beat', 'time_to_beat_hardcore'])
+                ->get();
+            foreach ($playerGames as $playerGame) {
+                $result[$playerGame->game_id] = ($awardKind === 'beaten-hardcore') ?
+                    $playerGame->time_to_beat_hardcore : $playerGame->time_to_beat;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/app/Platform/Services/PlayerCompletionProgressPageService.php
+++ b/app/Platform/Services/PlayerCompletionProgressPageService.php
@@ -63,6 +63,7 @@ class PlayerCompletionProgressPageService
         $filteredAndJoinedGamesList = $this->playerProgressionService->filterAndJoinGames(
             $userGamesList,
             $userSiteAwards,
+            $foundTargetUser->id,
             allowEvents: $targetSystemId === System::Events,
         );
         $primaryCountsMetrics = $this->playerProgressionService->buildPrimaryCountsMetrics($filteredAndJoinedGamesList);

--- a/public/API/API_GetUserCompletionProgress.php
+++ b/public/API/API_GetUserCompletionProgress.php
@@ -42,14 +42,18 @@ $offset = $input['o'] ?? 0;
 $count = $input['c'] ?? 100;
 
 $userModel = (new FindUserByIdentifierAction())->execute($input['u']);
+if (!$userModel) {
+    return response()->json(['Count' => 0, 'Total' => 0, 'Results' => []]);
+}
 
 $playerProgressionService = new PlayerProgressionService();
 
-$userGamesList = getUsersCompletedGamesAndMax($userModel?->username ?? "");
+$userGamesList = getUsersCompletedGamesAndMax($userModel->username ?? "");
 $userSiteAwards = getUsersSiteAwards($userModel);
 $filteredAndJoinedGamesList = $playerProgressionService->filterAndJoinGames(
     $userGamesList,
     $userSiteAwards,
+    $userModel->id,
 );
 
 // Sort the results by MostRecentAwardedDate

--- a/resources/views/components/game-list-item/index.blade.php
+++ b/resources/views/components/game-list-item/index.blade.php
@@ -17,12 +17,10 @@ $hasAward = isset($game['HighestAwardKind']);
 $hardcoreCompletionPercentage = floor($game['PctWonHC'] * 100);
 $totalCompletionPercentage = floor($game['PctWon'] * 100);
 
-// TODO: pass $game model with system child to avoid fetching system for every row
 $consoleId = $game['ConsoleID'];
-$system = System::find($game['ConsoleID']);
-$consoleName = $system->name;
-$consoleShortName = $system->name_short;
-$gameSystemIconSrc = getSystemIconUrl($system);
+$consoleName = $game['ConsoleName'];
+$consoleShortName = $game['ConsoleNameShort'];
+$gameSystemIconSrc = getSystemIconUrl($consoleShortName);
 
 $doesGameHaveAchievements = !!$game['MaxPossible'];
 ?>
@@ -67,6 +65,7 @@ $doesGameHaveAchievements = !!$game['MaxPossible'];
                 :mostRecentWonDate="$game['MostRecentWonDate']"
                 :highestAwardKind="$game['HighestAwardKind'] ?? null"
                 :highestAwardDate="$game['HighestAwardDate'] ?? null"
+                :highestAwardTimeTaken="$game['HighestAwardTimeTaken'] ?? null"
                 :variant="$variant"
             />
         </div>

--- a/resources/views/pages-legacy/userInfo.blade.php
+++ b/resources/views/pages-legacy/userInfo.blade.php
@@ -58,6 +58,7 @@ $playerProgressionService = new PlayerProgressionService();
 $userJoinedGamesAndAwards = $playerProgressionService->filterAndJoinGames(
     $userCompletedGamesList,
     $userAwards,
+    $userPageID,
 );
 
 $excludedConsoles = ["Hubs", "Events"];
@@ -154,6 +155,7 @@ if (getActiveClaimCount($userPageModel, true, true) > 0) {
             :recentAchievementEntities="$userMassData['RecentAchievements'] ?? []"
             :recentAwardedEntities="$userMassData['Awarded'] ?? []"
             :targetUsername="$userPage ?? ''"
+            :targetUserId="$userPageModel->id"
             :userAwards="$userAwards"
         />
     <?php

--- a/tests/Feature/Api/V1/UserCompletionProgressTest.php
+++ b/tests/Feature/Api/V1/UserCompletionProgressTest.php
@@ -34,7 +34,11 @@ class UserCompletionProgressTest extends TestCase
     {
         $this->get($this->apiUrl('GetUserCompletionProgress', ['u' => 'nonExistant']))
             ->assertSuccessful()
-            ->assertJson([]);
+            ->assertJson([
+                'Count' => 0,
+                'Total' => 0,
+                'Results' => [],
+            ]);
     }
 
     public function testGetUserCompletionProgress(): void


### PR DESCRIPTION
Surfaces some of the metrics calculated by #3496 on the player profile page and completion progress page.

If session duration has been calculated, the playtime will be reported as "Beaten in X"/"Mastered in X". If it hasn't been calculated yet, it will be reported as "Beaten over X". If the playtime is known and the "over X" is more than 50% larger than the playtime, then both will be shown: "Beaten in X over Y".

![image](https://github.com/user-attachments/assets/e0a6cd1f-6b17-41d0-9138-3914fb615250)
![image](https://github.com/user-attachments/assets/c79ddbdd-d1b8-4522-9189-2cca6c733c0e)
