### PR TITLE
fix(game): make some very minor css tweaks to React game pages

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -916,7 +916,7 @@
     "Base Set": "Base Set",
     "There aren't any achievements for this game yet.": "There aren't any achievements for this game yet.",
     "Subset {{subsetNumber, number}}": "Subset {{subsetNumber, number}}",
-    "{{achievementsCount, number}} achievements worth {{pointsCount, number}} <1>({{retroPointsCount, number}})</1> points": "{{achievementsCount, number}} achievements worth {{pointsCount, number}} <1>({{retroPointsCount, number}})</1> points",
+    "<1>{{achievementsCount, number}}</1> achievements worth <2>{{pointsCount, number}}</2> <3>({{retroPointsCount, number}})</3> points": "<1>{{achievementsCount, number}}</1> achievements worth <2>{{pointsCount, number}}</2> <3>({{retroPointsCount, number}})</3> points",
     "Points (least)": "Points (least)",
     "Points (most)": "Points (most)",
     "Title (Z - A)": "Title (Z - A)",

--- a/resources/js/common/components/PlayableCompareProgress/PopulatedPlayerCompletions/PopulatedPlayerCompletions.tsx
+++ b/resources/js/common/components/PlayableCompareProgress/PopulatedPlayerCompletions/PopulatedPlayerCompletions.tsx
@@ -100,7 +100,7 @@ const PlayerCompletionList: FC<PlayerCompletionListProps> = ({ completions, game
     <ul className="zebra-list">
       {completions.map((completion) => (
         <li
-          className="flex w-full items-center justify-between gap-2 p-2"
+          className="flex w-full items-center justify-between gap-2 p-2 first:rounded-t-lg last:rounded-b-lg"
           key={`completion-${completion.user.displayName}`}
         >
           <span className="lg:w-[130px] xl:w-[176px]">

--- a/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSetHeader/GameAchievementSetHeader.tsx
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSetHeader/GameAchievementSetHeader.tsx
@@ -41,13 +41,17 @@ export const GameAchievementSetHeader: FC<GameAchievementSetHeaderProps> = ({
 
           <span className="text-xs text-text">
             <Trans
-              i18nKey="{{achievementsCount, number}} achievements worth {{pointsCount, number}} <1>({{retroPointsCount, number}})</1> points"
+              i18nKey="<1>{{achievementsCount, number}}</1> achievements worth <2>{{pointsCount, number}}</2> <3>({{retroPointsCount, number}})</3> points"
               values={{
                 achievementsCount: achievements.length,
                 pointsCount: totalPoints,
                 retroPointsCount: totalPointsWeighted,
               }}
-              components={{ 1: <WeightedPointsContainer /> }}
+              components={{
+                1: <span className="font-bold" />,
+                2: <span className="font-bold" />,
+                3: <WeightedPointsContainer />,
+              }}
             />
           </span>
         </div>


### PR DESCRIPTION
Tiny PR to make two minor CSS tweaks to React game pages.

#### 1. Achievement and points counts are now bolded.
**Before**
<img width="421" height="161" alt="Screenshot 2025-07-19 at 5 07 01 PM" src="https://github.com/user-attachments/assets/072c76f1-4412-494f-bae6-c76ca9b3586b" />

**After**
<img width="422" height="162" alt="Screenshot 2025-07-19 at 5 06 08 PM" src="https://github.com/user-attachments/assets/be83037e-b2ad-41ce-a4da-d0cacd2df871" />

---

#### 2. Compare Progress top and bottom rows now have rounding applied for consistency with other things in the sidebar.
**Before**
<img width="359" height="125" alt="Screenshot 2025-07-19 at 5 07 08 PM" src="https://github.com/user-attachments/assets/9b8ac78e-df2b-4572-ad09-99d36ea99f7c" />

**After**
<img width="374" height="129" alt="Screenshot 2025-07-19 at 5 06 14 PM" src="https://github.com/user-attachments/assets/784a15ff-abde-46c3-b2b4-c751e864cf94" />
