### PR TITLE
fix(GameAchievementSetHeader): consistently position GameAchievementSetProgress

### DIFF
--- a/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSetHeader/GameAchievementSetHeader.tsx
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSetHeader/GameAchievementSetHeader.tsx
@@ -26,7 +26,7 @@ export const GameAchievementSetHeader: FC<GameAchievementSetHeaderProps> = ({
   );
 
   return (
-    <div className="flex w-full items-center justify-between text-neutral-300 light:text-neutral-700">
+    <div className="relative flex w-full items-center justify-between text-neutral-300 light:text-neutral-700">
       <div className="flex w-full items-center gap-3">
         <img
           src={imageAssetPathUrl}
@@ -83,14 +83,14 @@ export const GameAchievementSetHeader: FC<GameAchievementSetHeaderProps> = ({
               </span>
             )}
           </div>
-
-          {isViewingPublishedAchievements && achievements.length ? (
-            <div className="hidden sm:mt-1.5 sm:block sm:self-start sm:pr-2">
-              <GameAchievementSetProgress achievements={achievements} />
-            </div>
-          ) : null}
         </div>
       </div>
+
+      {isViewingPublishedAchievements && achievements.length ? (
+        <div className="absolute right-2 top-2 hidden sm:block">
+          <GameAchievementSetProgress achievements={achievements} />
+        </div>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
Resolves a minor visual discrepancy when tabbing between sets that have progress and sets that don't.

As shown in the clip below, the progress indicators aren't consistently positioned between the tabs. This PR resolves the issue.


https://github.com/user-attachments/assets/d2f76c78-b152-4174-9e96-6a3378dc1ddd

