### PR TITLE
fix(game): remediate deduping regression with Other Names metadata row

### DIFF
--- a/tests/Feature/Platform/Actions/ProcessGameReleasesForViewActionTest.php
+++ b/tests/Feature/Platform/Actions/ProcessGameReleasesForViewActionTest.php
@@ -85,11 +85,13 @@ class ProcessGameReleasesForViewActionTest extends TestCase
         // Arrange
         $game = $this->createGameWithReleases('Super Mario Bros.', [
             [
+                'title' => 'Super Mario Bros.', // !! Same title
                 'region' => GameReleaseRegion::Japan,
                 'released_at' => Carbon::parse('1985-09-13'),
                 'released_at_granularity' => ReleasedAtGranularity::Day,
             ],
             [
+                'title' => 'Super Mario Bros.', // !! Same title
                 'region' => GameReleaseRegion::Japan,
                 'released_at' => Carbon::parse('1986-02-21'), // !! Later release in the same region
                 'released_at_granularity' => ReleasedAtGranularity::Day,
@@ -109,11 +111,13 @@ class ProcessGameReleasesForViewActionTest extends TestCase
         // Arrange
         $game = $this->createGameWithReleases('Dragon Quest', [
             [
+                'title' => 'Dragon Quest', // !! Same title
                 'region' => GameReleaseRegion::Japan,
                 'released_at' => Carbon::parse('1986-01-01'), // !! Year granularity, so becomes 1986-12-31
                 'released_at_granularity' => ReleasedAtGranularity::Year,
             ],
             [
+                'title' => 'Dragon Quest', // !! Same title
                 'region' => GameReleaseRegion::Japan,
                 'released_at' => Carbon::parse('1986-05-27'), // !! Day granularity
                 'released_at_granularity' => ReleasedAtGranularity::Day,
@@ -134,11 +138,13 @@ class ProcessGameReleasesForViewActionTest extends TestCase
         // Arrange
         $game = $this->createGameWithReleases('Tetris', [
             [
+                'title' => 'Tetris', // !! Same title
                 'region' => GameReleaseRegion::Worldwide,
                 'released_at' => Carbon::parse('1984-06-06'),
                 'released_at_granularity' => ReleasedAtGranularity::Day,
             ],
             [
+                'title' => 'Tetris', // !! Same title
                 'region' => GameReleaseRegion::Other,
                 'released_at' => Carbon::parse('1985-01-01'), // !! Later date
                 'released_at_granularity' => ReleasedAtGranularity::Year,
@@ -279,12 +285,14 @@ class ProcessGameReleasesForViewActionTest extends TestCase
         GameRelease::where('game_id', $game->id)->delete();
         GameRelease::factory()->create([
             'game_id' => $game->id,
+            'title' => 'Null Region Game', // !! Same title
             'region' => null,
             'released_at' => Carbon::parse('1990-01-01'),
             'released_at_granularity' => ReleasedAtGranularity::Year,
         ]);
         GameRelease::factory()->create([
             'game_id' => $game->id,
+            'title' => 'Null Region Game', // !! Same title
             'region' => GameReleaseRegion::Worldwide,
             'released_at' => Carbon::parse('1989-06-01'),
             'released_at_granularity' => ReleasedAtGranularity::Month,
@@ -297,5 +305,101 @@ class ProcessGameReleasesForViewActionTest extends TestCase
         // Assert
         $this->assertCount(1, $result); // !! Both normalized to 'worldwide'
         $this->assertEquals('1989-06-01', $result[0]->released_at->format('Y-m-d'));
+    }
+
+    public function testItFiltersOutDatelessReleasesWhenDatedReleaseExistsForSameRegion(): void
+    {
+        // Arrange
+        $game = $this->createGameWithReleases('Bug Demo Game', [
+            [
+                'title' => 'Bug Demo Game', // !! Same title
+                'region' => GameReleaseRegion::Japan,
+                'released_at' => Carbon::parse('1987-12-18'),
+                'released_at_granularity' => ReleasedAtGranularity::Day,
+            ],
+            [
+                'title' => 'Bug Demo Game', // !! Same title
+                'region' => GameReleaseRegion::Japan, // !! Same region
+                'released_at' => null, // !! No date - this should be filtered out.
+                'released_at_granularity' => null,
+            ],
+        ]);
+
+        // Act
+        $result = $this->action->execute($game);
+
+        // Assert
+        $this->assertCount(1, $result);
+        $this->assertEquals('1987-12-18', $result[0]->released_at->format('Y-m-d'));
+        $this->assertNotNull($result[0]->released_at); // !! Only the dated release remains
+    }
+
+    public function testItReplacesDatelessReleaseWithDatedReleaseForSameRegion(): void
+    {
+        // Arrange
+        $game = $this->createGameWithReleases('Replace Demo Game', [
+            [
+                'title' => 'Replace Demo Game', // !! Same title
+                'region' => GameReleaseRegion::Japan, // !! Same region
+                'released_at' => null, // !! No date - this should be replaced
+                'released_at_granularity' => null,
+            ],
+            [
+                'title' => 'Replace Demo Game', // !! Same title
+                'region' => GameReleaseRegion::Japan,
+                'released_at' => Carbon::parse('1987-12-18'),
+                'released_at_granularity' => ReleasedAtGranularity::Day,
+            ],
+        ]);
+
+        // Act
+        $result = $this->action->execute($game);
+
+        // Assert
+        $this->assertCount(1, $result);
+        $this->assertEquals('1987-12-18', $result[0]->released_at->format('Y-m-d'));
+        $this->assertNotNull($result[0]->released_at); // !! Dated release replaces dateless one
+    }
+
+    public function testItPreservesReleasesWithUniqueTitles(): void
+    {
+        // Arrange
+        $game = Game::factory()->create(['Title' => 'Unique Titles Game', 'ConsoleID' => $this->system->id]);
+
+        // ... set up multiple releases with different titles, some without dates ...
+        GameRelease::where('game_id', $game->id)->delete();
+        GameRelease::factory()->create([
+            'game_id' => $game->id,
+            'title' => 'Main Title',
+            'region' => GameReleaseRegion::Japan,
+            'released_at' => Carbon::parse('1987-12-18'),
+            'released_at_granularity' => ReleasedAtGranularity::Day,
+        ]);
+        GameRelease::factory()->create([
+            'game_id' => $game->id,
+            'title' => 'Alternative Title', // !! Unique title
+            'region' => GameReleaseRegion::Japan, // !! Same region as above
+            'released_at' => null, // !! No date
+            'released_at_granularity' => null,
+        ]);
+        GameRelease::factory()->create([
+            'game_id' => $game->id,
+            'title' => 'European Title', // !! Another unique title
+            'region' => GameReleaseRegion::Europe,
+            'released_at' => null, // !! No date
+            'released_at_granularity' => null,
+        ]);
+        $game = $game->fresh(['releases']);
+
+        // Act
+        $result = $this->action->execute($game);
+
+        // Assert
+        $this->assertCount(3, $result); // !! all unique titles
+
+        $titles = array_map(fn ($release) => $release->title, $result);
+        $this->assertContains('Main Title', $titles);
+        $this->assertContains('Alternative Title', $titles); // !! Should be preserved despite no date
+        $this->assertContains('European Title', $titles); // !! Should be preserved despite no date
     }
 }


### PR DESCRIPTION
This PR fixes a regression where the "Other Names" row on game2 is no longer showing releases that don't have dates associated with them.

http://localhost:64000/game2/19043

**Before**
<img width="343" height="89" alt="Screenshot 2025-07-18 at 8 45 20 PM" src="https://github.com/user-attachments/assets/4ddb33d8-9bde-4aa3-ade2-3b072a8ae102" />


**After**
<img width="339" height="116" alt="Screenshot 2025-07-18 at 8 45 12 PM" src="https://github.com/user-attachments/assets/da26ac83-be54-47b4-94ba-fdfaf313326c" />
