### PR TITLE
fix: attempt to remediate Firefox JS asset caching issue

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,8 +4,10 @@ namespace App\Http\Middleware;
 
 use App\Actions\GetUserDeviceKindAction;
 use App\Data\UserData;
+use Closure;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
+use Symfony\Component\HttpFoundation\Response;
 use Tighten\Ziggy\Ziggy;
 
 class HandleInertiaRequests extends Middleware
@@ -27,6 +29,40 @@ class HandleInertiaRequests extends Middleware
     public function version(Request $request): ?string
     {
         return parent::version($request);
+    }
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = parent::handle($request, $next);
+
+        /**
+         * We want to prevent browsers from caching Intertia's 409 version mismatch responses.
+         *
+         * When Inertia detects that the client's asset version doesn't match the server's
+         * (after a deployment), it returns a 409 status code with an X-Inertia-Location header.
+         * The client-side Inertia.js library then performs a full page reload to the current location.
+         *
+         * 4xx responses are cacheable unless the origin says otherwise.
+         * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/410#cacheability
+         *
+         * If Inertia.js's 409 response gets cached (particularly by Firefox, which strictly follows
+         * HTTP caching specs even for error responses), subsequent navigation attempts will receive
+         * the cached 409 instead of fresh content, leaving the user with a broken UI until they manually
+         * clear their cache.
+         *
+         * The fix is to mark every 409 response from Inertia.js as strictly non-storeable. We need
+         * to instruct browsers/Cloudflare to _never_ write the response to disk or memory.
+         *
+         * @see https://inertiajs.com/asset-versioning
+         * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-store
+         */
+        if ($response->getStatusCode() === 409) {
+            $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+            $response->headers->set('Pragma', 'no-cache');
+            $response->headers->set('Expires', '0');
+        }
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
This PR attempts to remediate the JS caching issue that has been rampant among Firefox users over the last several weeks:

https://discord.com/channels/476211979464343552/1002693810037477377/1387018739274485882
https://discord.com/channels/310192285306454017/752271759138357249/1385159355128614925
https://discord.com/channels/310192285306454017/752271759138357249/1384603275591942174
https://discord.com/channels/310192285306454017/1384353748872073226/1384561786006671520

I have never been able to reproduce this issue, so I am not actually sure this change will work. At worst, nothing will change and we'll have ruled out a likely suspect.

After diving through Inertia's source code, I have a theory on why this problem has been happening.

On every deploy, all JS asset filenames change (this is good, they're cachebusted). Inertia's client-side runtime detects when the user's browser is still trying to execute a cached JS bundle and automatically performs a full page reload to get fresh JS assets. This is caused by the server returning a 409 status code on Inertia navigation requests when it detects a version mismatch (this is triggered by the server-side version of Inertia).

Firefox has a much stricter interpretation of HTTP caching specifications than WebKit or Chromium based browsers. It can potentially cache 409 responses, causing the user's UI to never fully heal until they manually wipe their browser cache.

This PR adds headers to specifically direct clients to not cache 409 responses, forcing browsers to make fresh requests when Inertia.js detects an asset version mismatch, allowing proper asset version reconciliation after new deployments.