### PR TITLE
fix(home): remediate bug where active players has multiple rows for the same user

### DIFF
--- a/app/Community/Actions/LoadThinActivePlayersListAction.php
+++ b/app/Community/Actions/LoadThinActivePlayersListAction.php
@@ -34,6 +34,7 @@ class LoadThinActivePlayersListAction
                 $activePlayers = GameRecentPlayer::with(['game'])
                     ->where('rich_presence_updated_at', '>', $timestampCutoff)
                     ->join('UserAccounts', 'UserAccounts.ID', '=', 'game_recent_players.user_id')
+                    ->whereColumn('game_recent_players.game_id', '=', 'UserAccounts.LastGameID')
                     ->where('UserAccounts.Permissions', '>=', $minimumPermissions)
                     ->whereNull('UserAccounts.banned_at')
                     ->orderBy('UserAccounts.Untracked', 'asc')


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1408814140843102470.

**Root Cause**
`game_recent_players` stores entries for all games a user has played recently. When a user switches between games, they have multiple entries in the table. The current query returns all these entries, showing the same user multiple times.

**Fix**
This PR adds an additional filter to the query that leverages `UserAccounts.LastGameID`.