### PR TITLE
feat(game): add meta description to React game pages

### DIFF
--- a/resources/js/features/games/utils/buildGameMetaDescription.test.ts
+++ b/resources/js/features/games/utils/buildGameMetaDescription.test.ts
@@ -1,0 +1,33 @@
+import { createGame, createSystem } from '@/test/factories';
+
+import { buildGameMetaDescription } from './buildGameMetaDescription';
+
+describe('Util: buildGameMetaDescription', () => {
+  it('is defined', () => {
+    // ASSERT
+    expect(buildGameMetaDescription).toBeDefined();
+  });
+
+  it('given the game has no achievements published, outputs the correct message', () => {
+    // ARRANGE
+    const game = createGame({ achievementsPublished: 0 });
+
+    // ACT
+    const result = buildGameMetaDescription(game);
+
+    // ASSERT
+    expect(result).toContain('No achievements have been created yet');
+  });
+
+  it('given the game has achievements published, outputs the correct message', () => {
+    // ARRANGE
+    const system = createSystem();
+    const game = createGame({ system, achievementsPublished: 100, pointsTotal: 800 });
+
+    // ACT
+    const result = buildGameMetaDescription(game);
+
+    // ASSERT
+    expect(result).toContain('There are 100 achievements');
+  });
+});

--- a/resources/js/features/games/utils/buildGameMetaDescription.ts
+++ b/resources/js/features/games/utils/buildGameMetaDescription.ts
@@ -1,0 +1,7 @@
+export function buildGameMetaDescription(game: App.Platform.Data.Game): string {
+  if (!game.achievementsPublished) {
+    return `No achievements have been created yet for ${game.title}. Join RetroAchievements to request achievements for this game and earn achievements on many other classic games.`;
+  }
+
+  return `There are ${game.achievementsPublished} achievements worth ${game.pointsTotal!.toLocaleString()}. ${game.title} for ${game.system!.name} - explore and compete on this classic game at RetroAchievements.`;
+}

--- a/resources/js/pages/game/[game].tsx
+++ b/resources/js/pages/game/[game].tsx
@@ -4,6 +4,7 @@ import { AppLayout } from '@/common/layouts/AppLayout';
 import type { AppPage } from '@/common/models';
 import { GameShowMainRoot } from '@/features/games/components/+show';
 import { GameShowSidebarRoot } from '@/features/games/components/+show-sidebar';
+import { buildGameMetaDescription } from '@/features/games/utils/buildGameMetaDescription';
 import type { TranslatedString } from '@/types/i18next';
 
 const GameShow: AppPage = () => {
@@ -13,7 +14,11 @@ const GameShow: AppPage = () => {
 
   return (
     <>
-      <SEO title={title as TranslatedString} description="TODO" ogImage={game!.badgeUrl} />
+      <SEO
+        title={title as TranslatedString}
+        description={buildGameMetaDescription(game)}
+        ogImage={game!.badgeUrl}
+      />
 
       <AppLayout.Main>
         <GameShowMainRoot />


### PR DESCRIPTION
This PR adds a meta description to React game pages. It is identical to the current meta description used on _gameInfo.blade.php_.