### PR TITLE
fix(BuildGameAchievementDistributionAction): handle null players_total

### DIFF
--- a/app/Platform/Actions/BuildGameAchievementDistributionAction.php
+++ b/app/Platform/Actions/BuildGameAchievementDistributionAction.php
@@ -20,7 +20,7 @@ class BuildGameAchievementDistributionAction
      */
     public function execute(Game $game, ?User $user): Collection
     {
-        $numDistinctPlayers = $game->players_total;
+        $numDistinctPlayers = $game->players_total ?? 0;
         $numAchievements = $game->achievements_published;
 
         $softcoreUnlocks = getAchievementDistribution(


### PR DESCRIPTION
Resolves this recurring error in the logs:

> getAchievementDistribution(): Argument #5 ($numPlayers) must be of type int, null given, called in /home/forge/retroachievements.org/releases/2025-07-03T102122-2025.07.03-0ce16d1e/app/Platform/Actions/BuildGameAchievementDistributionAction.php on line 26

**Root Cause**
`$game->players_total` can be `null` for event "legacy games", but `getAchievementDistribution()` requires an integer. The value now falls back to 0 if it's falsy.