### PR TITLE
fix(game): link guide URLs correctly on React game pages

### DIFF
--- a/resources/js/features/games/components/GameSidebarFullWidthButtons/GameSidebarFullWidthButtons.tsx
+++ b/resources/js/features/games/components/GameSidebarFullWidthButtons/GameSidebarFullWidthButtons.tsx
@@ -88,7 +88,7 @@ export const GameSidebarFullWidthButtons: FC<GameSidebarFullWidthButtonsProps> =
           ) : null}
 
           {game.guideUrl ? (
-            <PlayableSidebarButton href="#" IconComponent={LuBookText} target="_blank">
+            <PlayableSidebarButton href={game.guideUrl} IconComponent={LuBookText} target="_blank">
               {t('Guide')}
             </PlayableSidebarButton>
           ) : null}


### PR DESCRIPTION
This PR fixes a bug on React game pages where the `href` attribute of guide URLs is "#". Now, they properly link to where they're supposed to go.

An example of a game to test with is http://localhost:64000/game2/15020.

<img width="378" height="192" alt="Screenshot 2025-07-28 at 9 44 35 PM" src="https://github.com/user-attachments/assets/8cd87fd1-11f6-49e6-8f64-170b970673e4" />
