### PR TITLE
fix(settings): remediate another uncontrolled tooltip warning

### DIFF
--- a/resources/js/features/settings/components/KeysSectionCard/KeysSectionCard.test.tsx
+++ b/resources/js/features/settings/components/KeysSectionCard/KeysSectionCard.test.tsx
@@ -4,18 +4,9 @@ import * as ReactUseModule from 'react-use';
 import { route } from 'ziggy-js';
 
 import { render, screen } from '@/test';
-import { createUser } from '@/test/factories';
+import { createUser, createZiggyProps } from '@/test/factories';
 
 import { KeysSectionCard } from './KeysSectionCard';
-
-vi.mock('react-use', async (importOriginal) => {
-  const original: object = await importOriginal();
-
-  return {
-    ...original,
-    useMedia: vi.fn(),
-  };
-});
 
 describe('Component: KeysSectionCard', () => {
   it('renders without crashing', () => {
@@ -51,6 +42,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser(),
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -69,6 +61,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser({ apiKey: mockApiKey }),
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -91,6 +84,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser({ apiKey: mockApiKey }),
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -110,6 +104,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser({ apiKey: mockApiKey }),
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -120,7 +115,7 @@ describe('Component: KeysSectionCard', () => {
     expect(await screen.findByRole('tooltip', { name: /copy to clipboard/i })).toBeVisible();
   });
 
-  it('given the user is on the XS breakpoint and hovers over the web API key button, does not show a descriptive tooltip', async () => {
+  it('given the user is using a mobile device, does not show a descriptive tooltip', async () => {
     // ARRANGE
     console.error = vi.fn(); // Ignore act() errors.
 
@@ -132,6 +127,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser({ apiKey: mockApiKey }),
+        ziggy: createZiggyProps({ device: 'mobile' }),
       },
     });
 
@@ -152,6 +148,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser(),
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -171,6 +168,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser(),
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -191,6 +189,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser({ apiKey: mockApiKey }),
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -210,6 +209,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser(),
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -229,6 +229,7 @@ describe('Component: KeysSectionCard', () => {
       pageProps: {
         can: { manipulateApiKeys: true },
         userSettings: createUser(),
+        ziggy: createZiggyProps(),
       },
     });
 

--- a/resources/js/features/settings/components/KeysSectionCard/ManageWebApiKey.tsx
+++ b/resources/js/features/settings/components/KeysSectionCard/ManageWebApiKey.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { type FC, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { LuCircleAlert, LuCopy } from 'react-icons/lu';
-import { useCopyToClipboard, useMedia } from 'react-use';
+import { useCopyToClipboard } from 'react-use';
 import { route } from 'ziggy-js';
 
 import { BaseButton } from '@/common/components/+vendor/BaseButton';
@@ -18,14 +18,11 @@ import {
 import { usePageProps } from '@/common/hooks/usePageProps';
 
 export const ManageWebApiKey: FC = () => {
-  const { userSettings } = usePageProps<App.Community.Data.UserSettingsPageProps>();
+  const { userSettings, ziggy } = usePageProps<App.Community.Data.UserSettingsPageProps>();
 
   const { t } = useTranslation();
 
   const [, copyToClipboard] = useCopyToClipboard();
-
-  // Hide the copy button's tooltip on mobile.
-  const isXs = useMedia('(max-width: 640px)', true);
 
   const [currentWebApiKey, setCurrentWebApiKey] = useState(userSettings.apiKey ?? '');
 
@@ -63,7 +60,7 @@ export const ManageWebApiKey: FC = () => {
         <p className="w-48 text-menu-link">{t('Web API Key')}</p>
 
         <div className="col-span-3 flex w-full flex-col gap-2">
-          <BaseTooltip open={isXs ? false : undefined}>
+          <BaseTooltip open={ziggy.device === 'mobile' ? false : undefined}>
             <BaseTooltipTrigger asChild>
               <BaseButton
                 className="flex gap-2 md:max-w-fit md:px-12"


### PR DESCRIPTION
Remediates another one of these warnings:
<img width="899" height="68" alt="Screenshot 2025-08-20 at 6 15 46 PM" src="https://github.com/user-attachments/assets/6afe1e82-3e7b-452c-8c65-4f43780d403f" />

This occurs 100% of the time on http://localhost:64000/settings when SSR is enabled.

**Root Cause**
`useMedia` always returns undefined during SSR, which causes the `open` prop to transition between controlled and uncontrolled states.