### PR TITLE
fix: delete player stats when daily/weekly points reach zero

### DIFF
--- a/app/Platform/Actions/UpdatePlayerPointsStatsAction.php
+++ b/app/Platform/Actions/UpdatePlayerPointsStatsAction.php
@@ -89,8 +89,9 @@ class UpdatePlayerPointsStatsAction
 
     /**
      * This function will either perform a create, edit, or delete:
-     * - If no record exists, we'll create.
-     * - If a record already exists, has a non-zero value, and is receiving a new non-zero value, we'll update.
+     * - If no record exists and points > 0, we'll create.
+     * - If a record exists and points > 0, we'll update.
+     * - If a record exists and points = 0, we'll delete.
      */
     private function writePlayerPointsStat(
         User $user,
@@ -101,8 +102,12 @@ class UpdatePlayerPointsStatsAction
         $existingPlayerStat = PlayerStat::where($attributes)->first();
 
         if ($existingPlayerStat) {
-            $existingPlayerStat->value = $points;
-            $existingPlayerStat->save();
+            if ($points === 0) {
+                $existingPlayerStat->delete();
+            } else {
+                $existingPlayerStat->value = $points;
+                $existingPlayerStat->save();
+            }
         } elseif ($points !== 0) {
             PlayerStat::create(array_merge($attributes, ['value' => $points]));
         }

--- a/app/Platform/Actions/UpdatePlayerPointsStatsBatchAction.php
+++ b/app/Platform/Actions/UpdatePlayerPointsStatsBatchAction.php
@@ -88,20 +88,47 @@ class UpdatePlayerPointsStatsBatchAction
             }
         }
 
-        // Get existing stats to check for changes.
+        // Get existing stats to check for needed changes and/or deletions.
+        $statTypes = array_merge(
+            array_values(static::PERIOD_MAP['day']),
+            array_values(static::PERIOD_MAP['week'])
+        );
+
         $existingStats = PlayerStat::whereIn('user_id', $trackedUserIds)
-            ->whereIn('type', array_merge(
-                array_values(static::PERIOD_MAP['day']),
-                array_values(static::PERIOD_MAP['week'])
-            ))
-            ->get()
-            ->mapWithKeys(fn ($stat) => ["{$stat->user_id}:{$stat->type}" => $stat->value]);
+            ->whereIn('type', $statTypes)
+            ->get();
 
-        // Filter out unchanged stats.
-        $statsToUpsert = collect($bulkStats)->filter(function ($stat) use ($existingStats) {
+        $existingStatsMap = $existingStats->mapWithKeys(fn ($stat) => ["{$stat->user_id}:{$stat->type}" => $stat]);
+
+        // Build a map of stats that should exist (non-zero values).
+        $expectedStatsMap = collect($bulkStats)->mapWithKeys(fn ($stat) => ["{$stat['user_id']}:{$stat['type']}" => $stat]);
+
+        // Find stats to delete (already existing records, but should now be 0).
+        $statsToDelete = [];
+        foreach ($trackedUserIds as $userId) {
+            foreach ($statTypes as $statType) {
+                $key = "{$userId}:{$statType}";
+                if ($existingStatsMap->has($key) && !$expectedStatsMap->has($key)) {
+                    $statsToDelete[] = ['user_id' => $userId, 'type' => $statType];
+                }
+            }
+        }
+
+        // Delete stats that should now be 0.
+        if (!empty($statsToDelete)) {
+            foreach ($statsToDelete as $stat) {
+                PlayerStat::where('user_id', $stat['user_id'])
+                    ->where('type', $stat['type'])
+                    ->delete();
+            }
+        }
+
+        // Filter out unchanged stats for upsert.
+        $statsToUpsert = collect($bulkStats)->filter(function ($stat) use ($existingStatsMap) {
             $key = "{$stat['user_id']}:{$stat['type']}";
+            $existing = $existingStatsMap->get($key);
 
-            return !$existingStats->has($key) || $existingStats->get($key) !== $stat['value'];
+            return !$existing || $existing->value !== $stat['value'];
         })->values()->toArray();
 
         // Perform the bulk upsert.


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/752271759138357249/1384218456009998456

Player stats for daily and weekly periods are not currently being properly reset when a new time window (daily/weekly) begins. This causes stale data to appear in followed user leaderboards on user profiles, showing previous day/week values when users haven't earned points in the current daily/weekly time period.

This PR ensures that when points calculate to 0 for a given time period, the corresponding stat records are deleted rather than left unchanged. This should properly handle the rollover the start of each new day/week.