### PR TITLE
perf: make some tiny optimizations to ResumePlayerSessionAction

### DIFF
--- a/app/Platform/Actions/ResumePlayerSessionAction.php
+++ b/app/Platform/Actions/ResumePlayerSessionAction.php
@@ -58,11 +58,15 @@ class ResumePlayerSessionAction
             ->orderByDesc('id')
             ->first();
 
+        // As best as we can, we'll try to only write once to the user model.
+        $doesUserNeedsUpdate = false;
+
         if ($user->LastGameID !== $game->id) {
             expireRecentlyPlayedGames($user->User);
+
             // TODO deprecated, read from last player_sessions entry where needed
             $user->LastGameID = $game->id;
-            $user->saveQuietly();
+            $doesUserNeedsUpdate = true;
         }
 
         // if the session is less than 10 minutes old, resume session
@@ -91,7 +95,7 @@ class ResumePlayerSessionAction
                 // TODO deprecated, read from last player_sessions entry where needed
                 $user->RichPresenceMsg = utf8_sanitize($presence);
                 $user->RichPresenceMsgDate = $timestamp;
-                $user->saveQuietly();
+                $doesUserNeedsUpdate = true;
 
                 // Update the player's game_recent_players table entry.
                 GameRecentPlayer::upsert(
@@ -120,6 +124,10 @@ class ResumePlayerSessionAction
             }
 
             $playerSession->save(['touch' => true]);
+
+            if ($doesUserNeedsUpdate) {
+                $user->saveQuietly();
+            }
 
             PlayerSessionResumed::dispatch($user, $game, $presence);
 


### PR DESCRIPTION
This PR implements small optimizations to `ResumePlayerSessionAction`. Individually, these optimizations only save 3-5ms per execution, but at 49M executions/month they should yield significant CPU time savings.

**Changes:**
- `User` model updates have been consolidated from 3 separate saves to a single save.
- `AttachPlayerGameAction` now uses `firstOrCreate()` instead of a check-then-create pattern.

All in all, this should reduce queries from 7-8 to 5-6 per action invocation.

On my local, I benchmarked the before/after with 100 iterations.
- New session creation: 14.5ms -> 8.3ms (-6.2ms)
- Resume session: 17.01ms -> 13.85ms (-3.16ms)
- Resume with playtime: 17.12ms -> 12.53ms (-4.59ms)

These micro-optimizations should collectively save ~25 CPU hours per month.