### PR TITLE
fix(event): don't show empty tooltips for compare progress

### DIFF
--- a/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.tsx
+++ b/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.tsx
@@ -88,7 +88,8 @@ export const PlayerGameProgressBar: FC<PlayerGameProgressBarProps> = ({
    * Otherwise, if there's nothing left for them to unlock, showing those
    * details is largely redundant.
    */
-  const canShowDetailedProgress = achievementsUnlocked !== achievementsPublished;
+  const canShowDetailedProgress =
+    variant === 'event' || achievementsUnlocked !== achievementsPublished;
 
   const isEventGame = getIsEventGame(game);
 


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1017568867574362283/1391119801631637544.

**Root Cause**
These progress bars are assuming the user has beaten or mastered the game, which is not the case for events, ultimately causing an empty tooltip display to appear on hover.