### PR TITLE
fix(ActivePlayerFeedList): resolve margin regression

### DIFF
--- a/resources/js/common/components/ActivePlayerFeed/ActivePlayerFeedList.tsx
+++ b/resources/js/common/components/ActivePlayerFeed/ActivePlayerFeedList.tsx
@@ -23,7 +23,7 @@ export const ActivePlayerFeedList: FC<ActivePlayerFeedListProps> = ({ onLoadMore
             <GameAvatar {...player.game} showLabel={false} />
           </div>
 
-          <div className="flex flex-col">
+          <div className="ml-1 flex flex-col">
             <GameAvatar {...player.game} showImage={false} />
 
             <p className="line-clamp-1 text-2xs" style={{ wordBreak: 'break-word' }}>

--- a/resources/js/common/hooks/useAddOrRemoveFromUserGameList.test.ts
+++ b/resources/js/common/hooks/useAddOrRemoveFromUserGameList.test.ts
@@ -1,5 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
+// eslint-disable-next-line no-restricted-imports -- this is fine in a test
+import { toast } from 'sonner';
 
 import i18n from '@/i18n-client';
 import { renderHook, screen, waitFor } from '@/test';
@@ -9,6 +11,11 @@ import { useAddOrRemoveFromUserGameList } from './useAddOrRemoveFromUserGameList
 window.HTMLElement.prototype.setPointerCapture = vi.fn();
 
 describe('Hook: useAddOrRemoveFromUserGameList', () => {
+  afterEach(() => {
+    // Clean up all active toasts after each test to prevent timers from running after teardown.
+    toast.dismiss();
+  });
+
   it('renders without crashing', () => {
     // ARRANGE
     const { result } = renderHook(() => useAddOrRemoveFromUserGameList());


### PR DESCRIPTION
Resolves a very minor CSS regression introduced from changes in #3643. Active players don't have enough margin between the game avatar and game title/RP text.