### PR TITLE
feat(game): introduce server-side deduping of credits

### DIFF
--- a/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.test.tsx
@@ -18,7 +18,7 @@ describe('Component: AchievementAuthorsDisplay', () => {
     expect(container).toBeTruthy();
   });
 
-  it('given authors with >= 33%, shows them individually with labels', () => {
+  it('given authors with >= 30%, shows them individually with labels', () => {
     // ARRANGE
     const authors = [
       createUserCredits({ displayName: 'Alice', count: 40 }), // !! 40%
@@ -41,15 +41,15 @@ describe('Component: AchievementAuthorsDisplay', () => {
     const separators = screen.getAllByText('•');
     expect(separators).toHaveLength(2);
 
-    // ... Alice and Bob have labels because they have >= 33% contribution ...
+    // ... Alice and Bob have labels because they have >= 30% contribution ...
     expect(screen.getByText(/alice/i)).toBeVisible();
     expect(screen.getByText(/bob/i)).toBeVisible();
 
-    // ... Charlie is in the stack without a label (< 33% contribution) ...
+    // ... Charlie is in the stack without a label (< 30% contribution) ...
     expect(screen.queryByText(/charlie/i)).not.toBeInTheDocument();
   });
 
-  it('given one author with >= 33% and others with < 33%, shows prominent author individually and stacks the rest', () => {
+  it('given one author with >= 30% and others with < 30%, shows prominent author individually and stacks the rest', () => {
     // ARRANGE
     const authors = [
       createUserCredits({ displayName: 'Alice', count: 50 }), // !! 50%
@@ -77,7 +77,7 @@ describe('Component: AchievementAuthorsDisplay', () => {
     expect(screen.getByText(/alice/i)).toBeVisible();
   });
 
-  it('given all authors with < 33%, shows all avatars in a single stack', () => {
+  it('given all authors with < 30%, shows all avatars in a single stack', () => {
     // ARRANGE
     const authors = [
       createUserCredits({ displayName: 'Alice', count: 20 }), // !! 20%

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.tsx
@@ -35,11 +35,11 @@ export const AchievementAuthorsDisplay: FC<AchievementAuthorsDisplayProps> = ({ 
     percentage: totalAchievements > 0 ? (author.count / totalAchievements) * 100 : 0,
   }));
 
-  // Separate authors who contributed at least 33% from the rest.
-  const prominentAuthors = authorsWithPercentage.filter((author) => author.percentage >= 33);
-  const otherAuthors = authorsWithPercentage.filter((author) => author.percentage < 33);
+  // Separate authors who contributed at least 30% from the rest.
+  const prominentAuthors = authorsWithPercentage.filter((author) => author.percentage >= 30);
+  const otherAuthors = authorsWithPercentage.filter((author) => author.percentage < 30);
 
-  // If no prominent authors (all have < 33%), show them all in a stack.
+  // If no prominent authors (all have < 30%), show them all in a stack.
   if (prominentAuthors.length === 0) {
     return (
       <div className={containerClassNames}>

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.test.tsx
@@ -113,48 +113,6 @@ describe('Component: AchievementSetCredits', () => {
     expect(screen.getByTestId('design-credits-display')).toBeVisible();
   });
 
-  it('given duplicate users in artwork credits, deduplicates them before deciding to show the component', () => {
-    // ARRANGE
-    const sharedUser = createUserCredits({ displayName: 'Alice' });
-    const aggregateCredits = {
-      achievementsAuthors: [],
-      achievementSetArtwork: [sharedUser],
-      achievementsArtwork: [sharedUser], // !! same user in both arrays
-      achievementsLogic: [],
-      achievementsMaintainers: [],
-      achievementsDesign: [],
-      achievementsTesting: [],
-      achievementsWriting: [],
-    };
-
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
-
-    // ASSERT
-    // ... component should still show because there's at least one unique user ...
-    expect(screen.getByTestId('artwork-credits-display')).toBeVisible();
-  });
-
-  it('given all logic users are already authors, does not show the code credits display', () => {
-    // ARRANGE
-    const author = createUserCredits({ displayName: 'Alice' });
-    const aggregateCredits = {
-      achievementsAuthors: [author],
-      achievementSetArtwork: [],
-      achievementsArtwork: [],
-      achievementsLogic: [author], // !! same user is both author and logic credit
-      achievementsMaintainers: [], // !! no maintainers
-      achievementsDesign: [],
-      achievementsTesting: [],
-      achievementsWriting: [],
-    };
-
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
-
-    // ASSERT
-    // ... code credits should not show because filtered logic credits is empty and no maintainers ...
-    expect(screen.queryByTestId('code-credits-display')).not.toBeInTheDocument();
-  });
-
   it('given only empty credit arrays, only shows the authors display', () => {
     // ARRANGE
     const aggregateCredits = {
@@ -181,8 +139,8 @@ describe('Component: AchievementSetCredits', () => {
     // ARRANGE
     const aggregateCredits = {
       achievementsAuthors: [createUserCredits({ displayName: 'Author1' })],
-      achievementSetArtwork: [createUserCredits({ displayName: 'Artist1' })],
-      achievementsArtwork: [],
+      achievementSetArtwork: [],
+      achievementsArtwork: [createUserCredits({ displayName: 'Artist1' })],
       achievementsLogic: [createUserCredits({ displayName: 'Logic1' })],
       achievementsMaintainers: [],
       achievementsDesign: [createUserCredits({ displayName: 'Designer1' })],

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.tsx
@@ -14,33 +14,12 @@ export const AchievementSetCredits: FC = () => {
     return null;
   }
 
-  const artCreditUsers = [
-    ...aggregateCredits.achievementSetArtwork,
-    ...aggregateCredits.achievementsArtwork,
-  ].filter(
-    (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
-  );
-
-  const logicCreditUsers = aggregateCredits.achievementsLogic.filter(
-    (logicUser) =>
-      !aggregateCredits.achievementsAuthors.some(
-        (author) => author.displayName === logicUser.displayName,
-      ),
-  );
-  const codingCreditUsers = [
-    ...aggregateCredits.achievementsMaintainers,
-    ...logicCreditUsers,
-  ].filter(
-    (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
-  );
-
-  const designCreditUsers = [
-    ...aggregateCredits.achievementsDesign,
-    ...aggregateCredits.achievementsTesting,
-    ...aggregateCredits.achievementsWriting,
-  ].filter(
-    (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
-  );
+  // All deduplication is now handled server-side.
+  const hasArtworkCredits = aggregateCredits.achievementsArtwork.length > 0;
+  const hasCodeCredits =
+    aggregateCredits.achievementsLogic.length > 0 ||
+    aggregateCredits.achievementsMaintainers.length > 0;
+  const hasDesignCredits = aggregateCredits.achievementsDesign.length > 0;
 
   return (
     <div
@@ -51,22 +30,21 @@ export const AchievementSetCredits: FC = () => {
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 xl:gap-4">
           <AchievementAuthorsDisplay authors={aggregateCredits.achievementsAuthors} />
 
-          {artCreditUsers.length ? (
+          {hasArtworkCredits ? (
             <ArtworkCreditsDisplay
               achievementArtworkCredits={aggregateCredits.achievementsArtwork}
               badgeArtworkCredits={aggregateCredits.achievementSetArtwork}
             />
           ) : null}
 
-          {codingCreditUsers.length ? (
+          {hasCodeCredits ? (
             <CodeCreditsDisplay
-              authorCredits={aggregateCredits.achievementsAuthors}
               logicCredits={aggregateCredits.achievementsLogic}
               maintainerCredits={aggregateCredits.achievementsMaintainers}
             />
           ) : null}
 
-          {designCreditUsers.length ? (
+          {hasDesignCredits ? (
             <DesignCreditsDisplay
               designCredits={aggregateCredits.achievementsDesign}
               testingCredits={aggregateCredits.achievementsTesting}

--- a/resources/js/features/games/components/AchievementSetCredits/ArtworkCreditsDisplay/ArtworkCreditsDisplay.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/ArtworkCreditsDisplay/ArtworkCreditsDisplay.tsx
@@ -22,10 +22,6 @@ export const ArtworkCreditsDisplay: FC<ArtworkCreditsDisplayProps> = ({
   achievementArtworkCredits,
   badgeArtworkCredits,
 }) => {
-  const artCreditUsers = [...badgeArtworkCredits, ...achievementArtworkCredits].filter(
-    (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
-  );
-
   return (
     <div
       className={cn(
@@ -39,7 +35,7 @@ export const ArtworkCreditsDisplay: FC<ArtworkCreditsDisplayProps> = ({
       />
 
       <UserAvatarStack
-        users={artCreditUsers}
+        users={achievementArtworkCredits}
         maxVisible={5}
         size={20}
         isOverlappingAvatars={false}

--- a/resources/js/features/games/components/AchievementSetCredits/CodeCreditsDisplay/CodeCreditsDisplay.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/CodeCreditsDisplay/CodeCreditsDisplay.test.tsx
@@ -8,9 +8,7 @@ import { CodeCreditsDisplay } from './CodeCreditsDisplay';
 describe('Component: CodeCreditsDisplay', () => {
   it('renders without crashing', () => {
     // ARRANGE
-    const { container } = render(
-      <CodeCreditsDisplay authorCredits={[]} logicCredits={[]} maintainerCredits={[]} />,
-    );
+    const { container } = render(<CodeCreditsDisplay logicCredits={[]} maintainerCredits={[]} />);
 
     // ASSERT
     expect(container).toBeTruthy();
@@ -23,13 +21,7 @@ describe('Component: CodeCreditsDisplay', () => {
       createUserCredits({ displayName: 'Bob' }),
     ];
 
-    render(
-      <CodeCreditsDisplay
-        authorCredits={[]}
-        logicCredits={[]}
-        maintainerCredits={maintainerCredits}
-      />,
-    );
+    render(<CodeCreditsDisplay logicCredits={[]} maintainerCredits={maintainerCredits} />);
 
     // ACT
     await userEvent.hover(screen.getByRole('button'));
@@ -49,9 +41,7 @@ describe('Component: CodeCreditsDisplay', () => {
       createUserCredits({ displayName: 'David', count: 3 }),
     ];
 
-    render(
-      <CodeCreditsDisplay authorCredits={[]} logicCredits={logicCredits} maintainerCredits={[]} />,
-    );
+    render(<CodeCreditsDisplay logicCredits={logicCredits} maintainerCredits={[]} />);
 
     // ACT
     await userEvent.hover(screen.getByRole('button'));
@@ -70,11 +60,7 @@ describe('Component: CodeCreditsDisplay', () => {
     const logicCredits = [createUserCredits({ displayName: 'Bob', count: 5 })];
 
     render(
-      <CodeCreditsDisplay
-        authorCredits={[]}
-        logicCredits={logicCredits}
-        maintainerCredits={maintainerCredits}
-      />,
+      <CodeCreditsDisplay logicCredits={logicCredits} maintainerCredits={maintainerCredits} />,
     );
 
     // ACT
@@ -87,38 +73,6 @@ describe('Component: CodeCreditsDisplay', () => {
     expect(screen.getAllByText(/code contributors/i)[0]).toBeVisible();
   });
 
-  it('given a logic credit user is also an author, filters them out from the logic credits', async () => {
-    // ARRANGE
-    const sharedUserData = { displayName: 'Alice', count: 10 };
-    const authorCredits = [createUserCredits(sharedUserData)];
-    const logicCredits = [
-      createUserCredits(sharedUserData),
-      createUserCredits({ displayName: 'Bob', count: 5 }),
-    ];
-
-    render(
-      <CodeCreditsDisplay
-        authorCredits={authorCredits}
-        logicCredits={logicCredits}
-        maintainerCredits={[]}
-      />,
-    );
-
-    // ACT
-    await userEvent.hover(screen.getByRole('button'));
-
-    // ASSERT
-    await waitFor(() => {
-      expect(screen.getAllByText(/code contributors/i)[0]).toBeVisible();
-    });
-
-    // ... Alice should not appear in the tooltip since she's already an author ...
-    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
-
-    // ... only Bob should appear ...
-    expect(screen.getAllByText('Bob')[0]).toBeVisible();
-  });
-
   it('given the same user appears in multiple credit types, only shows them once in the avatar stack', () => {
     // ARRANGE
     const sharedUserData = { displayName: 'Alice' };
@@ -129,11 +83,7 @@ describe('Component: CodeCreditsDisplay', () => {
     ];
 
     render(
-      <CodeCreditsDisplay
-        authorCredits={[]}
-        logicCredits={logicCredits}
-        maintainerCredits={maintainerCredits}
-      />,
+      <CodeCreditsDisplay logicCredits={logicCredits} maintainerCredits={maintainerCredits} />,
     );
 
     // ASSERT
@@ -146,13 +96,7 @@ describe('Component: CodeCreditsDisplay', () => {
     // ARRANGE
     const maintainerCredits = [createUserCredits({ displayName: 'Alice' })];
 
-    render(
-      <CodeCreditsDisplay
-        authorCredits={[]}
-        logicCredits={[]}
-        maintainerCredits={maintainerCredits}
-      />,
-    );
+    render(<CodeCreditsDisplay logicCredits={[]} maintainerCredits={maintainerCredits} />);
 
     // ACT
     await userEvent.hover(screen.getByRole('button'));
@@ -162,28 +106,5 @@ describe('Component: CodeCreditsDisplay', () => {
       expect(screen.getAllByText(/achievement maintainers/i)[0]).toBeVisible();
     });
     expect(screen.queryByText(/code contributors/i)).not.toBeInTheDocument();
-  });
-
-  it('given all logic credits are already authors, displays nothing', () => {
-    // ARRANGE
-    const authorCredits = [
-      createUserCredits({ displayName: 'Alice', count: 10 }),
-      createUserCredits({ displayName: 'Bob', count: 5 }),
-    ];
-    const logicCredits = [
-      createUserCredits({ displayName: 'Alice', count: 10 }),
-      createUserCredits({ displayName: 'Bob', count: 5 }),
-    ];
-
-    render(
-      <CodeCreditsDisplay
-        authorCredits={authorCredits}
-        logicCredits={logicCredits}
-        maintainerCredits={[]}
-      />,
-    );
-
-    // ASSERT
-    expect(screen.queryAllByRole('img')).toHaveLength(0);
   });
 });

--- a/resources/js/features/games/components/AchievementSetCredits/CodeCreditsDisplay/CodeCreditsDisplay.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/CodeCreditsDisplay/CodeCreditsDisplay.tsx
@@ -14,27 +14,19 @@ import { TooltipCreditRow } from '../TooltipCreditRow';
 import { TooltipCreditsSection } from '../TooltipCreditsSection';
 
 interface CodeCreditsDisplayProps {
-  authorCredits: App.Platform.Data.UserCredits[];
   logicCredits: App.Platform.Data.UserCredits[];
   maintainerCredits: App.Platform.Data.UserCredits[];
 }
 
 export const CodeCreditsDisplay: FC<CodeCreditsDisplayProps> = ({
-  authorCredits,
   logicCredits,
   maintainerCredits,
 }) => {
-  // Dedupe logic credits with authors - it's a bit redundant.
-  // TODO do this on the server to reduce initial props size
-  const filteredLogicCredits = logicCredits.filter(
-    (logicUser) => !authorCredits.some((author) => author.displayName === logicUser.displayName),
-  );
-
-  const codeCreditUsers = [...maintainerCredits, ...filteredLogicCredits].filter(
+  const codeCreditUsers = [...maintainerCredits, ...logicCredits].filter(
     (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
   );
 
-  if (filteredLogicCredits.length === 0 && codeCreditUsers.length === 0) {
+  if (logicCredits.length === 0 && codeCreditUsers.length === 0) {
     return null;
   }
 
@@ -45,7 +37,7 @@ export const CodeCreditsDisplay: FC<CodeCreditsDisplayProps> = ({
         'light:border light:border-neutral-200 light:bg-white light:text-neutral-600',
       )}
     >
-      <CodeCreditIcon activeMaintainers={maintainerCredits} logicCredits={filteredLogicCredits} />
+      <CodeCreditIcon activeMaintainers={maintainerCredits} logicCredits={logicCredits} />
 
       <UserAvatarStack
         users={codeCreditUsers}

--- a/resources/js/features/games/components/AchievementSetCredits/DesignCreditsDisplay/DesignCreditsDisplay.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/DesignCreditsDisplay/DesignCreditsDisplay.test.tsx
@@ -119,28 +119,6 @@ describe('Component: DesignCreditsDisplay', () => {
     expect(screen.getAllByText(/writing contributions/i)[0]).toBeVisible();
   });
 
-  it('given the same user appears in multiple credit types, only shows them once in the avatar stack', () => {
-    // ARRANGE
-    const sharedUserData = { displayName: 'Alice', count: 5 };
-    const sharedUser = createUserCredits(sharedUserData);
-    const designCredits = [sharedUser, createUserCredits({ displayName: 'Bob', count: 3 })];
-    const testingCredits = [createUserCredits(sharedUserData)];
-    const writingCredits = [createUserCredits({ displayName: 'Charlie', count: 10 })];
-
-    render(
-      <DesignCreditsDisplay
-        designCredits={designCredits}
-        testingCredits={testingCredits}
-        writingCredits={writingCredits}
-      />,
-    );
-
-    // ASSERT
-    // ... 3 unique users (Alice, Bob, Charlie) ...
-    const avatarImages = screen.getAllByRole('img');
-    expect(avatarImages).toHaveLength(3);
-  });
-
   it('given no credits of a certain type, does not show that section in the tooltip', async () => {
     // ARRANGE
     const designCredits = [createUserCredits({ displayName: 'Alice', count: 5 })];

--- a/resources/js/features/games/components/AchievementSetCredits/DesignCreditsDisplay/DesignCreditsDisplay.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/DesignCreditsDisplay/DesignCreditsDisplay.tsx
@@ -24,10 +24,6 @@ export const DesignCreditsDisplay: FC<DesignCreditsDisplayProps> = ({
   testingCredits,
   writingCredits,
 }) => {
-  const designCreditUsers = [...designCredits, ...testingCredits, ...writingCredits].filter(
-    (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
-  );
-
   return (
     <div
       className={cn(
@@ -42,7 +38,7 @@ export const DesignCreditsDisplay: FC<DesignCreditsDisplayProps> = ({
       />
 
       <UserAvatarStack
-        users={designCreditUsers}
+        users={designCredits}
         maxVisible={8}
         size={24}
         isOverlappingAvatars={false}


### PR DESCRIPTION
https://discord.com/channels/@me/1065706550318084117/1388158735951728831

This PR moves all set credit deduplication logic to the server.

**Before**
![Screenshot 2025-06-27 at 5 37 17 PM](https://github.com/user-attachments/assets/e2e9dc51-e52f-43eb-a537-9e3b56c9e201)


**After**
![Screenshot 2025-06-27 at 5 46 57 PM](https://github.com/user-attachments/assets/5b43673b-2602-472f-afde-69cd5b619fd2)

Additionally, makes a minor tweak to the 33% authorship threshold, lowering it to 30%. This fixes an issue where only one author label was appearing for Super Mario 64, even though another user had contributed something like 31% of the set's achievements.