### PR TITLE
fix(AchievementSetClaimPolicy): don't include collab claims in activeClaimCount

### DIFF
--- a/app/Platform/Actions/BuildGamePageClaimDataAction.php
+++ b/app/Platform/Actions/BuildGamePageClaimDataAction.php
@@ -82,7 +82,7 @@ class BuildGamePageClaimDataAction
 
     private function calculateNumClaimsRemaining(User $user, int $maxClaims): int
     {
-        $activeClaimCount = once(fn () => getActiveClaimCount($user, true, false));
+        $activeClaimCount = once(fn () => getActiveClaimCount($user, false, false));
         $remaining = $maxClaims - $activeClaimCount;
 
         return max(0, $remaining);

--- a/app/Policies/AchievementSetClaimPolicy.php
+++ b/app/Policies/AchievementSetClaimPolicy.php
@@ -59,7 +59,7 @@ class AchievementSetClaimPolicy
         // Determine max claims based on role.
         $maxClaims = AchievementSetClaim::getMaxClaimsForUser($user);
 
-        $activeClaimCount = once(fn () => getActiveClaimCount($user, true, false));
+        $activeClaimCount = once(fn () => getActiveClaimCount($user, false, false));
         $isSoleAuthor = once(fn () => checkIfSoleDeveloper($user, $game->id));
 
         // The user can create a claim if they have claims remaining OR they're the sole author.


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1409093801997242383.

Developers with several collabs are no longer able to make new achievement set claims.

**Root Cause**
`getActiveClaimCount()` needed its 2nd arg (`$countCollaboration`) flipped from true to false.