### PR TITLE
feat(game): add mobile credit dialog to React game pages

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -1000,6 +1000,8 @@
     "Credits": "Credits",
     "{{val, number}} authors_one": "{{val, number}} author",
     "{{val, number}} authors_other": "{{val, number}} authors",
+    "+{{val, number}} contributors_one": "+{{val, number}} contributor",
+    "+{{val, number}} contributors_other": "+{{val, number}} contributors",
     "Achievement Authors": "Achievement Authors",
     "Game Badge Artwork": "Game Badge Artwork",
     "Achievement Artwork": "Achievement Artwork",
@@ -1050,5 +1052,6 @@
     "filterRequests_active": "Active",
     "filterRequests_all": "All",
     "Game Forum Topic": "Game Forum Topic",
-    "Subset Forum Topic": "Subset Forum Topic"
+    "Subset Forum Topic": "Subset Forum Topic",
+    "This is a list of everyone known to have contributed to this achievement set.": "This is a list of everyone known to have contributed to this achievement set."
 }

--- a/resources/js/common/components/+vendor/BaseDialog.tsx
+++ b/resources/js/common/components/+vendor/BaseDialog.tsx
@@ -73,7 +73,6 @@ const BaseDialogContent = React.forwardRef<
               )}
             >
               <RxCross2 className="size-4" />
-
               <span className="sr-only">{t('Close')}</span>
             </DialogPrimitive.Close>
           ) : null}

--- a/resources/js/common/components/UserAvatar/UserAvatar.test.tsx
+++ b/resources/js/common/components/UserAvatar/UserAvatar.test.tsx
@@ -99,4 +99,29 @@ describe('Component: UserAvatar', () => {
 
     expect(nameEl).toHaveClass('line-through');
   });
+
+  it('given the canLinkToUser prop is falsy, never renders a link to the user profile', () => {
+    // ARRANGE
+    const user = createUser({ displayName: 'Scott', deletedAt: new Date().toISOString() });
+
+    render(<UserAvatar {...user} canLinkToUser={false} />);
+
+    // ASSERT
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('given the user is deleted and canLinkToUser is true, does not render a link', () => {
+    // ARRANGE
+    const user = createUser({
+      displayName: 'Scott',
+      deletedAt: new Date().toISOString(), // !! deleted user
+    });
+
+    render(<UserAvatar {...user} canLinkToUser={true} />);
+
+    // ASSERT
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText(/scott/i)).toBeVisible();
+    expect(screen.getByText(/scott/i).parentElement?.tagName).toBe('SPAN');
+  });
 });

--- a/resources/js/common/components/UserAvatar/UserAvatar.tsx
+++ b/resources/js/common/components/UserAvatar/UserAvatar.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/common/utils/cn';
 
 type UserAvatarProps = BaseAvatarProps &
   App.Data.User & {
+    canLinkToUser?: boolean;
     labelClassName?: string;
     wrapperClassName?: string;
   };
