### PR TITLE
fix(hub): remediate 404 error in the server logs

### DIFF
--- a/app/Actions/ProcessPlausibleUrlAction.php
+++ b/app/Actions/ProcessPlausibleUrlAction.php
@@ -107,10 +107,10 @@ class ProcessPlausibleUrlAction
                         ? substr($route['titleField'], strrpos($route['titleField'], '.') + 1)
                         : $route['titleField'];
 
-                    $props = [
-                        'id' => $id,
-                        strtolower($propName) => $titleValue,
-                    ];
+                    $props = ['id' => $id];
+                    if ($titleValue !== null) {
+                        $props[strtolower($propName)] = $titleValue;
+                    }
                 } elseif ($id) {
                     $props = ['id' => $id];
                 }
@@ -245,7 +245,7 @@ class ProcessPlausibleUrlAction
     /**
      * Gets a value from a model relationship.
      */
-    private function getNestedValue(Model $model, string $path): string
+    private function getNestedValue(Model $model, string $path): ?string
     {
         $parts = explode('.', $path);
         $value = $model;


### PR DESCRIPTION
Resolves this error:
<img width="1276" height="187" alt="Screenshot 2025-08-06 at 6 03 54 PM" src="https://github.com/user-attachments/assets/7a2611f2-547b-45ca-a38e-35afa5fa14fc" />

The error occurs when navigating to `/hub/{game_set.id}` for a game_set where type equals "similar-games" and title is `null`, ie: http://localhost:64000/hub/29637

ProcessPlausibleUrlAction is trying to find a title, but there isn't one, even though the model technically does exist.