### PR TITLE
fix(getNonCanonicalTitles): improve deduping for tagged game titles

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -931,6 +931,8 @@
     "Missable": "Missable",
     "In game:": "In game:",
     "Recently played:": "Recently played:",
+    "metaOtherName_other": "Other Names",
+    "metaOtherName_one": "Other Name",
     "metaDeveloper_other": "Developers",
     "metaDeveloper_one": "Developer",
     "metaPublisher_other": "Publishers",

--- a/resources/js/features/games/components/GameMetadata/GameMetadata.test.tsx
+++ b/resources/js/features/games/components/GameMetadata/GameMetadata.test.tsx
@@ -277,4 +277,23 @@ describe('Component: GameMetadata', () => {
 
     expect(screen.queryByRole('button', { name: /see more/i })).not.toBeInTheDocument();
   });
+
+  it('given the game has unique non-canonical titles, displays a row for them', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({ title: 'Final Fantasy VII', isCanonicalGameTitle: true }),
+      createGameRelease({ title: 'FF7', isCanonicalGameTitle: false }),
+    ];
+
+    render(
+      <GameMetadata
+        allMetaRowElements={createMockMetaRowElements() as any}
+        game={createGame({ releases })}
+        hubs={[]}
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByText(/other name/i)).toBeVisible();
+  });
 });

--- a/resources/js/features/games/components/GameMetadata/GameMetadata.tsx
+++ b/resources/js/features/games/components/GameMetadata/GameMetadata.tsx
@@ -13,7 +13,9 @@ import { cleanHubTitle } from '@/common/utils/cleanHubTitle';
 import { cn } from '@/common/utils/cn';
 
 import type { useAllMetaRowElements } from '../../hooks/useAllMetaRowElements';
+import { getNonCanonicalTitles } from '../../utils/getNonCanonicalTitles';
 import { GameMetadataRow } from './GameMetadataRow';
