### PR TITLE
fix(home): use 'Most recent set mastered' label for consistency

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -191,7 +191,7 @@
     "More pages": "More pages",
     "Most of the website is still untranslated. If you'd like to help with translations, you can learn more about how to contribute <1>here</1>.": "Most of the website is still untranslated. If you'd like to help with translations, you can learn more about how to contribute <1>here</1>.",
     "Most recent game beaten": "Most recent game beaten",
-    "Most recent game mastered": "Most recent game mastered",
+    "Most recent set mastered": "Most recent set mastered",
     "Must be at least 8 characters.": "Must be at least 8 characters.",
     "New": "New",
     "New Email Address": "New Email Address",

--- a/resources/js/features/home/components/+sidebar/RecentGameAwards/RecentGameAwards.test.tsx
+++ b/resources/js/features/home/components/+sidebar/RecentGameAwards/RecentGameAwards.test.tsx
@@ -17,7 +17,7 @@ describe('Component: RecentGameAwards', () => {
     expect(container).toBeTruthy();
   });
 
-  it('given there is no recent game mastered, does not show the mastered award', () => {
+  it('given there is no recent set mastered, does not show the mastered award', () => {
     // ARRANGE
     render(<RecentGameAwards />, {
       pageProps: createHomePageProps({
@@ -26,7 +26,7 @@ describe('Component: RecentGameAwards', () => {
     });
 
     // ASSERT
-    expect(screen.queryByText(/most recent game mastered/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/most recent set mastered/i)).not.toBeInTheDocument();
   });
 
   it('given there is no recent game beaten, does not show the beaten award', () => {
@@ -70,7 +70,7 @@ describe('Component: RecentGameAwards', () => {
     });
 
     // ASSERT
-    expect(screen.getByText(/most recent game mastered/i)).toBeVisible();
+    expect(screen.getByText(/most recent set mastered/i)).toBeVisible();
     expect(screen.getByText(/sonic the hedgehog/i)).toBeVisible();
     expect(screen.getByText(/scott/i)).toBeVisible();
   });

--- a/resources/js/features/home/components/+sidebar/RecentGameAwards/RecentGameAwards.tsx
+++ b/resources/js/features/home/components/+sidebar/RecentGameAwards/RecentGameAwards.tsx
@@ -19,7 +19,7 @@ export const RecentGameAwards: FC = () => {
       {mostRecentGameMastered ? (
         <div className="flex flex-col gap-1">
           <GameAwardHeadline>
-            <p className="text-text">{t('Most recent game mastered')}</p>
+            <p className="text-text">{t('Most recent set mastered')}</p>
             <p>
               <DiffTimestamp at={mostRecentGameMastered.awardedAt} />
             </p>


### PR DESCRIPTION
Cleans up some copy I missed when changing the statbox label.