### PR TITLE
fix(individualdevstats): remediate stable username leak

### DIFF
--- a/app/Community/Components/DeveloperGameStatsTable.php
+++ b/app/Community/Components/DeveloperGameStatsTable.php
@@ -16,6 +16,7 @@ class DeveloperGameStatsTable extends Component
     private int $numGamesWithRichPresence = 0;
     private int $numTotalLeaderboards = 0;
     private string $statsKind = 'any'; // 'any' | 'majority' | 'sole'
+    private string $targetDeveloperDisplayName = '';
     private string $targetDeveloperUsername = '';
 
     public function __construct(
@@ -26,6 +27,7 @@ class DeveloperGameStatsTable extends Component
         int $numGamesWithRichPresence,
         int $numTotalLeaderboards,
         string $statsKind,
+        string $targetDeveloperDisplayName,
         string $targetDeveloperUsername,
     ) {
         $this->easiestGame = $easiestGame;
@@ -34,6 +36,7 @@ class DeveloperGameStatsTable extends Component
         $this->numGamesWithRichPresence = $numGamesWithRichPresence;
         $this->numTotalLeaderboards = $numTotalLeaderboards;
         $this->statsKind = $statsKind;
+        $this->targetDeveloperDisplayName = $targetDeveloperDisplayName;
         $this->targetDeveloperUsername = $targetDeveloperUsername;
         $this->targetGameIds = $targetGameIds;
     }
@@ -50,6 +53,7 @@ class DeveloperGameStatsTable extends Component
                 'numGamesWithRichPresence' => $this->numGamesWithRichPresence,
                 'numTotalLeaderboards' => $this->numTotalLeaderboards,
                 'statsKind' => $this->statsKind,
+                'targetDeveloperDisplayName' => $this->targetDeveloperDisplayName,
                 'targetDeveloperUsername' => $this->targetDeveloperUsername,
                 'targetGameIds' => $this->targetGameIds,
             ],

--- a/resources/views/components/developer/game-stats-table.blade.php
+++ b/resources/views/components/developer/game-stats-table.blade.php
@@ -14,7 +14,7 @@
     'numTotalLeaderboards',
     'ownAwards',
     'statsKind',
-    'targetDeveloperUsername',
+    'targetDeveloperDisplayName',
     'targetGameIds',
     'userMostBeatenHardcore',
     'userMostBeatenSoftcore',
@@ -39,11 +39,11 @@
         <tr class="do-not-highlight">
             <td colspan="2" align="center" class="pb-4">
                 @if ($statsKind === 'any')
-                    Stats below are for games that {{ $targetDeveloperUsername }} has published at least one achievement for.
+                    Stats below are for games that {{ $targetDeveloperDisplayName }} has published at least one achievement for.
                 @elseif ($statsKind === 'majority')
-                    Stats below are for games that {{ $targetDeveloperUsername }} has published at least half the achievements for.
+                    Stats below are for games that {{ $targetDeveloperDisplayName }} has published at least half the achievements for.
                 @elseif ($statsKind === 'sole')
-                    Stats below are for games that {{ $targetDeveloperUsername }} has published all the achievements for.
+                    Stats below are for games that {{ $targetDeveloperDisplayName }} has published all the achievements for.
                 @endif
             </td>
         </tr>

--- a/resources/views/pages-legacy/individualdevstats.blade.php
+++ b/resources/views/pages-legacy/individualdevstats.blade.php
@@ -500,6 +500,7 @@ $totalTicketPlusMinus = ($totalTicketPlusMinus > 0) ? '+' . $totalTicketPlusMinu
                 :numGamesWithRichPresence="$anyDevRichPresenceCount"
                 :numTotalLeaderboards="$anyDevLeaderboardTotal"
                 statsKind="any"
+                :targetDeveloperDisplayName="$devUser->display_name"
                 :targetDeveloperUsername="$devUser->username"
                 :targetGameIds="$anyDevGameIDs"
             />
@@ -512,6 +513,7 @@ $totalTicketPlusMinus = ($totalTicketPlusMinus > 0) ? '+' . $totalTicketPlusMinu
                 :numGamesWithRichPresence="$majorityDevRichPresenceCount"
                 :numTotalLeaderboards="$majorityDevLeaderboardTotal"
                 statsKind="majority"
+                :targetDeveloperDisplayName="$devUser->display_name"
                 :targetDeveloperUsername="$devUser->username"
                 :targetGameIds="$majorityDevGameIDs"
             />
@@ -524,6 +526,7 @@ $totalTicketPlusMinus = ($totalTicketPlusMinus > 0) ? '+' . $totalTicketPlusMinu
                 :numGamesWithRichPresence="$onlyDevRichPresenceCount"
                 :numTotalLeaderboards="$onlyDevLeaderboardTotal"
                 statsKind="sole"
+                :targetDeveloperDisplayName="$devUser->display_name"
                 :targetDeveloperUsername="$devUser->username"
                 :targetGameIds="$onlyDevGameIDs"
             />


### PR DESCRIPTION
The developer profile page is leaking stable usernames. That bug is resolved by this PR.

**Before**
<img width="629" height="91" alt="Screenshot 2025-08-23 at 5 10 11 PM" src="https://github.com/user-attachments/assets/004a723c-3119-495b-94cd-fb9449bfdcbb" />


**After**
<img width="579" height="83" alt="Screenshot 2025-08-23 at 5 10 22 PM" src="https://github.com/user-attachments/assets/e075ab96-268c-4643-9254-cee35357f375" />
