### PR TITLE
fix(game): resolve N+1 query problem with hubs RBAC

### DIFF
--- a/app/Models/GameSet.php
+++ b/app/Models/GameSet.php
@@ -292,12 +292,16 @@ class GameSet extends BaseModel
 
     public function getHasViewRoleRequirementAttribute(): bool
     {
-        return $this->viewRoles()->exists();
+        return $this->relationLoaded('viewRoles')
+            ? $this->viewRoles->isNotEmpty()
+            : $this->viewRoles()->exists();
     }
 
     public function getHasUpdateRoleRequirementAttribute(): bool
     {
-        return $this->updateRoles()->exists();
+        return $this->relationLoaded('updateRoles')
+            ? $this->updateRoles->isNotEmpty()
+            : $this->updateRoles()->exists();
     }
 
     // == mutators

--- a/app/Platform/Actions/LoadGameWithRelationsAction.php
+++ b/app/Platform/Actions/LoadGameWithRelationsAction.php
@@ -29,7 +29,9 @@ class LoadGameWithRelationsAction
                 $query->whereNotIn('type', $excludeSetTypes);
             },
             'hashes',
-            'hubs.children',
+            'hubs' => function ($query) {
+                $query->with(['children', 'viewRoles']);
+            },
             'visibleComments' => function ($query) {
                 $query->latest('Submitted')
                     ->limit(20)

--- a/resources/views/pages-legacy/gameInfo.blade.php
+++ b/resources/views/pages-legacy/gameInfo.blade.php
@@ -60,7 +60,7 @@ if (!isset($user) && ($sortBy == 3 || $sortBy == 13)) {
 }
 
 $numAchievements = getGameMetadata($gameID, $userModel, $achievementData, $gameData, $sortBy, null, $flagParam, metrics: true);
-$gameModel = Game::find($gameID);
+$gameModel = Game::with(['hubs.viewRoles'])->find($gameID);
 
 if (!$gameModel) {
     abort(404);


### PR DESCRIPTION
This PR resolves an N+1 query problem on both PHP game pages and React pages related to hubs RBAC.

In `master` on any game page with hubs, you'll see something like:
![Screenshot 2025-06-13 at 8 11 57 PM](https://github.com/user-attachments/assets/3a2b24cb-3b61-45b4-9e59-55950dc4bee6)

This is resolved by the changes in this branch.