+import { GameOtherNamesRow } from './GameOtherNamesRow';
 import { GameReleaseDatesRow } from './GameReleaseDatesRow';
 
 interface GameMetadataProps {
@@ -80,6 +82,7 @@ export const GameMetadata: FC<GameMetadataProps> = ({ allMetaRowElements, game, 
       !publisherRowElements.every((el) => el.label.includes('Hack -')));
 
   const gameReleasesWithDates = game.releases?.filter((r) => r.releasedAt);
+  const allNonCanonicalTitles = getNonCanonicalTitles(game.releases);
 
   return (
     <div className="rounded-lg bg-embed p-1 light:border light:border-neutral-200 light:bg-white">
@@ -105,6 +108,10 @@ export const GameMetadata: FC<GameMetadataProps> = ({ allMetaRowElements, game, 
 
           {gameReleasesWithDates?.length ? (
             <GameReleaseDatesRow releases={gameReleasesWithDates} />
+          ) : null}
+
+          {allNonCanonicalTitles?.length ? (
+            <GameOtherNamesRow nonCanonicalTitles={allNonCanonicalTitles} />
           ) : null}
 
           <GameMetadataRow

--- a/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.test.tsx
+++ b/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@/test';
+
+import { GameOtherNamesRow } from './GameOtherNamesRow';
+
+describe('Component: GameOtherNamesRow', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const { container } = render(<GameOtherNamesRow nonCanonicalTitles={[]} />);
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given a single title, displays the title', () => {
+    // ARRANGE
+    const titles = ['Zelda II: The Adventure of Link'];
+
+    // ACT
+    render(<GameOtherNamesRow nonCanonicalTitles={titles} />);
+
+    // ASSERT
+    expect(screen.getByText(/zelda ii: the adventure of link/i)).toBeVisible();
+  });
+
+  it('given multiple titles, displays all titles', () => {
+    // ARRANGE
+    const titles = ['Super Mario Bros.', 'Super Mario Brothers', 'SMB'];
+
+    // ACT
+    render(<GameOtherNamesRow nonCanonicalTitles={titles} />);
+
+    // ASSERT
+    expect(screen.getByText(/super mario bros\./i)).toBeVisible();
+    expect(screen.getByText(/super mario brothers/i)).toBeVisible();
+    expect(screen.getByText(/smb/i)).toBeVisible();
+  });
+});

--- a/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.test.tsx
+++ b/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.test.tsx
@@ -1,3 +1,4 @@
+import { BaseTable, BaseTableBody } from '@/common/components/+vendor/BaseTable';
 import { render, screen } from '@/test';
 
 import { GameOtherNamesRow } from './GameOtherNamesRow';
@@ -5,7 +6,13 @@ import { GameOtherNamesRow } from './GameOtherNamesRow';
 describe('Component: GameOtherNamesRow', () => {
   it('renders without crashing', () => {
     // ARRANGE
-    const { container } = render(<GameOtherNamesRow nonCanonicalTitles={[]} />);
+    const { container } = render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameOtherNamesRow nonCanonicalTitles={[]} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     expect(container).toBeTruthy();
@@ -15,8 +22,13 @@ describe('Component: GameOtherNamesRow', () => {
     // ARRANGE
     const titles = ['Zelda II: The Adventure of Link'];
 
-    // ACT
-    render(<GameOtherNamesRow nonCanonicalTitles={titles} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameOtherNamesRow nonCanonicalTitles={titles} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     expect(screen.getByText(/zelda ii: the adventure of link/i)).toBeVisible();
@@ -26,8 +38,13 @@ describe('Component: GameOtherNamesRow', () => {
     // ARRANGE
     const titles = ['Super Mario Bros.', 'Super Mario Brothers', 'SMB'];
 
-    // ACT
-    render(<GameOtherNamesRow nonCanonicalTitles={titles} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameOtherNamesRow nonCanonicalTitles={titles} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     expect(screen.getByText(/super mario bros\./i)).toBeVisible();

--- a/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.test.tsx
+++ b/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.test.tsx
@@ -51,4 +51,46 @@ describe('Component: GameOtherNamesRow', () => {
     expect(screen.getByText(/super mario brothers/i)).toBeVisible();
     expect(screen.getByText(/smb/i)).toBeVisible();
   });
+
+  it('given exactly 4 titles, displays all titles without a tooltip', () => {
+    // ARRANGE
+    const titles = ['Title 1', 'Title 2', 'Title 3', 'Title 4'];
+
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameOtherNamesRow nonCanonicalTitles={titles} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
+
+    // ASSERT
+    expect(screen.getByText(/title 1/i)).toBeVisible();
+    expect(screen.getByText(/title 2/i)).toBeVisible();
+    expect(screen.getByText(/title 3/i)).toBeVisible();
+    expect(screen.getByText(/title 4/i)).toBeVisible();
+    expect(screen.queryByText(/more/i)).not.toBeInTheDocument();
+  });
+
+  it('given 5 titles, displays the first 3 titles and shows "+2 more" tooltip trigger', () => {
+    // ARRANGE
+    const titles = ['Title 1', 'Title 2', 'Title 3', 'Title 4', 'Title 5'];
+
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameOtherNamesRow nonCanonicalTitles={titles} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
+
+    // ASSERT
+    expect(screen.getByText(/title 1/i)).toBeVisible();
+    expect(screen.getByText(/title 2/i)).toBeVisible();
+    expect(screen.getByText(/title 3/i)).toBeVisible();
+    expect(screen.getByText(/\+2 more/i)).toBeVisible();
+
+    expect(screen.queryByText(/title 4/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/title 5/i)).not.toBeInTheDocument();
+  });
 });

--- a/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.tsx
+++ b/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.tsx
@@ -1,0 +1,28 @@
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { BaseTableCell, BaseTableRow } from '@/common/components/+vendor/BaseTable';
+
+interface GameOtherNamesRowProps {
+  nonCanonicalTitles: string[];
+}
+
+export const GameOtherNamesRow: FC<GameOtherNamesRowProps> = ({ nonCanonicalTitles }) => {
+  const { t } = useTranslation();
+
+  return (
+    <BaseTableRow className="first:rounded-t-lg last:rounded-b-lg">
+      <BaseTableCell className="whitespace-nowrap text-right align-top">
+        {t('metaOtherName', { count: nonCanonicalTitles.length })}
+      </BaseTableCell>
+
+      <BaseTableCell>
+        <div className="flex flex-col">
+          {nonCanonicalTitles.map((title, titleIndex) => (
+            <span key={`title-${titleIndex}`}>{title}</span>
+          ))}
+        </div>
+      </BaseTableCell>
+    </BaseTableRow>
+  );
+};

--- a/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.tsx
+++ b/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/GameOtherNamesRow.tsx
@@ -2,6 +2,11 @@ import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { BaseTableCell, BaseTableRow } from '@/common/components/+vendor/BaseTable';
+import {
+  BaseTooltip,
+  BaseTooltipContent,
+  BaseTooltipTrigger,
+} from '@/common/components/+vendor/BaseTooltip';
 
 interface GameOtherNamesRowProps {
   nonCanonicalTitles: string[];
@@ -9,6 +14,13 @@ interface GameOtherNamesRowProps {
 
 export const GameOtherNamesRow: FC<GameOtherNamesRowProps> = ({ nonCanonicalTitles }) => {
   const { t } = useTranslation();
+
+  // Determine how many titles to display based on the total count.
+  const totalCount = nonCanonicalTitles.length;
+  const displayLimit = totalCount <= 4 ? totalCount : 3;
+  const displayedTitles = nonCanonicalTitles.slice(0, displayLimit);
+  const hiddenTitles = nonCanonicalTitles.slice(displayLimit);
+  const hiddenCount = hiddenTitles.length;
 
   return (
     <BaseTableRow className="first:rounded-t-lg last:rounded-b-lg">
@@ -18,9 +30,27 @@ export const GameOtherNamesRow: FC<GameOtherNamesRowProps> = ({ nonCanonicalTitl
 
       <BaseTableCell>
         <div className="flex flex-col">
-          {nonCanonicalTitles.map((title, titleIndex) => (
+          {displayedTitles.map((title, titleIndex) => (
             <span key={`title-${titleIndex}`}>{title}</span>
           ))}
+
+          {hiddenCount > 0 ? (
+            <BaseTooltip>
+              <BaseTooltipTrigger asChild>
+                <span className="max-w-fit text-neutral-400 underline decoration-dotted light:text-neutral-700">
+                  {t('+{{val, number}} more', { val: hiddenCount })}
+                </span>
+              </BaseTooltipTrigger>
+
+              <BaseTooltipContent className="max-w-xs">
+                <div className="flex flex-col gap-1">
+                  {hiddenTitles.map((title, titleIndex) => (
+                    <span key={`hidden-title-${titleIndex}`}>{title}</span>
+                  ))}
+                </div>
+              </BaseTooltipContent>
+            </BaseTooltip>
+          ) : null}
         </div>
       </BaseTableCell>
     </BaseTableRow>

--- a/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/index.ts
+++ b/resources/js/features/games/components/GameMetadata/GameOtherNamesRow/index.ts
@@ -1,0 +1,1 @@
+export * from './GameOtherNamesRow';

--- a/resources/js/features/games/components/GameMetadata/GameReleaseDatesRow/GameReleaseDatesRow.test.tsx
+++ b/resources/js/features/games/components/GameMetadata/GameReleaseDatesRow/GameReleaseDatesRow.test.tsx
@@ -1,3 +1,4 @@
+import { BaseTable, BaseTableBody } from '@/common/components/+vendor/BaseTable';
 import { render, screen } from '@/test';
 import { createGameRelease } from '@/test/factories';
 
@@ -6,7 +7,13 @@ import { GameReleaseDatesRow } from './GameReleaseDatesRow';
 describe('Component: GameReleaseDatesRow', () => {
   it('renders without crashing', () => {
     // ARRANGE
-    const { container } = render(<GameReleaseDatesRow releases={[]} />);
+    const { container } = render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={[]} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     expect(container).toBeTruthy();
@@ -14,13 +21,21 @@ describe('Component: GameReleaseDatesRow', () => {
 
   it('given a single worldwide release, does not show the region code', () => {
     // ARRANGE
-    const release = createGameRelease({
-      region: 'worldwide',
-      releasedAt: '2023-01-15T00:00:00Z',
-      releasedAtGranularity: 'day',
-    });
+    const releases = [
+      createGameRelease({
+        region: 'worldwide',
+        releasedAt: '2023-01-15T00:00:00Z',
+        releasedAtGranularity: 'day',
+      }),
+    ];
 
-    render(<GameReleaseDatesRow releases={[release]} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     expect(screen.getByText(/jan 15, 2023/i)).toBeVisible();
@@ -44,7 +59,13 @@ describe('Component: GameReleaseDatesRow', () => {
       }),
     ];
 
-    render(<GameReleaseDatesRow releases={releases} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     expect(screen.getByText(/na/i)).toBeVisible();
@@ -76,7 +97,13 @@ describe('Component: GameReleaseDatesRow', () => {
       }),
     ];
 
-    render(<GameReleaseDatesRow releases={releases} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     const wwElements = screen.getAllByText(/ww/i);
@@ -108,7 +135,13 @@ describe('Component: GameReleaseDatesRow', () => {
       }),
     ];
 
-    render(<GameReleaseDatesRow releases={releases} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     // ... should only show the January release ...
@@ -141,7 +174,13 @@ describe('Component: GameReleaseDatesRow', () => {
       }),
     ];
 
-    render(<GameReleaseDatesRow releases={releases} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     const allTextContent = screen.getByRole('cell', { name: /na.*jp.*eu/i });
@@ -167,7 +206,13 @@ describe('Component: GameReleaseDatesRow', () => {
       }),
     ];
 
-    render(<GameReleaseDatesRow releases={releases} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     // ... both should show as January, with JP first due to month granularity normalization ...
@@ -180,13 +225,21 @@ describe('Component: GameReleaseDatesRow', () => {
 
   it('given releases with year granularity, displays only the year', () => {
     // ARRANGE
-    const release = createGameRelease({
-      region: 'jp',
-      releasedAt: '2023-06-15T00:00:00Z',
-      releasedAtGranularity: 'year',
-    });
+    const releases = [
+      createGameRelease({
+        region: 'jp',
+        releasedAt: '2023-06-15T00:00:00Z',
+        releasedAtGranularity: 'year',
+      }),
+    ];
 
-    render(<GameReleaseDatesRow releases={[release]} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     expect(screen.getByText(/2023/)).toBeVisible();
@@ -218,7 +271,13 @@ describe('Component: GameReleaseDatesRow', () => {
       }),
     ];
 
-    render(<GameReleaseDatesRow releases={releases} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     const cells = screen.getAllByRole('cell');
@@ -250,7 +309,13 @@ describe('Component: GameReleaseDatesRow', () => {
       }),
     ];
 
-    render(<GameReleaseDatesRow releases={releases} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     expect(screen.getByText(/jan 1, 2023/i)).toBeVisible();
@@ -282,7 +347,13 @@ describe('Component: GameReleaseDatesRow', () => {
       }),
     ];
 
-    render(<GameReleaseDatesRow releases={releases} />);
+    render(
+      <BaseTable>
+        <BaseTableBody>
+          <GameReleaseDatesRow releases={releases} />
+        </BaseTableBody>
+      </BaseTable>,
+    );
 
     // ASSERT
     const cells = screen.getAllByRole('cell');

--- a/resources/js/features/games/utils/getNonCanonicalTitles.test.ts
+++ b/resources/js/features/games/utils/getNonCanonicalTitles.test.ts
@@ -91,33 +91,6 @@ describe('Util: getNonCanonicalTitles', () => {
     expect(result).toEqual(['Alternate Title', 'Another Title']);
   });
 
-  it('given releases without releasedAt dates, excludes them from results', () => {
-    // ARRANGE
-    const releases = [
-      createGameRelease({
-        title: 'Canonical Title',
-        isCanonicalGameTitle: true,
-        releasedAt: '2023-01-01',
-      }),
-      createGameRelease({
-        title: 'Released Game',
-        isCanonicalGameTitle: false,
-        releasedAt: '2023-01-01',
-      }),
-      createGameRelease({
-        title: 'Unreleased Game',
-        isCanonicalGameTitle: false,
-        releasedAt: null,
-      }),
-    ];
-
-    // ACT
-    const result = getNonCanonicalTitles(releases);
-
-    // ASSERT
-    expect(result).toEqual(['Released Game']);
-  });
-
   it('given a non-canonical title that matches the canonical title, excludes it', () => {
     // ARRANGE
     const releases = [

--- a/resources/js/features/games/utils/getNonCanonicalTitles.test.ts
+++ b/resources/js/features/games/utils/getNonCanonicalTitles.test.ts
@@ -118,4 +118,36 @@ describe('Util: getNonCanonicalTitles', () => {
     // ASSERT
     expect(result).toEqual(['FF7']);
   });
+
+  it('given releases with tag prefixes, strips tags and deduplicates properly', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({
+        title: '~Unlicensed~ Digimon Ruby',
+        isCanonicalGameTitle: true, // !! canonical has tag prefix
+        releasedAt: '2023-01-01',
+      }),
+      createGameRelease({
+        title: 'Digimon Ruby',
+        isCanonicalGameTitle: false, // !! same title without tag
+        releasedAt: '2023-01-01',
+      }),
+      createGameRelease({
+        title: '~Prototype~ Digimon Ruby',
+        isCanonicalGameTitle: false, // !! different tag, same base title
+        releasedAt: '2023-01-01',
+      }),
+      createGameRelease({
+        title: 'Digimon Sapphire',
+        isCanonicalGameTitle: false, // !! different title
+        releasedAt: '2023-01-01',
+      }),
+    ];
+
+    // ACT
+    const result = getNonCanonicalTitles(releases);
+
+    // ASSERT
+    expect(result).toEqual(['Digimon Sapphire']); // !! only unique non-canonical title after stripping tags
+  });
 });

--- a/resources/js/features/games/utils/getNonCanonicalTitles.test.ts
+++ b/resources/js/features/games/utils/getNonCanonicalTitles.test.ts
@@ -1,0 +1,148 @@
+import { createGameRelease } from '@/test/factories';
+
+import { getNonCanonicalTitles } from './getNonCanonicalTitles';
+
+describe('Util: getNonCanonicalTitles', () => {
+  it('is defined', () => {
+    // ASSERT
+    expect(getNonCanonicalTitles).toBeDefined();
+  });
+
+  it('given undefined releases, returns an empty array', () => {
+    // ARRANGE
+    const releases = undefined;
+
+    // ACT
+    const result = getNonCanonicalTitles(releases);
+
+    // ASSERT
+    expect(result).toEqual([]);
+  });
+
+  it('given an empty array of releases, returns an empty array', () => {
+    // ARRANGE
+    const releases: App.Platform.Data.GameRelease[] = [];
+
+    // ACT
+    const result = getNonCanonicalTitles(releases);
+
+    // ASSERT
+    expect(result).toEqual([]);
+  });
+
+  it('given releases with a canonical title, excludes the canonical title from results', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({
+        title: 'Super Mario Bros.',
+        isCanonicalGameTitle: true,
+        releasedAt: '2023-01-01',
+      }),
+      createGameRelease({
+        title: 'Super Mario Brothers',
+        isCanonicalGameTitle: false,
+        releasedAt: '2023-01-01',
+      }),
+      createGameRelease({
+        title: 'SMB',
+        isCanonicalGameTitle: false,
+        releasedAt: '2023-01-01',
+      }),
+    ];
+
+    // ACT
+    const result = getNonCanonicalTitles(releases);
+
+    // ASSERT
+    expect(result).toEqual(['SMB', 'Super Mario Brothers']);
+  });
+
+  it('given duplicate non-canonical titles, returns unique titles only', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({
+        title: 'Canonical Game',
+        isCanonicalGameTitle: true,
+        releasedAt: '2023-01-01',
+      }),
+      createGameRelease({
+        title: 'Alternate Title',
+        isCanonicalGameTitle: false,
+        releasedAt: '2023-01-01',
+        region: 'na',
+      }),
+      createGameRelease({
+        title: 'Alternate Title',
+        isCanonicalGameTitle: false,
+        releasedAt: '2023-01-01',
+        region: 'eu',
+      }),
+      createGameRelease({
+        title: 'Another Title',
+        isCanonicalGameTitle: false,
+        releasedAt: '2023-01-01',
+      }),
+    ];
+
+    // ACT
+    const result = getNonCanonicalTitles(releases);
+
+    // ASSERT
+    expect(result).toEqual(['Alternate Title', 'Another Title']);
+  });
+
+  it('given releases without releasedAt dates, excludes them from results', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({
+        title: 'Canonical Title',
+        isCanonicalGameTitle: true,
+        releasedAt: '2023-01-01',
+      }),
+      createGameRelease({
+        title: 'Released Game',
+        isCanonicalGameTitle: false,
+        releasedAt: '2023-01-01',
+      }),
+      createGameRelease({
+        title: 'Unreleased Game',
+        isCanonicalGameTitle: false,
+        releasedAt: null,
+      }),
+    ];
+
+    // ACT
+    const result = getNonCanonicalTitles(releases);
+
+    // ASSERT
+    expect(result).toEqual(['Released Game']);
+  });
+
+  it('given a non-canonical title that matches the canonical title, excludes it', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({
+        title: 'Final Fantasy VII',
+        isCanonicalGameTitle: true,
+        releasedAt: '2023-01-01',
+      }),
+      createGameRelease({
+        title: 'Final Fantasy VII',
+        isCanonicalGameTitle: false,
+        releasedAt: '2023-01-01',
+        region: 'jp',
+      }),
+      createGameRelease({
+        title: 'FF7',
+        isCanonicalGameTitle: false,
+        releasedAt: '2023-01-01',
+      }),
+    ];
+
+    // ACT
+    const result = getNonCanonicalTitles(releases);
+
+    // ASSERT
+    expect(result).toEqual(['FF7']);
+  });
+});

--- a/resources/js/features/games/utils/getNonCanonicalTitles.ts
+++ b/resources/js/features/games/utils/getNonCanonicalTitles.ts
@@ -8,7 +8,7 @@ export function getNonCanonicalTitles(
   const canonicalTitle = releases.find((r) => r.isCanonicalGameTitle)?.title;
 
   return releases
-    .filter((r) => r.releasedAt && !r.isCanonicalGameTitle)
+    .filter((r) => !r.isCanonicalGameTitle)
     .map((r) => r.title)
     .filter((title) => title !== canonicalTitle)
     .filter((title, index, self) => self.indexOf(title) === index)

--- a/resources/js/features/games/utils/getNonCanonicalTitles.ts
+++ b/resources/js/features/games/utils/getNonCanonicalTitles.ts
@@ -6,11 +6,12 @@ export function getNonCanonicalTitles(
   }
 
   const canonicalTitle = releases.find((r) => r.isCanonicalGameTitle)?.title;
+  const canonicalTitleWithoutTags = canonicalTitle?.replace(/^~[^~]+~\s*/, '');
 
   return releases
     .filter((r) => !r.isCanonicalGameTitle)
-    .map((r) => r.title)
-    .filter((title) => title !== canonicalTitle)
+    .map((r) => r.title.replace(/^~[^~]+~\s*/, ''))
+    .filter((title) => title !== canonicalTitle && title !== canonicalTitleWithoutTags)
     .filter((title, index, self) => self.indexOf(title) === index)
     .sort((a, b) => a.localeCompare(b));
 }

--- a/resources/js/features/games/utils/getNonCanonicalTitles.ts
+++ b/resources/js/features/games/utils/getNonCanonicalTitles.ts
@@ -1,0 +1,16 @@
+export function getNonCanonicalTitles(
+  releases: App.Platform.Data.GameRelease[] | undefined,
+): string[] {
+  if (!releases) {
+    return [];
+  }
+
+  const canonicalTitle = releases.find((r) => r.isCanonicalGameTitle)?.title;
+
+  return releases
+    .filter((r) => r.releasedAt && !r.isCanonicalGameTitle)
+    .map((r) => r.title)
+    .filter((title) => title !== canonicalTitle)
+    .filter((title, index, self) => self.indexOf(title) === index)
+    .sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
Implements the same deduping for non-canonical titles introduced in https://github.com/RetroAchievements/RAWeb/pull/3652 into the React UI.