### PR TITLE
fix(AchievementAuthorsDisplay): lower prominence threshold from 33% to 30%

### DIFF
--- a/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.test.tsx
@@ -20,7 +20,7 @@ describe('Component: AchievementAuthorsDisplay', () => {
     expect(container).toBeTruthy();
   });
 
-  it('given authors with >= 33%, shows them individually with labels', () => {
+  it('given authors with >= 30%, shows them individually with labels', () => {
     // ARRANGE
     const authors = [
       createUserCredits({ displayName: 'Alice', count: 40 }), // !! 40%
@@ -43,15 +43,15 @@ describe('Component: AchievementAuthorsDisplay', () => {
     const separators = screen.getAllByText('•');
     expect(separators).toHaveLength(2);
 
-    // ... Alice and Bob have labels because they have >= 33% contribution ...
+    // ... Alice and Bob have labels because they have >= 30% contribution ...
     expect(screen.getByText(/alice/i)).toBeVisible();
     expect(screen.getByText(/bob/i)).toBeVisible();
 
-    // ... Charlie is in the stack without a label (< 33% contribution) ...
+    // ... Charlie is in the stack without a label (< 30% contribution) ...
     expect(screen.queryByText(/charlie/i)).not.toBeInTheDocument();
   });
 
-  it('given one author with >= 33% and others with < 33%, shows prominent author individually and stacks the rest', () => {
+  it('given one author with >= 30% and others with < 30%, shows prominent author individually and stacks the rest', () => {
     // ARRANGE
     const authors = [
       createUserCredits({ displayName: 'Alice', count: 50 }), // !! 50%
@@ -79,7 +79,7 @@ describe('Component: AchievementAuthorsDisplay', () => {
     expect(screen.getByText(/alice/i)).toBeVisible();
   });
 
-  it('given all authors with < 33%, shows all avatars in a single stack', () => {
+  it('given all authors with < 30%, shows all avatars in a single stack', () => {
     // ARRANGE
     const authors = [
       createUserCredits({ displayName: 'Alice', count: 20 }), // !! 20%

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.tsx
@@ -35,11 +35,11 @@ export const AchievementAuthorsDisplay: FC<AchievementAuthorsDisplayProps> = ({ 
     percentage: totalAchievements > 0 ? (author.count / totalAchievements) * 100 : 0,
   }));
 
-  // Separate authors who contributed at least 33% from the rest.
-  const prominentAuthors = authorsWithPercentage.filter((author) => author.percentage >= 33);
-  const otherAuthors = authorsWithPercentage.filter((author) => author.percentage < 33);
+  // Separate authors who contributed at least 30% from the rest.
+  const prominentAuthors = authorsWithPercentage.filter((author) => author.percentage >= 30);
+  const otherAuthors = authorsWithPercentage.filter((author) => author.percentage < 30);
 
-  // If no prominent authors (all have < 33%), show them all in a stack.
+  // If no prominent authors (all have < 30%), show them all in a stack.
   if (prominentAuthors.length === 0) {
     return (
       <div className={containerClassNames}>


### PR DESCRIPTION
Extracts a minor tweak from the now-closed https://github.com/RetroAchievements/RAWeb/pull/3674:

> ... a minor tweak to the 33% authorship threshold, lowering it to 30%. This fixes an issue where only one author label was appearing for Super Mario 64, even though another user had contributed something like 31% of the set's achievements.

**Before**
<img width="358" height="111" alt="Screenshot 2025-07-22 at 4 06 55 PM" src="https://github.com/user-attachments/assets/aa7062b8-5869-4402-9465-4afeab076749" />


**After**
<img width="444" height="123" alt="Screenshot 2025-07-22 at 4 06 23 PM" src="https://github.com/user-attachments/assets/0fbb3942-5389-4ae4-b4a6-83a688d17637" />
