### PR TITLE
perf(game): read from game_recent_players

### DIFF
--- a/app/Models/GameRecentPlayer.php
+++ b/app/Models/GameRecentPlayer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Support\Database\Eloquent\BaseModel;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GameRecentPlayer extends BaseModel
+{
+    protected $table = 'game_recent_players';
+
+    protected $fillable = [
+        'game_id',
+        'user_id',
+        'rich_presence',
+        'rich_presence_updated_at',
+    ];
+
+    protected $casts = [
+        'rich_presence_updated_at' => 'datetime',
+    ];
+
+    public $timestamps = false;
+
+    // == accessors
+
+    // == mutators
+
+    // == relations
+
+    /**
+     * @return BelongsTo<Game, GameRecentPlayer>
+     */
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class, 'game_id', 'ID');
+    }
+
+    /**
+     * @return BelongsTo<User, GameRecentPlayer>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id', 'ID');
+    }
+
+    // == scopes
+}

--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -24,6 +24,7 @@ use App\Models\PlayerBadge;
 use App\Models\PlayerBadgeStage;
 use App\Models\PlayerSession;
 use App\Models\System;
+use App\Platform\Commands\BackfillGameRecentPlayers;
 use App\Platform\Commands\BackfillPlaytimeTotal;
 use App\Platform\Commands\CrawlPlayerWeightedPoints;
 use App\Platform\Commands\CreateAchievementOfTheWeek;
@@ -81,6 +82,7 @@ class AppServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 // Games
+                BackfillGameRecentPlayers::class,
                 TrimGameMetadata::class,
                 UpdateGameAchievementsMetrics::class,
                 UpdateGameBeatenMetrics::class,

--- a/app/Platform/Commands/BackfillGameRecentPlayers.php
+++ b/app/Platform/Commands/BackfillGameRecentPlayers.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Commands;
+
+use App\Models\Game;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+
+class BackfillGameRecentPlayers extends Command
+{
+    protected $signature = 'ra:platform:game:backfill-recent-players
+                            {gameIds? : Optional comma-separated list of game IDs}';
+    protected $description = "Backfill game_recent_players table from existing player sessions";
+
+    public function handle(): void
+    {
+        $query = Game::query();
+
+        if ($this->argument('gameIds')) {
+            $gameIds = collect(explode(',', $this->argument('gameIds')))->map(fn ($id) => (int) $id);
+            $query->whereIn('ID', $gameIds);
+        }
+
+        $totalGames = $query->count();
+        if ($totalGames === 0) {
+            $this->info('No games found.');
+
+            return;
+        }
+
+        $this->info("Processing {$totalGames} games...");
+        $this->info("Creating job batches...");
+
+        $batchCount = 0;
+        $query->chunk(1000, function ($games) use (&$batchCount) {
+            $batchJobs = [];
+
+            foreach ($games as $game) {
+                $batchJobs[] = function () use ($game) {
+                    // Use a single query with window function to get the most recent session per user.
+                    $query = <<<SQL
+                        INSERT INTO game_recent_players (game_id, user_id, rich_presence, rich_presence_updated_at)
+                        SELECT 
+                            ps.game_id,
+                            ps.user_id,
+                            ps.rich_presence,
+                            ps.rich_presence_updated_at
+                        FROM (
+                            SELECT 
+                                game_id,
+                                user_id,
+                                rich_presence,
+                                rich_presence_updated_at,
+                                ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY rich_presence_updated_at DESC) as rn
+                            FROM player_sessions
+                            WHERE game_id = ?
+                        ) ps
+                        WHERE ps.rn = 1
+                        ON DUPLICATE KEY UPDATE
+                            rich_presence = VALUES(rich_presence),
+                            rich_presence_updated_at = VALUES(rich_presence_updated_at)
+                    SQL;
+
+                    DB::statement($query, [$game->id]);
+                };
+            }
+
+            if (!empty($batchJobs)) {
+                Bus::batch($batchJobs)->onQueue('player-game-metrics-batch')->dispatch();
+                $batchCount++;
+            }
+        });
+
+        $this->info("Dispatched {$totalGames} jobs in {$batchCount} batches to backfill game recent players.");
+    }
+}

--- a/database/migrations/2025_07_04_000000_create_game_recent_players_table.php
+++ b/database/migrations/2025_07_04_000000_create_game_recent_players_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::create('game_recent_players', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('game_id');
+            $table->unsignedBigInteger('user_id');
+            $table->text('rich_presence')->nullable();
+            $table->timestamp('rich_presence_updated_at');
+
+            $table->unique(['game_id', 'user_id']);
+            $table->index(['game_id', 'rich_presence_updated_at'], 'idx_game_updated');
+
+            $table->foreign('game_id')
+                ->references('ID')
+                ->on('GameData')
+                ->onDelete('cascade');
+
+            $table->foreign('user_id')
+                ->references('ID')
+                ->on('UserAccounts')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('game_recent_players');
+    }
+};


### PR DESCRIPTION
Stacked on #3695.

Switches `getGameRecentPlayers()` to read from `game_recent_players` for a huge performance improvement. Should be deployed separately from #3695.