### PR TITLE
perf: compress user avatar URLs in Inertia page props

### DIFF
--- a/app/Data/UserData.php
+++ b/app/Data/UserData.php
@@ -60,7 +60,7 @@ class UserData extends Data
     {
         return new self(
             displayName: $topic['AuthorDisplayName'] ?? $topic['Author'],
-            avatarUrl: media_asset('UserPic/' . $topic['Author'] . '.png'),
+            avatarUrl: $topic['Author'] . '.png',
             id: Lazy::create(fn () => (int) $topic['author_id']),
             username: Lazy::create(fn () => $topic['Author']),
         );
@@ -71,7 +71,7 @@ class UserData extends Data
         return new self(
             // == eager fields
             displayName: $user->display_name,
-            avatarUrl: $user->avatar_url,
+            avatarUrl: "{$user->username}" . ".png",
 
             // == lazy fields
             apiKey: Lazy::create(fn () => $user->APIKey),

--- a/app/Data/UserData.php
+++ b/app/Data/UserData.php
@@ -71,7 +71,7 @@ class UserData extends Data
         return new self(
             // == eager fields
             displayName: $user->display_name,
-            avatarUrl: "{$user->username}" . ".png",
+            avatarUrl: "{$user->username}.png",
 
             // == lazy fields
             apiKey: Lazy::create(fn () => $user->APIKey),

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -12,6 +12,7 @@ import { Ziggy } from './ziggy';
 
 // @ts-expect-error -- we're injecting this on purpose
 globalThis.Ziggy = Ziggy;
+globalThis.mediaUrl = import.meta.env.VITE_MEDIA_URL;
 
 const appName = import.meta.env.APP_NAME || 'RetroAchievements';
 

--- a/resources/js/common/components/GlobalSearch/components/SearchResults/UserResultDisplay/UserResultDisplay.test.tsx
+++ b/resources/js/common/components/GlobalSearch/components/SearchResults/UserResultDisplay/UserResultDisplay.test.tsx
@@ -37,7 +37,10 @@ describe('Component: UserResultDisplay', () => {
 
     // ASSERT
     expect(avatar).toBeVisible();
-    expect(avatar).toHaveAttribute('src', 'https://example.com/john-avatar.png');
+    expect(avatar).toHaveAttribute(
+      'src',
+      expect.stringContaining('https://example.com/john-avatar.png'),
+    );
     expect(avatar).toHaveAttribute('alt', 'JohnDoe');
   });
 

--- a/resources/js/common/components/GlobalSearch/components/SearchResults/UserResultDisplay/UserResultDisplay.tsx
+++ b/resources/js/common/components/GlobalSearch/components/SearchResults/UserResultDisplay/UserResultDisplay.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import { type FC, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { buildUserAvatarUrl } from '@/common/utils/buildUserAvatarUrl';
 import { useDiffForHumans } from '@/common/utils/l10n/useDiffForHumans';
 
 interface UserResultDisplayProps {
@@ -16,7 +17,11 @@ export const UserResultDisplay: FC<UserResultDisplayProps> = ({ user }) => {
   return (
     <div className="flex w-full items-center gap-3">
       <div className="relative">
-        <img src={user.avatarUrl} alt={user.displayName} className="size-10 rounded" />
+        <img
+          src={buildUserAvatarUrl(user.avatarUrl)}
+          alt={user.displayName}
+          className="size-10 rounded"
+        />
 
         {isActive ? (
           <div

--- a/resources/js/common/components/PlayableCompareProgress/PlayableCompareProgress.tsx
+++ b/resources/js/common/components/PlayableCompareProgress/PlayableCompareProgress.tsx
@@ -6,6 +6,7 @@ import { BaseSelectAsync } from '@/common/components/+vendor/BaseSelectAsync';
 import { BaseSeparator } from '@/common/components/+vendor/BaseSeparator';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import { useUserSearchQuery } from '@/common/hooks/useUserSearchQuery';
+import { buildUserAvatarUrl } from '@/common/utils/buildUserAvatarUrl';
 
 import { PopulatedPlayerCompletions } from './PopulatedPlayerCompletions';
 import { useSelectAutoWidth } from './useSelectAutoWidth';
@@ -80,13 +81,13 @@ export const PlayableCompareProgress: FC<PlayableCompareProgressProps> = ({
             getOptionValue={(user) => user.displayName}
             getDisplayValue={(user) => (
               <div className="flex items-center gap-2">
-                <img className="size-6 rounded-sm" src={user.avatarUrl} />
+                <img className="size-6 rounded-sm" src={buildUserAvatarUrl(user.avatarUrl)} />
                 <span className="font-medium">{user.displayName}</span>
               </div>
             )}
             renderOption={(user) => (
               <div className="flex items-center gap-2">
-                <img className="size-6 rounded-sm" src={user.avatarUrl} />
+                <img className="size-6 rounded-sm" src={buildUserAvatarUrl(user.avatarUrl)} />
                 <span className="font-medium">{user.displayName}</span>
               </div>
             )}

--- a/resources/js/common/components/UserAvatar/UserAvatar.tsx
+++ b/resources/js/common/components/UserAvatar/UserAvatar.tsx
@@ -3,6 +3,7 @@ import { route } from 'ziggy-js';
 
 import { useCardTooltip } from '@/common/hooks/useCardTooltip';
 import type { BaseAvatarProps } from '@/common/models';
+import { buildUserAvatarUrl } from '@/common/utils/buildUserAvatarUrl';
 import { cn } from '@/common/utils/cn';
 
 type UserAvatarProps = BaseAvatarProps &
@@ -40,7 +41,11 @@ export const UserAvatar: FC<UserAvatarProps> = ({
           decoding="async"
           width={size}
           height={size}
-          src={avatarUrl ?? 'https://media.retroachievements.org/UserPic/Server.png'}
+          src={
+            avatarUrl
+              ? buildUserAvatarUrl(avatarUrl)
+              : 'https://media.retroachievements.org/UserPic/Server.png'
+          }
           alt={displayName ?? 'Deleted User'}
           className={cn('rounded-sm', imgClassName)}
         />

--- a/resources/js/common/utils/buildUserAvatarUrl.test.ts
+++ b/resources/js/common/utils/buildUserAvatarUrl.test.ts
@@ -1,0 +1,16 @@
+import { buildUserAvatarUrl } from './buildUserAvatarUrl';
+
+describe('Util: buildUserAvatarUrl', () => {
+  it('is defined', () => {
+    // ASSERT
+    expect(buildUserAvatarUrl).toBeDefined();
+  });
+
+  it('formats the URL correctly', () => {
+    // ACT
+    const result = buildUserAvatarUrl('Scott.png');
+
+    // ASSERT
+    expect(result).toContain('/UserPic/Scott.png');
+  });
+});

--- a/resources/js/common/utils/buildUserAvatarUrl.ts
+++ b/resources/js/common/utils/buildUserAvatarUrl.ts
@@ -1,0 +1,5 @@
+export function buildUserAvatarUrl(path: string) {
+  const baseUrl = globalThis.mediaUrl;
+
+  return `${baseUrl}/UserPic/${path}`;
+}

--- a/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.test.tsx
@@ -23,7 +23,7 @@ describe('Component: TooltipCreditRow', () => {
     // ASSERT
     const avatar = screen.getByRole('img');
     expect(avatar).toBeVisible();
-    expect(avatar).toHaveAttribute('src', credit.avatarUrl);
+    expect(avatar).toHaveAttribute('src', expect.stringContaining(credit.avatarUrl));
 
     expect(screen.getByText(/scott/i)).toBeVisible();
   });

--- a/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { FaTrophy } from 'react-icons/fa';
 
 import { useFormatNumber } from '@/common/hooks/useFormatNumber';
+import { buildUserAvatarUrl } from '@/common/utils/buildUserAvatarUrl';
 import { formatDate } from '@/common/utils/l10n/formatDate';
 
 interface TooltipCreditRowProps {
@@ -24,7 +25,7 @@ export const TooltipCreditRow: FC<TooltipCreditRowProps> = ({
   return (
     <p className="flex w-full justify-between gap-1">
       <span className="flex items-center gap-1">
-        <img src={credit.avatarUrl} className="size-4 rounded-full" />
+        <img src={buildUserAvatarUrl(credit.avatarUrl)} className="size-4 rounded-full" />
         <span>{credit.displayName}</span>
       </span>
 

--- a/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.tsx
+++ b/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.tsx
@@ -15,6 +15,7 @@ import { BaseSelectAsync } from '@/common/components/+vendor/BaseSelectAsync';
 import { ShortcodePanel } from '@/common/components/ShortcodePanel';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import { useUserSearchQuery } from '@/common/hooks/useUserSearchQuery';
+import { buildUserAvatarUrl } from '@/common/utils/buildUserAvatarUrl';
 import { getStringByteCount } from '@/common/utils/getStringByteCount';
 
 import { TemplateKindAlert } from '../TemplateKindAlert';
@@ -68,13 +69,19 @@ export const CreateMessageThreadForm: FC<CreateMessageThreadFormProps> = ({ onPr
                       getOptionValue={(user) => user.displayName}
                       getDisplayValue={(user) => (
                         <div className="flex items-center gap-2">
-                          <img className="size-6 rounded-sm" src={user.avatarUrl} />
+                          <img
+                            className="size-6 rounded-sm"
+                            src={buildUserAvatarUrl(user.avatarUrl)}
+                          />
                           <span className="font-medium">{user.displayName}</span>
                         </div>
                       )}
                       renderOption={(user) => (
                         <div className="flex items-center gap-2">
-                          <img className="size-6 rounded-sm" src={user.avatarUrl} />
+                          <img
+                            className="size-6 rounded-sm"
+                            src={buildUserAvatarUrl(user.avatarUrl)}
+                          />
                           <span className="font-medium">{user.displayName}</span>
                         </div>
                       )}

--- a/resources/js/pages/user/[user]/achievement-checklist.tsx
+++ b/resources/js/pages/user/[user]/achievement-checklist.tsx
@@ -11,6 +11,7 @@ import { usePageProps } from '@/common/hooks/usePageProps';
 import { useUserSearchQuery } from '@/common/hooks/useUserSearchQuery';
 import { AppLayout } from '@/common/layouts/AppLayout';
 import type { AppPage } from '@/common/models';
+import { buildUserAvatarUrl } from '@/common/utils/buildUserAvatarUrl';
 import { EventAchievementSection } from '@/features/events/components/EventAchievementSetContainer/EventAchievementSet/EventAchievementSection';
 
 const UserAchievementChecklist: AppPage = () => {
@@ -51,13 +52,13 @@ const UserAchievementChecklist: AppPage = () => {
               getOptionValue={(user) => user.displayName}
               getDisplayValue={(user) => (
                 <div className="flex items-center gap-2">
-                  <img className="size-6 rounded-sm" src={user.avatarUrl} />
+                  <img className="size-6 rounded-sm" src={buildUserAvatarUrl(user.avatarUrl)} />
                   <span className="font-medium">{user.displayName}</span>
                 </div>
               )}
               renderOption={(user) => (
                 <div className="flex items-center gap-2">
-                  <img className="size-6 rounded-sm" src={user.avatarUrl} />
+                  <img className="size-6 rounded-sm" src={buildUserAvatarUrl(user.avatarUrl)} />
                   <span className="font-medium">{user.displayName}</span>
                 </div>
               )}

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -19,6 +19,7 @@ import { Ziggy } from './ziggy';
 
 // @ts-expect-error -- we're injecting this on purpose
 globalThis.Ziggy = Ziggy;
+globalThis.mediaUrl = import.meta.env.VITE_MEDIA_URL;
 
 const appName = import.meta.env.APP_NAME ?? 'RetroAchievements';
 const inertiaDaemonPort = import.meta.env.VITE_INERTIA_SSR_PORT ?? 13714;

--- a/resources/js/test/factories/createUser.ts
+++ b/resources/js/test/factories/createUser.ts
@@ -9,7 +9,7 @@ export const createUser = createFactory<App.Data.User>((faker) => {
     username: displayName,
     isMuted: faker.datatype.boolean(),
     mutedUntil: null,
-    avatarUrl: `http://media.retroachievements.org/UserPic/${displayName}.png`,
+    avatarUrl: `${displayName}.png`,
     id: faker.number.int({ min: 1, max: 1000000 }),
     legacyPermissions: faker.number.int({ min: 0, max: 4 }),
     preferences: {

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -40,6 +40,7 @@ declare global {
   var getStringByteCount: typeof GetStringByteCount;
   var handleLeaderboardTabClick: typeof HandleLeaderboardTabClick;
   var initializeTextareaCounter: typeof InitializeTextareaCounter;
+  var mediaUrl: string;
   var modalComponent: typeof ModalComponent;
   var setCookie: typeof SetCookie;
   var showStatusFailure: (message: string) => void;

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -110,7 +110,7 @@ class HomeControllerTest extends TestCase
             ->where('mostRecentGameMastered.game.system.iconUrl', $system->iconUrl)
 
             ->where('mostRecentGameMastered.user.displayName', $player->username)
-            ->where('mostRecentGameMastered.user.avatarUrl', $player->avatarUrl)
+            ->where('mostRecentGameMastered.user.avatarUrl', $player->username . '.png')
         );
     }
 
@@ -141,7 +141,7 @@ class HomeControllerTest extends TestCase
             ->where('mostRecentGameBeaten.game.system.iconUrl', $system->iconUrl)
 
             ->where('mostRecentGameBeaten.user.displayName', $player->username)
-            ->where('mostRecentGameBeaten.user.avatarUrl', $player->avatarUrl)
+            ->where('mostRecentGameBeaten.user.avatarUrl', $player->username . '.png')
         );
     }
 
@@ -300,7 +300,7 @@ class HomeControllerTest extends TestCase
             ->where('completedClaims.0.game.system.name', $system->name)
 
             ->where('completedClaims.0.users.0.displayName', $user->display_name)
-            ->where('completedClaims.0.users.0.avatarUrl', $user->avatar_url)
+            ->where('completedClaims.0.users.0.avatarUrl', $user->username . '.png')
         );
     }
 
@@ -352,7 +352,7 @@ class HomeControllerTest extends TestCase
             ->where('completedClaims.0.game.system.name', $system->name)
 
             ->where('completedClaims.0.users.0.displayName', $user->display_name)
-            ->where('completedClaims.0.users.0.avatarUrl', $user->avatar_url)
+            ->where('completedClaims.0.users.0.avatarUrl', $user->username . '.png')
         );
     }
 
@@ -405,9 +405,9 @@ class HomeControllerTest extends TestCase
             ->has('completedClaims.0.users', 2)
 
             ->where('completedClaims.0.users.0.displayName', $userOne->display_name)
-            ->where('completedClaims.0.users.0.avatarUrl', $userOne->avatar_url)
+            ->where('completedClaims.0.users.0.avatarUrl', $userOne->username . '.png')
             ->where('completedClaims.0.users.1.displayName', $userTwo->display_name)
-            ->where('completedClaims.0.users.1.avatarUrl', $userTwo->avatar_url)
+            ->where('completedClaims.0.users.1.avatarUrl', $userTwo->username . '.png')
         );
     }
 
@@ -500,7 +500,7 @@ class HomeControllerTest extends TestCase
             ->where('newClaims.0.game.system.name', $system->name)
 
             ->where('newClaims.0.users.0.displayName', $user->display_name)
-            ->where('newClaims.0.users.0.avatarUrl', $user->avatar_url)
+            ->where('newClaims.0.users.0.avatarUrl', $user->username . '.png')
         );
     }
 
@@ -552,7 +552,7 @@ class HomeControllerTest extends TestCase
             ->where('newClaims.0.game.system.name', $system->name)
 
             ->where('newClaims.0.users.0.displayName', $user->display_name)
-            ->where('newClaims.0.users.0.avatarUrl', $user->avatar_url)
+            ->where('newClaims.0.users.0.avatarUrl', $user->username . '.png')
         );
     }
 
@@ -605,9 +605,9 @@ class HomeControllerTest extends TestCase
             ->has('newClaims.0.users', 2)
 
             ->where('newClaims.0.users.0.displayName', $userOne->display_name)
-            ->where('newClaims.0.users.0.avatarUrl', $userOne->avatar_url)
+            ->where('newClaims.0.users.0.avatarUrl', $userOne->username . '.png')
             ->where('newClaims.0.users.1.displayName', $userTwo->display_name)
-            ->where('newClaims.0.users.1.avatarUrl', $userTwo->avatar_url)
+            ->where('newClaims.0.users.1.avatarUrl', $userTwo->username . '.png')
         );
     }
 


### PR DESCRIPTION
No functional changes.

This PR removes more unnecessary data from Inertia page props by stripping user avatar base URLs (the media URL) from avatar URL fields.

On pages with lots of users loaded in memory, this can make a difference in client-side hydration performance.

**Before**
```
"https://media.retroachievements.org/UserPic/Scott.png"
```

**After**
```
"Scott.png"
```