### PR TITLE
fix(manage): don't allow adding tags on alt game titles

### DIFF
--- a/app/Filament/Resources/GameResource/RelationManagers/ReleasesRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/ReleasesRelationManager.php
@@ -65,7 +65,15 @@ class ReleasesRelationManager extends RelationManager
                 Forms\Components\TextInput::make('title')
                     ->required()
                     ->maxLength(80)
-                    ->label('Title'),
+                    ->label('Title')
+                    ->rules([
+                        fn (Get $get) => function ($attribute, $value, $fail) use ($get) {
+                            // If this is not a canonical title and it has a tag prefix, fail validation.
+                            if (!$get('is_canonical_game_title') && preg_match('/^~[^~]+~/', $value)) {
+                                $fail('Only canonical titles can have tag prefixes like "Unlicensed" or "Homebrew".');
+                            }
+                        },
+                    ]),
 
                 Forms\Components\Toggle::make('is_canonical_game_title')
                     ->label('Is Canonical Title')

--- a/app/Filament/Resources/GameResource/RelationManagers/ReleasesRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/ReleasesRelationManager.php
@@ -219,9 +219,19 @@ class ReleasesRelationManager extends RelationManager
                     ->mutateFormDataUsing(function (array $data) {
                         // If this is marked as canonical, unmark any other canonical titles.
                         if ($data['is_canonical_game_title'] ?? false) {
-                            GameRelease::where('game_id', $this->getOwnerRecord()->id)
+                            // Find existing canonical titles and remove their canonical status.
+                            $existingCanonical = GameRelease::where('game_id', $this->getOwnerRecord()->id)
                                 ->where('is_canonical_game_title', true)
-                                ->update(['is_canonical_game_title' => false]);
+                                ->get();
+
+                            foreach ($existingCanonical as $release) {
+                                // Strip any tag prefixes when removing the canonical status.
+                                $titleWithoutTag = preg_replace('/^~[^~]+~\s*/', '', $release->title);
+                                $release->update([
+                                    'is_canonical_game_title' => false,
+                                    'title' => $titleWithoutTag,
+                                ]);
+                            }
                         }
 
                         return $data;
@@ -244,10 +254,20 @@ class ReleasesRelationManager extends RelationManager
                     ->mutateFormDataUsing(function (array $data, GameRelease $record) {
                         // If this is now marked as canonical and wasn't before, unmark any other canonical titles.
                         if (($data['is_canonical_game_title'] ?? false) && !$record->is_canonical_game_title) {
-                            GameRelease::where('game_id', $this->getOwnerRecord()->id)
+                            // Find existing canonical titles and remove their canonical status.
+                            $existingCanonical = GameRelease::where('game_id', $this->getOwnerRecord()->id)
                                 ->where('id', '!=', $record->id)
                                 ->where('is_canonical_game_title', true)
-                                ->update(['is_canonical_game_title' => false]);
+                                ->get();
+
+                            foreach ($existingCanonical as $release) {
+                                // Strip any tag prefixes when removing the canonical status.
+                                $titleWithoutTag = preg_replace('/^~[^~]+~\s*/', '', $release->title);
+                                $release->update([
+                                    'is_canonical_game_title' => false,
+                                    'title' => $titleWithoutTag,
+                                ]);
+                            }
                         }
 
                         return $data;


### PR DESCRIPTION
**Post-deploy SQL:**
```sql
-- remove tags from all non-canonical game titles
UPDATE game_releases
SET
	title = TRIM(SUBSTRING(title, LOCATE('~', title, 2) + 1))
WHERE
	title LIKE '~%~%'
	AND is_canonical_game_title = 0;
```

---

This PR:
* Adds validation such that tags cannot be added to game non-canonical titles.
* When creating a canonical title or setting an existing title to be the canonical one, strips any pre-existing tags from the current canonical title on save.
* De-dupes titles on the game page regardless of whether or not they are tagged.

![Screenshot 2025-06-20 at 1 05 26 PM](https://github.com/user-attachments/assets/9357826b-9116-4cb3-a037-fed9ecbbc065)

https://github.com/RetroAchievements/RAWeb/pull/3645 will likely need a deduping fix as well. I'll probably merge that PR and do the fix in a followup.