### PR TITLE
add action for achievementwondata connect api

### DIFF
--- a/app/Connect/Actions/GetAchievementUnlocksAction.php
+++ b/app/Connect/Actions/GetAchievementUnlocksAction.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Connect\Actions;
+
+use App\Connect\Support\BaseAuthenticatedApiAction;
+use App\Models\Achievement;
+use Illuminate\Http\Request;
+
+class GetAchievementUnlocksAction extends BaseAuthenticatedApiAction
+{
+    protected int $achievementId;
+    protected int $offset;
+    protected int $count;
+    protected bool $friendsOnly;
+
+    public function execute(int $achievementId, bool $friendsOnly = false, int $offset = 0, int $count = 10): array
+    {
+        $this->achievementId = $achievementId;
+        $this->friendsOnly = $friendsOnly;
+        $this->offset = $offset;
+        $this->count = $count;
+
+        return $this->process();
+    }
+
+    protected function initialize(Request $request): ?array
+    {
+        if (!$request->has(['a'])) {
+            return $this->missingParameters();
+        }
+
+        $this->achievementId = request()->integer('a', 0);
+        $this->friendsOnly = request()->boolean('f', false);
+        $this->offset = request()->integer('o', 0);
+        $this->count = request()->integer('c', 10);
+
+        return null;
+    }
+
+    protected function process(): array
+    {
+        $achievement = Achievement::query()
+            ->where('ID', $this->achievementId)
+            ->with('game')
+            ->first();
+        if (!$achievement) {
+            return $this->achievementNotFound();
+        }
+
+        $playerAchievements = $achievement->playerAchievements()
+            ->when($this->friendsOnly, function ($q) {
+                $friendIds = $this->user->followedUsers()->pluck('related_user_id');
+                $q->whereIn('user_id', $friendIds);
+            })
+            ->with('user')
+            ->orderByRaw('COALESCE(unlocked_hardcore_at, unlocked_at) DESC')
+            ->offset($this->offset)
+            ->limit($this->count)
+            ->get();
+
+        $recentWinners = [];
+        foreach ($playerAchievements as $playerAchievement) {
+            $recentWinners[] = [
+                'User' => $playerAchievement->user->display_name,
+                'AvatarUrl' => media_asset('UserPic/' . $playerAchievement->user->User . '.png'),
+                'RAPoints' => $playerAchievement->user->RAPoints,
+                'DateAwarded' => $playerAchievement->unlocked_hardcore_at ?
+                    $playerAchievement->unlocked_hardcore_at->unix() :
+                    $playerAchievement->unlocked_at->unix(),
+            ];
+        }
+
+        return [
+            'Success' => true,
+            'AchievementID' => $this->achievementId,
+            'FriendsOnly' => $this->friendsOnly,
+            'Offset' => $this->offset,
+            'Count' => $this->count,
+            'Response' => [
+                'NumEarned' => $achievement->unlocks_total,
+                'GameID' => $achievement->game->ID,
+                'TotalPlayers' => $achievement->game->players_total,
+                'RecentWinner' => $recentWinners,
+            ],
+        ];
+    }
+}

--- a/app/Connect/Support/BaseApiAction.php
+++ b/app/Connect/Support/BaseApiAction.php
@@ -26,16 +26,16 @@ abstract class BaseApiAction
 
     protected function buildResponse(array $result): JsonResponse
     {
-        if (array_key_exists('Status', $result)) {
-            $status = $result['Status'];
-            if ($status === 401) {
-                return response()->json($result, $status)->header('WWW-Authenticate', 'Bearer');
-            }
+        $status = $result['Status'] ?? 200;
+        $response = response()->json($result, $status);
 
-            return response()->json($result, $status);
+        $response->header('Content-Length', (string) strlen($response->getContent()));
+
+        if ($status === 401) {
+            $response->header('WWW-Authenticate', 'Bearer');
         }
 
-        return response()->json($result);
+        return $response;
     }
 
     protected function missingParameters(): array

--- a/app/Connect/Support/BaseApiAction.php
+++ b/app/Connect/Support/BaseApiAction.php
@@ -77,4 +77,14 @@ abstract class BaseApiAction
             'Error' => 'Unknown game.',
         ];
     }
+
+    protected function achievementNotFound(): array
+    {
+        return [
+            'Success' => false,
+            'Status' => 404,
+            'Code' => 'not_found',
+            'Error' => 'Unknown achievement.',
+        ];
+    }
 }

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -4,6 +4,7 @@ use App\Actions\FindUserByIdentifierAction;
 use App\Community\Enums\ActivityType;
 use App\Connect\Actions\BuildClientPatchDataAction;
 use App\Connect\Actions\BuildClientPatchDataV2Action;
