### PR TITLE
perf: don't run scheduled commands in non-prod envs

### DIFF
--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -151,14 +151,15 @@ class AppServiceProvider extends ServiceProvider
             /** @var Schedule $schedule */
             $schedule = $this->app->make(Schedule::class);
 
+            $schedule->command(UpdateSearchIndexForQueuedEntities::class)->twiceDaily(1, 13); // 1AM and 1PM UTC
+            $schedule->command(DeleteStalePlayerPointsStatsEntries::class)->weekly();
+
             if (app()->environment() === 'production') {
                 $schedule->command(UpdateAwardsStaticData::class)->everyMinute();
                 $schedule->command(CrawlPlayerWeightedPoints::class)->everyFiveMinutes();
                 $schedule->command(BackfillPlaytimeTotal::class)->everyTenMinutes();
                 $schedule->command(UpdatePlayerPointsStats::class, ['--existing-only'])->hourly();
                 $schedule->command(ProcessExpiringClaims::class)->hourly();
-                $schedule->command(UpdateSearchIndexForQueuedEntities::class)->twiceDaily(1, 13); // 1AM and 1PM UTC
-                $schedule->command(DeleteStalePlayerPointsStatsEntries::class)->weekly();
                 $schedule->command(UpdateDeveloperContributionYield::class)->weeklyOn(2, '10:00'); // Tuesdays at 10AM UTC
             }
         });

--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -151,14 +151,16 @@ class AppServiceProvider extends ServiceProvider
             /** @var Schedule $schedule */
             $schedule = $this->app->make(Schedule::class);
 
-            $schedule->command(UpdateAwardsStaticData::class)->everyMinute();
-            $schedule->command(CrawlPlayerWeightedPoints::class)->everyFiveMinutes();
-            $schedule->command(BackfillPlaytimeTotal::class)->everyTenMinutes();
-            $schedule->command(UpdatePlayerPointsStats::class, ['--existing-only'])->hourly();
-            $schedule->command(ProcessExpiringClaims::class)->hourly();
-            $schedule->command(UpdateSearchIndexForQueuedEntities::class)->twiceDaily(1, 13); // 1AM and 1PM UTC
-            $schedule->command(DeleteStalePlayerPointsStatsEntries::class)->weekly();
-            $schedule->command(UpdateDeveloperContributionYield::class)->weeklyOn(2, '10:00'); // Tuesdays at 10AM UTC
+            if (app()->environment() === 'production') {
+                $schedule->command(UpdateAwardsStaticData::class)->everyMinute();
+                $schedule->command(CrawlPlayerWeightedPoints::class)->everyFiveMinutes();
+                $schedule->command(BackfillPlaytimeTotal::class)->everyTenMinutes();
+                $schedule->command(UpdatePlayerPointsStats::class, ['--existing-only'])->hourly();
+                $schedule->command(ProcessExpiringClaims::class)->hourly();
+                $schedule->command(UpdateSearchIndexForQueuedEntities::class)->twiceDaily(1, 13); // 1AM and 1PM UTC
+                $schedule->command(DeleteStalePlayerPointsStatsEntries::class)->weekly();
+                $schedule->command(UpdateDeveloperContributionYield::class)->weeklyOn(2, '10:00'); // Tuesdays at 10AM UTC
+            }
         });
 
         $this->loadMigrationsFrom([database_path('migrations/platform')]);

--- a/app/Platform/Commands/BackfillPlaytimeTotal.php
+++ b/app/Platform/Commands/BackfillPlaytimeTotal.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Log;
 class BackfillPlaytimeTotal extends Command
 {
     protected $signature = 'ra:platform:player:backfill-playtime-total
-                            {count=750 : The number of playtime_total entries to backfill}';
+                            {count=1000 : The number of playtime_total entries to backfill}';
     protected $description = 'Find player_game records without a playtime_total and calculate it for them';
 
     public function handle(): void

--- a/app/Platform/Commands/BackfillPlaytimeTotal.php
+++ b/app/Platform/Commands/BackfillPlaytimeTotal.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Log;
 class BackfillPlaytimeTotal extends Command
 {
     protected $signature = 'ra:platform:player:backfill-playtime-total
-                            {count=1000 : The number of playtime_total entries to backfill}';
+                            {count=750 : The number of playtime_total entries to backfill}';
     protected $description = 'Find player_game records without a playtime_total and calculate it for them';
 
     public function handle(): void

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -74,13 +74,15 @@ class AppServiceProvider extends ServiceProvider
         $this->app->booted(function () {
             $schedule = $this->app->make(Schedule::class);
 
-            $schedule->command(LogUsersOnlineCount::class)->everyThirtyMinutes();
+            if (app()->environment() === 'production') {
+                $schedule->command(LogUsersOnlineCount::class)->everyThirtyMinutes();
 
-            $schedule->command(DeleteExpiredEmailVerificationTokens::class)->daily();
-            $schedule->command(DeleteOverdueUserAccounts::class)->daily();
+                $schedule->command(DeleteExpiredEmailVerificationTokens::class)->daily();
+                $schedule->command(DeleteOverdueUserAccounts::class)->daily();
 
-            $schedule->command(CacheMostPopularEmulators::class)->weeklyOn(4, '8:00'); // Thursdays, ~3:00AM US Eastern
-            $schedule->command(CacheMostPopularSystems::class)->weeklyOn(4, '8:30'); // Thursdays, ~3:30AM US Eastern
+                $schedule->command(CacheMostPopularEmulators::class)->weeklyOn(4, '8:00'); // Thursdays, ~3:00AM US Eastern
+                $schedule->command(CacheMostPopularSystems::class)->weeklyOn(4, '8:30'); // Thursdays, ~3:30AM US Eastern
+            }
         });
 
         Blade::if('hasfeature', function ($feature) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -74,9 +74,9 @@ class AppServiceProvider extends ServiceProvider
         $this->app->booted(function () {
             $schedule = $this->app->make(Schedule::class);
 
-            if (app()->environment() === 'production') {
-                $schedule->command(LogUsersOnlineCount::class)->everyThirtyMinutes();
+            $schedule->command(LogUsersOnlineCount::class)->everyThirtyMinutes();
 
+            if (app()->environment() === 'production') {
                 $schedule->command(DeleteExpiredEmailVerificationTokens::class)->daily();
                 $schedule->command(DeleteOverdueUserAccounts::class)->daily();
 


### PR DESCRIPTION
This PR ever-so-slightly reduces these batch sizes from 1,000 to 750.

Prod was unresponsive for 60s+ [earlier today](https://discord.com/channels/476211979464343552/1026273695133605888/1385286039744282708), with CPU briefly pinned at 100%.

There was a significant plateau overnight where CPU was also pinned:
![Screenshot 2025-06-19 at 7 31 09 PM](https://github.com/user-attachments/assets/7f99a1e5-7640-438e-92bc-1872d7ccbdcc)

I'm hoping lowering from 1,000 to 750 takes a little bit of the edge off.