@@ -19,6 +20,7 @@ export const UserAvatar: FC<UserAvatarProps> = ({
   isGone,
   labelClassName,
   wrapperClassName,
+  canLinkToUser = true,
   hasTooltip = true,
   showImage = true,
   showLabel = true,
@@ -26,14 +28,14 @@ export const UserAvatar: FC<UserAvatarProps> = ({
 }) => {
   const { cardTooltipProps } = useCardTooltip({ dynamicType: 'user', dynamicId: displayName });
 
-  const canLinkToUser = displayName && !deletedAt && !isGone;
-  const Wrapper = canLinkToUser ? 'a' : 'span';
+  const shouldLinkToUser = canLinkToUser && displayName && !deletedAt && !isGone;
+  const Wrapper = shouldLinkToUser ? 'a' : 'span';
 
   return (
     <Wrapper
-      href={canLinkToUser ? route('user.show', [displayName]) : undefined}
+      href={shouldLinkToUser ? route('user.show', [displayName]) : undefined}
       className={cn('flex max-w-fit items-center gap-2', wrapperClassName)}
-      {...(hasTooltip && canLinkToUser ? cardTooltipProps : undefined)}
+      {...(hasTooltip && shouldLinkToUser ? cardTooltipProps : undefined)}
     >
       {showImage ? (
         <img

--- a/resources/js/common/components/UserAvatarStack/UserAvatarStack.test.tsx
+++ b/resources/js/common/components/UserAvatarStack/UserAvatarStack.test.tsx
@@ -165,4 +165,19 @@ describe('Component: UserAvatarStack', () => {
     const overflowIndicator = screen.getByTestId('overflow-indicator');
     expect(overflowIndicator).not.toHaveClass('ring-2');
   });
+
+  it('given canLinkToUsers is false, does not link to user profiles', () => {
+    // ARRANGE
+    const users = [createUser()];
+
+    render(
+      <UserAvatarStack
+        users={users}
+        canLinkToUsers={false} // !!
+      />,
+    );
+
+    // ASSERT
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
 });

--- a/resources/js/common/components/UserAvatarStack/UserAvatarStack.tsx
+++ b/resources/js/common/components/UserAvatarStack/UserAvatarStack.tsx
@@ -11,6 +11,8 @@ import { UserAvatar } from '../UserAvatar';
 interface UserAvatarStackProps {
   users: App.Data.User[];
 
+  canLinkToUsers?: boolean;
+
   isOverlappingAvatars?: boolean;
 
   /**
@@ -27,6 +29,7 @@ interface UserAvatarStackProps {
 
 export const UserAvatarStack: FC<UserAvatarStackProps> = ({
   users,
+  canLinkToUsers = true,
   isOverlappingAvatars = true,
   maxVisible = 5,
   size = 32,
@@ -58,6 +61,7 @@ export const UserAvatarStack: FC<UserAvatarStackProps> = ({
         <UserAvatar
           key={`user-avatar-stack-${id}-${user.displayName}`}
           {...user}
+          canLinkToUser={canLinkToUsers}
           size={size}
           showLabel={false}
           imgClassName={cn(

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.test.tsx
@@ -228,4 +228,24 @@ describe('Component: AchievementAuthorsDisplay', () => {
     expect(tooltipBob).not.toHaveClass('text-neutral-500');
     expect(tooltipBob).not.toHaveClass('line-through');
   });
+
+  it('given shouldAlwaysUseAvatarStack is true, still shows user avatars', () => {
+    // ARRANGE
+    const authors = [
+      createUserCredits({ displayName: 'Alice', count: 50 }),
+      createUserCredits({ displayName: 'Bob', count: 20 }),
+      createUserCredits({ displayName: 'Charlie', count: 15 }),
+      createUserCredits({ displayName: 'David', count: 10 }),
+      createUserCredits({ displayName: 'Eve', count: 5 }),
+    ];
+
+    render(<AchievementAuthorsDisplay authors={authors} shouldAlwaysUseAvatarStack={true} />, {
+      pageProps: {
+        game: createGame({ achievementsPublished: 100 }),
+      },
+    });
+
+    // ASSERT
+    expect(screen.getAllByRole('img')).toHaveLength(5);
+  });
 });

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementAuthorsDisplay/AchievementAuthorsDisplay.tsx
@@ -17,10 +17,16 @@ import { TooltipCreditsSection } from '../TooltipCreditsSection';
 
 interface AchievementAuthorsDisplayProps {
   authors: App.Platform.Data.UserCredits[];
+
+  shouldAlwaysUseAvatarStack?: boolean;
 }
 
-export const AchievementAuthorsDisplay: FC<AchievementAuthorsDisplayProps> = ({ authors }) => {
+export const AchievementAuthorsDisplay: FC<AchievementAuthorsDisplayProps> = ({
+  authors,
+  shouldAlwaysUseAvatarStack,
+}) => {
   const { game } = usePageProps<App.Platform.Data.GameShowPageProps>();
+  const { t } = useTranslation();
 
   const totalAchievements = game.achievementsPublished!;
 
@@ -28,6 +34,28 @@ export const AchievementAuthorsDisplay: FC<AchievementAuthorsDisplayProps> = ({ 
     'flex items-center rounded-md bg-neutral-800/70 py-1 pr-2',
     'light:bg-white light:border light:border-amber-300',
   );
+
+  if (shouldAlwaysUseAvatarStack) {
+    return (
+      <div className="flex items-center py-1">
+        <div className="flex flex-col gap-1.5 px-2 py-[2.25px]">
+          <div className="flex items-center gap-1.5">
+            <FaTrophy className="h-full text-yellow-500" />
+            <span className="pr-1">
+              {t('{{val, number}} authors', { val: authors.length, count: authors.length })}
+            </span>
+          </div>
+
+          <UserAvatarStack
+            users={authors}
+            maxVisible={999}
+            size={20}
+            isOverlappingAvatars={false}
+          />
+        </div>
+      </div>
+    );
+  }
 
   // Calculate each author's contribution percentage.
   const authorsWithPercentage = authors.map((author) => ({

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.test.tsx
@@ -218,7 +218,9 @@ describe('Component: AchievementSetCredits', () => {
       hashCompatibilityTesting: [createUserCredits({ displayName: 'HashTester1' })], // !!
     };
 
-    render(<AchievementSetCredits />, { pageProps: { aggregateCredits } });
+    render(<AchievementSetCredits />, {
+      pageProps: { achievementSetClaims: [], aggregateCredits },
+    });
 
     // ASSERT
     expect(screen.getByTestId('design-credits-display')).toBeVisible();

--- a/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/AchievementSetCredits.tsx
@@ -1,49 +1,21 @@
 import { type FC } from 'react';
 
-import { usePageProps } from '@/common/hooks/usePageProps';
-
 import { AchievementAuthorsDisplay } from './AchievementAuthorsDisplay';
 import { ArtworkCreditsDisplay } from './ArtworkCreditsDisplay';
 import { ClaimantsDisplay } from './ClaimantsDisplay';
 import { CodeCreditsDisplay } from './CodeCreditsDisplay';
 import { DesignCreditsDisplay } from './DesignCreditsDisplay';
+import { MobileCreditDialogTrigger } from './MobileCreditDialogTrigger';
+import { useAchievementSetCredits } from './useAchievementSetCredits';
 
 export const AchievementSetCredits: FC = () => {
-  const { achievementSetClaims, aggregateCredits } =
-    usePageProps<App.Platform.Data.GameShowPageProps>();
-
-  if (!achievementSetClaims?.length && !aggregateCredits) {
-    return null;
-  }
-
-  const artCreditUsers = [
-    ...aggregateCredits.achievementSetArtwork,
-    ...aggregateCredits.achievementsArtwork,
-  ].filter(
-    (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
-  );
-
-  const logicCreditUsers = aggregateCredits.achievementsLogic.filter(
-    (logicUser) =>
-      !aggregateCredits.achievementsAuthors.some(
-        (author) => author.displayName === logicUser.displayName,
-      ),
-  );
-  const codingCreditUsers = [
-    ...aggregateCredits.achievementsMaintainers,
-    ...logicCreditUsers,
-  ].filter(
-    (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
-  );
-
-  const designCreditUsers = [
-    ...aggregateCredits.achievementsDesign,
-    ...aggregateCredits.achievementsTesting,
-    ...aggregateCredits.achievementsWriting,
-    ...aggregateCredits.hashCompatibilityTesting,
-  ].filter(
-    (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
-  );
+  const {
+    achievementSetClaims,
+    aggregateCredits,
+    artCreditUsers,
+    codingCreditUsers,
+    designCreditUsers,
+  } = useAchievementSetCredits();
 
   if (
     !aggregateCredits.achievementsAuthors.length &&
@@ -58,9 +30,17 @@ export const AchievementSetCredits: FC = () => {
   return (
     <div
       data-testid="set-credits"
-      className="hidden items-center justify-between text-neutral-300 light:text-neutral-700 sm:flex"
+      className="flex items-center justify-between text-neutral-300 light:text-neutral-700"
     >
-      <div className="flex w-full items-center rounded lg:flex-col lg:items-start lg:gap-2 xl:flex-row xl:items-center xl:gap-0">
+      <MobileCreditDialogTrigger
+        achievementSetClaims={achievementSetClaims}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={artCreditUsers}
+        codingCreditUsers={codingCreditUsers}
+        designCreditUsers={designCreditUsers}
+      />
+
+      <div className="hidden w-full items-center rounded sm:flex lg:flex-col lg:items-start lg:gap-2 xl:flex-row xl:items-center xl:gap-0">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 xl:gap-4">
           {aggregateCredits.achievementsAuthors.length ? (
             <AchievementAuthorsDisplay authors={aggregateCredits.achievementsAuthors} />

--- a/resources/js/features/games/components/AchievementSetCredits/CodeCreditsDisplay/CodeCreditsDisplay.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/CodeCreditsDisplay/CodeCreditsDisplay.tsx
@@ -89,7 +89,7 @@ const CodeCreditIcon: FC<CodeCreditIconProps> = ({ activeMaintainers, logicCredi
             <TooltipCreditsSection headingLabel={t('Code Contributors')}>
               {logicCredits.map((credit) => (
                 <TooltipCreditRow
-                  key={`maintainer-credit-${credit.displayName}`}
+                  key={`logic-credit-${credit.displayName}`}
                   credit={credit}
                   showAchievementCount={true}
                 />

--- a/resources/js/features/games/components/AchievementSetCredits/MobileCreditDialogTrigger/MobileCreditDialogTrigger.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/MobileCreditDialogTrigger/MobileCreditDialogTrigger.test.tsx
@@ -1,0 +1,581 @@
+import userEvent from '@testing-library/user-event';
+import dayjs from 'dayjs';
+
+import { render, screen, waitFor } from '@/test';
+import {
+  createAchievementSetClaim,
+  createAggregateAchievementSetCredits,
+  createUser,
+  createUserCredits,
+} from '@/test/factories';
+
+import { MobileCreditDialogTrigger } from './MobileCreditDialogTrigger';
+
+describe('Component: MobileCreditDialogTrigger', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const { container } = render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={createAggregateAchievementSetCredits()}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given no claims and no credits, displays nothing', () => {
+    // ARRANGE
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={createAggregateAchievementSetCredits()}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ASSERT
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('given achievement set claims exist, shows the wrench icon', () => {
+    // ARRANGE
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[createAchievementSetClaim()]} // !!
+        aggregateCredits={createAggregateAchievementSetCredits()}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByRole('button')).toBeVisible();
+    expect(screen.getByText(/claimed/i)).toBeVisible(); // !! sr-only
+  });
+
+  it('given achievement authors exist and there are less than 5, shows the user avatar stack', () => {
+    // ARRANGE
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsAuthors: [
+        createUserCredits({ displayName: 'Author1' }),
+        createUserCredits({ displayName: 'Author2' }),
+        createUserCredits({ displayName: 'Author3' }),
+      ], // !! 3 authors
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByRole('button')).toBeVisible();
+    expect(screen.getAllByRole('img')).toHaveLength(3);
+  });
+
+  it('given there are 5 or more achievement authors, does not show the avatar stack', () => {
+    // ARRANGE
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsAuthors: [
+        createUserCredits({ displayName: 'Author1' }),
+        createUserCredits({ displayName: 'Author2' }),
+        createUserCredits({ displayName: 'Author3' }),
+        createUserCredits({ displayName: 'Author4' }),
+        createUserCredits({ displayName: 'Author5' }),
+      ], // !! 5 authors
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ASSERT
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.getByText(/5 authors/i)).toBeVisible();
+  });
+
+  it('given a single author, displays the count with proper pluralization', () => {
+    // ARRANGE
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsAuthors: [createUserCredits({ displayName: 'Author1' })], // !! just 1
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByText('1 author')).toBeVisible();
+  });
+
+  it('given non-author contributors exist, shows the contributor count', () => {
+    // ARRANGE
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={createAggregateAchievementSetCredits()}
+        artCreditUsers={[createUserCredits({ displayName: 'Artist1' })]}
+        codingCreditUsers={[createUserCredits({ displayName: 'Coder1' })]}
+        designCreditUsers={[createUserCredits({ displayName: 'Designer1' })]} // !! 3 unique contributors
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByText(/\+3 contributors/i)).toBeVisible();
+  });
+
+  it('given there are duplicate contributors across categories, deduplicates them in the count', () => {
+    // ARRANGE
+    const sharedUser = createUserCredits({ displayName: 'MultiTalented' });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={createAggregateAchievementSetCredits()}
+        artCreditUsers={[sharedUser]}
+        codingCreditUsers={[sharedUser]}
+        designCreditUsers={[sharedUser]} // !! same user in all categories
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByText(/\+1 contributor/i)).toBeVisible();
+  });
+
+  it('given there are both claims and authors, shows a separator dot', () => {
+    // ARRANGE
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[createAchievementSetClaim()]} // !!
+        aggregateCredits={createAggregateAchievementSetCredits({
+          achievementsAuthors: [createUserCredits({ displayName: 'Author1' })], // !!
+        })}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ASSERT
+    const separators = screen.getAllByText('·');
+    expect(separators).toHaveLength(1);
+  });
+
+  it('given there are both authors and contributors, shows a separator dot', () => {
+    // ARRANGE
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={createAggregateAchievementSetCredits({
+          achievementsAuthors: [createUserCredits({ displayName: 'Author1' })], // !!
+        })}
+        artCreditUsers={[createUserCredits({ displayName: 'Artist1' })]} // !!
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ASSERT
+    const separators = screen.getAllByText('·');
+    expect(separators).toHaveLength(1);
+  });
+
+  it('given the button is clicked, opens the dialog', async () => {
+    // ARRANGE
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[createAchievementSetClaim()]}
+        aggregateCredits={createAggregateAchievementSetCredits()}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible();
+    });
+    expect(screen.getByText(/credits/i)).toBeVisible();
+    expect(
+      screen.getByText(
+        /this is a list of everyone known to have contributed to this achievement set/i,
+      ),
+    ).toBeVisible();
+  });
+
+  it('given there are active claims, shows the Active Claims section in the dialog', async () => {
+    // ARRANGE
+    const achievementSetClaims = [
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'ClaimUser1' }),
+      }),
+    ];
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={achievementSetClaims}
+        aggregateCredits={createAggregateAchievementSetCredits()}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/active claims/i)).toBeVisible();
+    });
+    expect(screen.getByText(/claimuser1/i)).toBeVisible();
+  });
+
+  it('given a future finishedAt date on a claim, shows "Expires" text', async () => {
+    // ARRANGE
+    const futureDate = dayjs().add(1, 'month').toISOString();
+    const achievementSetClaims = [
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'ClaimUser1' }),
+        finishedAt: futureDate, // !!
+      }),
+    ];
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={achievementSetClaims}
+        aggregateCredits={createAggregateAchievementSetCredits()}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/expires/i)).toBeVisible();
+    });
+  });
+
+  it('given a past finishedAt date on a claim, shows "Expired" text', async () => {
+    // ARRANGE
+    const pastDate = dayjs().subtract(1, 'month').toISOString();
+    const achievementSetClaims = [
+      createAchievementSetClaim({
+        user: createUser({ displayName: 'ClaimUser1' }),
+        finishedAt: pastDate, // !!
+      }),
+    ];
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={achievementSetClaims}
+        aggregateCredits={createAggregateAchievementSetCredits()}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/expired/i)).toBeVisible();
+    });
+  });
+
+  it('given there is achievement author credit, shows the Achievement Authors section in the dialog', async () => {
+    // ARRANGE
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsAuthors: [
+        createUserCredits({ displayName: 'Author1', count: 10 }),
+        createUserCredits({ displayName: 'Author2', count: 5 }),
+      ],
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/achievement authors/i)).toBeVisible();
+    });
+    expect(screen.getByText(/author1/i)).toBeVisible();
+    expect(screen.getByText(/author2/i)).toBeVisible();
+  });
+
+  it('given there is game badge artwork credit, shows the Game Badge Artwork section in the dialog', async () => {
+    // ARRANGE
+    const badgeArtist = createUserCredits({
+      displayName: 'BadgeArtist1',
+      dateCredited: '2024-01-15T00:00:00Z',
+    });
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementSetArtwork: [badgeArtist],
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[badgeArtist]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/game badge artwork/i)).toBeVisible();
+    });
+    expect(screen.getByText(/badgeartist1/i)).toBeVisible();
+  });
+
+  it('given there is achievement artwork credit, shows the Achievement Artwork section in the dialog', async () => {
+    // ARRANGE
+    const achArtist = createUserCredits({
+      displayName: 'AchievementArtist1',
+      count: 25,
+    });
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsArtwork: [achArtist],
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[achArtist]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/achievement artwork/i)).toBeVisible();
+    });
+    expect(screen.getByText(/achievementartist1/i)).toBeVisible();
+  });
+
+  it('given there are achievement maintainers, shows the Achievement Maintainers section in the dialog', async () => {
+    // ARRANGE
+    const maintainer = createUserCredits({
+      displayName: 'Maintainer1',
+      dateCredited: '2024-02-01T00:00:00Z',
+    });
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsMaintainers: [maintainer],
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[maintainer]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/achievement maintainers/i)).toBeVisible();
+    });
+    expect(screen.getByText(/maintainer1/i)).toBeVisible();
+  });
+
+  it('given there are design credits, shows the Achievement Design/Ideas section in the dialog', async () => {
+    // ARRANGE
+    const designer = createUserCredits({
+      displayName: 'Designer1',
+      count: 7,
+    });
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsDesign: [designer],
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[designer]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/achievement design\/ideas/i)).toBeVisible();
+    });
+    expect(screen.getByText(/designer1/i)).toBeVisible();
+  });
+
+  it('given there are testing credits, shows the Playtesters section in the dialog', async () => {
+    // ARRANGE
+    const tester = createUserCredits({
+      displayName: 'Tester1',
+      count: 0,
+    });
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsTesting: [tester],
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[tester]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/playtesters/i)).toBeVisible();
+    });
+    expect(screen.getByText(/tester1/i)).toBeVisible();
+  });
+
+  it('given there are hash compatibility testing credits, shows the Hash Compatibility Testing section in the dialog', async () => {
+    // ARRANGE
+    const hashTester = createUserCredits({
+      displayName: 'HashTester1',
+      dateCredited: '2024-03-01T00:00:00Z',
+    });
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      hashCompatibilityTesting: [hashTester],
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[hashTester]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/hash compatibility testing/i)).toBeVisible();
+    });
+    expect(screen.getByText(/hashtester1/i)).toBeVisible();
+  });
+
+  it('given there are writing credits, shows the Writing Contributions section in the dialog', async () => {
+    // ARRANGE
+    const writer = createUserCredits({
+      displayName: 'Writer1',
+      count: 15,
+    });
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsWriting: [writer],
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[writer]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/writing contributions/i)).toBeVisible();
+    });
+    expect(screen.getByText(/writer1/i)).toBeVisible();
+  });
+
+  it('given there are only authors and no other kinds of credit, only shows authors in the button', () => {
+    // ARRANGE
+    const aggregateCredits = createAggregateAchievementSetCredits({
+      achievementsAuthors: [createUserCredits({ displayName: 'OnlyAuthor' })],
+    });
+
+    render(
+      <MobileCreditDialogTrigger
+        achievementSetClaims={[]}
+        aggregateCredits={aggregateCredits}
+        artCreditUsers={[]}
+        codingCreditUsers={[]}
+        designCreditUsers={[]}
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByText(/1 author/i)).toBeVisible();
+    expect(screen.queryByText(/contributor/i)).not.toBeInTheDocument();
+  });
+});

--- a/resources/js/features/games/components/AchievementSetCredits/MobileCreditDialogTrigger/MobileCreditDialogTrigger.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/MobileCreditDialogTrigger/MobileCreditDialogTrigger.tsx
@@ -1,0 +1,279 @@
+import dayjs from 'dayjs';
+import { type FC, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LuWrench } from 'react-icons/lu';
+
+import { BaseButton } from '@/common/components/+vendor/BaseButton';
+import {
+  BaseDialog,
+  BaseDialogClose,
+  BaseDialogContent,
+  BaseDialogDescription,
+  BaseDialogFooter,
+  BaseDialogHeader,
+  BaseDialogTitle,
+  BaseDialogTrigger,
+} from '@/common/components/+vendor/BaseDialog';
+import { UserAvatarStack } from '@/common/components/UserAvatarStack';
+import { formatDate } from '@/common/utils/l10n/formatDate';
+
+import { TooltipCreditRow } from '../TooltipCreditRow';
+import { TooltipCreditsSection } from '../TooltipCreditsSection';
+
+interface MobileCreditDialogTriggerProps {
+  achievementSetClaims: App.Platform.Data.AchievementSetClaim[];
+  aggregateCredits: App.Platform.Data.AggregateAchievementSetCredits;
+  artCreditUsers: App.Platform.Data.UserCredits[];
+  codingCreditUsers: App.Platform.Data.UserCredits[];
+  designCreditUsers: App.Platform.Data.UserCredits[];
+}
+
+export const MobileCreditDialogTrigger: FC<MobileCreditDialogTriggerProps> = ({
+  achievementSetClaims,
+  aggregateCredits,
+  artCreditUsers,
+  codingCreditUsers,
+  designCreditUsers,
+}) => {
+  const { t } = useTranslation();
+
+  const nonAuthorUniqueContributors = useMemo(() => {
+    return [...artCreditUsers, ...codingCreditUsers, ...designCreditUsers].filter(
+      (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
+    );
+  }, [artCreditUsers, codingCreditUsers, designCreditUsers]);
+
+  // Dedupe logic credits with authors - it's a bit redundant.
+  // TODO do this on the server to reduce initial props size
+  const filteredLogicCredits = aggregateCredits.achievementsLogic.filter(
+    (logicUser) =>
+      !aggregateCredits.achievementsAuthors.some(
+        (author) => author.displayName === logicUser.displayName,
+      ),
+  );
+
+  // If there's no claims or credit to show, then bail.
+  if (
+    !achievementSetClaims.length &&
+    !aggregateCredits.achievementsAuthors.length &&
+    !nonAuthorUniqueContributors.length
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-x-1 sm:hidden">
+      <BaseDialog>
+        <BaseDialogTrigger asChild>
+          <BaseButton size="sm" className="w-full gap-1.5 py-[15px]">
+            {achievementSetClaims.length ? (
+              <span>
+                <LuWrench className="size-4" />
+                <span className="sr-only">{t('Claimed')}</span>
+              </span>
+            ) : null}
+
+            {!!achievementSetClaims.length && !!aggregateCredits.achievementsAuthors.length ? (
+              <span>{'·'}</span>
+            ) : null}
+
+            {aggregateCredits.achievementsAuthors.length ? (
+              <>
+                {aggregateCredits.achievementsAuthors.length < 5 ? (
+                  <UserAvatarStack
+                    canLinkToUsers={false}
+                    isOverlappingAvatars={false}
+                    maxVisible={5}
+                    size={20}
+                    users={aggregateCredits.achievementsAuthors}
+                  />
+                ) : null}
+
+                <span>
+                  {t('{{val, number}} authors', {
+                    count: aggregateCredits.achievementsAuthors.length,
+                    val: aggregateCredits.achievementsAuthors.length,
+                  })}
+                </span>
+              </>
+            ) : null}
+
+            {!!aggregateCredits.achievementsAuthors.length &&
+            !!nonAuthorUniqueContributors.length ? (
+              <span>{'·'}</span>
+            ) : null}
+
+            {nonAuthorUniqueContributors.length ? (
+              <span className="flex items-center">
+                <span>
+                  {t('+{{val, number}} contributors', {
+                    count: nonAuthorUniqueContributors.length,
+                    val: nonAuthorUniqueContributors.length,
+                  })}
+                </span>
+              </span>
+            ) : null}
+          </BaseButton>
+        </BaseDialogTrigger>
+
+        <BaseDialogContent className="block h-full">
+          <BaseDialogHeader className="mb-6">
+            <BaseDialogTitle>{t('Credits')}</BaseDialogTitle>
+            <BaseDialogDescription className="text-balance text-xs">
+              {t('This is a list of everyone known to have contributed to this achievement set.')}
+            </BaseDialogDescription>
+          </BaseDialogHeader>
+
+          <div className="mb-8 flex h-[calc(100%-160px)] flex-col gap-6 overflow-auto">
+            {achievementSetClaims.length ? (
+              <TooltipCreditsSection headingLabel={t('Active Claims')}>
+                {achievementSetClaims.map((claim) => (
+                  <TooltipCreditRow
+                    key={`tooltip-claim-${claim.user!.displayName}`}
+                    canLinkToUser={true}
+                    credit={{
+                      avatarUrl: claim.user!.avatarUrl,
+                      count: 0, // noop
+                      dateCredited: new Date().toISOString(), // noop
+                      displayName: claim.user!.displayName,
+                    }}
+                  >
+                    {dayjs(claim.finishedAt!).isAfter(dayjs())
+                      ? t('Expires {{date}}', { date: formatDate(claim.finishedAt!, 'l') })
+                      : t('Expired {{date}}', { date: formatDate(claim.finishedAt!, 'l') })}
+                  </TooltipCreditRow>
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+
+            {aggregateCredits.achievementsAuthors.length ? (
+              <TooltipCreditsSection headingLabel={t('Achievement Authors')}>
+                {aggregateCredits.achievementsAuthors.map((credit) => (
+                  <TooltipCreditRow
+                    key={`tooltip-author-${credit.displayName}`}
+                    canLinkToUser={true}
+                    credit={credit}
+                    showAchievementCount={true}
+                  />
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+
+            {aggregateCredits.achievementSetArtwork.length ? (
+              <TooltipCreditsSection headingLabel={t('Game Badge Artwork')}>
+                {aggregateCredits.achievementSetArtwork.map((credit) => (
+                  <TooltipCreditRow
+                    key={`tooltip-badge-artwork-credit-${credit.displayName}`}
+                    canLinkToUser={true}
+                    credit={credit}
+                    showCreditDate={true}
+                  />
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+
+            {aggregateCredits.achievementsArtwork.length ? (
+              <TooltipCreditsSection headingLabel={t('Achievement Artwork')}>
+                {aggregateCredits.achievementsArtwork.map((credit) => (
+                  <TooltipCreditRow
+                    key={`tooltip-ach-artwork-credit-${credit.displayName}`}
+                    canLinkToUser={true}
+                    credit={credit}
+                    showAchievementCount={true}
+                  />
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+
+            {aggregateCredits.achievementsMaintainers.length ? (
+              <TooltipCreditsSection headingLabel={t('Achievement Maintainers')}>
+                {aggregateCredits.achievementsMaintainers.map((credit) => (
+                  <TooltipCreditRow
+                    key={`maintainer-credit-${credit.displayName}`}
+                    canLinkToUser={true}
+                    credit={credit}
+                    showCreditDate={true}
+                  />
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+
+            {filteredLogicCredits.length ? (
+              <TooltipCreditsSection headingLabel={t('Code Contributors')}>
+                {filteredLogicCredits.map((credit) => (
+                  <TooltipCreditRow
+                    key={`logic-credit-${credit.displayName}`}
+                    canLinkToUser={true}
+                    credit={credit}
+                    showAchievementCount={true}
+                  />
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+
+            {aggregateCredits.achievementsDesign.length ? (
+              <TooltipCreditsSection headingLabel={t('Achievement Design/Ideas')}>
+                {aggregateCredits.achievementsDesign.map((credit) => (
+                  <TooltipCreditRow
+                    key={`design-credit-${credit.displayName}`}
+                    canLinkToUser={true}
+                    credit={credit}
+                    showAchievementCount={true}
+                  />
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+
+            {aggregateCredits.achievementsTesting.length ? (
+              <TooltipCreditsSection headingLabel={t('Playtesters')}>
+                {aggregateCredits.achievementsTesting.map((credit) => (
+                  /**
+                   * TODO show dates
+                   * right now these are attached to achievements... it should probably be set credit
+                   */
+                  <TooltipCreditRow
+                    key={`testing-credit-${credit.displayName}`}
+                    canLinkToUser={true}
+                    credit={credit}
+                  />
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+
+            {aggregateCredits.hashCompatibilityTesting.length ? (
+              <TooltipCreditsSection headingLabel={t('Hash Compatibility Testing')}>
+                {aggregateCredits.hashCompatibilityTesting.map((credit) => (
+                  <TooltipCreditRow
+                    key={`hash-compatibility-credit-${credit.displayName}`}
+                    canLinkToUser={true}
+                    credit={credit}
+                    showCreditDate={true}
+                  />
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+
+            {aggregateCredits.achievementsWriting.length ? (
+              <TooltipCreditsSection headingLabel={t('Writing Contributions')}>
+                {aggregateCredits.achievementsWriting.map((credit) => (
+                  <TooltipCreditRow
+                    key={`writing-credit-${credit.displayName}`}
+                    canLinkToUser={true}
+                    credit={credit}
+                    showAchievementCount={true}
+                  />
+                ))}
+              </TooltipCreditsSection>
+            ) : null}
+          </div>
+
+          <BaseDialogFooter>
+            <BaseDialogClose asChild>
+              <BaseButton type="button">{t('Close')}</BaseButton>
+            </BaseDialogClose>
+          </BaseDialogFooter>
+        </BaseDialogContent>
+      </BaseDialog>
+    </div>
+  );
+};

--- a/resources/js/features/games/components/AchievementSetCredits/MobileCreditDialogTrigger/index.ts
+++ b/resources/js/features/games/components/AchievementSetCredits/MobileCreditDialogTrigger/index.ts
@@ -1,0 +1,1 @@
+export * from './MobileCreditDialogTrigger';

--- a/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.test.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.test.tsx
@@ -170,4 +170,17 @@ describe('Component: TooltipCreditRow', () => {
     expect(displayNameElement).not.toHaveClass('text-neutral-500');
     expect(displayNameElement).not.toHaveClass('line-through');
   });
+
+  it('given canLinkToUser is true, links to the user profile', () => {
+    // ARRANGE
+    const credit = createUserCredits({
+      displayName: 'Scott',
+      isGone: false,
+    });
+
+    render(<TooltipCreditRow credit={credit} canLinkToUser={true} />);
+
+    // ASSERT
+    expect(screen.getByRole('link', { name: /scott/i })).toBeVisible();
+  });
 });

--- a/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/TooltipCreditRow/TooltipCreditRow.tsx
@@ -1,6 +1,7 @@
 import type { FC, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaTrophy } from 'react-icons/fa';
+import { route } from 'ziggy-js';
 
 import { useFormatNumber } from '@/common/hooks/useFormatNumber';
 import { cn } from '@/common/utils/cn';
@@ -10,6 +11,7 @@ interface TooltipCreditRowProps {
   credit: App.Platform.Data.UserCredits;
 
   children?: ReactNode;
+  canLinkToUser?: boolean;
   showAchievementCount?: boolean;
   showCreditDate?: boolean;
 }
@@ -17,6 +19,7 @@ interface TooltipCreditRowProps {
 export const TooltipCreditRow: FC<TooltipCreditRowProps> = ({
   children,
   credit,
+  canLinkToUser = false,
   showAchievementCount = false,
   showCreditDate = false,
 }) => {
@@ -26,12 +29,22 @@ export const TooltipCreditRow: FC<TooltipCreditRowProps> = ({
 
   return (
     <p className="flex w-full justify-between gap-2">
-      <span className="flex items-center gap-1">
-        <img src={credit.avatarUrl} alt={credit.displayName} className="size-4 rounded-full" />
-        <span className={cn(credit.isGone ? 'text-neutral-500 line-through' : null)}>
-          {credit.displayName}
+      {!credit.isGone && canLinkToUser ? (
+        <a
+          href={route('user.show', { user: credit.displayName })}
+          className="flex items-center gap-1"
+        >
+          <img src={credit.avatarUrl} alt={credit.displayName} className="size-4 rounded-full" />
+          <span>{credit.displayName}</span>
+        </a>
+      ) : (
+        <span className="flex items-center gap-1">
+          <img src={credit.avatarUrl} alt={credit.displayName} className="size-4 rounded-full" />
+          <span className={cn(credit.isGone ? 'text-neutral-500 line-through' : null)}>
+            {credit.displayName}
+          </span>
         </span>
-      </span>
+      )}
 
       {children ? <span className="text-neutral-500">{children}</span> : null}
 

--- a/resources/js/features/games/components/AchievementSetCredits/TooltipCreditsSection/TooltipCreditsSection.tsx
+++ b/resources/js/features/games/components/AchievementSetCredits/TooltipCreditsSection/TooltipCreditsSection.tsx
@@ -12,7 +12,7 @@ export const TooltipCreditsSection: FC<TooltipCreditsSectionProps> = ({
   headingLabel,
 }) => {
   return (
-    <div>
+    <div className="flex flex-col gap-1 sm:gap-0">
       <p className="font-bold">{headingLabel}</p>
       <div className="flex flex-col gap-1">{children}</div>
     </div>

--- a/resources/js/features/games/components/AchievementSetCredits/useAchievementSetCredits.ts
+++ b/resources/js/features/games/components/AchievementSetCredits/useAchievementSetCredits.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+
+import { usePageProps } from '@/common/hooks/usePageProps';
+
+export function useAchievementSetCredits() {
+  const { achievementSetClaims, aggregateCredits } =
+    usePageProps<App.Platform.Data.GameShowPageProps>();
+
+  const artCreditUsers = useMemo(() => {
+    return [
+      ...aggregateCredits.achievementSetArtwork,
+      ...aggregateCredits.achievementsArtwork,
+    ].filter(
+      (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
+    );
+  }, [aggregateCredits.achievementSetArtwork, aggregateCredits.achievementsArtwork]);
+
+  const logicCreditUsers = useMemo(() => {
+    return aggregateCredits.achievementsLogic.filter(
+      (logicUser) =>
+        !aggregateCredits.achievementsAuthors.some(
+          (author) => author.displayName === logicUser.displayName,
+        ),
+    );
+  }, [aggregateCredits.achievementsAuthors, aggregateCredits.achievementsLogic]);
+
+  const codingCreditUsers = useMemo(() => {
+    return [...aggregateCredits.achievementsMaintainers, ...logicCreditUsers].filter(
+      (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
+    );
+  }, [aggregateCredits.achievementsMaintainers, logicCreditUsers]);
+
+  const designCreditUsers = useMemo(() => {
+    return [
+      ...aggregateCredits.achievementsDesign,
+      ...aggregateCredits.achievementsTesting,
+      ...aggregateCredits.achievementsWriting,
+      ...aggregateCredits.hashCompatibilityTesting,
+    ].filter(
+      (user, index, self) => index === self.findIndex((u) => u.displayName === user.displayName),
+    );
+  }, [
+    aggregateCredits.achievementsDesign,
+    aggregateCredits.achievementsTesting,
+    aggregateCredits.achievementsWriting,
+    aggregateCredits.hashCompatibilityTesting,
+  ]);
+
+  return {
+    achievementSetClaims,
+    aggregateCredits,
+    artCreditUsers,
+    codingCreditUsers,
+    designCreditUsers,
+  };
+}

--- a/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSetToolbar/GameAchievementSetToolbar.tsx
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSetToolbar/GameAchievementSetToolbar.tsx
@@ -80,51 +80,55 @@ export const GameAchievementSetToolbar: FC<GameAchievementSetToolbarProps> = ({
         buttonClassName="w-full sm:w-auto"
       />
 
-      <div className="flex w-full gap-2 sm:w-auto">
-        {missableAchievementsCount ? (
-          <BaseToggle
-            size="sm"
-            className={cn([
-              'group flex h-[30px] w-full items-center gap-1 !text-[13px] sm:w-auto lg:active:translate-y-[1px] lg:active:scale-[0.98]',
-              'light:bg-white light:hover:bg-neutral-50 light:hover:text-neutral-700',
-              'data-[state=on]:light:border-neutral-700 data-[state=on]:light:bg-neutral-50 data-[state=on]:light:text-neutral-900',
-            ])}
-            variant="outline"
-            pressed={isMissableOnlyFilterEnabled}
-            onPressedChange={handleToggleMissableOnlyFilter}
-          >
-            <IoAlert className="-mt-0.5 size-4" />
-            <span>{t('Missable Only')}</span>
-
-            <BaseChip
+      {missableAchievementsCount || (lockedAchievementsCount && unlockedAchievementsCount) ? (
+        <div className="flex w-full gap-2 sm:w-auto">
+          {missableAchievementsCount ? (
+            <BaseToggle
+              size="sm"
               className={cn([
-                'ml-1.5 bg-neutral-950 px-2 text-neutral-300 opacity-50 transition',
-                'group-hover:opacity-100 light:border-neutral-500 light:text-neutral-800',
-                isMissableOnlyFilterEnabled ? 'opacity-100' : null,
+                'group flex h-[30px] w-full items-center gap-1 !text-[13px] sm:w-auto lg:active:translate-y-[1px] lg:active:scale-[0.98]',
+                'light:bg-white light:hover:bg-neutral-50 light:hover:text-neutral-700',
+                'data-[state=on]:light:border-neutral-700 data-[state=on]:light:bg-neutral-50 data-[state=on]:light:text-neutral-900',
               ])}
+              variant="outline"
+              pressed={isMissableOnlyFilterEnabled}
+              onPressedChange={handleToggleMissableOnlyFilter}
             >
-              {formatNumber(missableAchievementsCount)}
-            </BaseChip>
-          </BaseToggle>
-        ) : null}
+              <IoAlert className="-mt-0.5 size-4" />
+              <span>{t('Missable Only')}</span>
 
-        {lockedAchievementsCount && unlockedAchievementsCount ? (
-          <BaseToggle
-            size="sm"
-            className={cn([
-              'flex h-[30px] items-center gap-1 whitespace-nowrap !text-[13px] lg:active:translate-y-[1px] lg:active:scale-[0.98]',
-              'light:bg-white light:hover:bg-neutral-50 light:hover:text-neutral-700',
-              'data-[state=on]:light:border-neutral-700 data-[state=on]:light:bg-neutral-50 data-[state=on]:light:text-neutral-900',
-            ])}
-            variant="outline"
-            pressed={isLockedOnlyFilterEnabled}
-            onPressedChange={handleToggleLockedOnlyFilter}
-          >
-            <LuEyeOff className="-mt-0.5" />
-            <span>{t('Locked Only')}</span>
-          </BaseToggle>
-        ) : null}
-      </div>
+              <BaseChip
+                className={cn([
+                  'ml-1.5 bg-neutral-950 px-2 text-neutral-300 opacity-50 transition',
+                  'group-hover:opacity-100 light:border-neutral-500 light:text-neutral-800',
+                  'w-full sm:w-auto',
+                  isMissableOnlyFilterEnabled ? 'opacity-100' : null,
+                ])}
+              >
+                {formatNumber(missableAchievementsCount)}
+              </BaseChip>
+            </BaseToggle>
+          ) : null}
+
+          {lockedAchievementsCount && unlockedAchievementsCount ? (
+            <BaseToggle
+              size="sm"
+              className={cn([
+                'flex h-[30px] items-center gap-1 whitespace-nowrap !text-[13px] lg:active:translate-y-[1px] lg:active:scale-[0.98]',
+                'light:bg-white light:hover:bg-neutral-50 light:hover:text-neutral-700',
+                'data-[state=on]:light:border-neutral-700 data-[state=on]:light:bg-neutral-50 data-[state=on]:light:text-neutral-900',
+                'w-full sm:w-auto',
+              ])}
+              variant="outline"
+              pressed={isLockedOnlyFilterEnabled}
+              onPressedChange={handleToggleLockedOnlyFilter}
+            >
+              <LuEyeOff className="-mt-0.5" />
+              <span>{t('Locked Only')}</span>
+            </BaseToggle>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
This PR adds a dedicated credit dialog/display for mobile users on React game pages.

The button is very condensed, showing only high-level detail until tapped:

**Example A**
<img width="360" height="116" alt="Screenshot 2025-07-26 at 8 26 57 PM" src="https://github.com/user-attachments/assets/8c9be113-f40a-4a6f-af10-2d8ac756faf9" />

<img width="380" height="672" alt="Screenshot 2025-07-26 at 8 27 04 PM" src="https://github.com/user-attachments/assets/666a767a-b6e5-49fe-8864-8f84924fdc87" />

---

**Example B**
<img width="356" height="119" alt="Screenshot 2025-07-26 at 8 27 21 PM" src="https://github.com/user-attachments/assets/ed3e31d4-595c-44f9-ad0f-b86491741bac" />

<img width="389" height="680" alt="Screenshot 2025-07-26 at 8 27 24 PM" src="https://github.com/user-attachments/assets/97b22a2b-5aad-4ddb-ac3a-ecf9b0a81011" />
