### PR TITLE
fix(game): decode safe html entities in the meta description

### DIFF
--- a/app/Helpers/render/game.php
+++ b/app/Helpers/render/game.php
@@ -312,15 +312,17 @@ function generateGameMetaDescription(
     int $gamePoints = 0,
     bool $isEventGame = false,
 ): string {
+    $decodedGameTitle = html_entity_decode(strip_tags($gameTitle), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
     if ($isEventGame) {
-        return "$gameTitle: An event at RetroAchievements. Check out the page for more details on this unique challenge.";
+        return "$decodedGameTitle: An event at RetroAchievements. Check out the page for more details on this unique challenge.";
     } elseif ($numAchievements === 0) {
-        return "No achievements have been created yet for $gameTitle. Join RetroAchievements to request achievements for $gameTitle and earn achievements on many other classic games.";
+        return "No achievements have been created yet for $decodedGameTitle. Join RetroAchievements to request achievements for $decodedGameTitle and earn achievements on many other classic games.";
     }
 
     $localizedPoints = localized_number($gamePoints);
 
-    return "There are $numAchievements achievements worth $localizedPoints points. $gameTitle for $consoleName - explore and compete on this classic game at RetroAchievements.";
+    return "There are $numAchievements achievements worth $localizedPoints points. $decodedGameTitle for $consoleName - explore and compete on this classic game at RetroAchievements.";
 }
 
 function generateEmptyBucketsWithBounds(int $numAchievements): array


### PR DESCRIPTION
This PR resolves this encoding issue in PHP game page meta descriptions:
![Screenshot 2025-06-26 at 6 51 03 PM](https://github.com/user-attachments/assets/61e9a54f-a5c7-4d13-98a7-10ca48f501e6)

Tags are stripped to mitigate any risk of malicious content injection.