### PR TITLE
fix: override Inertia's greedy manual scroll restoration

### DIFF
--- a/resources/js/tall-stack/app.ts
+++ b/resources/js/tall-stack/app.ts
@@ -18,6 +18,7 @@ import {
   autoExpandTextInput,
   copyToClipboard,
   deleteCookie,
+  enforceAutoScrollRestoration,
   fetcher,
   getCookie,
   handleLeaderboardTabClick,
@@ -61,6 +62,9 @@ Livewire.start();
 
 // Automatically clean up any orphaned tooltips during Inertia router transitions.
 initializeTooltipCleanup();
+
+// Enforce the browser's native scroll restoration (override Inertia's manual mode).
+enforceAutoScrollRestoration();
 
 // TODO if you add another one of these, move them to a module
 // Livewire

--- a/resources/js/tall-stack/utils/enforceAutoScrollRestoration.ts
+++ b/resources/js/tall-stack/utils/enforceAutoScrollRestoration.ts
@@ -1,0 +1,72 @@
+/**
+ * Enforces browser's native scroll restoration behavior.
+ *
+ * Inertia.js v2 automatically sets window.history.scrollRestoration to 'manual'
+ * to support encrypted history. @see https://github.com/inertiajs/inertia/pull/2051
+ *
+ * This is undesirable for RAWeb and breaks scroll restoration throughout the app.
+ *
+ * This util overrides any attempts to set scrollRestoration to 'manual',
+ * ensuring it stays on 'auto' for both Inertia and traditional page navigation.
+ */
+export function enforceAutoScrollRestoration(): void {
+  // Bail unless we're running in a compatible environment.
+  if (typeof window === 'undefined' || !window.history?.scrollRestoration) {
+    return;
+  }
+
+  const setToAuto = () => {
+    if (window.history.scrollRestoration !== 'auto') {
+      window.history.scrollRestoration = 'auto';
+    }
+  };
+
+  // Run immediately on mount ...
+  setToAuto();
+
+  // ... and also stack some runs at the end of a few event loop cycles.
+  // This naively tries to catch any (unlikely) changes made by stray dynamic modules.
+  setTimeout(setToAuto, 0);
+  setTimeout(setToAuto, 1000);
+
+  // Override the scrollRestoration property to prevent runtime changes to 'manual'.
+  try {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      History.prototype,
+      'scrollRestoration',
+    );
+
+    if (originalDescriptor) {
+      Object.defineProperty(History.prototype, 'scrollRestoration', {
+        get() {
+          return originalDescriptor.get?.call(this);
+        },
+        set(value: ScrollRestoration) {
+          if (value === 'manual') {
+            return originalDescriptor.set?.call(this, 'auto');
+          }
+
+          return originalDescriptor.set?.call(this, value);
+        },
+        configurable: true,
+        enumerable: true,
+      });
+    }
+  } catch {
+    // We don't care if it errors. Just silently fail.
+  }
+
+  // Listen for various navigation events to ensure scroll restoration stays on.
+  const events = ['pageshow', 'popstate', 'load', 'DOMContentLoaded'] as const;
+  for (const eventName of events) {
+    window.addEventListener(eventName, setToAuto);
+  }
+
+  // Also listen for Inertia navigation events.
+  if (typeof document !== 'undefined') {
+    const inertiaEvents = ['inertia:navigate', 'inertia:start', 'inertia:finish'] as const;
+    for (const eventName of inertiaEvents) {
+      document.addEventListener(eventName, setToAuto);
+    }
+  }
+}

--- a/resources/js/tall-stack/utils/index.ts
+++ b/resources/js/tall-stack/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './autoExpandTextInput';
 export * from './cookie';
 export * from './copyToClipboard';
+export * from './enforceAutoScrollRestoration';
 export * from './fetcher';
 export * from './handleLeaderboardTabClick';
 export * from './helpers';


### PR DESCRIPTION
**This PR should be tested with SSR running.**
```
pnpm build && sail artisan inertia:start-ssr
```

This PR resolves two different bugs in the app related to scroll restoration, both with the same root cause. Both bugs are exhibited on page refresh. Based on whether it's a Blade/PHP page or an Inertia page, the bug is different.

**Blade/PHP Pages**
These pages currently have no scroll restoration at all. On refresh, the page pops to the top of the screen:

https://github.com/user-attachments/assets/51a9f965-0810-4739-a3ba-8b57aa46eb8d

**Inertia/React Pages**
These pages have scroll restoration, but on refresh, the browser sits for a few frames at the top of the screen before eventually correcting itself.


https://github.com/user-attachments/assets/539765ff-5844-4d6b-ae0d-f28bed542ae1

**Root Cause**
Inertia 2.0 introduced a non-configurable behavior change in https://github.com/inertiajs/inertia/pull/2051. Any time anything related to Inertia is mounted, Inertia disables the browser's automatic scroll restoration. This is unfortunate for RAWeb, because we have Inertia stuff mounted on non-Inertia pages.

**Resolution**
This PR introduces an always-running lightweight util, `enforceAutoScrollRestoration`, which arm wrestles with Inertia to force the site to continue using the browser's automated scroll restoration.


https://github.com/user-attachments/assets/1568dfed-865f-4ba5-844a-d15c73d34242

