### PR TITLE
fix(GameListItemContent): remediate mobile system games hydration error

### DIFF
--- a/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemContent/GameListItemContent.test.tsx
+++ b/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemContent/GameListItemContent.test.tsx
@@ -1,16 +1,8 @@
-import { route } from 'ziggy-js';
-
 import { BaseDialog } from '@/common/components/+vendor/BaseDialog';
 import { render, screen } from '@/test';
 import { createGame, createGameListEntry, createSystem } from '@/test/factories';
 
 import { GameListItemContent } from './GameListItemContent';
-
-vi.mock('ziggy-js', () => ({
-  route: vi.fn(() => ({
-    current: vi.fn(() => 'some.other.route'),
-  })),
-}));
 
 describe('Component: GameListItemContent', () => {
   it('renders without crashing', () => {
@@ -18,6 +10,7 @@ describe('Component: GameListItemContent', () => {
     const { container } = render(
       <BaseDialog>
         <GameListItemContent
+          apiRouteName="api.game.index"
           backlogState={{
             isInBacklogMaybeOptimistic: false,
             isPending: false,
@@ -38,6 +31,7 @@ describe('Component: GameListItemContent', () => {
     render(
       <BaseDialog>
         <GameListItemContent
+          apiRouteName="api.game.index"
           backlogState={{
             isInBacklogMaybeOptimistic: false,
             isPending: false,
@@ -54,12 +48,8 @@ describe('Component: GameListItemContent', () => {
     expect(screen.queryByTestId('progress-chip')).not.toBeInTheDocument();
   });
 
-  it('given the current route is "system.game.index", does not display the system chip', () => {
+  it('given the apiRouteName is "api.system.game.index", does not display the system chip', () => {
     // ARRANGE
-    vi.mocked(route).mockReturnValue({
-      current: vi.fn(() => 'system.game.index'), // !!
-    } as any);
-
     const gameListEntry = createGameListEntry({
       game: createGame({ system: createSystem({ nameShort: 'NES' }) }),
     });
@@ -67,6 +57,7 @@ describe('Component: GameListItemContent', () => {
     render(
       <BaseDialog>
         <GameListItemContent
+          apiRouteName="api.system.game.index" // !!
           backlogState={{
             isInBacklogMaybeOptimistic: false,
             isPending: false,
@@ -82,12 +73,8 @@ describe('Component: GameListItemContent', () => {
     expect(screen.queryByText(gameListEntry.game.system!.name)).not.toBeInTheDocument();
   });
 
-  it('given the current route is not "system.game.index", displays the system chip when game has a system', () => {
+  it('given the apiRouteName is not "api.system.game.index", displays the system chip when game has a system', () => {
     // ARRANGE
-    vi.mocked(route).mockReturnValue({
-      current: vi.fn(() => 'game.show'), // !! different route
-    } as any);
-
     const gameListEntry = createGameListEntry({
       game: createGame({ system: createSystem({ nameShort: 'NES' }) }), // !! ensure the game has a system
     });
@@ -95,6 +82,7 @@ describe('Component: GameListItemContent', () => {
     render(
       <BaseDialog>
         <GameListItemContent
+          apiRouteName="api.game.index" // !! different API route
           backlogState={{
             isInBacklogMaybeOptimistic: false,
             isPending: false,

--- a/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemContent/GameListItemContent.tsx
+++ b/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemContent/GameListItemContent.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdClose } from 'react-icons/md';
 import { RxDotsVertical } from 'react-icons/rx';
-import { route } from 'ziggy-js';
+import { route, type RouteName } from 'ziggy-js';
 
 import { BaseDrawerTrigger } from '@/common/components/+vendor/BaseDrawer';
 import { GameAvatar } from '@/common/components/GameAvatar';
@@ -22,6 +22,7 @@ import { ChipOfInterest } from './ChipofInterest';
  */
 
 interface GameListItemContentProps {
+  apiRouteName: RouteName;
   backlogState: ReturnType<typeof useGameBacklogState>;
   isLastItem: boolean;
   gameListEntry: App.Platform.Data.GameListEntry;
@@ -32,6 +33,7 @@ interface GameListItemContentProps {
 }
 
 export const GameListItemContent: FC<GameListItemContentProps> = ({
+  apiRouteName,
   backlogState,
   defaultChipOfInterest,
   defaultColumnSort,
@@ -60,7 +62,7 @@ export const GameListItemContent: FC<GameListItemContentProps> = ({
             </a>
 
             <div className="flex flex-wrap items-center gap-1">
-              {route().current() !== 'system.game.index' && game.system ? (
+              {apiRouteName !== 'api.system.game.index' && game.system ? (
                 <SystemChip
                   {...game.system}
                   className="light:bg-neutral-200/70"

--- a/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemElement.test.tsx
+++ b/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemElement.test.tsx
@@ -31,7 +31,9 @@ describe('Component: GameListItemElement', () => {
 
   it('renders without crashing', () => {
     // ARRANGE
-    const { container } = render(<GameListItemElement gameListEntry={createGameListEntry()} />);
+    const { container } = render(
+      <GameListItemElement apiRouteName="api.game.index" gameListEntry={createGameListEntry()} />,
+    );
 
     // ASSERT
     expect(container).toBeTruthy();
@@ -42,7 +44,12 @@ describe('Component: GameListItemElement', () => {
     const system = createSystem({ id: 1, nameShort: 'MD' });
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
-    render(<GameListItemElement gameListEntry={createGameListEntry({ game })} />);
+    render(
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game })}
+      />,
+    );
 
     // ASSERT
     expect(screen.getByRole('img', { name: /sonic the hedgehog/i })).toBeVisible();
@@ -55,7 +62,12 @@ describe('Component: GameListItemElement', () => {
     const system = createSystem({ id: 1, nameShort: 'MD' });
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
-    render(<GameListItemElement gameListEntry={createGameListEntry({ game })} />);
+    render(
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game })}
+      />,
+    );
 
     // ASSERT
     const linkEls = screen.getAllByRole('link', { name: /sonic the hedgehog/i });
@@ -70,7 +82,12 @@ describe('Component: GameListItemElement', () => {
     const system = createSystem({ id: 1, nameShort: 'MD' });
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
-    render(<GameListItemElement gameListEntry={createGameListEntry({ game })} />);
+    render(
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game })}
+      />,
+    );
 
     // ASSERT
     expect(screen.getByText(/md/i)).toBeVisible();
@@ -81,7 +98,10 @@ describe('Component: GameListItemElement', () => {
     const game = createGame({ system: undefined, id: 1, title: 'Sonic the Hedgehog' });
 
     const { container } = render(
-      <GameListItemElement gameListEntry={createGameListEntry({ game })} />,
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game })}
+      />,
     );
 
     // ASSERT
@@ -102,6 +122,7 @@ describe('Component: GameListItemElement', () => {
 
     render(
       <GameListItemElement
+        apiRouteName="api.game.index"
         gameListEntry={createGameListEntry({ game, playerGame })}
         isLastItem={true}
       />,
@@ -124,6 +145,7 @@ describe('Component: GameListItemElement', () => {
 
     render(
       <GameListItemElement
+        apiRouteName="api.game.index"
         gameListEntry={createGameListEntry({
           game,
           playerGame: null, // !!
@@ -141,7 +163,13 @@ describe('Component: GameListItemElement', () => {
     const system = createSystem({ id: 1, nameShort: 'MD' });
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
-    render(<GameListItemElement gameListEntry={createGameListEntry({ game })} isLastItem={true} />);
+    render(
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game })}
+        isLastItem={true}
+      />,
+    );
 
     // ASSERT
     expect(screen.queryByRole('separator')).not.toBeInTheDocument();
@@ -152,7 +180,12 @@ describe('Component: GameListItemElement', () => {
     const system = createSystem({ id: 1, nameShort: 'MD' });
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
-    render(<GameListItemElement gameListEntry={createGameListEntry({ game })} />);
+    render(
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game })}
+      />,
+    );
 
     // ACT
     await userEvent.click(screen.getByRole('button', { name: /open game details/i }));
@@ -166,7 +199,12 @@ describe('Component: GameListItemElement', () => {
     const system = createSystem({ id: 1, nameShort: 'MD' });
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
-    render(<GameListItemElement gameListEntry={createGameListEntry({ game })} />);
+    render(
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game })}
+      />,
+    );
 
     // ACT
     await userEvent.click(screen.getByRole('button', { name: /open game details/i }));
@@ -183,6 +221,7 @@ describe('Component: GameListItemElement', () => {
 
     render(
       <GameListItemElement
+        apiRouteName="api.game.index"
         gameListEntry={createGameListEntry({ game })}
         sortFieldId="pointsTotal"
       />,
@@ -199,6 +238,7 @@ describe('Component: GameListItemElement', () => {
 
     render(
       <GameListItemElement
+        apiRouteName="api.game.index"
         gameListEntry={createGameListEntry({
           game,
           isInBacklog: null, // !!
@@ -218,7 +258,10 @@ describe('Component: GameListItemElement', () => {
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
     render(
-      <GameListItemElement gameListEntry={createGameListEntry({ game, isInBacklog: false })} />,
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game, isInBacklog: false })}
+      />,
       {
         pageProps: { auth: null },
       },
@@ -239,7 +282,10 @@ describe('Component: GameListItemElement', () => {
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
     render(
-      <GameListItemElement gameListEntry={createGameListEntry({ game, isInBacklog: false })} />,
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game, isInBacklog: false })}
+      />,
       {
         pageProps: { auth: { user: createAuthenticatedUser() } },
       },
@@ -263,7 +309,10 @@ describe('Component: GameListItemElement', () => {
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
     render(
-      <GameListItemElement gameListEntry={createGameListEntry({ game, isInBacklog: true })} />,
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game, isInBacklog: true })}
+      />,
       {
         pageProps: { auth: { user: createAuthenticatedUser() } },
       },
@@ -286,6 +335,7 @@ describe('Component: GameListItemElement', () => {
 
     render(
       <GameListItemElement
+        apiRouteName="api.game.index"
         gameListEntry={createGameListEntry({ game, isInBacklog: false })}
         shouldHideItemIfNotInBacklog={true}
       />,
@@ -317,7 +367,10 @@ describe('Component: GameListItemElement', () => {
     const game = createGame({ system, id: 1, title: 'Sonic the Hedgehog' });
 
     render(
-      <GameListItemElement gameListEntry={createGameListEntry({ game, isInBacklog: false })} />,
+      <GameListItemElement
+        apiRouteName="api.game.index"
+        gameListEntry={createGameListEntry({ game, isInBacklog: false })}
+      />,
       {
         pageProps: { auth: { user: createAuthenticatedUser() } },
       },
@@ -366,6 +419,7 @@ describe('Component: GameListItemElement', () => {
 
     render(
       <GameListItemElement
+        apiRouteName="api.game.index"
         gameListEntry={createGameListEntry({ game, isInBacklog: true })}
         shouldHideItemIfNotInBacklog={true}
       />,

--- a/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemElement.tsx
+++ b/resources/js/features/game-list/components/GameListItems/GameListItemElement/GameListItemElement.tsx
@@ -1,5 +1,6 @@
 import type { ColumnSort } from '@tanstack/react-table';
 import { type FC, useState } from 'react';
+import type { RouteName } from 'ziggy-js';
 
 import { BaseDrawer } from '@/common/components/+vendor/BaseDrawer';
 
@@ -8,6 +9,7 @@ import { GameListItemContent } from './GameListItemContent';
 import { GameListItemDrawerContent } from './GameListItemDrawerContent';
 
 interface GameListItemElementProps {
+  apiRouteName: RouteName;
   gameListEntry: App.Platform.Data.GameListEntry;
 
   defaultChipOfInterest?: App.Platform.Enums.GameListSortField;
@@ -28,6 +30,7 @@ interface GameListItemElementProps {
 }
 
 export const GameListItemElement: FC<GameListItemElementProps> = ({
+  apiRouteName,
   defaultChipOfInterest,
   defaultColumnSort,
   gameListEntry,
@@ -63,6 +66,7 @@ export const GameListItemElement: FC<GameListItemElementProps> = ({
   return (
     <BaseDrawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen} shouldScaleBackground={false}>
       <GameListItemContent
+        apiRouteName={apiRouteName}
         backlogState={backlogState}
         defaultChipOfInterest={defaultChipOfInterest}
         defaultColumnSort={defaultColumnSort}

--- a/resources/js/features/game-list/components/GameListItems/GameListItems.tsx
+++ b/resources/js/features/game-list/components/GameListItems/GameListItems.tsx
@@ -166,6 +166,7 @@ const GameListItems: FC<GameListItemsProps> = ({
               return (
                 <GameListItemElement
                   key={`mobile-${item.game.id}`}
+                  apiRouteName={apiRouteName}
                   defaultChipOfInterest={defaultChipOfInterest}
                   defaultColumnSort={defaultColumnSort}
                   gameListEntry={item}


### PR DESCRIPTION
Resolves https://retroachievementsorg.sentry.io/issues/26749701/?environment=production&query=is%3Aunresolved&referrer=issue-stream.

Mobile views for `/system/{system}/games` are throwing a hydration error right now related to the system chip conditionally displaying. This is occurring because `route().current()` is undefined during SSR.