### PR TITLE
feat(game): add active claims to React game pages

### DIFF
--- a/app/Data/AchievementSetClaimGroupData.php
+++ b/app/Data/AchievementSetClaimGroupData.php
@@ -10,8 +10,8 @@ use Carbon\Carbon;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
-#[TypeScript('AchievementSetClaim')]
-class AchievementSetClaimData extends Data
+#[TypeScript('AchievementSetClaimGroup')]
+class AchievementSetClaimGroupData extends Data
 {
     public function __construct(
         public int $id,

--- a/app/Http/Actions/BuildHomePageClaimsDataAction.php
+++ b/app/Http/Actions/BuildHomePageClaimsDataAction.php
@@ -6,7 +6,7 @@ namespace App\Http\Actions;
 
 use App\Community\Enums\ClaimStatus;
 use App\Community\Enums\ClaimType;
-use App\Data\AchievementSetClaimData;
+use App\Data\AchievementSetClaimGroupData;
 use App\Models\AchievementSetClaim;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
@@ -17,7 +17,7 @@ class BuildHomePageClaimsDataAction
      * Get the most recent achievement claims for the home page, grouped by game.
      * $status corresponds to `ClaimStatus`.
      *
-     * @return Collection<int, AchievementSetClaimData>
+     * @return Collection<int, AchievementSetClaimGroupData>
      */
     public function execute(int $status, int $count): Collection
     {
@@ -53,7 +53,7 @@ class BuildHomePageClaimsDataAction
      * We want to merge collaborative claims into a single row, grouped by game.
      *
      * @param EloquentCollection<int, AchievementSetClaim> $claims
-     * @return Collection<int, AchievementSetClaimData>
+     * @return Collection<int, AchievementSetClaimGroupData>
      */
     private function transformClaimsForDisplay(EloquentCollection $claims, int $count): Collection
     {
@@ -69,7 +69,7 @@ class BuildHomePageClaimsDataAction
                 ];
             })
             ->take($count)
-            ->map(fn ($group) => AchievementSetClaimData::fromAchievementSetClaim(
+            ->map(fn ($group) => AchievementSetClaimGroupData::fromAchievementSetClaim(
                     $group['claim'],
                     $group['users']
                 )

--- a/app/Http/Data/HomePagePropsData.php
+++ b/app/Http/Data/HomePagePropsData.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Data;
 
 use App\Community\Data\TrendingGameData;
-use App\Data\AchievementSetClaimData;
+use App\Data\AchievementSetClaimGroupData;
 use App\Data\CurrentlyOnlineData;
 use App\Data\ForumTopicData;
 use App\Data\NewsData;
@@ -22,9 +22,9 @@ class HomePagePropsData extends Data
 {
     /**
      * @param Collection<int, NewsData> $recentNews
-     * @param Collection<int, AchievementSetClaimData> $completedClaims
+     * @param Collection<int, AchievementSetClaimGroupData> $completedClaims
      * @param Collection<int, TrendingGameData> $trendingGames
-     * @param Collection<int, AchievementSetClaimData> $newClaims
+     * @param Collection<int, AchievementSetClaimGroupData> $newClaims
      * @param Collection<int, ForumTopicData> $recentForumPosts
      */
     public function __construct(

--- a/app/Models/AchievementSetClaim.php
+++ b/app/Models/AchievementSetClaim.php
@@ -97,6 +97,21 @@ class AchievementSetClaim extends BaseModel
         return $this->attributes['Status'] ?? null;
     }
 
+    public function getUserLastPlayedAtAttribute(): ?\Carbon\Carbon
+    {
+        if (!$this->user_id || !$this->game_id) {
+            return null;
+        }
+
+        $playerSession = PlayerSession::query()
+            ->where('game_id', $this->game_id)
+            ->where('user_id', $this->user_id)
+            ->orderByDesc('updated_at')
+            ->first(['updated_at']);
+
+        return $playerSession?->updated_at;
+    }
+
     // == mutators
 
     // == relations

--- a/app/Platform/Actions/LoadGameWithRelationsAction.php
+++ b/app/Platform/Actions/LoadGameWithRelationsAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Platform\Actions;
 
+use App\Community\Enums\ClaimStatus;
 use App\Models\Game;
 use App\Platform\Enums\AchievementFlag;
 use App\Platform\Enums\AchievementSetType;
@@ -25,6 +26,10 @@ class LoadGameWithRelationsAction
         ];
 
         $game->loadMissing([
+            'achievementSetClaims' => function ($query) {
+                $query->whereIn('status', [ClaimStatus::Active, ClaimStatus::InReview])
+                    ->with('user');
+            },
             // TODO only load core set(s) up front
             'gameAchievementSets' => function ($query) use ($excludeSetTypes) {
                 $query->whereNotIn('type', $excludeSetTypes);

--- a/app/Platform/Data/AchievementSetClaimData.php
+++ b/app/Platform/Data/AchievementSetClaimData.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Data;
+
+use App\Data\UserData;
+use App\Models\AchievementSetClaim;
+use Carbon\Carbon;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Lazy;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript('AchievementSetClaim')]
+class AchievementSetClaimData extends Data
+{
+    public function __construct(
+        public int $id,
+        public Lazy|UserData $user,
+        public Lazy|GameData $game,
+        public Lazy|int $claimType,
+        public Lazy|int $setType,
+        public Lazy|int $status,
+        public Lazy|Carbon $createdAt,
+        public Lazy|Carbon $finishedAt,
+        public Lazy|Carbon|null $userLastPlayedAt,
+    ) {
+    }
+
+    public static function fromAchievementSetClaim(AchievementSetClaim $claim): self
+    {
+        return new self(
+            id: $claim->ID,
+            user: Lazy::create(fn () => UserData::fromUser($claim->user)),
+            game: Lazy::create(fn () => GameData::from($claim->game)->include('badgeUrl', 'system')),
+            claimType: Lazy::create(fn () => $claim->ClaimType),
+            setType: Lazy::create(fn () => $claim->SetType),
+            status: Lazy::create(fn () => $claim->Status),
+            createdAt: Lazy::create(fn () => Carbon::parse($claim->Created)),
+            finishedAt: Lazy::create(fn () => Carbon::parse($claim->Finished)),
+            userLastPlayedAt: Lazy::create(fn () => $claim->user_last_played_at),
+        );
+    }
+}

--- a/app/Platform/Data/GameShowPagePropsData.php
+++ b/app/Platform/Data/GameShowPagePropsData.php
@@ -14,13 +14,15 @@ use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 class GameShowPagePropsData extends Data
 {
     /**
-     * @param Collection<int, FollowedPlayerCompletionData> $followedPlayerCompletions
-     * @param Collection<int, PlayerAchievementChartBucketData> $playerAchievementChartBuckets
+     * @param Collection<int, AchievementSetClaimData> $achievementSetClaims
      * @param Collection<int, CommentData> $recentVisibleComments
+     * @param Collection<int, FollowedPlayerCompletionData> $followedPlayerCompletions
      * @param Collection<int, GameTopAchieverData> $topAchievers
+     * @param Collection<int, PlayerAchievementChartBucketData> $playerAchievementChartBuckets
      */
     public function __construct(
-        public ?AggregateAchievementSetCreditsData $aggregateCredits,
+        public Collection $achievementSetClaims,
+        public AggregateAchievementSetCreditsData $aggregateCredits,
         public GameData $game,
         public UserPermissionsData $can,
         /** @var GameSetData[] */

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -1009,5 +1009,9 @@
     "Code Contributors": "Code Contributors",
     "Achievement Design/Ideas": "Achievement Design/Ideas",
     "Playtesters": "Playtesters",
-    "Writing Contributions": "Writing Contributions"
+    "Writing Contributions": "Writing Contributions",
+    "Claimed by": "Claimed by",
+    "Active Claims": "Active Claims",
+    "Last Played": "Last Played",
+    "Expires {{date}}": "Expires {{date}}"
 }

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.test.tsx
@@ -1,5 +1,9 @@
 import { render, screen } from '@/test';
-import { createAchievementSetClaim, createUserCredits } from '@/test/factories';
+import {
+  createAchievementSetClaim,
+  createAggregateAchievementSetCredits,
+  createUserCredits,
+} from '@/test/factories';
 
 import { AchievementSetCredits } from './AchievementSetCredits';
 
@@ -23,19 +27,11 @@ vi.mock('./DesignCreditsDisplay', () => ({
 describe('Component: AchievementSetCredits', () => {
   it('renders without crashing', () => {
     // ARRANGE
-    const aggregateCredits = {
-      achievementsAuthors: [],
-      achievementSetArtwork: [],
-      achievementsArtwork: [],
-      achievementsLogic: [],
-      achievementsMaintainers: [],
-      achievementsDesign: [],
-      achievementsTesting: [],
-      achievementsWriting: [],
-    };
-
     const { container } = render(<AchievementSetCredits />, {
-      pageProps: { achievementSetClaims: [], aggregateCredits },
+      pageProps: {
+        achievementSetClaims: [],
+        aggregateCredits: createAggregateAchievementSetCredits(),
+      },
     });
 
     // ASSERT
@@ -44,19 +40,11 @@ describe('Component: AchievementSetCredits', () => {
 
   it('given there are no credits and no claims, displays nothing', () => {
     // ARRANGE
-    const aggregateCredits = {
-      achievementsAuthors: [],
-      achievementSetArtwork: [],
-      achievementsArtwork: [],
-      achievementsLogic: [],
-      achievementsMaintainers: [],
-      achievementsDesign: [],
-      achievementsTesting: [],
-      achievementsWriting: [],
-    };
-
     render(<AchievementSetCredits />, {
-      pageProps: { achievementSetClaims: [], aggregateCredits },
+      pageProps: {
+        achievementSetClaims: [],
+        aggregateCredits: createAggregateAchievementSetCredits(),
+      },
     });
 
     // ASSERT
@@ -66,16 +54,10 @@ describe('Component: AchievementSetCredits', () => {
 
   it('given artwork credits exist, shows the artwork credits display', () => {
     // ARRANGE
-    const aggregateCredits = {
-      achievementsAuthors: [],
+    const aggregateCredits = createAggregateAchievementSetCredits({
       achievementSetArtwork: [createUserCredits({ displayName: 'Alice' })],
       achievementsArtwork: [createUserCredits({ displayName: 'Bob' })],
-      achievementsLogic: [],
-      achievementsMaintainers: [],
-      achievementsDesign: [],
-      achievementsTesting: [],
-      achievementsWriting: [],
-    };
+    });
 
     render(<AchievementSetCredits />, {
       pageProps: { achievementSetClaims: [], aggregateCredits },
@@ -87,16 +69,10 @@ describe('Component: AchievementSetCredits', () => {
 
   it('given coding credits exist, shows the code credits display', () => {
     // ARRANGE
-    const aggregateCredits = {
-      achievementsAuthors: [],
-      achievementSetArtwork: [],
-      achievementsArtwork: [],
+    const aggregateCredits = createAggregateAchievementSetCredits({
       achievementsLogic: [createUserCredits({ displayName: 'Charlie' })],
       achievementsMaintainers: [createUserCredits({ displayName: 'David' })],
-      achievementsDesign: [],
-      achievementsTesting: [],
-      achievementsWriting: [],
-    };
+    });
 
     render(<AchievementSetCredits />, {
       pageProps: { achievementSetClaims: [], aggregateCredits },
@@ -108,16 +84,11 @@ describe('Component: AchievementSetCredits', () => {
 
   it('given design credits exist, shows the design credits display', () => {
     // ARRANGE
-    const aggregateCredits = {
-      achievementsAuthors: [],
-      achievementSetArtwork: [],
-      achievementsArtwork: [],
-      achievementsLogic: [],
-      achievementsMaintainers: [],
+    const aggregateCredits = createAggregateAchievementSetCredits({
       achievementsDesign: [createUserCredits({ displayName: 'Eve' })],
       achievementsTesting: [createUserCredits({ displayName: 'Frank' })],
       achievementsWriting: [createUserCredits({ displayName: 'Grace' })],
-    };
+    });
 
     render(<AchievementSetCredits />, {
       pageProps: { achievementSetClaims: [], aggregateCredits },
@@ -130,16 +101,10 @@ describe('Component: AchievementSetCredits', () => {
   it('given duplicate users in artwork credits, deduplicates them before deciding to show the component', () => {
     // ARRANGE
     const sharedUser = createUserCredits({ displayName: 'Alice' });
-    const aggregateCredits = {
-      achievementsAuthors: [],
+    const aggregateCredits = createAggregateAchievementSetCredits({
       achievementSetArtwork: [sharedUser],
       achievementsArtwork: [sharedUser], // !! same user in both arrays
-      achievementsLogic: [],
-      achievementsMaintainers: [],
-      achievementsDesign: [],
-      achievementsTesting: [],
-      achievementsWriting: [],
-    };
+    });
 
     render(<AchievementSetCredits />, {
       pageProps: { achievementSetClaims: [], aggregateCredits },
@@ -153,16 +118,11 @@ describe('Component: AchievementSetCredits', () => {
   it('given all logic users are already authors, does not show the code credits display', () => {
     // ARRANGE
     const author = createUserCredits({ displayName: 'Alice' });
-    const aggregateCredits = {
+    const aggregateCredits = createAggregateAchievementSetCredits({
       achievementsAuthors: [author],
-      achievementSetArtwork: [],
-      achievementsArtwork: [],
       achievementsLogic: [author], // !! same user is both author and logic credit
       achievementsMaintainers: [], // !! no maintainers
-      achievementsDesign: [],
-      achievementsTesting: [],
-      achievementsWriting: [],
-    };
+    });
 
     render(<AchievementSetCredits />, {
       pageProps: { achievementSetClaims: [], aggregateCredits },
@@ -175,19 +135,11 @@ describe('Component: AchievementSetCredits', () => {
 
   it('given active claims, shows claimants', () => {
     // ARRANGE
-    const aggregateCredits = {
-      achievementsAuthors: [],
-      achievementSetArtwork: [],
-      achievementsArtwork: [],
-      achievementsLogic: [],
-      achievementsMaintainers: [],
-      achievementsDesign: [],
-      achievementsTesting: [],
-      achievementsWriting: [],
-    };
-
     render(<AchievementSetCredits />, {
-      pageProps: { achievementSetClaims: [createAchievementSetClaim()], aggregateCredits },
+      pageProps: {
+        achievementSetClaims: [createAchievementSetClaim()],
+        aggregateCredits: createAggregateAchievementSetCredits(),
+      },
     });
 
     // ASSERT
@@ -196,7 +148,7 @@ describe('Component: AchievementSetCredits', () => {
 
   it('given all credit types have users, shows all displays', () => {
     // ARRANGE
-    const aggregateCredits = {
+    const aggregateCredits = createAggregateAchievementSetCredits({
       achievementsAuthors: [createUserCredits({ displayName: 'Author1' })],
       achievementSetArtwork: [createUserCredits({ displayName: 'Artist1' })],
       achievementsArtwork: [],
@@ -205,7 +157,7 @@ describe('Component: AchievementSetCredits', () => {
       achievementsDesign: [createUserCredits({ displayName: 'Designer1' })],
       achievementsTesting: [],
       achievementsWriting: [],
-    };
+    });
 
     render(<AchievementSetCredits />, {
       pageProps: { achievementSetClaims: [], aggregateCredits },

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.test.tsx
@@ -1,11 +1,14 @@
 import { render, screen } from '@/test';
-import { createUserCredits } from '@/test/factories';
+import { createAchievementSetClaim, createUserCredits } from '@/test/factories';
 
 import { AchievementSetCredits } from './AchievementSetCredits';
 
 // Shallow render the children.
 vi.mock('./AchievementAuthorsDisplay', () => ({
   AchievementAuthorsDisplay: vi.fn(() => <div data-testid="achievement-authors-display" />),
+}));
+vi.mock('./ClaimantsDisplay', () => ({
+  ClaimantsDisplay: vi.fn(() => <div data-testid="claimants-display" />),
 }));
 vi.mock('./ArtworkCreditsDisplay', () => ({
   ArtworkCreditsDisplay: vi.fn(() => <div data-testid="artwork-credits-display" />),
@@ -20,23 +23,26 @@ vi.mock('./DesignCreditsDisplay', () => ({
 describe('Component: AchievementSetCredits', () => {
   it('renders without crashing', () => {
     // ARRANGE
-    const { container } = render(<AchievementSetCredits />);
+    const aggregateCredits = {
+      achievementsAuthors: [],
+      achievementSetArtwork: [],
+      achievementsArtwork: [],
+      achievementsLogic: [],
+      achievementsMaintainers: [],
+      achievementsDesign: [],
+      achievementsTesting: [],
+      achievementsWriting: [],
+    };
+
+    const { container } = render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [], aggregateCredits },
+    });
 
     // ASSERT
     expect(container).toBeTruthy();
   });
 
-  it('given no aggregate credits, returns null', () => {
-    // ARRANGE
-    render(<AchievementSetCredits />, {
-      pageProps: { aggregateCredits: null },
-    });
-
-    // ASSERT
-    expect(screen.queryByTestId('set-credits')).not.toBeInTheDocument();
-  });
-
-  it('given aggregate credits exist, always shows the achievement authors display', () => {
+  it('given there are no credits and no claims, displays nothing', () => {
     // ARRANGE
     const aggregateCredits = {
       achievementsAuthors: [],
@@ -49,11 +55,13 @@ describe('Component: AchievementSetCredits', () => {
       achievementsWriting: [],
     };
 
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
+    render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [], aggregateCredits },
+    });
 
     // ASSERT
-    expect(screen.getByTestId('set-credits')).toBeVisible();
-    expect(screen.getByTestId('achievement-authors-display')).toBeVisible();
+    expect(screen.queryByTestId('set-credits')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('achievement-authors-display')).not.toBeInTheDocument();
   });
 
   it('given artwork credits exist, shows the artwork credits display', () => {
@@ -69,7 +77,9 @@ describe('Component: AchievementSetCredits', () => {
       achievementsWriting: [],
     };
 
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
+    render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [], aggregateCredits },
+    });
 
     // ASSERT
     expect(screen.getByTestId('artwork-credits-display')).toBeVisible();
@@ -88,7 +98,9 @@ describe('Component: AchievementSetCredits', () => {
       achievementsWriting: [],
     };
 
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
+    render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [], aggregateCredits },
+    });
 
     // ASSERT
     expect(screen.getByTestId('code-credits-display')).toBeVisible();
@@ -107,7 +119,9 @@ describe('Component: AchievementSetCredits', () => {
       achievementsWriting: [createUserCredits({ displayName: 'Grace' })],
     };
 
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
+    render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [], aggregateCredits },
+    });
 
     // ASSERT
     expect(screen.getByTestId('design-credits-display')).toBeVisible();
@@ -127,7 +141,9 @@ describe('Component: AchievementSetCredits', () => {
       achievementsWriting: [],
     };
 
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
+    render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [], aggregateCredits },
+    });
 
     // ASSERT
     // ... component should still show because there's at least one unique user ...
@@ -148,14 +164,16 @@ describe('Component: AchievementSetCredits', () => {
       achievementsWriting: [],
     };
 
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
+    render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [], aggregateCredits },
+    });
 
     // ASSERT
     // ... code credits should not show because filtered logic credits is empty and no maintainers ...
     expect(screen.queryByTestId('code-credits-display')).not.toBeInTheDocument();
   });
 
-  it('given only empty credit arrays, only shows the authors display', () => {
+  it('given active claims, shows claimants', () => {
     // ARRANGE
     const aggregateCredits = {
       achievementsAuthors: [],
@@ -168,13 +186,12 @@ describe('Component: AchievementSetCredits', () => {
       achievementsWriting: [],
     };
 
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
+    render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [createAchievementSetClaim()], aggregateCredits },
+    });
 
     // ASSERT
-    expect(screen.getByTestId('achievement-authors-display')).toBeVisible();
-    expect(screen.queryByTestId('artwork-credits-display')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('code-credits-display')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('design-credits-display')).not.toBeInTheDocument();
+    expect(screen.getByTestId('claimants-display')).toBeVisible();
   });
 
   it('given all credit types have users, shows all displays', () => {
@@ -190,7 +207,9 @@ describe('Component: AchievementSetCredits', () => {
       achievementsWriting: [],
     };
 
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
+    render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [], aggregateCredits },
+    });
 
     // ASSERT
     expect(screen.getByTestId('achievement-authors-display')).toBeVisible();

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.tsx
@@ -12,6 +12,10 @@ export const AchievementSetCredits: FC = () => {
   const { achievementSetClaims, aggregateCredits } =
     usePageProps<App.Platform.Data.GameShowPageProps>();
 
+  if (!achievementSetClaims?.length && !aggregateCredits) {
+    return null;
+  }
+
   const artCreditUsers = [
     ...aggregateCredits.achievementSetArtwork,
     ...aggregateCredits.achievementsArtwork,

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.tsx
@@ -4,15 +4,13 @@ import { usePageProps } from '@/common/hooks/usePageProps';
 
 import { AchievementAuthorsDisplay } from './AchievementAuthorsDisplay';
 import { ArtworkCreditsDisplay } from './ArtworkCreditsDisplay';
+import { ClaimantsDisplay } from './ClaimantsDisplay';
 import { CodeCreditsDisplay } from './CodeCreditsDisplay';
 import { DesignCreditsDisplay } from './DesignCreditsDisplay';
 
 export const AchievementSetCredits: FC = () => {
-  const { aggregateCredits } = usePageProps<App.Platform.Data.GameShowPageProps>();
-
-  if (!aggregateCredits) {
-    return null;
-  }
+  const { achievementSetClaims, aggregateCredits } =
+    usePageProps<App.Platform.Data.GameShowPageProps>();
 
   const artCreditUsers = [
     ...aggregateCredits.achievementSetArtwork,
@@ -42,14 +40,30 @@ export const AchievementSetCredits: FC = () => {
     (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
   );
 
+  if (
+    !aggregateCredits.achievementsAuthors.length &&
+    !artCreditUsers.length &&
+    !codingCreditUsers.length &&
+    !designCreditUsers.length &&
+    !achievementSetClaims.length
+  ) {
+    return null;
+  }
+
   return (
     <div
       data-testid="set-credits"
       className="hidden items-center justify-between text-neutral-300 light:text-neutral-700 sm:flex"
     >
-      <div className="flex w-full items-center rounded py-1 lg:flex-col lg:items-start lg:gap-2 xl:flex-row xl:items-center xl:gap-0">
+      <div className="flex w-full items-center rounded lg:flex-col lg:items-start lg:gap-2 xl:flex-row xl:items-center xl:gap-0">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 xl:gap-4">
-          <AchievementAuthorsDisplay authors={aggregateCredits.achievementsAuthors} />
+          {aggregateCredits.achievementsAuthors.length ? (
+            <AchievementAuthorsDisplay authors={aggregateCredits.achievementsAuthors} />
+          ) : null}
+
+          {achievementSetClaims.length ? (
+            <ClaimantsDisplay achievementSetClaims={achievementSetClaims} />
+          ) : null}
 
           {artCreditUsers.length ? (
             <ArtworkCreditsDisplay

--- a/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/ClaimantsDisplay.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/ClaimantsDisplay.test.tsx
@@ -1,0 +1,145 @@
+import userEvent from '@testing-library/user-event';
+
+import { render, screen, waitFor } from '@/test';
+import { createAchievementSetClaim, createUser } from '@/test/factories';
+
+import { ClaimantsDisplay } from './ClaimantsDisplay';
+
+describe('Component: ClaimantsDisplay', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const { container } = render(<ClaimantsDisplay achievementSetClaims={[]} />);
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given achievement set claims exist, shows user avatars', () => {
+    // ARRANGE
+    const achievementSetClaims = [
+      createAchievementSetClaim({ user: createUser({ displayName: 'Alice' }) }),
+      createAchievementSetClaim({ user: createUser({ displayName: 'Bob' }) }),
+    ];
+
+    render(<ClaimantsDisplay achievementSetClaims={achievementSetClaims} />);
+
+    // ASSERT
+    const avatarImages = screen.getAllByRole('img');
+    expect(avatarImages).toHaveLength(2);
+  });
+
+  it('shows the claims icon with tooltip on hover', async () => {
+    // ARRANGE
+    const achievementSetClaims = [
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Alice' }),
+        finishedAt: '2025-12-31T23:59:59Z',
+      }),
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Bob' }),
+        finishedAt: '2025-06-30T23:59:59Z',
+      }),
+    ];
+
+    render(<ClaimantsDisplay achievementSetClaims={achievementSetClaims} />);
+
+    // ACT
+    await userEvent.hover(screen.getAllByRole('button')[0]);
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getAllByText(/active claims/i)[0]).toBeVisible();
+    });
+    expect(screen.getAllByText('Alice')[0]).toBeVisible();
+    expect(screen.getAllByText('Bob')[0]).toBeVisible();
+    expect(screen.getAllByText(/expires/i)[0]).toBeVisible();
+  });
+
+  it('given claims with userLastPlayedAt, shows the calendar icon', () => {
+    // ARRANGE
+    const achievementSetClaims = [
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Alice' }),
+        userLastPlayedAt: '2025-01-15T10:30:00Z', // !! has last played date
+      }),
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Bob' }),
+        userLastPlayedAt: '2025-01-15T10:30:00Z', // !! has last played date
+      }),
+    ];
+
+    render(<ClaimantsDisplay achievementSetClaims={achievementSetClaims} />);
+
+    // ASSERT
+    // ... should show calendar icon since at least one claim has userLastPlayedAt ...
+    expect(screen.getByRole('button', { name: '' })).toBeInTheDocument();
+  });
+
+  it('given no claims have userLastPlayedAt, does not show the calendar icon', () => {
+    // ARRANGE
+    const achievementSetClaims = [
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Alice' }),
+        userLastPlayedAt: null, // !! no last played date
+      }),
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Bob' }),
+        userLastPlayedAt: null, // !! no last played date
+      }),
+    ];
+
+    render(<ClaimantsDisplay achievementSetClaims={achievementSetClaims} />);
+
+    // ASSERT
+    // ... should only have one button (the claims icon), not the calendar icon ...
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(1);
+  });
+
+  it('shows last played dates in descending order when hovering calendar icon', async () => {
+    // ARRANGE
+    const achievementSetClaims = [
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Alice' }),
+        userLastPlayedAt: '2025-01-10T10:00:00Z', // !! older date
+      }),
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Bob' }),
+        userLastPlayedAt: '2025-01-20T10:00:00Z', // !! newer date
+      }),
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Charlie' }),
+        userLastPlayedAt: '2025-01-15T10:00:00Z', // !! middle date
+      }),
+    ];
+
+    render(<ClaimantsDisplay achievementSetClaims={achievementSetClaims} />);
+
+    // ACT
+    const buttons = screen.getAllByRole('button');
+    await userEvent.hover(buttons[1]); // calendar icon is the second button
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getAllByText(/last played/i)[0]).toBeVisible();
+    });
+
+    // ... check that users appear in the correct order (most recent first) ...
+    const tooltipRows = screen.getAllByText(/bob|charlie|alice/i);
+    expect(tooltipRows[0]).toHaveTextContent('Bob');
+    expect(tooltipRows[1]).toHaveTextContent('Charlie');
+    expect(tooltipRows[2]).toHaveTextContent('Alice');
+  });
+
+  it('shows "Claimed by" text on larger screens', () => {
+    // ARRANGE
+    const achievementSetClaims = [
+      createAchievementSetClaim({ user: createUser({ displayName: 'Alice' }) }),
+    ];
+
+    render(<ClaimantsDisplay achievementSetClaims={achievementSetClaims} />);
+
+    // ASSERT
+    expect(screen.getByText(/claimed by/i)).toBeInTheDocument();
+  });
+});

--- a/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/ClaimantsDisplay.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/ClaimantsDisplay.tsx
@@ -1,0 +1,124 @@
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LuCalendar, LuWrench } from 'react-icons/lu';
+
+import {
+  BaseTooltip,
+  BaseTooltipContent,
+  BaseTooltipTrigger,
+} from '@/common/components/+vendor/BaseTooltip';
+import { UserAvatarStack } from '@/common/components/UserAvatarStack';
+import { cn } from '@/common/utils/cn';
+import { formatDate } from '@/common/utils/l10n/formatDate';
+import { useDiffForHumans } from '@/common/utils/l10n/useDiffForHumans';
+
+import { TooltipCreditRow } from '../TooltipCreditRow';
+import { TooltipCreditsSection } from '../TooltipCreditsSection';
+
+interface ClaimantsDisplayProps {
+  achievementSetClaims: App.Platform.Data.AchievementSetClaim[];
+}
+
+export const ClaimantsDisplay: FC<ClaimantsDisplayProps> = ({ achievementSetClaims }) => {
+  const canShowLastPlayedAt = achievementSetClaims.some((c) => !!c.userLastPlayedAt);
+
+  return (
+    <div
+      className={cn(
+        'flex items-center rounded-md bg-neutral-800/70 py-1 pr-2 text-neutral-400',
+        'light:border light:border-neutral-200 light:bg-white light:text-neutral-600',
+      )}
+    >
+      <ClaimsIcon achievementSetClaims={achievementSetClaims} />
+
+      <UserAvatarStack
+        users={achievementSetClaims.map((c) => c.user!)}
+        maxVisible={999}
+        size={20}
+        isOverlappingAvatars={false}
+      />
+
+      {canShowLastPlayedAt ? <LastPlayedIcon achievementSetClaims={achievementSetClaims} /> : null}
+    </div>
+  );
+};
+
+interface LastPlayedIconProps {
+  achievementSetClaims: App.Platform.Data.AchievementSetClaim[];
+}
+
+const LastPlayedIcon: FC<LastPlayedIconProps> = ({ achievementSetClaims }) => {
+  const { t } = useTranslation();
+
+  const { diffForHumans } = useDiffForHumans();
+
+  const sortedClaims = [...achievementSetClaims].sort((a, b) => {
+    // Sort by userLastPlayedAt in descending order (most recent first).
+    return new Date(b.userLastPlayedAt!).getTime() - new Date(a.userLastPlayedAt!).getTime();
+  });
+
+  return (
+    <BaseTooltip>
+      <BaseTooltipTrigger>
+        <LuCalendar className="ml-2 size-3.5 text-neutral-500 hover:text-neutral-300" />
+      </BaseTooltipTrigger>
+
+      <BaseTooltipContent className="whitespace-nowrap">
+        <div className="flex flex-col gap-3">
+          <TooltipCreditsSection headingLabel={t('Last Played')}>
+            {sortedClaims.map((claim) => (
+              <TooltipCreditRow
+                key={`tooltip-claim-last-played-${claim.user!.displayName}`}
+                credit={{
+                  avatarUrl: claim.user!.avatarUrl,
+                  count: 0, // noop
+                  dateCredited: new Date().toISOString(), // noop
+                  displayName: claim.user!.displayName,
+                }}
+              >
+                {diffForHumans(claim.userLastPlayedAt!)}
+              </TooltipCreditRow>
+            ))}
+          </TooltipCreditsSection>
+        </div>
+      </BaseTooltipContent>
+    </BaseTooltip>
+  );
+};
+
+interface ClaimsIconProps {
+  achievementSetClaims: App.Platform.Data.AchievementSetClaim[];
+}
+
+const ClaimsIcon: FC<ClaimsIconProps> = ({ achievementSetClaims }) => {
+  const { t } = useTranslation();
+
+  return (
+    <BaseTooltip>
+      <BaseTooltipTrigger className="flex items-center gap-1.5 px-2 py-[2.25px] text-neutral-300 light:text-neutral-700">
+        <LuWrench className="size-3.5" />
+        <span className="hidden pr-1 md:inline lg:hidden xl:inline">{t('Claimed by')}</span>
+      </BaseTooltipTrigger>
+
+      <BaseTooltipContent className="whitespace-nowrap">
+        <div className="flex flex-col gap-3">
+          <TooltipCreditsSection headingLabel={t('Active Claims')}>
+            {achievementSetClaims.map((claim) => (
+              <TooltipCreditRow
+                key={`tooltip-claim-${claim.user!.displayName}`}
+                credit={{
+                  avatarUrl: claim.user!.avatarUrl,
+                  count: 0, // noop
+                  dateCredited: new Date().toISOString(), // noop
+                  displayName: claim.user!.displayName,
+                }}
+              >
+                {t('Expires {{date}}', { date: formatDate(claim.finishedAt!, 'l') })}
+              </TooltipCreditRow>
+            ))}
+          </TooltipCreditsSection>
+        </div>
+      </BaseTooltipContent>
+    </BaseTooltip>
+  );
+};

--- a/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/index.ts
+++ b/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/index.ts
@@ -1,0 +1,1 @@
+export * from './ClaimantsDisplay';

--- a/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.tsx
@@ -1,4 +1,4 @@
-import { type FC } from 'react';
+import type { FC, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaTrophy } from 'react-icons/fa';
 
@@ -8,11 +8,13 @@ import { formatDate } from '@/common/utils/l10n/formatDate';
 interface TooltipCreditRowProps {
   credit: App.Platform.Data.UserCredits;
 
+  children?: ReactNode;
   showAchievementCount?: boolean;
   showCreditDate?: boolean;
 }
 
 export const TooltipCreditRow: FC<TooltipCreditRowProps> = ({
+  children,
   credit,
   showAchievementCount = false,
   showCreditDate = false,
@@ -22,11 +24,13 @@ export const TooltipCreditRow: FC<TooltipCreditRowProps> = ({
   const { formatNumber } = useFormatNumber();
 
   return (
-    <p className="flex w-full justify-between gap-1">
+    <p className="flex w-full justify-between gap-2">
       <span className="flex items-center gap-1">
         <img src={credit.avatarUrl} className="size-4 rounded-full" />
         <span>{credit.displayName}</span>
       </span>
+
+      {children ? <span className="text-neutral-500">{children}</span> : null}
 
       {showAchievementCount ? (
         <span className="flex items-center text-neutral-500">

--- a/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSet.tsx
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSet.tsx
@@ -41,7 +41,7 @@ export const GameAchievementSet: FC<GameAchievementSetProps> = ({
         >
           <div
             className={cn(
-              'flex w-full flex-col gap-2 rounded bg-embed px-2 pb-1 pt-2',
+              'flex w-full flex-col gap-2 rounded bg-embed px-2 py-2',
               'light:border light:border-embed-highlight light:bg-neutral-50',
             )}
           >

--- a/resources/js/features/home/components/+root/NewSetsList/NewSetsList.test.tsx
+++ b/resources/js/features/home/components/+root/NewSetsList/NewSetsList.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@/test';
-import { createAchievementSetClaim, createHomePageProps } from '@/test/factories';
+import { createAchievementSetClaimGroup, createHomePageProps } from '@/test/factories';
 
 import { NewSetsList } from './NewSetsList';
 
@@ -46,12 +46,12 @@ describe('Component: NewSetsList', () => {
     render<App.Http.Data.HomePageProps>(<NewSetsList />, {
       pageProps: createHomePageProps({
         completedClaims: [
-          createAchievementSetClaim(),
-          createAchievementSetClaim(),
-          createAchievementSetClaim(),
-          createAchievementSetClaim(),
-          createAchievementSetClaim(),
-          createAchievementSetClaim(),
+          createAchievementSetClaimGroup(),
+          createAchievementSetClaimGroup(),
+          createAchievementSetClaimGroup(),
+          createAchievementSetClaimGroup(),
+          createAchievementSetClaimGroup(),
+          createAchievementSetClaimGroup(),
         ],
       }),
     });

--- a/resources/js/features/home/components/+root/SetsInProgressList/SetsInProgressList.test.tsx
+++ b/resources/js/features/home/components/+root/SetsInProgressList/SetsInProgressList.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@/test';
-import { createAchievementSetClaim, createHomePageProps } from '@/test/factories';
+import { createAchievementSetClaimGroup, createHomePageProps } from '@/test/factories';
 
 import { SetsInProgressList } from './SetsInProgressList';
 
@@ -46,11 +46,11 @@ describe('Component: SetsInProgressList', () => {
     render<App.Http.Data.HomePageProps>(<SetsInProgressList />, {
       pageProps: createHomePageProps({
         newClaims: [
-          createAchievementSetClaim(),
-          createAchievementSetClaim(),
-          createAchievementSetClaim(),
-          createAchievementSetClaim(),
-          createAchievementSetClaim(),
+          createAchievementSetClaimGroup(),
+          createAchievementSetClaimGroup(),
+          createAchievementSetClaimGroup(),
+          createAchievementSetClaimGroup(),
+          createAchievementSetClaimGroup(),
         ],
       }),
     });

--- a/resources/js/features/home/components/ClaimMobileBlock/ClaimMobileBlock.test.tsx
+++ b/resources/js/features/home/components/ClaimMobileBlock/ClaimMobileBlock.test.tsx
@@ -2,7 +2,12 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 
 import { render, screen } from '@/test';
-import { createAchievementSetClaimGroup, createGame, createSystem, createUser } from '@/test/factories';
+import {
+  createAchievementSetClaimGroup,
+  createGame,
+  createSystem,
+  createUser,
+} from '@/test/factories';
 
 import { ClaimMobileBlock } from './ClaimMobileBlock';
 

--- a/resources/js/features/home/components/ClaimMobileBlock/ClaimMobileBlock.test.tsx
+++ b/resources/js/features/home/components/ClaimMobileBlock/ClaimMobileBlock.test.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 
 import { render, screen } from '@/test';
-import { createAchievementSetClaim, createGame, createSystem, createUser } from '@/test/factories';
+import { createAchievementSetClaimGroup, createGame, createSystem, createUser } from '@/test/factories';
 
 import { ClaimMobileBlock } from './ClaimMobileBlock';
 
@@ -12,7 +12,7 @@ describe('Component: ClaimMobileBlock', () => {
   it('renders without crashing', () => {
     // ARRANGE
     const { container } = render(
-      <ClaimMobileBlock claim={createAchievementSetClaim()} variant="completed" />,
+      <ClaimMobileBlock claim={createAchievementSetClaimGroup()} variant="completed" />,
     );
 
     // ASSERT
@@ -22,7 +22,7 @@ describe('Component: ClaimMobileBlock', () => {
   it('displays the game title', () => {
     // ARRANGE
     const game = createGame({ title: 'Sonic the Hedgehog' });
-    const claim = createAchievementSetClaim({ game });
+    const claim = createAchievementSetClaimGroup({ game });
 
     render(<ClaimMobileBlock claim={claim} variant="completed" />);
 
@@ -34,7 +34,7 @@ describe('Component: ClaimMobileBlock', () => {
     // ARRANGE
     const system = createSystem({ name: 'NES/Famicom' });
     const game = createGame({ system });
-    const claim = createAchievementSetClaim({ game });
+    const claim = createAchievementSetClaimGroup({ game });
 
     render(<ClaimMobileBlock claim={claim} variant="completed" />);
 
@@ -46,7 +46,7 @@ describe('Component: ClaimMobileBlock', () => {
   it('given there is no system associated with the game model, still renders successfully', () => {
     // ARRANGE
     const game = createGame({ system: undefined });
-    const claim = createAchievementSetClaim({ game });
+    const claim = createAchievementSetClaimGroup({ game });
 
     render(<ClaimMobileBlock claim={claim} variant="completed" />);
 
@@ -57,7 +57,7 @@ describe('Component: ClaimMobileBlock', () => {
   it('displays the developer display name', () => {
     // ARRANGE
     const user = createUser({ displayName: 'Scott' });
-    const claim = createAchievementSetClaim({ users: [user] });
+    const claim = createAchievementSetClaimGroup({ users: [user] });
 
     render(<ClaimMobileBlock claim={claim} variant="completed" />);
 
@@ -73,7 +73,7 @@ describe('Component: ClaimMobileBlock', () => {
 
     const created = dayjs.utc().subtract(1, 'week').toISOString();
     const finished = dayjs.utc().subtract(1, 'hour').toISOString();
-    const claim = createAchievementSetClaim({ created, finished, users: [user] });
+    const claim = createAchievementSetClaimGroup({ created, finished, users: [user] });
 
     render(<ClaimMobileBlock claim={claim} variant="completed" />);
 
@@ -90,7 +90,7 @@ describe('Component: ClaimMobileBlock', () => {
 
     const created = dayjs.utc().subtract(1, 'week').toISOString();
     const finished = dayjs.utc().subtract(1, 'hour').toISOString();
-    const claim = createAchievementSetClaim({ created, finished, users: [user] });
+    const claim = createAchievementSetClaimGroup({ created, finished, users: [user] });
 
     render(<ClaimMobileBlock claim={claim} variant="new" />);
 

--- a/resources/js/features/home/components/ClaimMobileBlock/ClaimMobileBlock.tsx
+++ b/resources/js/features/home/components/ClaimMobileBlock/ClaimMobileBlock.tsx
@@ -10,7 +10,7 @@ import type { AvatarSize } from '@/common/models';
 import { ClaimSetType } from '@/common/utils/generatedAppConstants';
 
 interface ClaimMobileBlockProps {
-  claim: App.Data.AchievementSetClaim;
+  claim: App.Data.AchievementSetClaimGroup;
   variant: 'completed' | 'new';
 }
 

--- a/resources/js/test/factories/createAchievementSetClaim.ts
+++ b/resources/js/test/factories/createAchievementSetClaim.ts
@@ -1,18 +1,14 @@
-import { ClaimSetType, ClaimStatus, ClaimType } from '@/common/utils/generatedAppConstants';
-
 import { createFactory } from '../createFactory';
 import { createGame } from './createGame';
 import { createUser } from './createUser';
 
-export const createAchievementSetClaim = createFactory<App.Data.AchievementSetClaim>((faker) => {
-  return {
-    claimType: faker.helpers.arrayElement([...Object.values(ClaimType)]),
-    created: faker.date.past().toISOString(),
-    finished: faker.date.recent().toISOString(),
-    game: createGame(),
-    id: faker.number.int({ min: 1, max: 50000 }),
-    setType: faker.helpers.arrayElement([...Object.values(ClaimSetType)]),
-    status: faker.helpers.arrayElement([...Object.values(ClaimStatus)]),
-    users: [createUser()],
-  };
-});
+export const createAchievementSetClaim = createFactory<App.Platform.Data.AchievementSetClaim>(
+  (faker) => {
+    return {
+      id: faker.number.int({ min: 1, max: 99999 }),
+      game: createGame(),
+      user: createUser(),
+      finishedAt: faker.date.soon().toISOString(),
+    };
+  },
+);

--- a/resources/js/test/factories/createAchievementSetClaimGroup.ts
+++ b/resources/js/test/factories/createAchievementSetClaimGroup.ts
@@ -1,0 +1,20 @@
+import { ClaimSetType, ClaimStatus, ClaimType } from '@/common/utils/generatedAppConstants';
+
+import { createFactory } from '../createFactory';
+import { createGame } from './createGame';
+import { createUser } from './createUser';
+
+export const createAchievementSetClaimGroup = createFactory<App.Data.AchievementSetClaimGroup>(
+  (faker) => {
+    return {
+      claimType: faker.helpers.arrayElement([...Object.values(ClaimType)]),
+      created: faker.date.past().toISOString(),
+      finished: faker.date.recent().toISOString(),
+      game: createGame(),
+      id: faker.number.int({ min: 1, max: 50000 }),
+      setType: faker.helpers.arrayElement([...Object.values(ClaimSetType)]),
+      status: faker.helpers.arrayElement([...Object.values(ClaimStatus)]),
+      users: [createUser()],
+    };
+  },
+);

--- a/resources/js/test/factories/createAggregateAchievementSetCredits.ts
+++ b/resources/js/test/factories/createAggregateAchievementSetCredits.ts
@@ -1,0 +1,15 @@
+import { createFactory } from '@/test/createFactory';
+
+export const createAggregateAchievementSetCredits =
+  createFactory<App.Platform.Data.AggregateAchievementSetCredits>(() => {
+    return {
+      achievementsArtwork: [],
+      achievementsAuthors: [],
+      achievementsDesign: [],
+      achievementSetArtwork: [],
+      achievementsLogic: [],
+      achievementsMaintainers: [],
+      achievementsTesting: [],
+      achievementsWriting: [],
+    };
+  });

--- a/resources/js/test/factories/createHomePageProps/createHomePageProps.ts
+++ b/resources/js/test/factories/createHomePageProps/createHomePageProps.ts
@@ -1,7 +1,7 @@
 import { ClaimStatus } from '@/common/utils/generatedAppConstants';
 import { createFactory } from '@/test/createFactory';
 
-import { createAchievementSetClaim } from '../createAchievementSetClaim';
+import { createAchievementSetClaimGroup } from '../createAchievementSetClaimGroup';
 import { createActivePlayer } from '../createActivePlayer';
 import { createNews } from '../createNews';
 import { createPaginatedData } from '../createPaginatedData';
@@ -20,20 +20,20 @@ export const createHomePageProps = createFactory<App.Http.Data.HomePageProps>((f
     recentNews: [createNews(), createNews(), createNews()],
 
     completedClaims: [
-      createAchievementSetClaim({ status: ClaimStatus.Complete }),
-      createAchievementSetClaim({ status: ClaimStatus.Complete }),
-      createAchievementSetClaim({ status: ClaimStatus.Complete }),
-      createAchievementSetClaim({ status: ClaimStatus.Complete }),
-      createAchievementSetClaim({ status: ClaimStatus.Complete }),
-      createAchievementSetClaim({ status: ClaimStatus.Complete }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Complete }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Complete }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Complete }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Complete }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Complete }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Complete }),
     ],
 
     newClaims: [
-      createAchievementSetClaim({ status: ClaimStatus.Active }),
-      createAchievementSetClaim({ status: ClaimStatus.Active }),
-      createAchievementSetClaim({ status: ClaimStatus.Active }),
-      createAchievementSetClaim({ status: ClaimStatus.Active }),
-      createAchievementSetClaim({ status: ClaimStatus.Active }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Active }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Active }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Active }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Active }),
+      createAchievementSetClaimGroup({ status: ClaimStatus.Active }),
     ],
 
     activePlayers: createPaginatedData(

--- a/resources/js/test/factories/index.ts
+++ b/resources/js/test/factories/index.ts
@@ -4,6 +4,7 @@ export * from './createAchievementSet';
 export * from './createAchievementSetClaim';
 export * from './createAchievementSetClaimGroup';
 export * from './createActivePlayer';
+export * from './createAggregateAchievementSetCredits';
 export * from './createAwardEarner';
 export * from './createComment';
 export * from './createDownloadsPageProps';

--- a/resources/js/test/factories/index.ts
+++ b/resources/js/test/factories/index.ts
@@ -2,6 +2,7 @@ export * from './createAchievement';
 export * from './createAchievementGroup';
 export * from './createAchievementSet';
 export * from './createAchievementSetClaim';
+export * from './createAchievementSetClaimGroup';
 export * from './createActivePlayer';
 export * from './createAwardEarner';
 export * from './createComment';

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -209,7 +209,7 @@ declare namespace App.Community.Enums {
   export type TicketType = 1 | 2;
 }
 declare namespace App.Data {
-  export type AchievementSetClaim = {
+  export type AchievementSetClaimGroup = {
     id: number;
     users: Array<App.Data.User>;
     game: App.Platform.Data.Game;
@@ -429,11 +429,11 @@ declare namespace App.Http.Data {
     mostRecentGameMastered: App.Data.StaticGameAward | null;
     mostRecentGameBeaten: App.Data.StaticGameAward | null;
     recentNews: Array<App.Data.News>;
-    completedClaims: Array<App.Data.AchievementSetClaim>;
+    completedClaims: Array<App.Data.AchievementSetClaimGroup>;
     currentlyOnline: App.Data.CurrentlyOnline;
     activePlayers: App.Data.PaginatedData<TItems>;
     trendingGames: Array<App.Community.Data.TrendingGame>;
-    newClaims: Array<App.Data.AchievementSetClaim>;
+    newClaims: Array<App.Data.AchievementSetClaimGroup>;
     recentForumPosts: Array<App.Data.ForumTopic>;
     persistedActivePlayersSearch: string | null;
     userCurrentGame: App.Platform.Data.Game | null;
@@ -491,6 +491,17 @@ declare namespace App.Platform.Data {
     unlockPercentage?: string;
     unlocksHardcoreTotal?: number;
     unlocksTotal?: number;
+  };
+  export type AchievementSetClaim = {
+    id: number;
+    user?: App.Data.User;
+    game?: App.Platform.Data.Game;
+    claimType?: number;
+    setType?: number;
+    status?: number;
+    createdAt?: string;
+    finishedAt?: string;
+    userLastPlayedAt?: string | null;
   };
   export type AchievementSet = {
     id: number;
@@ -700,7 +711,8 @@ declare namespace App.Platform.Data {
     hasMatureContent?: boolean;
   };
   export type GameShowPageProps = {
-    aggregateCredits: App.Platform.Data.AggregateAchievementSetCredits | null;
+    achievementSetClaims: Array<App.Platform.Data.AchievementSetClaim>;
+    aggregateCredits: App.Platform.Data.AggregateAchievementSetCredits;
     game: App.Platform.Data.Game;
     can: App.Data.UserPermissions;
     hubs: Array<App.Platform.Data.GameSet>;


### PR DESCRIPTION
This PR adds active claims to React game pages. Good game IDs to test with are 19928 and 18529.

![Screenshot 2025-06-29 at 7 03 17 PM](https://github.com/user-attachments/assets/119686d4-7e05-445d-bf92-514119a903de)

![Screenshot 2025-06-29 at 7 04 30 PM](https://github.com/user-attachments/assets/893b1a53-4b32-428c-b45e-156ddd6b9020)

The calendar icon is only visible to developer compliance, moderators, admins.

![Screenshot 2025-06-29 at 7 05 07 PM](https://github.com/user-attachments/assets/9820d2e8-8a4c-4b61-899b-02dccc0406e4)
