### PR TITLE
fix(ShortcodeSpoiler): respect dynamic content height

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
 
   php-checks:
     needs: changes
-    if: ${{ needs.changes.outputs.php == 'true' }}
     runs-on: ubuntu-22.04
     name: PHP Checks
     strategy:
@@ -74,9 +73,11 @@ jobs:
           - check: test
             command: composer paratest -- --processes=$(nproc)
     steps:
-      - name: Check PHP changes
+      - name: Skip if no PHP changes
         if: ${{ needs.changes.outputs.php != 'true' }}
-        run: echo "No PHP changes; skipping checks" && exit 0
+        run: |
+          echo "No PHP changes detected - skipping ${{ matrix.check }}"
+          exit 0
 
       - name: Checkout code
         if: ${{ needs.changes.outputs.php == 'true' }}
@@ -130,9 +131,11 @@ jobs:
           - check: lint
             command: pnpm lint
     steps:
-      - name: Check Node changes
+      - name: Skip if no Node changes
         if: ${{ needs.changes.outputs.node != 'true' }}
-        run: echo "No Node changes; skipping checks" && exit 0
+        run: |
+          echo "No Node changes detected - skipping ${{ matrix.check }}"
+          exit 0
 
       - name: Checkout code
         if: ${{ needs.changes.outputs.node == 'true' }}
@@ -165,31 +168,41 @@ jobs:
     needs: [changes, node-setup]
     runs-on: ubuntu-22.04
     name: Node.js Checks (test)
-    if: ${{ needs.changes.outputs.node == 'true' }}
     strategy:
       matrix:
         shardIndex: [1, 2, 3, 4, 5]
         shardTotal: [5]
     steps:
+      - name: Skip if no Node changes
+        if: ${{ needs.changes.outputs.node != 'true' }}
+        run: |
+          echo "No Node changes detected - skipping tests (shard ${{ matrix.shardIndex }})"
+          exit 0
+
       - name: Checkout code
+        if: ${{ needs.changes.outputs.node == 'true' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Install pnpm
+        if: ${{ needs.changes.outputs.node == 'true' }}
         uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Use Node 20
+        if: ${{ needs.changes.outputs.node == 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install dependencies
+        if: ${{ needs.changes.outputs.node == 'true' }}
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run tests with sharding
+        if: ${{ needs.changes.outputs.node == 'true' }}
         run: pnpm test:run --coverage --coverage.thresholds=false --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           VITE_BUILD_PATH: dist
@@ -197,7 +210,7 @@ jobs:
           LARAVEL_BYPASS_ENV_CHECK: 1
 
       - name: Upload blob report
-        if: ${{ !cancelled() }}
+        if: ${{ needs.changes.outputs.node == 'true' && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: blob-report-${{ matrix.shardIndex }}

--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeSpoiler/ShortcodeSpoiler.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeSpoiler/ShortcodeSpoiler.tsx
@@ -1,5 +1,3 @@
-import { AnimatePresence } from 'motion/react';
-import * as m from 'motion/react-m';
 import { type FC, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LuChevronDown } from 'react-icons/lu';
@@ -22,7 +20,7 @@ interface ShortcodeSpoilerProps {
 export const ShortcodeSpoiler: FC<ShortcodeSpoilerProps> = ({ children }) => {
   const { t } = useTranslation();
 
-  const { contentHeight, contentRef, isOpen, setIsOpen } = useAnimatedCollapse();
+  const { isOpen, setIsOpen } = useAnimatedCollapse();
 
   return (
     <BaseCollapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -42,26 +40,20 @@ export const ShortcodeSpoiler: FC<ShortcodeSpoilerProps> = ({ children }) => {
         </BaseButton>
       </BaseCollapsibleTrigger>
 
-      <AnimatePresence initial={false}>
-        {isOpen ? (
-          <BaseCollapsibleContent forceMount asChild>
-            <m.div
-              initial={{ height: 0 }}
-              animate={{ height: contentHeight }}
-              exit={{ height: 0 }}
-              transition={{
-                duration: 0.3,
-                ease: [0.4, 0, 0.2, 1], // Custom easing curve for natural motion.
-              }}
-              className="overflow-hidden"
-            >
-              <div ref={contentRef} className="rounded-b-lg rounded-tr-lg bg-embed px-3 py-2">
-                {stripLeadingWhitespaceFromChildren(children)}
-              </div>
-            </m.div>
-          </BaseCollapsibleContent>
-        ) : null}
-      </AnimatePresence>
+      <BaseCollapsibleContent forceMount>
+        <div
+          className={cn(
+            'grid transition-[grid-template-rows] duration-300 ease-in-out',
+            isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+          )}
+        >
+          <div className="overflow-hidden">
+            <div className="rounded-b-lg rounded-tr-lg bg-embed px-3 py-2">
+              {stripLeadingWhitespaceFromChildren(children)}
+            </div>
+          </div>
+        </div>
+      </BaseCollapsibleContent>
     </BaseCollapsible>
   );
 };


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/3642.

`ShortcodeSpoiler` currently doesn't respect the dynamic height of its content. I've tweaked the CSS so it now does.
Easy to repro at http://localhost:64000/forums/topic/19615?comment=144996#144996.

**Before**
![Screenshot 2025-06-18 at 7 57 45 PM](https://github.com/user-attachments/assets/771b45a2-f2d4-48cf-930a-e74798427503)


**After**
![Screenshot 2025-06-18 at 7 56 40 PM](https://github.com/user-attachments/assets/25678cd1-4567-42e7-ad81-1ea623549ebc)
