### PR TITLE
fix: clean up orphaned Alpine.js tooltips on Inertia router transitions

### DIFF
--- a/resources/js/tall-stack/alpine/tooltipComponent/index.ts
+++ b/resources/js/tall-stack/alpine/tooltipComponent/index.ts
@@ -1,1 +1,2 @@
 export * from './tooltipComponent';
+export * from './utils/initializeTooltipCleanup';

--- a/resources/js/tall-stack/alpine/tooltipComponent/utils/initializeTooltipCleanup.ts
+++ b/resources/js/tall-stack/alpine/tooltipComponent/utils/initializeTooltipCleanup.ts
@@ -1,0 +1,45 @@
+import { router } from '@inertiajs/react';
+
+import { tooltipStore } from '../state/tooltipStore';
+import { hideTooltip } from './hideTooltip';
+
+/**
+ * Initializes tooltip cleanup on Inertia navigation.
+ * This should be called once when the app initializes.
+ * This prevents orphaned tooltips from lingering on the page during Inertia router transitions.
+ */
+export function initializeTooltipCleanup() {
+  // Skip if we're in SSR environment.
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const handleNavigationStart = () => {
+    // First, properly hide any active tooltip (this clears dynamic timeouts).
+    if (tooltipStore.tooltipEl || tooltipStore.dynamicTimeoutId) {
+      hideTooltip();
+    }
+
+    // Clear any pending dynamic tooltip timeouts explicitly.
+    if (tooltipStore.dynamicTimeoutId) {
+      clearTimeout(tooltipStore.dynamicTimeoutId);
+      tooltipStore.dynamicTimeoutId = null;
+    }
+
+    // Query and remove all tooltip elements by their data attribute as a safety net.
+    const tooltips = document.querySelectorAll('[data-alpine-tooltip]');
+    for (const tooltip of tooltips) {
+      tooltip.remove();
+    }
+
+    // Clear all tooltip store state.
+    tooltipStore.tooltipEl = null;
+    tooltipStore.currentTooltipId = null;
+    tooltipStore.isHoveringOverAnchorEl = false;
+    tooltipStore.activeAnchorEl = null;
+  };
+
+  // Listen for navigation events.
+  router.on('before', handleNavigationStart);
+  router.on('success', handleNavigationStart);
+}

--- a/resources/js/tall-stack/alpine/tooltipComponent/utils/loadDynamicTooltip.ts
+++ b/resources/js/tall-stack/alpine/tooltipComponent/utils/loadDynamicTooltip.ts
@@ -43,6 +43,12 @@ export async function loadDynamicTooltip(
     return;
   }
 
+  // Only show the loading spinner if the anchor element is still connected to the DOM.
+  // This prevents orphaned spinners when navigation occurs during tooltip loading.
+  if (!anchorEl.isConnected) {
+    return;
+  }
+
   // Temporarily show a loading spinner while we're fetching the content.
   const genericLoadingTemplate = /** @html */ `
     <div>
@@ -65,8 +71,14 @@ export async function loadDynamicTooltip(
 
       // We don't want to continue on with displaying this dynamic tooltip
       // if a static tooltip is opened while we're fetching data.
+      // Also check that the anchor element is still connected to the DOM.
       const wasTimeoutCleared = !store.dynamicTimeoutId;
-      if (anchorEl === store.activeAnchorEl && !wasTimeoutCleared && store.isHoveringOverAnchorEl) {
+      if (
+        anchorEl === store.activeAnchorEl &&
+        !wasTimeoutCleared &&
+        store.isHoveringOverAnchorEl &&
+        anchorEl.isConnected
+      ) {
         renderTooltip(anchorEl, fetchedDynamicContent, offsetX, offsetY);
         pinTooltipToCursorPosition(
           anchorEl,

--- a/resources/js/tall-stack/alpine/tooltipComponent/utils/renderTooltip.ts
+++ b/resources/js/tall-stack/alpine/tooltipComponent/utils/renderTooltip.ts
@@ -36,6 +36,7 @@ export function renderTooltip(
 
   store.currentTooltipId = Math.random();
   store.tooltipEl = document.createElement('div');
+  store.tooltipEl.setAttribute('data-alpine-tooltip', 'true');
 
   store.tooltipEl.classList.add(
     'animate-fade-in',

--- a/resources/js/tall-stack/app.ts
+++ b/resources/js/tall-stack/app.ts
@@ -7,6 +7,7 @@ import { getStringByteCount } from '@/common/utils/getStringByteCount';
 
 import { Alpine, Livewire } from '../../../vendor/livewire/livewire/dist/livewire.esm';
 import {
+  initializeTooltipCleanup,
   linkifyDirective,
   modalComponent,
   toggleAchievementRowsComponent,
@@ -57,6 +58,9 @@ window.tooltipComponent = tooltipComponent;
 Alpine.directive('linkify', linkifyDirective);
 
 Livewire.start();
+
+// Automatically clean up any orphaned tooltips during Inertia router transitions.
+initializeTooltipCleanup();
 
 // TODO if you add another one of these, move them to a module
 // Livewire


### PR DESCRIPTION
This PR resolves an issue which has been present for some time but is particularly prominent from the home page.

If an Inertia transition completes too quickly, the Alpine.js code can fall into a race condition where tooltips become orphaned on the navigated-to page. Example:


https://github.com/user-attachments/assets/190ff9dd-035f-40d0-bcb6-47a6c09075bf

Now, the tooltip component watches for router transitions and cleans itself up when one occurs.