### PR TITLE
fix(ClaimantsDisplay): show 'In Review' status

### DIFF
--- a/app/Platform/Actions/BuildGameShowPagePropsAction.php
+++ b/app/Platform/Actions/BuildGameShowPagePropsAction.php
@@ -274,7 +274,7 @@ class BuildGameShowPagePropsAction
     private function buildAchievementSetClaims(Game $game, ?User $user): Collection
     {
         // Build the include array based on current user permissions.
-        $claimIncludes = ['user', 'finishedAt'];
+        $claimIncludes = ['user', 'finishedAt', 'status'];
         if ($user && $user->hasAnyRole([Role::DEV_COMPLIANCE, Role::MODERATOR, Role::ADMINISTRATOR])) {
             $claimIncludes[] = 'userLastPlayedAt';
         }

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -1050,5 +1050,6 @@
     "filterRequests_active": "Active",
     "filterRequests_all": "All",
     "Game Forum Topic": "Game Forum Topic",
-    "Subset Forum Topic": "Subset Forum Topic"
+    "Subset Forum Topic": "Subset Forum Topic",
+    "In Review": "In Review"
 }

--- a/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/ClaimantsDisplay.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/ClaimantsDisplay.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from '@testing-library/user-event';
 
+import { ClaimStatus } from '@/common/utils/generatedAppConstants';
 import { render, screen, waitFor } from '@/test';
 import { createAchievementSetClaim, createUser } from '@/test/factories';
 
@@ -163,5 +164,27 @@ describe('Component: ClaimantsDisplay', () => {
 
     // ASSERT
     expect(screen.getByText(/claimed by/i)).toBeInTheDocument();
+  });
+
+  it('given the claim has the In Review status, shows the correct label', async () => {
+    // ARRANGE
+    const achievementSetClaims = [
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'Alice' }),
+        status: ClaimStatus.InReview, // !!
+      }),
+    ];
+
+    render(<ClaimantsDisplay achievementSetClaims={achievementSetClaims} />);
+
+    // ACT
+    await userEvent.hover(screen.getAllByRole('button')[0]);
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getAllByText(/in review/i)[0]).toBeVisible();
+    });
+
+    expect(screen.queryByText(/expir/i)).not.toBeInTheDocument();
   });
 });

--- a/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/ClaimantsDisplay.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/ClaimantsDisplay/ClaimantsDisplay.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/common/components/+vendor/BaseTooltip';
 import { UserAvatarStack } from '@/common/components/UserAvatarStack';
 import { cn } from '@/common/utils/cn';
+import { ClaimStatus } from '@/common/utils/generatedAppConstants';
 import { formatDate } from '@/common/utils/l10n/formatDate';
 import { useDiffForHumans } from '@/common/utils/l10n/useDiffForHumans';
 
@@ -114,9 +115,15 @@ const ClaimsIcon: FC<ClaimsIconProps> = ({ achievementSetClaims }) => {
                   displayName: claim.user!.displayName,
                 }}
               >
-                {dayjs(claim.finishedAt!).isAfter(dayjs())
-                  ? t('Expires {{date}}', { date: formatDate(claim.finishedAt!, 'l') })
-                  : t('Expired {{date}}', { date: formatDate(claim.finishedAt!, 'l') })}
+                {claim.status === ClaimStatus.InReview ? (
+                  t('In Review')
+                ) : (
+                  <>
+                    {dayjs(claim.finishedAt!).isAfter(dayjs())
+                      ? t('Expires {{date}}', { date: formatDate(claim.finishedAt!, 'l') })
+                      : t('Expired {{date}}', { date: formatDate(claim.finishedAt!, 'l') })}
+                  </>
+                )}
               </TooltipCreditRow>
             ))}
           </TooltipCreditsSection>


### PR DESCRIPTION
This PR fixes an issue where "In Review" claim statuses are not shown on React game pages.

**Before**
<img width="251" height="98" alt="Screenshot 2025-07-25 at 5 31 02 PM" src="https://github.com/user-attachments/assets/33dd9ab0-8076-4917-8658-e3c5bd12a8d7" />

**After**
<img width="193" height="108" alt="Screenshot 2025-07-25 at 5 30 49 PM" src="https://github.com/user-attachments/assets/9a947ffb-def5-4dcd-a7fc-1cb267403e1a" />
