### PR TITLE
fix: prevent attempted underflows of dev stats

### DIFF
--- a/app/Platform/Actions/IncrementDeveloperContributionYieldAction.php
+++ b/app/Platform/Actions/IncrementDeveloperContributionYieldAction.php
@@ -61,8 +61,8 @@ class IncrementDeveloperContributionYieldAction
             DB::table('UserAccounts')
                 ->where('ID', $developer->id)
                 ->update([
-                    'ContribCount' => DB::raw('ContribCount - 1'),
-                    'ContribYield' => DB::raw('ContribYield - ' . $achievement->Points),
+                    'ContribCount' => DB::raw('CASE WHEN ContribCount > 0 THEN ContribCount - 1 ELSE 0 END'),
+                    'ContribYield' => DB::raw('CASE WHEN ContribYield >= ' . $achievement->Points . ' THEN ContribYield - ' . $achievement->Points . ' ELSE 0 END'),
                 ]);
         }
 

--- a/app/Platform/Actions/ResetPlayerProgressAction.php
+++ b/app/Platform/Actions/ResetPlayerProgressAction.php
@@ -100,7 +100,7 @@ class ResetPlayerProgressAction
                     $developer = $achievement->developer;
                 }
 
-                if ($developer && $developer->id !== $user->id) {
+                if ($developer && $developer->id !== $user->id && !$developer->trashed()) {
                     // Perform a quick incremental decrement.
                     // For resets, we don't need to worry about the
                     // isHardcore flag since we're removing the unlock entirely.

--- a/app/Platform/Jobs/IncrementDeveloperContributionYieldJob.php
+++ b/app/Platform/Jobs/IncrementDeveloperContributionYieldJob.php
@@ -44,7 +44,7 @@ class IncrementDeveloperContributionYieldJob implements ShouldQueue
 
     public function handle(): void
     {
-        $developer = User::withTrashed()->find($this->developerId);
+        $developer = User::find($this->developerId);
         if (!$developer) {
             return;
         }


### PR DESCRIPTION
This PR:
* Skips invocation of `IncrementDeveloperContributionYieldAction` if the developer is deleted.
* Forces the action itself to never attempt an underflow write via a small modification to the query.

Resolves https://retroachievements.org/log-viewer?file=06e47184-laravel-2025-06-12.log&query=log-index%3A101