### PR TITLE
perf: optimize vite script loading

### DIFF
--- a/resources/views/layouts/components/head.blade.php
+++ b/resources/views/layouts/components/head.blade.php
@@ -48,13 +48,21 @@
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.23/themes/sunny/jquery-ui.css">
 
     @viteReactRefresh
-    @vite(['resources/js/tall-stack/app.ts', 'resources/css/app.css'], config('vite.build_path'))
     @if (!empty($page))
         @inertiaHead
-        @vite(['resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"], config('vite.build_path'))
+        @vite([
+            'resources/js/tall-stack/app.ts',
+            'resources/css/app.css',
+            'resources/js/app.tsx',
+            "resources/js/pages/{$page['component']}.tsx"
+        ], config('vite.build_path'))
     @else
         {{-- Load global search standalone for non-Inertia pages --}}
-        @vite(['resources/js/global-search-standalone.tsx'], config('vite.build_path'))
+        @vite([
+            'resources/js/tall-stack/app.ts',
+            'resources/css/app.css',
+            'resources/js/global-search-standalone.tsx'
+        ], config('vite.build_path'))
     @endif
 
     <livewire:styles />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,9 +19,22 @@ export default defineConfig(({ mode, isSsrBuild }) => {
     throw Error('APP_URL not set');
   }
 
+  /**
+   * This ensures all assets use the same domain to prevent duplicate asset loading.
+   * Without this, assets get loaded twice - once from ASSET_URL (eg: static.retroachievements.org)
+   * and once from APP_URL (eg: retroachievements.org) due to how Vite and Inertia handle
+   * dynamic imports.
+   *
+   * SSR builds always use relative paths since they run server-side.
+   * Client builds use the full ASSET_URL.
+   */
+  const assetUrl = env.ASSET_URL || env.APP_URL;
+  const base = assetUrl
+    ? new URL(`/${env.VITE_BUILD_PATH}`, assetUrl).href
+    : `/${env.VITE_BUILD_PATH}`;
+
   return {
-    // Required for SSR assets to load properly
-    base: '/assets/build',
+    base: isSsrBuild ? `/${env.VITE_BUILD_PATH}` : base,
 
     // https://vitejs.dev/config/#build-options
     build: {


### PR DESCRIPTION
While examining https://discord.com/channels/476211979464343552/1002696640001478769/1407480494840610856, I discovered in prod all Vite compiled assets (JS, CSS) are being loaded twice by the browser.

This is easily observable by filtering any asset in the network tab:
<img width="295" height="279" alt="Screenshot 2025-08-19 at 6 18 26 PM" src="https://github.com/user-attachments/assets/9b6a1450-42b1-4beb-9494-c6ce7d51e78c" />

The culprit is in the `<head>` tag - there are duplicate module loads:
<img width="1081" height="794" alt="Screenshot 2025-08-19 at 6 19 03 PM" src="https://github.com/user-attachments/assets/e647aa02-1e42-4776-a474-a8e6eb940d16" />

Notice one set is for the `static.retroachievements.org` domain, and another duplicate set is for the `/` domain.

**Root Cause**
1. There should only be a single `@vite` tag in _head.blade.php_.
2. The `base` option in _vote.config.ts_ is currently misconfigured.

**How to test this PR**
```
pnpm build
sail artisan inertia:start-ssr
```
You should only see a single set of JS `<link>` tags on the home page in the DOM `<head>`.

It is possible this is the cause of all the Firefox issues.