### PR TITLE
fix(settings): update label to be accurate

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -79,7 +79,7 @@
     "Comments - {{leaderboardTitle}}": "Comments - {{leaderboardTitle}}",
     "Comments - {{user}}": "Comments - {{user}}",
     "Comments on a forum topic I'm involved in": "Comments on a forum topic I'm involved in",
-    "Comments on an achievement I created": "Comments on an achievement I created",
+    "Comments on achievements or games I've been active with": "Comments on achievements or games I've been active with",
     "Comments on my activity": "Comments on my activity",
     "Comments on my user wall": "Comments on my user wall",
     "Comments: {{leaderboardTitle}}": "Comments: {{leaderboardTitle}}",

--- a/resources/js/features/settings/components/NotificationsSectionCard/NotificationsSectionCard.tsx
+++ b/resources/js/features/settings/components/NotificationsSectionCard/NotificationsSectionCard.tsx
@@ -86,7 +86,7 @@ function useNotificationSettings() {
       siteFieldName: StringifiedUserPreference.SiteMsgOn_ActivityComment,
     },
     {
-      t_label: t('Comments on an achievement I created'),
+      t_label: t("Comments on achievements or games I've been active with"),
       emailFieldName: StringifiedUserPreference.EmailOn_AchievementComment,
       siteFieldName: StringifiedUserPreference.SiteMsgOn_AchievementComment,
     },


### PR DESCRIPTION
**Before**
<img width="691" height="341" alt="Screenshot 2025-08-28 at 6 23 21 PM" src="https://github.com/user-attachments/assets/13d56f32-07e5-470d-a453-fda4acda4151" />

**After**
<img width="702" height="237" alt="Screenshot 2025-08-28 at 6 38 23 PM" src="https://github.com/user-attachments/assets/5d735db1-ab7e-42ac-b5c6-41e17a4fb6ef" />
