### PR TITLE
perf(home): read Active Players from game_recent_players table

### DIFF
--- a/app/Models/GameRecentPlayer.php
+++ b/app/Models/GameRecentPlayer.php
@@ -5,10 +5,15 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Support\Database\Eloquent\BaseModel;
+use Database\Factories\GameRecentPlayerFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class GameRecentPlayer extends BaseModel
 {
+    /** @use HasFactory<GameRecentPlayerFactory> */
+    use HasFactory;
+
     protected $table = 'game_recent_players';
 
     protected $fillable = [
@@ -23,6 +28,11 @@ class GameRecentPlayer extends BaseModel
     ];
 
     public $timestamps = false;
+
+    protected static function newFactory(): GameRecentPlayerFactory
+    {
+        return GameRecentPlayerFactory::new();
+    }
 
     // == accessors
 

--- a/database/factories/GameRecentPlayerFactory.php
+++ b/database/factories/GameRecentPlayerFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Game;
+use App\Models\GameRecentPlayer;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<GameRecentPlayer>
+ */
+class GameRecentPlayerFactory extends Factory
+{
+    protected $model = GameRecentPlayer::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'game_id' => Game::factory(),
+            'user_id' => User::factory(),
+            'rich_presence' => $this->faker->sentence(),
+            'rich_presence_updated_at' => now(),
+        ];
+    }
+}

--- a/tests/Feature/Community/Actions/BuildActivePlayersActionTest.php
+++ b/tests/Feature/Community/Actions/BuildActivePlayersActionTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Community\Actions;
 use App\Community\Actions\BuildActivePlayersAction;
 use App\Enums\Permissions;
 use App\Models\Game;
