### PR TITLE
fix(game): use correct player counts for games with shared subsets

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -412,16 +412,18 @@ class Game extends BaseModel implements HasMedia, HasVersionedTrigger
     public function getParentGameIdAttribute(): ?int
     {
         return once(function () {
-            // Get all achievement sets associated with this game.
-            $achievementSets = GameAchievementSet::where('game_id', $this->id)
+            // Get this game's core achievement set(s).
+            $coreAchievementSets = GameAchievementSet::where('game_id', $this->id)
+                ->where('type', AchievementSetType::Core)
                 ->pluck('achievement_set_id');
 
-            if ($achievementSets->isEmpty()) {
+            if ($coreAchievementSets->isEmpty()) {
                 return null;
             }
 
-            // Check if any of these achievement sets are used in other games with non-core types.
-            $nonCoreUsage = GameAchievementSet::whereIn('achievement_set_id', $achievementSets)
+            // Check if another game uses any of this game's core achievement sets as a non-core type.
+            // This would indicate that the other game is the parent.
+            $nonCoreUsage = GameAchievementSet::whereIn('achievement_set_id', $coreAchievementSets)
                 ->where('game_id', '!=', $this->id)
                 ->where('type', '!=', AchievementSetType::Core)
                 ->orderBy('created_at') // if more than one parent exists, take the first associated


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1411328576954957977.

"Pokemon Red Version | Pokemon Blue Version" was recently unmerged into two separate games. Strangely, Pokemon Red's playercount is now pinned to ~85:
<img width="867" height="509" alt="Screenshot 2025-08-30 at 9 21 16 AM" src="https://github.com/user-attachments/assets/98ca6b1d-4c2f-47d8-9390-e757d4592079" />

Running various Artisan commands to update the game's denormalized data does not resolve the issue.

**Root Cause**
The `Game::getParentGameIdAttribute()` method has a subtle flaw. It checks if any of the current game's achievement sets (including non-core ones) are used as non-core by other games. When it finds such a relationship, it incorrectly assumes the other game is the parent.

This causes the server to believe Pokemon Blue is the parent of Pokemon Red because both games share the same bonus achievement sets.

**Solution**
The fix reverses the logic to correctly identify parent relationships:
- A game is only a parent if another game uses this game's core achievement set as a non-core type.

In other words:
- Parent game: Pokemon Red
- Parent game: Pokemon Blue
- Child game: Pokemon Red | Pokemon Blue [Subset - Bonus]

The subset game has its own core achievement set, and Pokemon Red references that achievement set as a bonus set. This makes Pokemon Red and Pokemon Blue sibling parents.

The old code got confused when two independent games both included the same bonus/specialty/exclusive set. It incorrectly thought "Pokemon Blue uses content that Pokemon Red also has, so Blue must be Red's parent". They're actually siblings sharing the same bonus set, not parent and child.

Now we only look for parent relationships where a game uses another game's core achievements as supplemental content. This correctly identifies true subset relationships while allowing independent games to share subsets without confusion.