### PR TITLE
chore(deps): force linkifyjs to 4.3.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 3.0.5
       linkify-html:
         specifier: ^4.3.2
-        version: 4.3.2(linkifyjs@4.1.3)
+        version: 4.3.2(linkifyjs@4.3.2)
       motion:
         specifier: ^12.6.3
         version: 12.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3834,8 +3834,8 @@ packages:
     peerDependencies:
       linkifyjs: ^4.0.0
 
-  linkifyjs@4.1.3:
-    resolution: {integrity: sha512-auMesunaJ8yfkHvK4gfg1K0SaKX/6Wn9g2Aac/NwX+l5VdmFZzo/hdPGxEOETj+ryRa4/fiOPjeeKURSAJx1sg==}
+  linkifyjs@4.3.2:
+    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -9140,11 +9140,11 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-html@4.3.2(linkifyjs@4.1.3):
+  linkify-html@4.3.2(linkifyjs@4.3.2):
     dependencies:
-      linkifyjs: 4.1.3
+      linkifyjs: 4.3.2
 
-  linkifyjs@4.1.3: {}
+  linkifyjs@4.3.2: {}
 
   locate-path@6.0.0:
     dependencies:


### PR DESCRIPTION
Resolves a high CVE.