+use App\Models\GameRecentPlayer;
 use App\Models\System;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -15,6 +16,16 @@ use Tests\TestCase;
 class BuildActivePlayersActionTest extends TestCase
 {
     use RefreshDatabase;
+
+    private function createActivePlayer(User $user, Game $game, ?string $richPresence = null): void
+    {
+        GameRecentPlayer::factory()->create([
+            'user_id' => $user->id,
+            'game_id' => $game->id,
+            'rich_presence' => $richPresence ?? 'Playing Stage 1',
+            'rich_presence_updated_at' => now(),
+        ]);
+    }
 
     public function testItReturnsEmptyDataWhenNoActivePlayers(): void
     {
@@ -33,11 +44,15 @@ class BuildActivePlayersActionTest extends TestCase
         $system = System::factory()->create();
         $game = Game::factory()->create(['ConsoleID' => $system->id]);
 
-        User::factory()->count(5)->create([
+        $users = User::factory()->count(5)->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
         ]);
+
+        foreach ($users as $user) {
+            $this->createActivePlayer($user, $game);
+        }
 
         // Act
         $result = (new BuildActivePlayersAction())->execute(perPage: 2, page: 1);
@@ -56,16 +71,23 @@ class BuildActivePlayersActionTest extends TestCase
         $game1 = Game::factory()->create(['ConsoleID' => $system->id]);
         $game2 = Game::factory()->create(['ConsoleID' => $system->id]);
 
-        User::factory()->count(5)->create([
+        $game1Users = User::factory()->count(5)->create([
             'LastGameID' => $game1->id, // !!
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
         ]);
-        User::factory()->count(3)->create([
+        $game2Users = User::factory()->count(3)->create([
             'LastGameID' => $game2->id, // !!
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
         ]);
+
+        foreach ($game1Users as $user) {
+            $this->createActivePlayer($user, $game1);
+        }
+        foreach ($game2Users as $user) {
+            $this->createActivePlayer($user, $game2);
+        }
 
         // Act
         $result = (new BuildActivePlayersAction())->execute(gameIds: [$game1->id]);
@@ -83,20 +105,23 @@ class BuildActivePlayersActionTest extends TestCase
         $system = System::factory()->create();
         $game = Game::factory()->create(['ConsoleID' => $system->id]);
 
-        User::factory()->create([
+        $user1 = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
             'User' => 'testuser123', // !!
             'RichPresenceMsg' => 'Playing game',
         ]);
-        User::factory()->create([
+        $user2 = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
             'User' => 'otheruser456', // !!
             'RichPresenceMsg' => 'Playing game',
         ]);
+
+        $this->createActivePlayer($user1, $game, 'Playing game');
+        $this->createActivePlayer($user2, $game, 'Playing game');
 
         // Act
         $result = (new BuildActivePlayersAction())->execute(search: 'testuser');
@@ -112,20 +137,23 @@ class BuildActivePlayersActionTest extends TestCase
         $system = System::factory()->create();
         $game = Game::factory()->create(['ConsoleID' => $system->id]);
 
-        User::factory()->create([
+        $user1 = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
             'User' => 'testuser123',
             'RichPresenceMsg' => 'Developing achievements',
         ]);
-        User::factory()->create([
+        $user2 = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
             'User' => 'otheruser456',
             'RichPresenceMsg' => 'Playing game',
         ]);
+
+        $this->createActivePlayer($user1, $game, 'Developing achievements');
+        $this->createActivePlayer($user2, $game, 'Playing game');
 
         // Act
         $result = (new BuildActivePlayersAction())->execute(search: 'developing');
@@ -143,18 +171,21 @@ class BuildActivePlayersActionTest extends TestCase
         $game1 = Game::factory()->create(['ConsoleID' => $system->id, 'Title' => 'Sonic the Hedgehog']);
         $game2 = Game::factory()->create(['ConsoleID' => $system->id, 'Title' => 'Legend of Zelda']);
 
-        User::factory()->create([
+        $user1 = User::factory()->create([
             'LastGameID' => $game1->id, // !!
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
             'User' => 'Scott',
         ]);
-        User::factory()->create([
+        $user2 = User::factory()->create([
             'LastGameID' => $game2->id, // !!
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
             'User' => 'Batman',
         ]);
+
+        $this->createActivePlayer($user1, $game1);
+        $this->createActivePlayer($user2, $game2);
 
         // Act
         $result = (new BuildActivePlayersAction())->execute(search: 'zelda');
@@ -171,24 +202,28 @@ class BuildActivePlayersActionTest extends TestCase
         $system = System::factory()->create();
         $game = Game::factory()->create(['ConsoleID' => $system->id]);
 
-        User::factory()->create([
+        $user1 = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
             'RichPresenceMsg' => 'Playing game',
         ]);
-        User::factory()->create([
+        $user2 = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
             'RichPresenceMsg' => 'Developing achievements',
         ]);
-        User::factory()->create([
+        $user3 = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
             'RichPresenceMsg' => 'Fixing achievements',
         ]);
+
+        $this->createActivePlayer($user1, $game, 'Playing game');
+        $this->createActivePlayer($user2, $game, 'Developing achievements');
+        $this->createActivePlayer($user3, $game, 'Fixing achievements');
 
         // Act
         $result = (new BuildActivePlayersAction())->execute(search: 'developing|fixing');
@@ -203,15 +238,26 @@ class BuildActivePlayersActionTest extends TestCase
         $system = System::factory()->create();
         $game = Game::factory()->create(['ConsoleID' => $system->id]);
 
-        User::factory()->create([
+        $activeUser = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
         ]);
-        User::factory()->create([
+        $inactiveUser = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now()->subDays(2),
             'Permissions' => Permissions::Registered,
+        ]);
+
+        // ... create recent activity for the active user ...
+        $this->createActivePlayer($activeUser, $game);
+
+        // ... create old activity for the inactive user ...
+        GameRecentPlayer::factory()->create([
+            'user_id' => $inactiveUser->id,
+            'game_id' => $game->id,
+            'rich_presence' => 'Playing Stage 1',
+            'rich_presence_updated_at' => now()->subDays(2), // !! old timestamp -- edge case
         ]);
 
         // Act
@@ -227,7 +273,7 @@ class BuildActivePlayersActionTest extends TestCase
         $system = System::factory()->create();
         $game = Game::factory()->create(['ConsoleID' => $system->id]);
 
-        User::factory()->create([
+        $trackedHighPoints = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
@@ -235,7 +281,7 @@ class BuildActivePlayersActionTest extends TestCase
             'Untracked' => 0,
             'RAPoints' => 100000,
         ]);
-        User::factory()->create([
+        $untrackedHighPoints = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
@@ -243,7 +289,7 @@ class BuildActivePlayersActionTest extends TestCase
             'Untracked' => 1,
             'RAPoints' => 999999,
         ]);
-        User::factory()->create([
+        $trackedLowPoints = User::factory()->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
@@ -251,6 +297,10 @@ class BuildActivePlayersActionTest extends TestCase
             'Untracked' => 0,
             'RAPoints' => 50000,
         ]);
+
+        $this->createActivePlayer($trackedHighPoints, $game);
+        $this->createActivePlayer($untrackedHighPoints, $game);
+        $this->createActivePlayer($trackedLowPoints, $game);
 
         // Act
         $result = (new BuildActivePlayersAction())->execute();

--- a/tests/Feature/Community/Actions/BuildTrendingGamesActionTest.php
+++ b/tests/Feature/Community/Actions/BuildTrendingGamesActionTest.php
@@ -8,6 +8,7 @@ use App\Community\Actions\BuildTrendingGamesAction;
 use App\Community\Data\TrendingGameData;
 use App\Enums\Permissions;
 use App\Models\Game;
+use App\Models\GameRecentPlayer;
 use App\Models\System;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -38,26 +39,53 @@ class BuildTrendingGamesActionTest extends TestCase
         $game2 = Game::factory()->create(['ConsoleID' => $system->id, 'Title' => 'second_most_popular']);
         $game5 = Game::factory()->create(['ConsoleID' => $system->id, 'Title' => 'fifth_most_popular']);
 
-        User::factory()->create([
+        $game4User = User::factory()->create([
             'LastGameID' => $game4->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
         ]);
-        User::factory()->count(2)->create([
+        $game3Users = User::factory()->count(2)->create([
             'LastGameID' => $game3->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
         ]);
-        User::factory()->count(3)->create([
+        $game2Users = User::factory()->count(3)->create([
             'LastGameID' => $game2->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
         ]);
-        User::factory()->count(4)->create([
+        $game1Users = User::factory()->count(4)->create([
             'LastGameID' => $game1->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
         ]);
+
+        GameRecentPlayer::factory()->create([
+            'user_id' => $game4User->id,
+            'game_id' => $game4->id,
+            'rich_presence_updated_at' => now(),
+        ]);
+        foreach ($game3Users as $user) {
+            GameRecentPlayer::factory()->create([
+                'user_id' => $user->id,
+                'game_id' => $game3->id,
+                'rich_presence_updated_at' => now(),
+            ]);
+        }
+        foreach ($game2Users as $user) {
+            GameRecentPlayer::factory()->create([
+                'user_id' => $user->id,
+                'game_id' => $game2->id,
+                'rich_presence_updated_at' => now(),
+            ]);
+        }
+        foreach ($game1Users as $user) {
+            GameRecentPlayer::factory()->create([
+                'user_id' => $user->id,
+                'game_id' => $game1->id,
+                'rich_presence_updated_at' => now(),
+            ]);
+        }
 
         // Act
         $result = (new BuildTrendingGamesAction())->execute();

--- a/tests/Feature/Community/Controllers/Api/ActivePlayersApiControllerTest.php
+++ b/tests/Feature/Community/Controllers/Api/ActivePlayersApiControllerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Community\Controllers\Api;
 
 use App\Enums\Permissions;
 use App\Models\Game;
+use App\Models\GameRecentPlayer;
 use App\Models\System;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -48,11 +49,20 @@ class ActivePlayersApiControllerTest extends TestCase
         $system = System::factory()->create();
         $game = Game::factory()->create(['ConsoleID' => $system->id]);
 
-        User::factory()->count(5)->create([
+        $users = User::factory()->count(5)->create([
             'LastGameID' => $game->id,
             'RichPresenceMsgDate' => now(),
             'Permissions' => Permissions::Registered,
         ]);
+
+        foreach ($users as $user) {
+            GameRecentPlayer::factory()->create([
+                'user_id' => $user->id,
+                'game_id' => $game->id,
+                'rich_presence' => 'Playing Stage 1',
+                'rich_presence_updated_at' => now(),
+            ]);
+        }
 
         // Act
         $response = $this->getJson(route('api.active-player.index', [


### PR DESCRIPTION
This PR adjusts `LoadThinActivePlayersListAction` (the home page Active Players query) to read from the new `game_recent_players` table rather than `UserAccounts` for a significant query performance improvement.

**Benchmark Results (100 iterations):**

| Implementation | Average Time | Min Time | Max Time |
|----------------|--------------|----------|----------|
| Old (UserAccounts) | 206.95 ms | 201.33 ms | 218.75 ms |
| New (game_recent_players) | 90.92 ms | 88.28 ms | 109.19 ms |

The new query maintains the same data contract used by the old one. The SWR cache is retained, so it's probably not much of a difference in the grand scheme of things. I just wanted the cache miss to be a bit faster.