### PR TITLE
feat: enhance Discord team inbox webhooks

### DIFF
--- a/app/Community/Actions/ForwardMessageToDiscordAction.php
+++ b/app/Community/Actions/ForwardMessageToDiscordAction.php
@@ -1,0 +1,435 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Community\Actions;
+
+use App\Community\Data\ProcessedDiscordMessageData;
+use App\Models\DiscordMessageThreadMapping;
+use App\Models\Message;
+use App\Models\MessageThread;
+use App\Models\User;
+use App\Support\Shortcode\Shortcode;
+use GuzzleHttp\Client;
+
+class ForwardMessageToDiscordAction
+{
+    /** Discord API limits */
+    private const DISCORD_EMBED_DESCRIPTION_LIMIT = 2000;
+    private const DISCORD_THREAD_NAME_LIMIT = 100;
+
+    /** Message processing limits */
+    private const MESSAGE_BODY_MAX_LENGTH = 10_000;
+
+    /** Timing constants */
+    private const CHUNK_SEND_DELAY_MICROSECONDS = 100_000;
+
+    /** Embed colors */
+    private const COLOR_DEFAULT = 0x0066CC;
+    private const COLOR_VERIFICATION = 0x00CC66;
+
+    private Client $client;
+
+    public function __construct(?Client $client = null)
+    {
+        // Optionally inject a mock client in tests to avoid real Discord API calls.
+        $this->client = $client ?? new Client();
+    }
+
+    /**
+     * Forward a message to Discord via webhook.
+     */
+    public function execute(
+        User $userFrom,
+        User $userTo,
+        MessageThread $messageThread,
+        Message $message
+    ): void {
+        $fullBody = Shortcode::stripAndClamp($message->body, self::MESSAGE_BODY_MAX_LENGTH, preserveWhitespace: true);
+
+        $inboxConfig = config('services.discord.inbox_webhook.' . $userTo->username);
+        if ($inboxConfig === null || empty($inboxConfig['url'] ?? null)) {
+            return;
+        }
+
+        $webhookUrl = $inboxConfig['url']; // each inbox has its own dedicated webhook url
+
+        if (empty($messageThread->title) || empty($fullBody)) {
+            return;
+        }
+
+        $color = self::COLOR_DEFAULT;
+        $isForum = $inboxConfig['is_forum'] ?? false;
+
+        $isNewThread = $isForum ? !$this->getExistingDiscordThreadId($messageThread, $userTo) : true;
+
+        $processedData = $this->processSpecialMessageTypes(
+            $messageThread,
+            $fullBody,
+            $inboxConfig,
+            $webhookUrl,
+            $color,
+            $isForum,
+            $isNewThread
+        );
+
+        $messageThread->title = $processedData->threadTitle;
+
+        $this->sendDiscordWebhooks(
+            $processedData->webhookUrl,
+            $userFrom,
+            $userTo,
+            $messageThread,
+            $processedData->messageBody,
+            $processedData->color,
+            $processedData->isForum
+        );
+    }
+
+    /**
+     * Process special message types and determine routing.
+     */
+    private function processSpecialMessageTypes(
+        MessageThread $messageThread,
+        string $messageBody,
+        array $inboxConfig,
+        string $webhookUrl,
+        int $color,
+        bool $isForum,
+        bool $isNewThread
+    ): ProcessedDiscordMessageData {
+        $messageTitle = mb_strtolower($messageThread->title);
+        $threadTitle = $messageThread->title;
+
+        // Detect Discord verification messages and route them to a channel for moderators.
+        if (isset($inboxConfig['verify_url']) && $this->isVerificationMessage($messageTitle)) {
+            $webhookUrl = $inboxConfig['verify_url'];
+            $color = self::COLOR_VERIFICATION;
+            $isForum = false;
+        }
+
+        // These structured messages get routed to team-specific forum channels for
+        // better organization, internal discussion, and tracking of achievement-related issues.
+        $structuredTitlePrefixes = [
+            'Incorrect type:' => 'incorrect_type_url',
+            'Issue:' => 'achievement_issues_url',
+            'Unwelcome Concept:' => 'unwelcome_concept_url',
+            'Writing:' => 'url',
+        ];
+
+        foreach ($structuredTitlePrefixes as $prefix => $configKey) {
+            if (mb_strpos($threadTitle, $prefix) !== false && isset($inboxConfig[$configKey])) {
+                $webhookUrl = $inboxConfig[$configKey];
+                $isForum = true;
+
+                if (preg_match('/\[([0-9]+)\]/', $threadTitle, $matches)) {
+                    $achievementId = $matches[1];
+
+                    // Add the achievement URL only for new threads (the OP) to
+                    // avoid duplicate links appearing in replies.
+                    if ($isNewThread) {
+                        $achievementUrl = route('achievement.show', $achievementId);
+                        $messageBody = $achievementUrl . "\n\n" . $messageBody;
+                    }
+
+                    // Reformat title to put achievement ID first for easier scanning in forum view.
+                    // This also can drive RABot behavior. Changing this format could be breaking!
+                    if ($isNewThread && preg_match(
+                            '/^(Incorrect type:|Issue:|Unwelcome Concept:|Writing:)\s*(.*)\s*\[([0-9]+)\]\s*(\(.*\))$/',
+                            $threadTitle,
+                            $titleMatches
+                        )
+                    ) {
+                        $threadTitle = $achievementId . ': ' . trim($titleMatches[2]) . ' ' . $titleMatches[4];
+                    }
+                }
+
+                break;
+            }
+        }
+
+        return new ProcessedDiscordMessageData(
+            color: $color,
+            isForum: $isForum,
+            messageBody: $messageBody,
+            threadTitle: $threadTitle,
+            webhookUrl: $webhookUrl,
+        );
+    }
+
+    /**
+     * Send the Discord webhooks, handling multi-part messages for forums.
+     */
+    private function sendDiscordWebhooks(
+        string $webhookUrl,
+        User $userFrom,
+        User $userTo,
+        MessageThread $messageThread,
+        string $messageBody,
+        int $color,
+        bool $isForum
+    ): void {
+        if ($isForum) {
+            $existingThreadId = $this->getExistingDiscordThreadId($messageThread, $userTo);
+            $isNewThread = !$existingThreadId;
+
+            $discordThreadId = $existingThreadId ?? $this->createDiscordThread(
+                $webhookUrl,
+                $userFrom,
+                $userTo,
+                $messageThread,
+                $messageBody,
+                $color
+            );
+
+            if ($discordThreadId) {
+                $this->sendMessagesToDiscordThread(
+                    $webhookUrl,
+                    $discordThreadId,
+                    $userFrom,
+                    $userTo,
+                    $messageThread,
+                    $messageBody,
+                    $color,
+                    $isNewThread
+                );
+            }
+        } else {
+            $this->sendSingleDiscordMessage(
+                $webhookUrl,
+                $userFrom,
+                $userTo,
+                $messageThread,
+                mb_substr($messageBody, 0, self::DISCORD_EMBED_DESCRIPTION_LIMIT),
+                $color
+            );
+        }
+    }
+
+    /**
+     * Check if we have an existing Discord thread for this message thread.
+     * If we do, we'll attach replies to the existing thread rather than making new threads.
+     */
+    private function getExistingDiscordThreadId(MessageThread $messageThread, User $userTo): ?string
+    {
+        $mapping = DiscordMessageThreadMapping::findMapping($messageThread->id, $userTo->ID);
+
+        return $mapping?->discord_thread_id;
+    }
+
+    /**
+     * Create a new Discord thread and store the mapping.
+     * The mapping is used so we know where to attach replies to.
+     */
+    private function createDiscordThread(
+        string $webhookUrl,
+        User $userFrom,
+        User $userTo,
+        MessageThread $messageThread,
+        string $messageBody,
+        int $color
+    ): ?string {
+        $isLongMessage = mb_strlen($messageBody) > self::DISCORD_EMBED_DESCRIPTION_LIMIT;
+        $firstChunk = $isLongMessage
+            ? mb_substr($messageBody, 0, self::DISCORD_EMBED_DESCRIPTION_LIMIT)
+            : $messageBody;
+
+        $payload = $this->buildDiscordPayload(
+            $userFrom,
+            $userTo,
+            $messageThread,
+            $firstChunk,
+            $color,
+            true
+        );
+        $payload['thread_name'] = mb_substr($messageThread->title, 0, self::DISCORD_THREAD_NAME_LIMIT);
+
+        if ($isLongMessage) {
+            $totalParts = count(mb_str_split($messageBody, self::DISCORD_EMBED_DESCRIPTION_LIMIT));
+            $payload['content'] = "[Part 1 of {$totalParts}]";
+        }
+
+        // wait=true is required for Discord to give us the thread ID in the response.
+        $response = $this->client->post($webhookUrl . '?wait=true', ['json' => $payload]);
+        $responseData = json_decode($response->getBody()->getContents(), true);
+        $threadId = $responseData['channel_id'] ?? null;
+
+        if ($threadId) {
+            DiscordMessageThreadMapping::storeMapping(
+                $messageThread->id,
+                $userTo->ID,
+                $threadId
+            );
+        }
+
+        return $threadId;
+    }
+
+    /**
+     * Send messages to an existing Discord thread.
+     * This only works if we've previously stored the thread ID in our mapping table.
+     */
+    private function sendMessagesToDiscordThread(
+        string $webhookUrl,
+        string $discordThreadId,
+        User $userFrom,
+        User $userTo,
+        MessageThread $messageThread,
+        string $messageBody,
+        int $color,
+        bool $isNewThread = false
+    ): void {
+        $threadWebhookUrl = $webhookUrl . '?thread_id=' . $discordThreadId;
+
+        if (mb_strlen($messageBody) > self::DISCORD_EMBED_DESCRIPTION_LIMIT) {
+            $this->sendChunkedMessages(
+                $threadWebhookUrl,
+                $userFrom,
+                $userTo,
+                $messageThread,
+                $messageBody,
+                $color,
+                $isNewThread
+            );
+        } else {
+            // Skip sending for new threads since the first message was already sent during thread creation.
+            if (!$isNewThread) {
+                $payload = $this->buildDiscordPayload(
+                    $userFrom,
+                    $userTo,
+                    $messageThread,
+                    $messageBody,
+                    $color,
+                    true
+                );
+
+                $this->client->post($threadWebhookUrl, ['json' => $payload]);
+            }
+        }
+    }
+
+    /**
+     * Send chunked messages to a Discord thread.
+     * Discord has a max character limit which is much shorter than our own.
+     * To get around this, we chunk messages from RA into a size Discord is happy with
+     * and send them sequentially to the team inbox with multiple webhook calls.
+     */
+    private function sendChunkedMessages(
+        string $threadWebhookUrl,
+        User $userFrom,
+        User $userTo,
+        MessageThread $messageThread,
+        string $messageBody,
+        int $color,
+        bool $skipFirstChunk = false
+    ): void {
+        $chunks = mb_str_split($messageBody, self::DISCORD_EMBED_DESCRIPTION_LIMIT);
+        $totalParts = count($chunks);
+        $startIndex = $skipFirstChunk ? 1 : 0;
+
+        for ($i = $startIndex; $i < $totalParts; $i++) {
+            $partNumber = $i + 1;
+
+            $payload = $this->buildDiscordPayload(
+                $userFrom,
+                $userTo,
+                $messageThread,
+                $chunks[$i],
+                $color,
+                $i === $startIndex
+            );
+
+            if ($totalParts > 1) {
+                $payload['content'] = "[Part {$partNumber} of {$totalParts}]";
+            }
+
+            $this->client->post($threadWebhookUrl, ['json' => $payload]);
+
+            // Use a naive delay to prevent Discord from deciding to randomly reorder messages.
+            if ($i < $totalParts - 1) {
+                usleep(self::CHUNK_SEND_DELAY_MICROSECONDS);
+            }
+        }
+    }
+
+    /**
+     * Send a single Discord message (for non-forum channels).
+     */
+    private function sendSingleDiscordMessage(
+        string $webhookUrl,
+        User $userFrom,
+        User $userTo,
+        MessageThread $messageThread,
+        string $messageBody,
+        int $color
+    ): void {
+        $payload = $this->buildDiscordPayload(
+            $userFrom,
+            $userTo,
+            $messageThread,
+            $messageBody,
+            $color,
+            true
+        );
+
+        $this->client->post($webhookUrl, ['json' => $payload]);
+    }
+
+    /**
+     * Build the base Discord webhook payload.
+     * This is what their webhook API expects. `color` is hex.
+     */
+    private function buildDiscordPayload(
+        User $userFrom,
+        User $userTo,
+        MessageThread $messageThread,
+        string $description,
+        int $color,
+        bool $includeAuthor = true
+    ): array {
+        $embed = [
+            'description' => $description,
+            'color' => $color,
+        ];
+
+        if ($includeAuthor) {
+            $embed['author'] = [
+                'name' => $userFrom->display_name,
+                // TODO 'url' => route('user.show', $userFrom), -- we've lost context on why this TODO was ever added.
+                'url' => url('user/' . $userFrom->display_name),
+                'icon_url' => $userFrom->avatar_url,
+            ];
+            $embed['title'] = mb_substr($messageThread->title, 0, self::DISCORD_THREAD_NAME_LIMIT);
+            $embed['url'] = route('message-thread.show', ['messageThread' => $messageThread->id]);
+        }
+
+        return [
+            'username' => $userTo->username . ' Inbox',
+            'avatar_url' => $userTo->avatar_url,
+            'embeds' => [$embed],
+        ];
+    }
+
+    /**
+     * Check if a message title indicates a verification-related message.
+     * These get routed to a special inbox for moderators.
+     */
+    private function isVerificationMessage(string $messageTitle): bool
+    {
+        $verificationKeywords = [
+            'discord',
+            'verification',
+            'verified',
+            'verify',
+            'verifying',
+        ];
+
+        foreach ($verificationKeywords as $keyword) {
+            if (mb_strpos($messageTitle, $keyword) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Community/Data/ProcessedDiscordMessageData.php
+++ b/app/Community/Data/ProcessedDiscordMessageData.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Community\Data;
+
+use Spatie\LaravelData\Data;
+
+class ProcessedDiscordMessageData extends Data
+{
+    public function __construct(
+        public int $color,
+        public bool $isForum,
+        public string $messageBody,
+        public string $threadTitle,
+        public string $webhookUrl,
+    ) {
+    }
+}

--- a/app/Community/Listeners/NotifyMessageThreadParticipants.php
+++ b/app/Community/Listeners/NotifyMessageThreadParticipants.php
@@ -4,16 +4,14 @@ declare(strict_types=1);
 
 namespace App\Community\Listeners;
 
+use App\Community\Actions\ForwardMessageToDiscordAction;
 use App\Community\Actions\UpdateUnreadMessageCountAction;
 use App\Community\Events\MessageCreated;
 use App\Enums\UserPreference;
 use App\Mail\PrivateMessageReceivedMail;
-use App\Models\Message;
 use App\Models\MessageThread;
 use App\Models\MessageThreadParticipant;
 use App\Models\User;
-use App\Support\Shortcode\Shortcode;
-use GuzzleHttp\Client;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 
@@ -72,130 +70,7 @@ class NotifyMessageThreadParticipants
                 }
             }
 
-            $this->forwardToDiscord($userFrom, $userTo, $thread, $message);
+            (new ForwardMessageToDiscordAction())->execute($userFrom, $userTo, $thread, $message);
         }
-    }
-
-    private function forwardToDiscord(
-        User $userFrom,
-        User $userTo,
-        MessageThread $messageThread,
-        Message $message
-    ): void {
-        $message->body = Shortcode::stripAndClamp($message->body, 1850, preserveWhitespace: true);
-
-        $inboxConfig = config('services.discord.inbox_webhook.' . $userTo->username);
-
-        // If no config exists for this user or no URL is configured, bail early.
-        if ($inboxConfig === null || empty($inboxConfig['url'] ?? null)) {
-            return;
-        }
-
-        // Default webhook URL.
-        $webhookUrl = $inboxConfig['url'];
-
-        if (empty($messageThread->title) || empty($message->body)) {
-            return;
-        }
-
-        // Set default values.
-        $color = hexdec('0x0066CC');
-        $isForum = $inboxConfig['is_forum'] ?? false;
-
-        // Process special message types only if the corresponding config keys exist.
-        $messageTitle = mb_strtolower($messageThread->title);
-
-        // Discord user verification messages.
-        if (isset($inboxConfig['verify_url']) && (
-            mb_strpos($messageTitle, 'verify') !== false
-            || mb_strpos($messageTitle, 'verified') !== false
-            || mb_strpos($messageTitle, 'verifying') !== false
-            || mb_strpos($messageTitle, 'verification') !== false
-            || mb_strpos($messageTitle, 'discord') !== false
-        )) {
-            $webhookUrl = $inboxConfig['verify_url'];
-            $color = hexdec('0x00CC66');
-            $isForum = false;
-        }
-
-        // Deletion messages - just change the color, don't change the URL.
-        if (
-            mb_strpos($messageTitle, 'delete') !== false
-            || mb_strpos($messageTitle, 'deleting') !== false
-            || mb_strpos($messageTitle, 'deletion') !== false
-        ) {
-            $color = hexdec('0xCC6600');
-        }
-
-        // Manual unlock messages.
-        if (isset($inboxConfig['manual_unlock_url']) && mb_strpos($messageTitle, 'manual') !== false) {
-            $webhookUrl = $inboxConfig['manual_unlock_url'];
-            $color = hexdec('0xCC0066');
-            $isForum = false;
-        }
-
-        // If true, has title like "Kind: Achievement Name [Achievement ID] (Game Name)"
-        $structuredTitlePrefixes = [
-            'Incorrect type:' => 'incorrect_type_url',
-            'Issue:' => 'achievement_issues_url',
-            'Unwelcome Concept:' => 'unwelcome_concept_url',
-            'Writing:' => 'url',
-        ];
-
-        foreach ($structuredTitlePrefixes as $prefix => $configKey) {
-            if (mb_strpos($messageThread->title, $prefix) !== false && isset($inboxConfig[$configKey])) {
-                $webhookUrl = $inboxConfig[$configKey];
-                $isForum = true;
-
-                // Extract the achievement ID from the message thread title.
-                // We'll auto-insert a link to the achievement at the top of the message.
-                if (preg_match('/\[([0-9]+)\]/', $messageThread->title, $matches)) {
-                    $achievementId = $matches[1];
-                    $achievementUrl = route('achievement.show', $achievementId);
-                    $message->body = $achievementUrl . "\n\n" . $message->body;
-
-                    // We want to reformat the incoming structured title before it lands in the team forum.
-                    //  - Original:  "Unwelcome Concept: Lots of Rings [12345] (Sonic the Hedgehog)"
-                    //  - Formatted: "12345: Lots of Rings (Sonic the Hedgehog)"
-                    if (preg_match(
-                            '/^(Incorrect type:|Issue:|Unwelcome Concept:|Writing:)\s*(.*)\s*\[([0-9]+)\]\s*(\(.*\))$/',
-                            $messageThread->title,
-                            $titleMatches
-                        )
-                    ) {
-                        $newTitle = $achievementId . ': ' . $titleMatches[2] . ' ' . $titleMatches[4];
-                        $messageThread->title = $newTitle;
-                    }
-                }
-
-                break;
-            }
-        }
-
-        $payload = [
-            'username' => $userTo->username . ' Inbox',
-            'avatar_url' => $userTo->avatar_url,
-            'embeds' => [
-                [
-                    'author' => [
-                        'name' => $userFrom->display_name,
-                        // TODO 'url' => route('user.show', $userFrom),
-                        'url' => url('user/' . $userFrom->display_name),
-                        'icon_url' => $userFrom->avatar_url,
-                    ],
-                    'title' => mb_substr($messageThread->title, 0, 100),
-                    'url' => route('message-thread.show', ['messageThread' => $messageThread->id]),
-                    'description' => mb_substr($message->body, 0, 2000),
-                    'color' => $color,
-                ],
-            ],
-        ];
-
-        if ($isForum) {
-            // Forum channels require an additional 'thread_name' JSON parameter to be successfully posted.
-            $payload['thread_name'] = mb_substr($messageThread->title, 0, 100);
-        }
-
-        (new Client())->post($webhookUrl, ['json' => $payload]);
     }
 }

