### PR TITLE
perf(game): improve hydration performance of games with lots of hubs

### DIFF
--- a/app/Platform/Actions/BuildGameShowPagePropsAction.php
+++ b/app/Platform/Actions/BuildGameShowPagePropsAction.php
@@ -92,7 +92,24 @@ class BuildGameShowPagePropsAction
 
                 return $user->can('view', $hub);
             })
-            ->map(fn ($hub) => GameSetData::from($hub)->include('isEventHub'))
+            ->map(function ($hub) {
+                $data = GameSetData::from($hub)->include('isEventHub');
+
+                // Always remove updatedAt.
+                $data = $data->except('updatedAt');
+
+                // Remove isEventHub if it isn't true.
+                if (!$hub->is_event_hub) {
+                    $data = $data->except('isEventHub');
+                }
+
+                // Remove fields from hubs that don't have "Series" or "Meta|" in the title.
+                if (!str_contains($hub->title, 'Series') && !str_contains($hub->title, 'Meta|')) {
+                    $data = $data->except('badgeUrl', 'gameCount', 'linkCount', 'type');
+                }
+
+                return $data;
+            })
             ->values()
             ->all();
 


### PR DESCRIPTION
Updates `BuildGameShowPagePropsAction` to strip unneeded props from hubs only shown in the game metadata sidebar section. This can shave off quite a few KB on games with many hubs attached.