### PR TITLE
fix: remediate rare server error on developer feed page

### DIFF
--- a/app/Community/Actions/BuildDeveloperFeedDataAction.php
+++ b/app/Community/Actions/BuildDeveloperFeedDataAction.php
@@ -71,6 +71,10 @@ class BuildDeveloperFeedDataAction
         // window function instead of a self-join improves performance from 130-180ms
         // down to ~40ms.
 
+        if (empty($gameIds)) {
+            return 0;
+        }
+
         return DB::table(DB::raw('(
             SELECT *,
                 ROW_NUMBER() OVER (


### PR DESCRIPTION
Resolves this error in the logs:
> SQLSTATE: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')

This occurs if a user has a non-zero `ContribCount` and `ContribYield`, but `$allUserGameIds` is empty.