### PR TITLE
fix(game): don't show empty tooltips for some Recent Players

### DIFF
--- a/app/Platform/Actions/LoadGameRecentPlayersAction.php
+++ b/app/Platform/Actions/LoadGameRecentPlayersAction.php
@@ -57,7 +57,7 @@ class LoadGameRecentPlayersAction
                 $recentPlayer,
                 $playerGame,
                 $highestAward
-            );
+            )->include('highestAward');
         });
     }
 

--- a/resources/js/common/components/PlayableCompareProgress/PopulatedPlayerCompletions/PopulatedPlayerCompletions.tsx
+++ b/resources/js/common/components/PlayableCompareProgress/PopulatedPlayerCompletions/PopulatedPlayerCompletions.tsx
@@ -106,10 +106,11 @@ const PlayerCompletionList: FC<PlayerCompletionListProps> = ({ completions, game
           <span className="lg:w-[130px] xl:w-[176px]">
             <UserAvatar {...completion.user} size={24} labelClassName="truncate" />
           </span>
+
           <PlayerGameProgressBar
             playerGame={completion.playerGame}
             game={game}
-            variant="event"
+            variant="minimal"
             width={108}
             href={route('game.compare-unlocks', {
               game: game.id,

--- a/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.test.tsx
+++ b/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.test.tsx
@@ -168,7 +168,7 @@ describe('Component: PlayerGameProgressBar', () => {
     expect(tooltipEl).toHaveTextContent(/mastered/i);
   });
 
-  it('given variant is "event" and pointsTotal equals achievementsPublished, does not show points metadata in the tooltip', async () => {
+  it('given variant is "minimal" and pointsTotal equals achievementsPublished, does not show points metadata in the tooltip', async () => {
     // ARRANGE
     const system = createSystem({ id: 1 });
     const game = createGame({ system, achievementsPublished: 400, pointsTotal: 400 });
@@ -184,7 +184,7 @@ describe('Component: PlayerGameProgressBar', () => {
       }),
     });
 
-    render(<PlayerGameProgressBar game={game} playerGame={playerGame} variant="event" />);
+    render(<PlayerGameProgressBar game={game} playerGame={playerGame} variant="minimal" />);
 
     // ACT
     await userEvent.hover(screen.getByRole('progressbar'));

--- a/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.tsx
+++ b/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.tsx
@@ -48,10 +48,10 @@ interface PlayerGameProgressBarProps {
 
   /**
    * base: The award label is subdued. Useful when many progress bars are in a "stacked" layout.
-   * event: The award label is not shown. Points is only shown in the tooltip if pointsTotal is different from achievementsPublished.
+   * minimal: The award label is not shown. Points is only shown in the tooltip if pointsTotal is different from achievementsPublished.
    * unmuted: The award label is not subdued. Good for when there aren't many bars to display.
    */
-  variant?: 'base' | 'event' | 'unmuted';
+  variant?: 'base' | 'minimal' | 'unmuted';
 
   width?: number;
 }
@@ -91,7 +91,7 @@ export const PlayerGameProgressBar: FC<PlayerGameProgressBarProps> = ({
    * details is largely redundant.
    */
   const canShowDetailedProgress =
-    variant === 'event' || achievementsUnlocked !== achievementsPublished;
+    variant === 'minimal' || achievementsUnlocked !== achievementsPublished;
 
   const isEventGame = getIsEventGame(game);
 
@@ -108,7 +108,7 @@ export const PlayerGameProgressBar: FC<PlayerGameProgressBarProps> = ({
 
   const canLink = href && achievementsUnlocked;
   const canShowTooltipPoints =
-    (variant === 'event' && achievementsPublished !== pointsTotal) || variant !== 'event';
+    (variant === 'minimal' && achievementsPublished !== pointsTotal) || variant !== 'minimal';
 
   const Wrapper = canLink && achievementsUnlocked ? 'a' : 'div';
 
@@ -142,7 +142,7 @@ export const PlayerGameProgressBar: FC<PlayerGameProgressBarProps> = ({
           />
 
           <div className={cn('flex w-full items-center justify-between')}>
-            {highestAward && !isEventGame && variant !== 'event' ? (
+            {highestAward && !isEventGame && variant !== 'minimal' ? (
               <div className={cn('flex items-center gap-1')}>
                 <PlayerBadgeIndicator playerBadge={highestAward} className="mt-px" />
                 <p>

--- a/resources/js/features/games/components/GameRecentPlayers/GameRecentPlayersList/GameRecentPlayersList.tsx
+++ b/resources/js/features/games/components/GameRecentPlayers/GameRecentPlayersList/GameRecentPlayersList.tsx
@@ -64,6 +64,7 @@ export const GameRecentPlayersList: FC = () => {
                     pointsHardcore: recentPlayer.pointsHardcore,
                   }}
                   className="!py-0"
+                  variant="minimal"
                 />
               </div>
             </div>

--- a/resources/js/features/games/components/GameRecentPlayers/GameRecentPlayersTable/GameRecentPlayersTable.tsx
+++ b/resources/js/features/games/components/GameRecentPlayers/GameRecentPlayersTable/GameRecentPlayersTable.tsx
@@ -68,6 +68,7 @@ export const GameRecentPlayersTable: FC = () => {
                   points: recentPlayer.points,
                   pointsHardcore: recentPlayer.pointsHardcore,
                 }}
+                variant="minimal"
               />
             </BaseTableCell>
 


### PR DESCRIPTION
Fixes a bug on React game pages in the Recent Players section. If a player shown has a mastery award for the game, the tooltip content is empty.

**Before**
<img width="423" height="104" alt="Screenshot 2025-07-22 at 3 43 29 PM" src="https://github.com/user-attachments/assets/c3301be3-0461-458d-b9c0-2b59c30c1efc" />

**After**
<img width="441" height="129" alt="Screenshot 2025-07-22 at 3 54 03 PM" src="https://github.com/user-attachments/assets/68cc51f5-5f5a-4b74-be1a-b944ca8c8679" />
