### PR TITLE
chore: React warnings cleanup

### DIFF
--- a/resources/js/common/components/GlobalSearch/GlobalSearch.test.tsx
+++ b/resources/js/common/components/GlobalSearch/GlobalSearch.test.tsx
@@ -116,11 +116,12 @@ describe('Component: GlobalSearch', () => {
           users: [],
           games: [],
           hubs: [],
+          events: [],
           achievements: [],
         },
         query: 'xyz',
-        scopes: ['users', 'games', 'hubs', 'achievements'],
-        scopeRelevance: { users: 0, games: 0, hubs: 0, achievements: 0 },
+        scopes: ['users', 'games', 'hubs', 'events', 'achievements'],
+        scopeRelevance: { users: 0, games: 0, hubs: 0, events: 0, achievements: 0 },
       },
     };
 

--- a/resources/js/common/hooks/useUserSearchQuery.ts
+++ b/resources/js/common/hooks/useUserSearchQuery.ts
@@ -48,9 +48,8 @@ export function useUserSearchQuery(options: UseUserSearchQueryOptions = {}): Use
     refetchInterval: false,
   });
 
-  return {
-    ...query,
+  return Object.assign(query, {
     searchTerm,
     setSearchTerm,
-  };
+  });
 }

--- a/resources/js/features/events/components/EventAwardEarnersMainRoot/EventAwardEarnersMainRoot.tsx
+++ b/resources/js/features/events/components/EventAwardEarnersMainRoot/EventAwardEarnersMainRoot.tsx
@@ -36,7 +36,7 @@ export const EventAwardEarnersMainRoot: FC = memo(() => {
       />
       <PlayableHeader
         badgeUrl={eventAward.badgeUrl}
-        systemLabel={event.legacyGame?.title ?? 'Event'}
+        systemLabel={event.legacyGame!.title}
         systemIconUrl="/assets/images/system/events.png"
         title={cleanAwardLabel}
       >

--- a/resources/js/features/events/components/EventAwardTiers/AwardTierItem.test.tsx
+++ b/resources/js/features/events/components/EventAwardTiers/AwardTierItem.test.tsx
@@ -170,4 +170,22 @@ describe('Component: AwardTierItem', () => {
     const linkEl = screen.queryByRole('link', { name: /bronze/i });
     expect(linkEl).not.toBeInTheDocument();
   });
+
+  it('given a tierIndex greater than 0, displays a link', () => {
+    // ARRANGE
+    const event = createRaEvent({ id: 123 });
+    const eventAward = createEventAward({
+      badgeCount: 10,
+      label: 'Gold',
+      eventId: 123,
+      tierIndex: 2,
+    });
+
+    render(<AwardTierItem event={event} eventAward={eventAward} hasVirtualTier={false} />);
+
+    // ASSERT
+    const linkEl = screen.getByRole('link', { name: /gold/i });
+    expect(linkEl).toBeVisible();
+    expect(linkEl).toHaveAttribute('href', expect.stringContaining('event.award-earners.index'));
+  });
 });

