### PR TITLE
add API_GetGameProgression

### DIFF
--- a/app/Platform/Actions/ResumePlayerSessionAction.php
+++ b/app/Platform/Actions/ResumePlayerSessionAction.php
@@ -65,6 +65,11 @@ class ResumePlayerSessionAction
             $user->saveQuietly();
         }
 
+        // if the timestamp is within the session, just return it (backdated unlocks)
+        if ($playerSession && $timestamp->between($playerSession->created_at, $playerSession->rich_presence_updated_at)) {
+            return $playerSession;
+        }
+
         // if the session is less than 10 minutes old, resume session
         if ($playerSession && ($timestamp->diffInMinutes($playerSession->rich_presence_updated_at, true) < 10)) {
             $newDuration = max(1, (int) $timestamp->diffInMinutes($playerSession->created_at, true));

--- a/public/API/API_GetGameProgression.php
+++ b/public/API/API_GetGameProgression.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ *  API_GetGameProgression - returns information about the average time to unlock achievements in a game
+ *    i : game id
+ *    h : 1=ignore users with no hardcore unlocks
+ *
+ *  int        ID                                unique identifier of the game
+ *  string     Title                             name of the game
+ *  int        ConsoleID                         unique identifier of the console associated to the game
+ *  string     ConsoleName                       name of the console associated to the game
+ *  string     ImageIcon                         site-relative path to the game's icon image
+ *  int        NumDistinctPlayers                number of unique players who have earned achievements for the game
+ *  int        TimesUsedInBeatMedian             number of beats analyzed for the MedianTimeToBeat metric
+ *  int        TimesUsedInHardcoreBeatMedian     number of hardcore beats analyzed for the MedianTimeToBeatHardcore metric
+ *  int?       MedianTimeToBeat                  median number of seconds required to beat the game
+ *  int?       MedianTimeToBeatHardcore          median number of seconds required to beat the game in hardcore
+ *  int        TimesUsedInCompletionMedian       number of completions analyzed for the MedianTimeToComplete metric
+ *  int        TimesUsedInMasteryMedian          number of masteries analyzed for the MedianTimeToMaster metric
+ *  int?       MedianTimeToComplete              median number of seconds required to complete the game
+ *  int?       MedianTimeToMaster                median number of seconds required to master the game
+ *  int        NumAchievements                   count of core achievements associated to the game
+ *  array      Achievements
+ *   int        ID                               unique identifier of the achievement
+ *   string     Title                            title of the achievement
+ *   string     Description                      description of the achievement
+ *   int        Points                           number of points the achievement is worth
+ *   int        TrueRatio                        number of RetroPoints ("white points") the achievement is worth
+ *   string?    Type                             type of the achievement (progression/win_condition/missable/null)
+ *   string     BadgeName                        unique identifier of the badge image for the achievement
+ *   int        NumAwarded                       number of times the achievement has been awarded
+ *   int        NumAwardedHardcore               number of times the achievement has been awarded in hardcore
+ *   int        TimesUsedInUnlockMedian          number of unlocks analyzed for the MedianTimeToUnlock metric
+ *   int        TimesUsedInHardcoreUnlockMedian  number of unlocks analyzed for the MedianTimeToUnlockHardcore metric
+ *   int        MedianTimeToUnlock               median number of seconds required to unlock this achievement from starting to play the game
+ *   int        MedianTimeToUnlockHardcore       median number of seconds required to unlock this achievement in hardcore from starting to play the game
+ */
+
+use App\Models\Achievement;
+use App\Models\Game;
+use App\Models\PlayerAchievement;
+use App\Models\PlayerGame;
+use App\Models\PlayerProgressReset;
+use App\Models\PlayerSession;
+use App\Platform\Enums\PlayerProgressResetType;
+
+$gameId = (int) request()->query('i');
+$preferHardcore = (int) request()->query('h');
+
+$game = Game::with('system')->find($gameId);
+if (!$game) {
+    return response()->json([], 404);
+}
+
+// ===== basic game information =====
+$coreSet = $game->gameAchievementSets()->core()->first()?->achievementSet;
+
+$response = [
+    'ID' => $game->ID,
+    'Title' => $game->Title,
+    'ConsoleID' => $game->system->ID,
+    'ConsoleName' => $game->system->Name,
+    'ImageIcon' => $game->ImageIcon,
+    'NumDistinctPlayers' => $game->players_total,
+    'TimesUsedInBeatMedian' => $game->times_beaten,
+    'TimesUsedInHardcoreBeatMedian' => $game->times_beaten_hardcore,
+    'MedianTimeToBeat' => $game->median_time_to_beat,
+    'MedianTimeToBeatHardcore' => $game->median_time_to_beat_hardcore,
+    'TimesUsedInCompletionMedian' => $coreSet?->times_completed ?? 0,
+    'TimesUsedInMasteryMedian' => $coreSet?->times_completed_hardcore ?? 0,
+    'MedianTimeToComplete' => $coreSet?->median_time_to_complete,
+    'MedianTimeToMaster' => $coreSet?->median_time_to_complete_hardcore,
+    'NumAchievements' => $game->achievements_published,
+    'Achievements' => [],
+];
+
+$achievements = $game->achievements()->published()->get();
+$achievementIds = $achievements->pluck('ID');
+$unlock_times = [];
+$unlock_hardcore_times = [];
+foreach ($achievementIds as $achievementId) {
+    $unlock_times[$achievementId] = [];
+    $unlock_hardcore_times[$achievementId] = [];
+}
+
+// ===== process the 100 most recent players to earn at least half of the achievements in the set =====
+$recentPlayerIds = PlayerGame::query()
+    ->where('game_id', $game->ID)
+    ->where($preferHardcore ? 'achievements_unlocked_hardcore' : 'achievements_unlocked', '>=', $game->achievements_published / 2)
+    ->orderByDesc('last_unlock_at')
+    ->limit(100)
+    ->pluck('user_id');
+
+$resets = PlayerProgressReset::query()
+    ->where('type', PlayerProgressResetType::Game)
+    ->where('type_id', $game->ID)
+    ->whereIn('user_id', $recentPlayerIds)
+    ->pluck('created_at', 'user_id');
+
+foreach ($recentPlayerIds as $playerId) {
+    $unlocks = PlayerAchievement::query()
+        ->where('user_id', $playerId)
+        ->whereIn('achievement_id', $achievementIds)
+        ->whereNull('unlocker_id')
+        ->get();
+    if ($unlocks->count() === 0) {
+        continue;
+    }
+
+    $achievementSessionStart = $resets[$playerId] ?? $coreSet?->achievements_first_published_at;
+
+    $sessionQuery = PlayerSession::query()
+        ->where('user_id', $playerId)
+        ->where('game_id', $game->ID)
+        ->when($achievementSessionStart, fn ($q) => $q->where('rich_presence_updated_at', '>', $achievementSessionStart))
+        ->select(['created_at', 'duration', 'rich_presence_updated_at']);
+
+    $elapsed = 0;
+    foreach ($sessionQuery->orderBy('rich_presence_updated_at')->get() as $session) {
+        $sessionStart = $achievementSessionStart ? max($achievementSessionStart, $session->created_at) : $session->created_at;
+        $sessionEnd = max($session->rich_presence_updated_at, $session->created_at->addMinutes($session->duration));
+
+        foreach ($unlocks as $unlock) {
+            if ($unlock->unlocked_at && $unlock->unlocked_at->between($sessionStart, $sessionEnd)) {
+                $unlock_times[$unlock->achievement_id][] =
+                    $unlock->unlocked_at->diffInSeconds($sessionStart, true) + $elapsed;
+            }
+            if ($unlock->unlocked_hardcore_at && $unlock->unlocked_hardcore_at->between($sessionStart, $sessionEnd)) {
+                $unlock_hardcore_times[$unlock->achievement_id][] =
+                    $unlock->unlocked_hardcore_at->diffInSeconds($sessionStart, true) + $elapsed;
+            }
+        }
+
+        $elapsed += $sessionEnd->diffInSeconds($sessionStart, true);
+    }
+}
+
+// ===== summarize achievement metrics =====
+$get_median = function (array $a): int {
+    $length = count($a);
+    if ($length === 0) {
+        return 0;
+    }
+
+    $values = array_values($a);
+    sort($values);
+
+    $index = floor($length / 2);
+    if (($length % 2) == 1) {
+        return $values[$index];
+    }
+
+    return (int) round(($values[$index - 1] + $values[$index]) / 2);
+};
+
+foreach ($achievements as $achievement) {
+    $response['Achievements'][] = [
+        'ID' => $achievement->ID,
+        'Title' => $achievement->Title,
+        'Description' => $achievement->Description,
+        'Points' => $achievement->Points,
+        'TrueRatio' => $achievement->TrueRatio,
+        'Type' => $achievement->type,
+        'BadgeName' => $achievement->BadgeName,
+        'NumAwarded' => $achievement->unlocks_total,
+        'NumAwardedHardcore' => $achievement->unlocks_hardcore_total,
+        'TimesUsedInUnlockMedian' => count($unlock_times[$achievement->ID]),
+        'TimesUsedInHardcoreUnlockMedian' => count($unlock_hardcore_times[$achievement->ID]),
+        'MedianTimeToUnlock' => $get_median($unlock_times[$achievement->ID]),
+        'MedianTimeToUnlockHardcore' => $get_median($unlock_hardcore_times[$achievement->ID]),
+    ];
+}
+
+usort($response['Achievements'], fn ($a, $b) => $a['MedianTimeToUnlockHardcore'] - $b['MedianTimeToUnlockHardcore']);
+
+// ===== send response =====
+return response()->json($response);

--- a/tests/Feature/Api/V1/GameProgressionTest.php
+++ b/tests/Feature/Api/V1/GameProgressionTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Achievement;
+use App\Models\Game;
+use App\Models\PlayerSession;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\Feature\Platform\Concerns\TestsPlayerAchievements;
+use Tests\TestCase;
+
+class GameProgressionTest extends TestCase
+{
+    use RefreshDatabase;
+    use BootstrapsApiV1;
+    use TestsPlayerAchievements;
+
+    public function testUnknownGame(): void
+    {
+        $this->get($this->apiUrl('GetGameProgress', ['i' => 999999]))
+            ->assertStatus(404)
+            ->assertExactJson([
+                'message' => 'Not Found',
+                'errors' => [[
+                    'code' => 'not_found',
+                    'status' => 404,
+                    'title' => 'Not Found',
+                ]],
+            ]);
+    }
+
+    private function createSession(User $user, Game $game, Carbon $startTime, int $durationInSeconds): PlayerSession
+    {
+        $session = PlayerSession::create([
+            'user_id' => $user->id,
+            'game_id' => $game->id,
+            'duration' => (int) floor($durationInSeconds / 60),
+            'rich_presence_updated_at' => $startTime->clone()->addSeconds($durationInSeconds),
+        ]);
+        $session->created_at = $startTime;
+        $session->updated_at = $session->rich_presence_updated_at;
+        $session->save();
+
+        return $session;
+    }
+
+    private function achievementData(Achievement $achievement, int $unlockTimesCount,
+        int $medianTimeToUnlock, int $unlockHardcoreTimesCount, int $medianTimeToUnlockHardcore): array
+    {
+        return [
+            'ID' => $achievement->ID,
+            'Title' => $achievement->Title,
+            'Description' => $achievement->Description,
+            'Points' => $achievement->Points,
+            'TrueRatio' => $achievement->TrueRatio,
+            'Type' => $achievement->type,
+            'BadgeName' => $achievement->BadgeName,
+            'NumAwarded' => $achievement->unlocks_total,
+            'NumAwardedHardcore' => $achievement->unlocks_hardcore_total,
+            'TimesUsedInUnlockMedian' => $unlockTimesCount,
+            'TimesUsedInHardcoreUnlockMedian' => $unlockHardcoreTimesCount,
+            'MedianTimeToUnlock' => $medianTimeToUnlock,
+            'MedianTimeToUnlockHardcore' => $medianTimeToUnlockHardcore,
+        ];
+    }
+
+    public function testGetGameProgress(): void
+    {
+        $game = $this->seedGame(achievements: 4);
+        $coreSet = $game->gameAchievementSets()->core()->first()->achievementSet;
+        $coreSet->achievements_first_published_at = new Carbon('2024-01-07 13:55:51');
+        $coreSet->save();
+
+        $achievement1 = $game->achievements->get(0);
+        $achievement1->type = 'progression';
+        $achievement1->save();
+
+        $achievement2 = $game->achievements->get(1);
+        $achievement2->type = 'missable';
+        $achievement2->save();
+
+        $achievement3 = $game->achievements->get(2);
+
+        $achievement4 = $game->achievements->get(3);
+        $achievement4->type = 'win_condition';
+        $achievement4->save();
+
+        /** @var User $user1 */
+        $user1 = User::factory()->create();
+        /** @var User $user2 */
+        $user2 = User::factory()->create();
+        /** @var User $user3 */
+        $user3 = User::factory()->create();
+
+        // user1 has all achievements unlocked in hardcore
+        $session1a = $this->createSession($user1, $game, new Carbon('2024-01-08 07:13:45'), 3247);
+        $this->addHardcoreUnlock($user1, $achievement1, $session1a->created_at->clone()->addSeconds(521));
+        $this->addHardcoreUnlock($user1, $achievement2, $session1a->created_at->clone()->addSeconds(633));
+        $this->addHardcoreUnlock($user1, $achievement3, $session1a->created_at->clone()->addSeconds(3093));
+        $session1b = $this->createSession($user1, $game, new Carbon('2024-01-08 18:43:01'), 759);
+        $this->addHardcoreUnlock($user1, $achievement4, $session1b->created_at->clone()->addSeconds(688));
+
+        // pick up updated metrics
+        $game->refresh();
+        $coreSet->refresh();
+        $achievement1->refresh();
+        $achievement2->refresh();
+        $achievement3->refresh();
+        $achievement4->refresh();
+
+        $this->get($this->apiUrl('GetGameProgression', ['i' => $game->ID]))
+            ->assertSuccessful()
+            ->assertExactJson([
+                'ID' => $game->ID,
+                'Title' => $game->Title,
+                'ConsoleID' => $game->system->ID,
+                'ConsoleName' => $game->system->Name,
+                'ImageIcon' => $game->ImageIcon,
+                'NumAchievements' => 4,
+                'NumDistinctPlayers' => 1,
+                'TimesUsedInBeatMedian' => $game->times_beaten,
+                'TimesUsedInHardcoreBeatMedian' => $game->times_beaten_hardcore,
+                'MedianTimeToBeat' => $game->median_time_to_beat,
+                'MedianTimeToBeatHardcore' => $game->median_time_to_beat_hardcore,
+                'TimesUsedInCompletionMedian' => $coreSet->times_completed ?? 0,
+                'TimesUsedInMasteryMedian' => $coreSet->times_completed_hardcore ?? 0,
+                'MedianTimeToComplete' => $coreSet->median_time_to_complete,
+                'MedianTimeToMaster' => $coreSet->median_time_to_complete_hardcore,
+                'Achievements' => [
+                    $this->achievementData($achievement1, 1, 521, 1, 521),
+                    $this->achievementData($achievement2, 1, 633, 1, 633),
+                    $this->achievementData($achievement3, 1, 3093, 1, 3093),
+                    $this->achievementData($achievement4, 1, 3247 + 688, 1, 3247 + 688),
+                ],
+            ]);
+
+        // user2 has only progression achievements unlocked (in hardcore)
+        $session2a = $this->createSession($user2, $game, new Carbon('2024-01-12 19:20:21'), 1897);
+        $this->addHardcoreUnlock($user2, $achievement1, $session2a->created_at->clone()->addSeconds(477));
+        $this->addHardcoreUnlock($user2, $achievement4, $session2a->created_at->clone()->addSeconds(1883));
+
+        // pick up updated metrics
+        $game->refresh();
+        $coreSet->refresh();
+        $achievement1->refresh();
+        $achievement2->refresh();
+        $achievement3->refresh();
+        $achievement4->refresh();
+
+        $this->get($this->apiUrl('GetGameProgression', ['i' => $game->ID]))
+            ->assertSuccessful()
+            ->assertExactJson([
+                'ID' => $game->ID,
+                'Title' => $game->Title,
+                'ConsoleID' => $game->system->ID,
+                'ConsoleName' => $game->system->Name,
+                'ImageIcon' => $game->ImageIcon,
+                'NumAchievements' => 4,
+                'NumDistinctPlayers' => 2,
+                'TimesUsedInBeatMedian' => $game->times_beaten,
+                'TimesUsedInHardcoreBeatMedian' => $game->times_beaten_hardcore,
+                'MedianTimeToBeat' => $game->median_time_to_beat,
+                'MedianTimeToBeatHardcore' => $game->median_time_to_beat_hardcore,
+                'TimesUsedInCompletionMedian' => $coreSet->times_completed ?? 0,
+                'TimesUsedInMasteryMedian' => $coreSet->times_completed_hardcore ?? 0,
+                'MedianTimeToComplete' => $coreSet->median_time_to_complete,
+                'MedianTimeToMaster' => $coreSet->median_time_to_complete_hardcore,
+                'Achievements' => [
+                    $this->achievementData($achievement1, 2, (int) floor((477 + 521) / 2), 2, (int) floor((477 + 521) / 2)),
+                    $this->achievementData($achievement2, 1, 633, 1, 633),
+                    $this->achievementData($achievement4, 2, (int) floor((3247 + 688 + 1883) / 2), 2, (int) floor((3247 + 688 + 1883) / 2)),
+                    $this->achievementData($achievement3, 1, 3093, 1, 3093),
+                ],
+            ]);
+
+        // user3 has non-hardcore unlocks
+        $session3a = $this->createSession($user3, $game, new Carbon('2024-01-14 01:01:53'), 673);
+        $this->addSoftcoreUnlock($user3, $achievement1, $session3a->created_at->clone()->addSeconds(613));
+        $session3b = $this->createSession($user3, $game, new Carbon('2024-01-14 09:31:44'), 217);
+        $this->addSoftcoreUnlock($user3, $achievement3, $session3b->created_at->clone()->addSeconds(148));
+        $session3c = $this->createSession($user3, $game, new Carbon('2024-01-15 01:17:21'), 946);
+        $this->addSoftcoreUnlock($user3, $achievement4, $session3c->created_at->clone()->addSeconds(511));
+        $this->addSoftcoreUnlock($user3, $achievement2, $session3c->created_at->clone()->addSeconds(909));
+
+        // pick up updated metrics
+        $game->refresh();
+        $coreSet->refresh();
+        $achievement1->refresh();
+        $achievement2->refresh();
+        $achievement3->refresh();
+        $achievement4->refresh();
+
+        $this->get($this->apiUrl('GetGameProgression', ['i' => $game->ID]))
+            ->assertSuccessful()
+            ->assertExactJson([
+                'ID' => $game->ID,
+                'Title' => $game->Title,
+                'ConsoleID' => $game->system->ID,
+                'ConsoleName' => $game->system->Name,
+                'ImageIcon' => $game->ImageIcon,
+                'NumAchievements' => 4,
+                'NumDistinctPlayers' => 3,
+                'TimesUsedInBeatMedian' => $game->times_beaten,
+                'TimesUsedInHardcoreBeatMedian' => $game->times_beaten_hardcore,
+                'MedianTimeToBeat' => $game->median_time_to_beat,
+                'MedianTimeToBeatHardcore' => $game->median_time_to_beat_hardcore,
+                'TimesUsedInCompletionMedian' => $coreSet->times_completed ?? 0,
+                'TimesUsedInMasteryMedian' => $coreSet->times_completed_hardcore ?? 0,
+                'MedianTimeToComplete' => $coreSet->median_time_to_complete,
+                'MedianTimeToMaster' => $coreSet->median_time_to_complete_hardcore,
+                'Achievements' => [
+                    $this->achievementData($achievement1, 3, 521 /* 477,521,613 */, 2, (int) floor((477 + 521) / 2)),
+                    $this->achievementData($achievement2, 2, (int) floor((633 + 673 + 217 + 909) / 2), 1, 633),
+                    $this->achievementData($achievement4, 3, 1883 /* 673 + 217 + 511, 1883, 3247 + 688 */, 2, (int) floor((3247 + 688 + 1883) / 2)),
+                    $this->achievementData($achievement3, 2, (int) floor((3093 + 673 + 148) / 2), 1, 3093),
+                ],
+            ]);
+
+        // request hardcore players ignores user3
+        $this->get($this->apiUrl('GetGameProgression', ['i' => $game->ID, 'h' => 1]))
+            ->assertSuccessful()
+            ->assertExactJson([
+                'ID' => $game->ID,
+                'Title' => $game->Title,
+                'ConsoleID' => $game->system->ID,
+                'ConsoleName' => $game->system->Name,
+                'ImageIcon' => $game->ImageIcon,
+                'NumAchievements' => 4,
+                'NumDistinctPlayers' => 3,
+                'TimesUsedInBeatMedian' => $game->times_beaten,
+                'TimesUsedInHardcoreBeatMedian' => $game->times_beaten_hardcore,
+                'MedianTimeToBeat' => $game->median_time_to_beat,
+                'MedianTimeToBeatHardcore' => $game->median_time_to_beat_hardcore,
+                'TimesUsedInCompletionMedian' => $coreSet->times_completed ?? 0,
+                'TimesUsedInMasteryMedian' => $coreSet->times_completed_hardcore ?? 0,
+                'MedianTimeToComplete' => $coreSet->median_time_to_complete,
+                'MedianTimeToMaster' => $coreSet->median_time_to_complete_hardcore,
+                'Achievements' => [
+                    $this->achievementData($achievement1, 2, (int) floor((477 + 521) / 2), 2, (int) floor((477 + 521) / 2)),
+                    $this->achievementData($achievement2, 1, 633, 1, 633),
+                    $this->achievementData($achievement4, 2, (int) floor((3247 + 688 + 1883) / 2), 2, (int) floor((3247 + 688 + 1883) / 2)),
+                    $this->achievementData($achievement3, 1, 3093, 1, 3093),
+                ],
+            ]);
+    }
+}


### PR DESCRIPTION
Meant to replace the APIs used by the RATools tool for determining how long it takes to reach various achievements in a set.

<img width="418" height="552" alt="image" src="https://github.com/user-attachments/assets/26b98d6d-fe83-4892-9b3e-6ef9155e21e1" />

There's three main changes:
1) Uses actual session data instead of estimates from unlock timestamps (accounts for time leading up to first achievement).
2) Only looks at the last 100 active players of a set to better account for revisions, achievement fixes, and comments revealing ways to "cheese" the set.
3) All data can be fetched with a single API call instead of fetching data for all users individually and collating them on the client.

```
     {
         "ID":360110,
         "Title":"A Harder Journey",
         "Description":"Complete Story Mode on 4 Star difficulty or higher.",
         "Points":10,
         "TrueRatio":17,
         "Type":null,
         "BadgeName":"405469",
         "NumAwarded":29,
         "NumAwardedHardcore":26,
         "TimesUsedInUnlockMedian":16,
         "TimesUsedInHardcoreUnlockMedian":13,
         "MedianTimeToUnlock":2729,
         "MedianTimeToUnlockHardcore":2799
      },
```

Event managers use this tool to pick achievements with a rough target playtime:
* AotW = 2 hours = ~7200 MedianTimeToUnlockHardcore
* AotM = 8 hours = ~28800 MediumTimeToUnlockHardcore