### PR TITLE
feat(manage): improve game relation tab ux

### DIFF
--- a/app/Filament/Resources/GameResource/RelationManagers/AchievementSetsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/AchievementSetsRelationManager.php
@@ -20,6 +20,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
@@ -31,6 +32,20 @@ class AchievementSetsRelationManager extends RelationManager
     protected static string $relationship = 'achievementSets';
 
     protected static ?string $title = 'Sets';
+
+    protected static ?string $icon = 'heroicon-o-rectangle-stack';
+
+    public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
+    {
+        return !$ownerRecord->is_subset_game;
+    }
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        $count = $ownerRecord->gameAchievementSets->count();
+
+        return $count > 0 ? "{$count}" : null;
+    }
 
     public function form(Form $form): Form
     {

--- a/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/AchievementsRelationManager.php
@@ -34,6 +34,10 @@ class AchievementsRelationManager extends RelationManager
 {
     protected static string $relationship = 'achievements';
 
+    protected static ?string $title = 'Achievements';
+
+    protected static ?string $icon = 'fas-trophy';
+
     public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
     {
         /** @var User $user */
@@ -44,6 +48,16 @@ class AchievementsRelationManager extends RelationManager
         }
 
         return false;
+    }
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        /** @var Game $game */
+        $game = $ownerRecord;
+
+        $count = $game->achievements()->published()->count();
+
+        return $count > 0 ? "{$count}" : null;
     }
 
     public function form(Form $form): Form

--- a/app/Filament/Resources/GameResource/RelationManagers/CoreSetAuthorshipCreditsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/CoreSetAuthorshipCreditsRelationManager.php
@@ -24,7 +24,16 @@ class CoreSetAuthorshipCreditsRelationManager extends RelationManager
 {
     protected static string $relationship = 'coreSetAuthorshipCredits';
 
-    protected static ?string $title = 'Credits';
+    protected static ?string $title = 'Set Credits';
+
+    protected static ?string $icon = 'fas-users';
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        $count = $ownerRecord->coreSetAuthorshipCredits->count();
+
+        return $count > 0 ? "{$count}" : null;
+    }
 
     public function form(Form $form): Form
     {

--- a/app/Filament/Resources/GameResource/RelationManagers/LeaderboardsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/LeaderboardsRelationManager.php
@@ -24,12 +24,21 @@ class LeaderboardsRelationManager extends RelationManager
 {
     protected static string $relationship = 'leaderboards';
 
+    protected static ?string $icon = 'fas-bars-staggered';
+
     public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
     {
         /** @var User $user */
         $user = Auth::user();
 
         return $user->can('manage', Leaderboard::class);
+    }
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        $count = $ownerRecord->leaderboards->count();
+
+        return $count > 0 ? "{$count}" : null;
     }
 
     public function form(Form $form): Form

--- a/app/Filament/Resources/GameResource/RelationManagers/MemoryNotesRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/MemoryNotesRelationManager.php
@@ -14,6 +14,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 
 class MemoryNotesRelationManager extends RelationManager
 {
@@ -21,12 +22,21 @@ class MemoryNotesRelationManager extends RelationManager
 
     protected static ?string $title = 'Code Notes';
 
+    protected static ?string $icon = 'fas-note-sticky';
+
     public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
     {
         /** @var User $user */
-        $user = auth()->user();
+        $user = Auth::user();
 
         return $user->can('manage', MemoryNote::class);
+    }
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        $count = $ownerRecord->memoryNotes->count();
+
+        return $count > 0 ? "{$count}" : null;
     }
 
     public function form(Form $form): Form
@@ -92,7 +102,7 @@ class MemoryNotesRelationManager extends RelationManager
                         })
                         ->modalDescription(function (MemoryNote $memoryNote): ?string {
                             /** @var User $user */
-                            $user = auth()->user();
+                            $user = Auth::user();
 
                             if ($user->is($memoryNote->user)) {
                                 return null;
@@ -102,7 +112,7 @@ class MemoryNotesRelationManager extends RelationManager
                         })
                         ->modalSubmitActionLabel(function (MemoryNote $memoryNote): string {
                             /** @var User $user */
-                            $user = auth()->user();
+                            $user = Auth::user();
 
                             if ($user->is($memoryNote->user)) {
                                 return "Save changes";
@@ -112,7 +122,7 @@ class MemoryNotesRelationManager extends RelationManager
                         })
                         ->mutateFormDataUsing(function (array $data): array {
                             /** @var User $user */
-                            $user = auth()->user();
+                            $user = Auth::user();
 
                             // The code note will always be "owned" by whoever last edited it.
                             $data['user_id'] = $user->id;
@@ -131,7 +141,7 @@ class MemoryNotesRelationManager extends RelationManager
                         ->modalDescription('Are you sure you want to delete this note? It will be irreversibly lost.')
                         ->action(function (MemoryNote $memoryNote): void {
                             /** @var User $user */
-                            $user = auth()->user();
+                            $user = Auth::user();
 
                             if (!$user->can('delete', $memoryNote)) {
                                 return;
@@ -143,7 +153,7 @@ class MemoryNotesRelationManager extends RelationManager
                         })
                         ->visible(function (MemoryNote $memoryNote): bool {
                             /** @var User $user */
-                            $user = auth()->user();
+                            $user = Auth::user();
 
                             return $user->can('delete', $memoryNote);
                         }),

--- a/app/Filament/Resources/GameResource/RelationManagers/ReleasesRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/ReleasesRelationManager.php
@@ -29,6 +29,8 @@ class ReleasesRelationManager extends RelationManager
 
     protected static ?string $recordTitleAttribute = 'title';
 
+    protected static ?string $icon = 'heroicon-c-shopping-bag';
+
     public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
     {
         /** @var User $user */
@@ -39,6 +41,16 @@ class ReleasesRelationManager extends RelationManager
         }
 
         return false;
+    }
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        /** @var Game $game */
+        $game = $ownerRecord;
+
+        $count = $game->releases()->count();
+
+        return $count > 0 ? "{$count}" : null;
     }
 
     public function form(Form $form): Form


### PR DESCRIPTION
This PR:
* Adds icons and counts to the game resource's relation manager tabs.
* Removes the "Sets" tab for subset games.

**Before**
![Screenshot 2025-06-12 at 6 50 10 PM](https://github.com/user-attachments/assets/8c84fe19-74cd-45ac-b461-d13024908fc5)


**After**
![Screenshot 2025-06-12 at 6 50 00 PM](https://github.com/user-attachments/assets/12985dbb-e1c4-4882-aa5c-c0ebd5ba0c5b)