--- a/resources/js/features/events/components/EventAwardTiers/AwardTierItem.tsx
+++ b/resources/js/features/events/components/EventAwardTiers/AwardTierItem.tsx
@@ -32,17 +32,9 @@ export const AwardTierItem: FC<AwardTierItemProps> = ({ event, eventAward, hasVi
     (ea) => ea.achievement?.points && ea.achievement.points === 1,
   );
 
-  const awardEarnersLink =
-    eventAward.badgeCount! < 1
-      ? ''
-      : eventAward.tierIndex > 0
-        ? route('event.award-earners.index', {
-            event: eventAward.eventId,
-            tier: eventAward.tierIndex,
-          })
-        : route('event.award-earners.index', { event: eventAward.eventId });
+  const awardEarnersLink = getAwardEarnersLink(eventAward);
 
-  const ConditionalLink = awardEarnersLink !== '' ? InertiaLink : 'div';
+  const ConditionalLink = awardEarnersLink !== undefined ? InertiaLink : 'div';
 
   return (
     <div
@@ -53,7 +45,7 @@ export const AwardTierItem: FC<AwardTierItemProps> = ({ event, eventAward, hasVi
           : 'bg-zinc-800/50 light:bg-zinc-100',
       )}
     >
-      <ConditionalLink href={awardEarnersLink}>
+      <ConditionalLink href={awardEarnersLink as string}>
         <div className="relative flex items-center gap-3">
           <div className="relative">
             <img
@@ -77,7 +69,9 @@ export const AwardTierItem: FC<AwardTierItemProps> = ({ event, eventAward, hasVi
                       data-testid="award-tier-label"
                       className={cn([
                         'flex gap-2 text-xs font-medium',
-                        awardEarnersLink !== '' ? 'transition group-hover:text-link-hover' : null,
+                        awardEarnersLink !== undefined
+                          ? 'transition group-hover:text-link-hover'
+                          : null,
                       ])}
                     >
                       {cleanedAwardLabel}
@@ -106,7 +100,13 @@ export const AwardTierItem: FC<AwardTierItemProps> = ({ event, eventAward, hasVi
                 <BaseTooltipTrigger>
                   <div
                     data-testid="award-earned-checkmark"
-                    className="mr-1 flex size-6 items-center justify-center rounded-full bg-embed light:bg-neutral-200 light:text-neutral-700"
+                    className={cn([
+                      'mr-1 flex size-6 items-center justify-center rounded-full bg-embed',
+                      'light:bg-neutral-200 light:text-neutral-700',
+                      awardEarnersLink !== undefined
+                        ? 'transition group-hover:text-link-hover'
+                        : null,
+                    ])}
                   >
                     <LuCheck className="size-4" />
                   </div>
@@ -125,6 +125,21 @@ export const AwardTierItem: FC<AwardTierItemProps> = ({ event, eventAward, hasVi
     </div>
   );
 };
+
+function getAwardEarnersLink(eventAward: App.Platform.Data.EventAward): string | undefined {
+  if (eventAward.badgeCount! < 1) {
+    return;
+  }
+
+  if (eventAward.tierIndex > 0) {
+    return route('event.award-earners.index', {
+      event: eventAward.eventId,
+      tier: eventAward.tierIndex,
+    });
+  }
+
+  return route('event.award-earners.index', { event: eventAward.eventId });
+}
 
 function useEarnersMessage(didCurrentUserEarn: boolean, totalEarners: number): string {
   const { t } = useTranslation();

--- a/resources/js/features/game-list/components/SuggestionReasonCell/SharedAuthorReason/SharedAuthorReason.tsx
+++ b/resources/js/features/game-list/components/SuggestionReasonCell/SharedAuthorReason/SharedAuthorReason.tsx
@@ -18,6 +18,9 @@ export const SharedAuthorReason: FC<SharedAuthorReasonProps> = ({ relatedAuthor,
     dynamicId: relatedAuthor.displayName,
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- extract ref from cardTooltipProps to avoid React 19 <Trans /> bug
+  const { ref, ...cardTooltipPropsWithoutRef } = cardTooltipProps;
+
   return (
     <BaseChip
       data-testid="shared-author-reason"
@@ -31,7 +34,7 @@ export const SharedAuthorReason: FC<SharedAuthorReasonProps> = ({ relatedAuthor,
           1: (
             <a
               href={route('user.show', { user: relatedAuthor.displayName })}
-              {...cardTooltipProps}
+              {...cardTooltipPropsWithoutRef}
             />
           ),
         }}


### PR DESCRIPTION
This PR resolves numerous warnings that are being logged:

```
stderr | resources/js/features/events/components/EventAwardTiers/AwardTierItem.test.tsx > Component: AwardTierItem > given no earn count, does not show a link to earners
An empty string ("") was passed to the href attribute. To fix this, either do not render the element at all or pass null to href instead of an empty string.
```
More empty string woes in `<AwardTierItem />`. Resolved by setting this to be `undefined` when there's no link and a type cast to `<InertiaLink />`'s `href` prop.

---

```
stderr | resources/js/features/game-list/components/SuggestionReasonCell/SuggestionReasonCell.test.tsx > Component: SuggestionReasonCell > given the suggestion reason is shared-author, renders the SharedAuthorReason component
Accessing element.ref was removed in React 19. ref is now a regular prop. It will be removed from the JSX Element type in a future release.
```
Resolved by removing the `ref` prop from `SharedAuthorReason`. The `<Trans />` component gets really upset when this prop is used.

---

```
  52:5  warning  Object rest destructuring on a query will observe all changes to the query, leading to excessive re-renders  @tanstack/query/no-rest-destructuring
```
This has been resolved by using `Object.assign()` instead of a spread to have a stable object reference for React's context.