--- a/app/Models/DiscordMessageThreadMapping.php
+++ b/app/Models/DiscordMessageThreadMapping.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Support\Database\Eloquent\BaseModel;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DiscordMessageThreadMapping extends BaseModel
+{
+    protected $table = 'discord_message_thread_mappings';
+
+    protected $fillable = [
+        'message_thread_id',
+        'recipient_id',
+        'discord_thread_id',
+    ];
+
+    // == accessors
+
+    // == mutators
+
+    // == relations
+
+    /**
+     * @return BelongsTo<MessageThread, DiscordMessageThreadMapping>
+     */
+    public function messageThread(): BelongsTo
+    {
+        return $this->belongsTo(MessageThread::class, 'message_thread_id');
+    }
+
+    /**
+     * @return BelongsTo<User, DiscordMessageThreadMapping>
+     */
+    public function recipient(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'recipient_id', 'ID');
+    }
+
+    // == scopes
+
+    /**
+     * Find an existing Discord thread mapping for a message thread and recipient.
+     */
+    public static function findMapping(int $messageThreadId, int $recipientId): ?self
+    {
+        return self::where('message_thread_id', $messageThreadId)
+            ->where('recipient_id', $recipientId)
+            ->first();
+    }
+
+    // == helpers
+
+    /**
+     * Store a new Discord thread mapping.
+     */
+    public static function storeMapping(int $messageThreadId, int $recipientId, string $discordThreadId): self
+    {
+        return self::updateOrCreate(
+            [
+                'message_thread_id' => $messageThreadId,
+                'recipient_id' => $recipientId,
+            ],
+            [
+                'discord_thread_id' => $discordThreadId,
+            ]
+        );
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -75,7 +75,6 @@ return [
                     env('DISCORD_ROLE_ADMIN'),
                     env('DISCORD_ROLE_MODERATOR'),
                 ],
-                'manual_unlock_url' => env('DISCORD_WEBHOOK_MOD_MANUAL_UNLOCK'),
                 'verify_url' => env('DISCORD_WEBHOOK_MOD_VERIFY'),
             ],
             'RAEvents' => [

--- a/database/migrations/2025_08_17_000000_create_discord_message_thread_mappings_table.php
+++ b/database/migrations/2025_08_17_000000_create_discord_message_thread_mappings_table.php
@@ -13,7 +13,7 @@ return new class() extends Migration {
             $table->id();
             $table->unsignedBigInteger('message_thread_id');
             $table->unsignedBigInteger('recipient_id');
-            $table->string('discord_thread_id', 100);
+            $table->string('discord_thread_id', 20); // Discord snowflakes are 64-bit integers (max 20 digits)
             $table->timestamps();
 
             $table->index('discord_thread_id');

--- a/database/migrations/2025_08_17_000000_create_discord_message_thread_mappings_table.php
+++ b/database/migrations/2025_08_17_000000_create_discord_message_thread_mappings_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::create('discord_message_thread_mappings', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('message_thread_id');
+            $table->unsignedBigInteger('recipient_id');
+            $table->string('discord_thread_id', 100);
+            $table->timestamps();
+
+            $table->index('discord_thread_id');
+            $table->unique(['message_thread_id', 'recipient_id'], 'unique_discord_mapping'); // default name is too long
+
+            $table->foreign('message_thread_id')->references('id')->on('message_threads')->onDelete('cascade');
+            $table->foreign('recipient_id')->references('ID')->on('UserAccounts')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('discord_message_thread_mappings');
+    }
+};

--- a/tests/Feature/Community/Actions/ForwardMessageToDiscordActionTest.php
+++ b/tests/Feature/Community/Actions/ForwardMessageToDiscordActionTest.php
@@ -1,0 +1,517 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Community\Actions;
+
+use App\Community\Actions\ForwardMessageToDiscordAction;
+use App\Models\DiscordMessageThreadMapping;
+use App\Models\Message;
+use App\Models\MessageThread;
+use App\Models\User;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ForwardMessageToDiscordActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private MockHandler $mockHandler;
+    private array $webhookHistory = [];
+    private ForwardMessageToDiscordAction $action;
+    private User $sender;
+    private User $recipient;
+    private MessageThread $thread;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Set up a mock Guzzle client to capture webhook payloads.
+        // We don't want to actually try to call Discord's API.
+        $this->mockHandler = new MockHandler();
+        $handlerStack = HandlerStack::create($this->mockHandler);
+
+        // Add history middleware to capture requests.
+        $history = Middleware::history($this->webhookHistory);
+        $handlerStack->push($history);
+
+        $mockClient = new Client(['handler' => $handlerStack]);
+
+        // Create the action with mocked client.
+        $this->action = new ForwardMessageToDiscordAction($mockClient);
+
+        // Create test users and thread.
+        $this->sender = User::factory()->create(['User' => 'TestSender']);
+        $this->recipient = User::factory()->create(['User' => 'TestRecipient']);
+        $this->thread = MessageThread::factory()->create(['title' => 'Test Thread']);
+    }
+
+    /**
+     * Create a new message from $this->sender that's associated with $this->thread.
+     */
+    private function createMessage(string $body): Message
+    {
+        return Message::factory()->create([
+            'thread_id' => $this->thread->id,
+            'author_id' => $this->sender->id,
+            'body' => $body,
+        ]);
+    }
+
+    /**
+     * Set up the Discord webhook config for a specific user.
+     */
+    private function setDiscordConfig(
+        User $user,
+        string $webhookUrl = 'https://discord.com/api/webhooks/123/abc',
+        bool $isForum = false,
+        ?string $verifyUrl = null,
+        ?string $achievementIssuesUrl = null
+    ): void {
+        config([
+            'services.discord.inbox_webhook.' . $user->username => [
+                'url' => $webhookUrl,
+                'is_forum' => $isForum,
+                'verify_url' => $verifyUrl,
+                'achievement_issues_url' => $achievementIssuesUrl,
+            ],
+        ]);
+    }
+
+    private function queueDiscordResponses(int $count = 1, array $responseData = []): void
+    {
+        $defaultResponse = [
+            'id' => '123456789',
+            'channel_id' => 'thread_123',
+        ];
+
+        for ($i = 0; $i < $count; $i++) {
+            $this->mockHandler->append(
+                new Response(200, [], json_encode(array_merge($defaultResponse, $responseData)))
+            );
+        }
+    }
+
+    private function getLastWebhookPayload(): ?array
+    {
+        if (empty($this->webhookHistory)) {
+            return null;
+        }
+
+        $lastRequest = end($this->webhookHistory)['request'];
+
+        return json_decode($lastRequest->getBody()->getContents(), true);
+    }
+
+    private function getAllWebhookPayloads(): array
+    {
+        $payloads = [];
+        foreach ($this->webhookHistory as $transaction) {
+            $payloads[] = json_decode($transaction['request']->getBody()->getContents(), true);
+        }
+
+        return $payloads;
+    }
+
+    public function testItDoesNothingWhenNoWebhookIsConfigured(): void
+    {
+        // Arrange
+        $message = $this->createMessage('Test message');
+        // ... no Discord config is set...
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(0, $this->webhookHistory);
+    }
+
+    public function testItDoesNothingWhenTheThreadTitleIsEmpty(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient);
+        $this->thread->title = ''; // !! this is an edge case, shouldn't happen in real life
+        $this->thread->save();
+        $message = $this->createMessage('Test message');
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(0, $this->webhookHistory);
+    }
+
+    public function testItDoesNothingWhenTheMessageBodyIsEmpty(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient);
+        $message = $this->createMessage(''); // !! this is an edge case, shouldn't happen in real life
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(0, $this->webhookHistory);
+    }
+
+    public function testItSendsSimpleMessageToNonForumChannel(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: false);
+        $message = $this->createMessage('This is a test message');
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(1, $this->webhookHistory);
+
+        $payload = $this->getLastWebhookPayload();
+        $this->assertEquals($this->recipient->username . ' Inbox', $payload['username']);
+        $this->assertCount(1, $payload['embeds']);
+        $this->assertEquals('This is a test message', $payload['embeds'][0]['description']);
+        $this->assertEquals($this->sender->display_name, $payload['embeds'][0]['author']['name']);
+        $this->assertEquals($this->thread->title, $payload['embeds'][0]['title']);
+    }
+
+    public function testItTruncatesLongMessagesForNonForumChannels(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: false);
+        $message = $this->createMessage(str_repeat('A', 3000));
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(1, $this->webhookHistory);
+
+        $payload = $this->getLastWebhookPayload();
+        $this->assertEquals(2000, mb_strlen($payload['embeds'][0]['description'])); // !! truncated to 2000 chars
+        $this->assertEquals(str_repeat('A', 2000), $payload['embeds'][0]['description']);
+    }
+
+    public function testItCreatesNewThreadForForumChannels(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+        $message = $this->createMessage('First message to forum');
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(1, $this->webhookHistory);
+
+        $request = $this->webhookHistory[0]['request'];
+        $this->assertStringContainsString('wait=true', $request->getUri()->getQuery());
+
+        $payload = $this->getLastWebhookPayload();
+        $this->assertArrayHasKey('thread_name', $payload);
+        $this->assertEquals($this->thread->title, $payload['thread_name']);
+        $this->assertEquals('First message to forum', $payload['embeds'][0]['description']);
+    }
+
+    public function testItStoresDiscordThreadMappingsOnThreadCreate(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+        $message = $this->createMessage('Create thread message');
+        $this->queueDiscordResponses(1, ['channel_id' => 'discord_thread_123']);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $mapping = DiscordMessageThreadMapping::findMapping($this->thread->id, $this->recipient->id);
+        $this->assertNotNull($mapping);
+        $this->assertEquals('discord_thread_123', $mapping->discord_thread_id);
+        $this->assertEquals($this->thread->id, $mapping->message_thread_id);
+        $this->assertEquals($this->recipient->ID, $mapping->recipient_id);
+    }
+
+    public function testItUsesExistingThreadsForReplies(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+
+        // ... store an existing thread mapping ...
+        DiscordMessageThreadMapping::storeMapping(
+            $this->thread->id,
+            $this->recipient->ID,
+            'existing_thread_456'
+        );
+
+        $message = $this->createMessage('Reply to existing thread');
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(1, $this->webhookHistory);
+
+        $request = $this->webhookHistory[0]['request'];
+        $this->assertStringContainsString('thread_id=existing_thread_456', $request->getUri()->getQuery());
+
+        $payload = $this->getLastWebhookPayload();
+        $this->assertArrayNotHasKey('thread_name', $payload); // !! no thread_name for existing threads
+    }
+
+    public function testItChunksLongMessagesInForumChannels(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+        $message = $this->createMessage(str_repeat('B', 4500)); // !! 4500 chars = 3 chunks
+        $this->queueDiscordResponses(3); // !! 1 for thread creation + 2 for additional chunks
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(3, $this->webhookHistory);
+
+        $payloads = $this->getAllWebhookPayloads();
+
+        // ... the first payload creates the Discord thread with the first chunk ...
+        $this->assertArrayHasKey('thread_name', $payloads[0]);
+        $this->assertEquals('[Part 1 of 3]', $payloads[0]['content']);
+        $this->assertEquals(2000, mb_strlen($payloads[0]['embeds'][0]['description']));
+
+        // ... the second payload is part 2 ...
+        $this->assertEquals('[Part 2 of 3]', $payloads[1]['content']);
+        $this->assertEquals(2000, mb_strlen($payloads[1]['embeds'][0]['description']));
+
+        // ... the third payload is part 3 ...
+        $this->assertEquals('[Part 3 of 3]', $payloads[2]['content']);
+        $this->assertEquals(500, mb_strlen($payloads[2]['embeds'][0]['description']));
+    }
+
+    public function testItRoutesVerificationMessagesToTheVerifyUrl(): void
+    {
+        // Arrange
+        $this->setDiscordConfig(
+            $this->recipient,
+            verifyUrl: 'https://discord.com/api/webhooks/verify/xyz'
+        );
+        $this->thread->title = 'Discord Verification Request';
+        $this->thread->save();
+        $message = $this->createMessage('Please verify my Discord account');
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(1, $this->webhookHistory);
+
+        $request = $this->webhookHistory[0]['request'];
+        $this->assertEquals('https://discord.com/api/webhooks/verify/xyz', (string) $request->getUri());
+
+        $payload = $this->getLastWebhookPayload();
+        $this->assertEquals(hexdec('0x00CC66'), $payload['embeds'][0]['color']);
+    }
+
+    public function testItHandlesAchievementIssueMessagesWithStructuredTitle(): void
+    {
+        // Arrange
+        $this->setDiscordConfig(
+            $this->recipient,
+            achievementIssuesUrl: 'https://discord.com/api/webhooks/issues/def',
+            isForum: true
+        );
+        $this->thread->title = 'Issue: That Was Easy [12345] (Sonic the Hedgehog)';
+        $this->thread->save();
+        $message = $this->createMessage('The achievement is not triggering properly');
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(1, $this->webhookHistory);
+
+        $request = $this->webhookHistory[0]['request'];
+        $uri = (string) $request->getUri();
+        $this->assertStringStartsWith('https://discord.com/api/webhooks/issues/def', $uri);
+
+        $payload = $this->getLastWebhookPayload();
+        $this->assertEquals('12345: That Was Easy (Sonic the Hedgehog)', $payload['thread_name']); // !! reformatted
+        $this->assertStringContainsString('achievement/12345', $payload['embeds'][0]['description']); // !! achievement URL added
+    }
+
+    public function testItDoesNotAddAchievementUrlToReplies(): void
+    {
+        // Arrange
+        $this->setDiscordConfig(
+            $this->recipient,
+            achievementIssuesUrl: 'https://discord.com/api/webhooks/issues/def',
+            isForum: true
+        );
+
+        // ... store an existing thread mapping for to handle a reply scenario ...
+        DiscordMessageThreadMapping::storeMapping(
+            $this->thread->id,
+            $this->recipient->ID,
+            'existing_issue_thread'
+        );
+
+        $this->thread->title = 'Issue: That Was Easy [12345] (Sonic the Hedgehog)';
+        $this->thread->save();
+        $message = $this->createMessage('Following up on this issue');
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $payload = $this->getLastWebhookPayload();
+        $this->assertStringNotContainsString('achievement/12345', $payload['embeds'][0]['description']); // !! no URL in reply
+        $this->assertEquals('Following up on this issue', $payload['embeds'][0]['description']);
+    }
+
+    public function testItHandlesExactly2000CharacterMessage(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+        $exactMessage = str_repeat('X', 2000); // !!
+        $message = $this->createMessage($exactMessage);
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(1, $this->webhookHistory);
+
+        $payload = $this->getLastWebhookPayload();
+        $this->assertArrayNotHasKey('content', $payload);
+        $this->assertEquals(2000, mb_strlen($payload['embeds'][0]['description']));
+    }
+
+    public function testItHandles2001CharacterMessageWithChunking(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+        $longMessage = str_repeat('Y', 2001); // !! 2001 chars triggers chunking
+        $message = $this->createMessage($longMessage);
+        $this->queueDiscordResponses(2);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(2, $this->webhookHistory);
+
+        $payloads = $this->getAllWebhookPayloads();
+        $this->assertEquals('[Part 1 of 2]', $payloads[0]['content']);
+        $this->assertEquals('[Part 2 of 2]', $payloads[1]['content']);
+        $this->assertEquals(1, mb_strlen($payloads[1]['embeds'][0]['description']));
+    }
+
+    public function testItHandlesMultipleRepliesInSameThread(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+
+        // ... the first message creates a thread ...
+        $message1 = $this->createMessage('First message');
+        $this->queueDiscordResponses(1, ['channel_id' => 'thread_789']);
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message1);
+
+        // ... clear the webhook history to prepare for the second message ...
+        $this->webhookHistory = [];
+
+        // ... the second message should use the existing thread ...
+        $message2 = $this->createMessage('Second message');
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message2);
+
+        // Assert
+        $this->assertCount(1, $this->webhookHistory);
+
+        $request = $this->webhookHistory[0]['request'];
+        $this->assertStringContainsString('thread_id=thread_789', $request->getUri()->getQuery());
+
+        $payload = $this->getLastWebhookPayload();
+        $this->assertEquals('Second message', $payload['embeds'][0]['description']);
+    }
+
+    public function testItTruncatesLongThreadTitlesToDiscordLimit(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+        $this->thread->title = str_repeat('Z', 150); // !!
+        $this->thread->save();
+        $message = $this->createMessage('Message with long title');
+        $this->queueDiscordResponses(1);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $payload = $this->getLastWebhookPayload();
+        $this->assertEquals(100, mb_strlen($payload['thread_name'])); // !! truncated
+        $this->assertEquals(str_repeat('Z', 100), $payload['thread_name']);
+    }
+
+    public function testItHandlesNullDiscordThreadIdInResponse(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+        $message = $this->createMessage('Message without thread ID');
+        $this->queueDiscordResponses(1, ['channel_id' => null]);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $mapping = DiscordMessageThreadMapping::findMapping($this->thread->id, $this->recipient->id);
+        $this->assertNull($mapping); // !! no mapping is stored when thread ID is null, but at least we don't crash
+    }
+
+    public function testItHandlesMultipleChunksForExistingThread(): void
+    {
+        // Arrange
+        $this->setDiscordConfig($this->recipient, isForum: true);
+
+        // ... store an existing thread mapping ...
+        DiscordMessageThreadMapping::storeMapping(
+            $this->thread->id,
+            $this->recipient->ID,
+            'existing_thread_multi'
+        );
+
+        $longMessage = str_repeat('M', 4500); // !! 3 chunks
+        $message = $this->createMessage($longMessage);
+        $this->queueDiscordResponses(3);
+
+        // Act
+        $this->action->execute($this->sender, $this->recipient, $this->thread, $message);
+
+        // Assert
+        $this->assertCount(3, $this->webhookHistory);
+
+        // ... all requests should use the thread_id parameter ...
+        foreach ($this->webhookHistory as $transaction) {
+            $request = $transaction['request'];
+            $this->assertStringContainsString('thread_id=existing_thread_multi', $request->getUri()->getQuery());
+        }
+
+        $payloads = $this->getAllWebhookPayloads();
+        $this->assertEquals('[Part 1 of 3]', $payloads[0]['content']);
+        $this->assertEquals('[Part 2 of 3]', $payloads[1]['content']);
+        $this->assertEquals('[Part 3 of 3]', $payloads[2]['content']);
+    }
+}


### PR DESCRIPTION
This PR completely refactors how messages are forwarded to Discord team inboxes, ultimately making two key enhancements.

**A migration is included in this PR.**

**1. Messages longer than 2000 characters are now chunked in the same thread.**
Users are no longer left with a truncated message which requires someone to manually go into the inbox and paste the rest into the thread. The message is now chunked, and subsequent webhook calls are made for each chunk so the entire message content appears in a single thread:
<img width="694" height="365" alt="Screenshot 2025-08-17 at 4 23 03 PM" src="https://github.com/user-attachments/assets/d2c6677e-ea59-4358-a0bc-c559f207b006" />

**2. Replies made by the sender no longer create new threads.**
The migration included in this PR creates a mapping table between our message thread IDs and Discord thread IDs. Replies can then be appended to Discord threads rather than us needing to create new ones.

<img width="464" height="130" alt="Screenshot 2025-08-17 at 4 24 13 PM" src="https://github.com/user-attachments/assets/68cc02e6-af5e-408e-b180-fb0c4cab16e7" />


https://discord.com/channels/476211979464343552/1406734407943065660