### PR TITLE
fix(home): change 'Games Mastered' to 'Sets Mastered'

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -141,7 +141,7 @@
     "Game Details": "Game Details",
     "Games": "Games",
     "Games Beaten": "Games Beaten",
-    "Games Mastered": "Games Mastered",
+    "Sets Mastered": "Sets Mastered",
     "Getting involved in a QA sub-team.": "Getting involved in a QA sub-team.",
     "Getting involved with RANews.": "Getting involved with RANews.",
     "Global Beaten Games Ranking": "Global Beaten Games Ranking",

--- a/resources/js/features/home/components/+sidebar/GlobalStatistics/GlobalStatistics.test.tsx
+++ b/resources/js/features/home/components/+sidebar/GlobalStatistics/GlobalStatistics.test.tsx
@@ -59,7 +59,7 @@ describe('Component: GlobalStatistics', () => {
     );
   });
 
-  it('displays the correct count of games mastered and has the right href on that element', () => {
+  it('displays the correct count of sets mastered and has the right href on that element', () => {
     // ARRANGE
     render(<GlobalStatistics />, {
       pageProps: createHomePageProps({
@@ -68,12 +68,12 @@ describe('Component: GlobalStatistics', () => {
     });
 
     // ASSERT
-    const gamesMasteredEl = screen.getByLabelText('Games Mastered');
+    const gamesMasteredEl = screen.getByLabelText('Sets Mastered');
 
     expect(gamesMasteredEl).toBeVisible();
     expect(gamesMasteredEl).toHaveTextContent('318,450');
 
-    expect(screen.getByRole('link', { name: 'Games Mastered' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Sets Mastered' })).toHaveAttribute(
       'href',
       '/recentMastery.php?t=1&m=1',
     );

--- a/resources/js/features/home/components/+sidebar/GlobalStatistics/GlobalStatistics.tsx
+++ b/resources/js/features/home/components/+sidebar/GlobalStatistics/GlobalStatistics.tsx
@@ -42,7 +42,7 @@ export const GlobalStatistics: FC = () => {
           </StatBox>
 
           <StatBox
-            t_label={t('Games Mastered')}
+            t_label={t('Sets Mastered')}
             href="/recentMastery.php?t=1&m=1"
             anchorClassName={buildTrackingClassNames('Click Statistic Games Mastered')}
           >


### PR DESCRIPTION
Tiny PR to update this label so that it makes more sense as we inch closer and closer to a multiset-enabled world.

![Screenshot 2025-06-26 at 5 15 06 PM](https://github.com/user-attachments/assets/019a923c-954c-4c69-b1ca-662b79cb14e3)
