### PR TITLE
fix(search): remediate flash of cached results

### DIFF
--- a/resources/js/common/components/GlobalSearch/GlobalSearch.tsx
+++ b/resources/js/common/components/GlobalSearch/GlobalSearch.tsx
@@ -1,4 +1,4 @@
-import { type FC, type KeyboardEvent, useState } from 'react';
+import { type FC, type KeyboardEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LuChevronRight, LuLoaderCircle, LuSearch } from 'react-icons/lu';
 
@@ -37,8 +37,9 @@ export const GlobalSearch: FC<GlobalSearchProps> = ({ isOpen, onOpenChange }) =>
   const [rawQuery, setRawQuery] = useState('');
 
   const {
-    setSearchTerm,
     isLoading,
+    setSearchTerm,
+    setShouldUsePlaceholderData,
     data: searchResults,
   } = useSearchQuery({
     // This is required for global search to work in Blade contexts.
@@ -80,12 +81,24 @@ export const GlobalSearch: FC<GlobalSearchProps> = ({ isOpen, onOpenChange }) =>
     }
   };
 
+  useEffect(() => {
+    if (!isLoading) {
+      // Turn `placeholderData` in the query back on. With it enabled,
+      // users won't see a flash of empty state in between search queries.
+      setShouldUsePlaceholderData(true);
+    }
+  }, [isLoading, setShouldUsePlaceholderData]);
+
   const handleOnOpenChange = (open: boolean) => {
     onOpenChange(open);
 
     if (!open) {
       setRawQuery('');
       setSearchTerm('');
+
+      // If we don't do this, if the user reopens the dialog on the same
+      // page and makes a new search, they'll see a flash of previous results.
+      setShouldUsePlaceholderData(false);
     }
   };
 

--- a/resources/js/common/hooks/queries/useSearchQuery.ts
+++ b/resources/js/common/hooks/queries/useSearchQuery.ts
@@ -36,10 +36,12 @@ interface UseSearchQueryOptions {
 export function useSearchQuery(options: UseSearchQueryOptions = {}) {
   const { initialSearchTerm = '', scopes = ['users'], route: customRoute } = options;
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
+  const [shouldUsePlaceholderData, setShouldUsePlaceholderData] = useState(true);
 
   return {
     searchTerm,
     setSearchTerm,
+    setShouldUsePlaceholderData,
     ...useQuery<SearchQueryResponse>({
       queryKey: ['search', searchTerm, scopes, customRoute],
 
@@ -59,7 +61,8 @@ export function useSearchQuery(options: UseSearchQueryOptions = {}) {
       },
 
       enabled: searchTerm.length >= 3,
-      placeholderData: searchTerm.length >= 3 ? keepPreviousData : undefined,
+      placeholderData:
+        searchTerm.length >= 3 && shouldUsePlaceholderData ? keepPreviousData : undefined,
       refetchInterval: false,
     }),
   };

--- a/resources/js/features/events/components/+show/EventShowMainRoot.test.tsx
+++ b/resources/js/features/events/components/+show/EventShowMainRoot.test.tsx
@@ -55,6 +55,7 @@ describe('Component: EventShowMainRoot', () => {
     // ARRANGE
     const event = createRaEvent({
       legacyGame: createGame({
+        title: 'Achievement of the Week 2025',
         imageIngameUrl: 'test.jpg',
         imageTitleUrl: 'test.jpg',
       }),


### PR DESCRIPTION
This PR remediates the issue exhibited in this video:

https://github.com/user-attachments/assets/73e4fcb6-01e1-4975-83a4-977daa03d617


If the user makes a search, closes the dialog, then opens the dialog on the same page and makes another search, there's a brief flash of cached data that appears.

This is caused by the eager internal caching mechanism of `@tanstack/react-query`, which powers the `useSearchQuery` hook.