### PR TITLE
feat: Added sort by award date functionality

### DIFF
--- a/app/Helpers/render/site-award.php
+++ b/app/Helpers/render/site-award.php
@@ -317,6 +317,15 @@ function RenderAwardOrderTable(
 
     echo "<div class='flex w-full items-center justify-between'>";
     echo "<h4>$title</h4>";
+    echo <<<HTML
+        <div class="flex items-center gap-x-1 ml-auto mr-4">
+            <p class="text-3xs">
+                Sort by Award Date:
+            </p>
+            <button onclick='reorderSiteAwards.handleSortByAwardDate("asc", "$humanReadableAwardKind")' class="btn text-3xs py-0.5">↑</button>
+            <button onclick='reorderSiteAwards.handleSortByAwardDate("desc", "$humanReadableAwardKind")' class="btn text-3xs py-0.5">↓</button>
+        </div>
+    HTML;
     echo "<select data-award-kind='$humanReadableAwardKind'>";
     for ($i = 1; $i <= $renderedSectionCount; $i++) {
         if ($initialSectionOrder === $i) {
@@ -344,6 +353,7 @@ function RenderAwardOrderTable(
         $awardType = $award['AwardType'];
         $awardData = $award['AwardData'];
         $awardDataExtra = $award['AwardDataExtra'];
+        $awardDate = $award['AwardedAt'];
         $awardTitle = $award['Title'];
         $awardDisplayOrder = $award['DisplayOrder'];
 
@@ -380,6 +390,7 @@ function RenderAwardOrderTable(
             <tr
                 data-row-index='$awardCounter'
                 data-award-kind='$humanReadableAwardKind'
+                data-award-date='$awardDate'
                 draggable='$isDraggable'
                 class='$rowClassNames'
                 ondragstart='reorderSiteAwards.handleRowDragStart(event)'

--- a/resources/js/tall-stack/dynamic/reorderSiteAwards.ts
+++ b/resources/js/tall-stack/dynamic/reorderSiteAwards.ts
@@ -1,5 +1,6 @@
 export * from './reorderSiteAwards/handleRowDragOver';
 export * from './reorderSiteAwards/handleShowSavedHiddenRowsChange';
+export * from './reorderSiteAwards/handleSortByAwardDate';
 export * from './reorderSiteAwards/index';
 export * from './reorderSiteAwards/refreshVisibilityAfterSave';
 export { reorderSiteAwardsStore as store } from './reorderSiteAwards/reorderSiteAwardsStore';

--- a/resources/js/tall-stack/dynamic/reorderSiteAwards/handleSortByAwardDate.ts
+++ b/resources/js/tall-stack/dynamic/reorderSiteAwards/handleSortByAwardDate.ts
@@ -1,0 +1,38 @@
+export function handleSortByAwardDate(
+    direction: "asc" | "desc",
+    awardKind: string
+): void {
+    // Determine the correct table by awardKind
+    const tableId = `${awardKind}-reorder-table`;
+    const table = document.getElementById(tableId) as HTMLTableElement | null;
+    const tbody = table ? table.querySelector("tbody") : null;
+    if (!tbody) return;
+
+    // Only select rows for this awardKind in this table
+    const rows = Array.from(
+        tbody.querySelectorAll<HTMLTableRowElement>(".award-table-row")
+    ).filter(
+        (row) => row.getAttribute("data-award-kind") === awardKind
+    );
+
+    // Sort rows by data-completion-date (descending or ascending)
+    rows.sort((a, b) => {
+        const dateA = a.getAttribute("data-award-date") ?? "";
+        const dateB = b.getAttribute("data-award-date") ?? "";
+
+        let numA: number;
+        let numB: number;
+
+        if (!isNaN(Number(dateA)) && !isNaN(Number(dateB))) {
+            numA = parseInt(dateA, 10);
+            numB = parseInt(dateB, 10);
+        } else {
+            numA = Date.parse(dateA) || 0;
+            numB = Date.parse(dateB) || 0;
+        }
+
+        return direction === "asc" ? numA - numB : numB - numA;
+    });
+
+    for (const row of rows) tbody.appendChild(row);
+}


### PR DESCRIPTION
This PR adds a minor feature to the "Reorder Site Awards" page that I have personally been wanting for a while, and hopefully other users will find it useful as well.

The feature provides users with an easy way to sort their awards in ascending or descending order by date of acquisition. For some users like me, looking back at awards in order of completion serves as a nice trip down memory lane. But like many other users, I often want to re-sort my awards by game series or other preferences. However, I felt that an option for easily resetting awards to the "default" order was missing.

I've tested the functionality locally and it works for all three award tables: game awards, event awards, and site awards. Users still need to press the "Save All Changes" button for the sort to take effect, as the help text suggests.

<img width="882" height="450" alt="bild" src="https://github.com/user-attachments/assets/31ebe2c4-f9fe-44e1-9c5f-4b46d79aac74" />

<img width="930" height="409" alt="bild" src="https://github.com/user-attachments/assets/75033133-4f6c-45e7-8c93-b2da4a69b8c0" />

