### PR TITLE
perf: remove ziggy routes from Inertia props

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -8,7 +8,6 @@ use Closure;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 use Symfony\Component\HttpFoundation\Response;
-use Tighten\Ziggy\Ziggy;
 
 class HandleInertiaRequests extends Middleware
 {
@@ -108,10 +107,12 @@ class HandleInertiaRequests extends Middleware
             ],
 
             'ziggy' => fn () => [
-                ...(new Ziggy())->toArray(),
+                'defaults' => [],
                 'device' => (new GetUserDeviceKindAction())->execute(),
                 'location' => $request->url(),
+                'port' => $request->getPort(),
                 'query' => $request->query(),
+                'url' => $request->getSchemeAndHttpHost(),
             ],
         ]);
     }


### PR DESCRIPTION
No functional changes.

This PR removes Ziggy routes from Inertia page props (a leftover from the `@routes` directive).

This cuts props size on all Inertia pages by ~45KB and speeds up client-side hydration runtime performance.