+use App\Connect\Actions\GetAchievementUnlocksAction;
 use App\Connect\Actions\GetClientSupportLevelAction;
 use App\Connect\Actions\GetCodeNotesAction;
 use App\Connect\Actions\GetFriendListAction;
@@ -34,6 +35,7 @@ use Illuminate\Support\Carbon;
 
 $requestType = request()->input('r');
 $handler = match ($requestType) {
+    'achievementwondata' => new GetAchievementUnlocksAction(),
     'codenotes2' => new GetCodeNotesAction(),
     'getfriendlist' => new GetFriendListAction(),
     'hashlibrary' => new GetHashLibraryAction(),
@@ -114,10 +116,8 @@ $credentialsOK = match ($requestType) {
     /*
      * Registration required and user=local
      */
-    "achievementwondata",
     "awardachievement",
     "awardachievements",
-    "getfriendlist",
     "patch",
     "ping",
     "postactivity",
@@ -338,15 +338,6 @@ switch ($requestType) {
 
             $response['Success'] = true;
         }
-        break;
-
-    case "achievementwondata":
-        $friendsOnly = (bool) request()->input('f', 0);
-        $response['Offset'] = $offset;
-        $response['Count'] = $count;
-        $response['FriendsOnly'] = $friendsOnly;
-        $response['AchievementID'] = $achievementID;
-        $response['Response'] = getRecentUnlocksPlayersData($achievementID, $offset, $count, $username, $friendsOnly);
         break;
 
     case "awardachievement":

--- a/tests/Feature/Connect/AchievementWonDataTest.php
+++ b/tests/Feature/Connect/AchievementWonDataTest.php
@@ -70,6 +70,7 @@ class AchievementWonDataTest extends TestCase
 
         // first achievement - 5 most recent
         $this->get($this->apiUrl('achievementwondata', ['a' => $achievement1->ID, 'c' => 5]))
+            ->assertStatus(200)
             ->assertExactJson([
                 'Success' => true,
                 'Offset' => 0,
@@ -92,6 +93,7 @@ class AchievementWonDataTest extends TestCase
 
         // first achievement - offset and ask for more than available
         $this->get($this->apiUrl('achievementwondata', ['a' => $achievement1->ID, 'o' => 12, 'c' => 6]))
+            ->assertStatus(200)
             ->assertExactJson([
                 'Success' => true,
                 'Offset' => 12,
@@ -111,6 +113,7 @@ class AchievementWonDataTest extends TestCase
 
         // other achievement - different earn rate/winners
         $this->get($this->apiUrl('achievementwondata', ['a' => $achievement2->ID, 'o' => 3, 'c' => 4]))
+            ->assertStatus(200)
             ->assertExactJson([
                 'Success' => true,
                 'Offset' => 3,
@@ -132,6 +135,7 @@ class AchievementWonDataTest extends TestCase
 
         // third achievement - no unlocks
         $this->get($this->apiUrl('achievementwondata', ['a' => $achievement3->ID]))
+            ->assertStatus(200)
             ->assertExactJson([
                 'Success' => true,
                 'Offset' => 0,
@@ -148,18 +152,12 @@ class AchievementWonDataTest extends TestCase
 
         // non-existent achievement
         $this->get($this->apiUrl('achievementwondata', ['a' => 999999]))
+            ->assertStatus(404)
             ->assertExactJson([
-                'Success' => true,
-                'Offset' => 0,
-                'Count' => 10,
-                'FriendsOnly' => false,
-                'AchievementID' => 999999,
-                'Response' => [
-                    'NumEarned' => 0,
-                    'GameID' => 0,
-                    'TotalPlayers' => 0,
-                    'RecentWinner' => [],
-                ],
+                'Success' => false,
+                'Status' => 404,
+                'Code' => 'not_found',
+                'Error' => 'Unknown achievement.',
             ]);
 
         // second achievement - friends only
@@ -177,6 +175,7 @@ class AchievementWonDataTest extends TestCase
         ]);
 
         $this->get($this->apiUrl('achievementwondata', ['a' => $achievement2->ID, 'f' => 1]))
+            ->assertStatus(200)
             ->assertExactJson([
                 'Success' => true,
                 'Offset' => 0,


### PR DESCRIPTION
* Converted `getRecentUnlocksPlayersData` to eloquent.
* Added `Content-Length` header to response (as suggested in #3634).
* Changed the response for an unknown achievement ID to return 404 instead of success with no unlocks.