### PR TITLE
fix(multiset): correctly send sibling parent unlocks to clients

### DIFF
--- a/app/Connect/Actions/GetPlayerAchievementUnlocksForGameSetsAction.php
+++ b/app/Connect/Actions/GetPlayerAchievementUnlocksForGameSetsAction.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Connect\Actions;
+
+use App\Models\Game;
+use App\Models\GameAchievementSet;
+use App\Models\User;
+use App\Platform\Enums\AchievementFlag;
+
+class GetPlayerAchievementUnlocksForGameSetsAction
+{
+    /**
+     * Get player achievement unlocks for all achievement sets associated with a game.
+     * Handles multi-parent subsets by finding all related games through shared achievement sets.
+     *
+     * @return array<int, array{DateEarned?: string, DateEarnedHardcore?: string}>
+     */
+    public function execute(
+        User $user,
+        Game $game,
+        AchievementFlag $flag = AchievementFlag::OfficialCore
+    ): array {
+        $achievementSetIds = $game->gameAchievementSets()->pluck('achievement_set_id');
+
+        if ($achievementSetIds->isEmpty()) {
+            return [];
+        }
+
+        // Find all games that share these achievement sets in a single query.
+        // This includes the game itself, sibling games, and parent games.
+        $relatedGameIds = GameAchievementSet::whereIn('achievement_set_id', $achievementSetIds)
+            ->pluck('game_id')
+            ->unique();
+
+        // Fetch player unlocks for achievements from all related games.
+        return $user
+            ->playerAchievements()
+            ->join('Achievements', 'Achievements.ID', '=', 'player_achievements.achievement_id')
+            ->whereIn('Achievements.GameID', $relatedGameIds)
+            ->where('Achievements.Flags', $flag->value)
+            ->orderBy('player_achievements.achievement_id')
+            ->get([
+                'player_achievements.achievement_id',
+                'player_achievements.unlocked_at',
+                'player_achievements.unlocked_hardcore_at',
+            ])
+            ->mapWithKeys(fn ($unlock) => [
+                $unlock->achievement_id => $this->formatUnlockDates($unlock),
+            ])
+            ->toArray();
+    }
+
+    /**
+     * Format unlock dates for API response.
+     *
+     * @return array{DateEarned?: string, DateEarnedHardcore?: string}
+     */
+    private function formatUnlockDates(object $unlock): array
+    {
+        $result = [];
+
+        if ($unlock->unlocked_at) {
+            $result['DateEarned'] = $unlock->unlocked_at->__toString();
+        }
+
+        if ($unlock->unlocked_hardcore_at) {
+            $result['DateEarnedHardcore'] = $unlock->unlocked_hardcore_at->__toString();
+        }
+
+        return $result;
+    }
+}

--- a/public/dorequest.php
+++ b/public/dorequest.php
@@ -10,6 +10,7 @@ use App\Connect\Actions\GetCodeNotesAction;
 use App\Connect\Actions\GetFriendListAction;
 use App\Connect\Actions\GetHashLibraryAction;
 use App\Connect\Actions\GetLeaderboardEntriesAction;
+use App\Connect\Actions\GetPlayerAchievementUnlocksForGameSetsAction;
 use App\Connect\Actions\InjectPatchClientSupportLevelDataAction;
 use App\Connect\Actions\ResolveRootGameFromGameAndGameHashAction;
 use App\Connect\Actions\SubmitCodeNoteAction;
@@ -627,7 +628,7 @@ switch ($requestType) {
 
         $response['Success'] = true;
         $userModel = User::whereName($username)->first();
-        $userUnlocks = getUserAchievementUnlocksForGame($userModel, $game->id);
+        $userUnlocks = (new GetPlayerAchievementUnlocksForGameSetsAction())->execute($userModel, $game);
         $userUnlocks = reactivateUserEventAchievements($userModel, $userUnlocks);
         foreach ($userUnlocks as $achId => $unlock) {
             if (array_key_exists('DateEarnedHardcore', $unlock)) {
@@ -732,7 +733,9 @@ switch ($requestType) {
         $hardcoreMode = (int) request()->input('h', 0) === UnlockMode::Hardcore;
         $userModel = User::whereName($username)->first();
         $game = Game::find($gameID);
-        $userUnlocks = getUserAchievementUnlocksForGame($userModel, $game ? $game->id : $gameID);
+        $userUnlocks = $game
+            ? (new GetPlayerAchievementUnlocksForGameSetsAction())->execute($userModel, $game)
+            : [];
         if ($hardcoreMode) {
             $userUnlocks = reactivateUserEventAchievements($userModel, $userUnlocks);
             $response['UserUnlocks'] = collect($userUnlocks)

--- a/tests/Feature/Connect/Actions/GetPlayerAchievementUnlocksForGameSetsActionTest.php
+++ b/tests/Feature/Connect/Actions/GetPlayerAchievementUnlocksForGameSetsActionTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Connect\Actions;
+
+use App\Connect\Actions\GetPlayerAchievementUnlocksForGameSetsAction;
+use App\Models\Achievement;
+use App\Models\Game;
+use App\Models\PlayerAchievement;
+use App\Models\System;
+use App\Models\User;
+use App\Platform\Actions\AssociateAchievementSetToGameAction;
+use App\Platform\Actions\UpsertGameCoreAchievementSetFromLegacyFlagsAction;
+use App\Platform\Enums\AchievementSetType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GetPlayerAchievementUnlocksForGameSetsActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private System $system;
+    private UpsertGameCoreAchievementSetFromLegacyFlagsAction $upsertGameCoreSetAction;
+    private AssociateAchievementSetToGameAction $associateAchievementSetToGameAction;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->system = System::factory()->create(['ID' => 1, 'Name' => 'NES/Famicom']);
+        $this->upsertGameCoreSetAction = new UpsertGameCoreAchievementSetFromLegacyFlagsAction();
+        $this->associateAchievementSetToGameAction = new AssociateAchievementSetToGameAction();
+    }
+
+    public function testItReturnsEmptyForGameWithNoAchievementSets(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $game = Game::factory()->create(['ConsoleID' => $this->system->id]);
+
+        // Act
+        $result = (new GetPlayerAchievementUnlocksForGameSetsAction())->execute($user, $game);
+
+        // Assert
+        $this->assertEmpty($result);
+    }
+
+    public function testItReturnsUnlocksForRegularGame(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $game = Game::factory()->create(['ConsoleID' => $this->system->id]);
+        $achievement = Achievement::factory()->published()->create(['GameID' => $game->id]);
+        $this->upsertGameCoreSetAction->execute($game);
+
+        PlayerAchievement::factory()->create([
+            'user_id' => $user->id,
+            'achievement_id' => $achievement->id,
+            'unlocked_at' => '2024-01-15 10:00:00',
+            'unlocked_hardcore_at' => '2024-01-15 11:00:00',
+        ]);
+
+        // Act
+        $result = (new GetPlayerAchievementUnlocksForGameSetsAction())->execute($user, $game);
+
+        // Assert
+        $this->assertCount(1, $result);
+        $this->assertArrayHasKey($achievement->id, $result);
+        $this->assertEquals('2024-01-15 10:00:00', $result[$achievement->id]['DateEarned']);
+        $this->assertEquals('2024-01-15 11:00:00', $result[$achievement->id]['DateEarnedHardcore']);
+    }
+
+    public function testItReturnsUnlocksFromMultipleSiblingGames(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+
+        // ... create two parent games ...
+        $parentGame1 = Game::factory()->create(['Title' => 'Parent 1', 'ConsoleID' => $this->system->id]);
+        $parentGame2 = Game::factory()->create(['Title' => 'Parent 2', 'ConsoleID' => $this->system->id]);
+
+        // ... create achievements for each parent ...
+        $parentAch1 = Achievement::factory()->published()->create(['GameID' => $parentGame1->id]);
+        $parentAch2 = Achievement::factory()->published()->create(['GameID' => $parentGame2->id]);
+
+        $this->upsertGameCoreSetAction->execute($parentGame1);
+        $this->upsertGameCoreSetAction->execute($parentGame2);
+
+        // ... create the subset game ...
+        $subsetGame = Game::factory()->create(['Title' => 'Multi-Parent Subset', 'ConsoleID' => $this->system->id]);
+        $subsetAch = Achievement::factory()->published()->create(['GameID' => $subsetGame->id]);
+        $this->upsertGameCoreSetAction->execute($subsetGame);
+
+        // ... link the subset to both parents ...
+        $this->associateAchievementSetToGameAction->execute($parentGame1, $subsetGame, AchievementSetType::Bonus, 'Bonus');
+        $this->associateAchievementSetToGameAction->execute($parentGame2, $subsetGame, AchievementSetType::Bonus, 'Bonus');
+
+        // ... the user has unlocks from both parents and the subset ...
+        PlayerAchievement::factory()->create([
+            'user_id' => $user->id,
+            'achievement_id' => $parentAch1->id, // !! from parent 1
+            'unlocked_hardcore_at' => '2024-01-01 10:00:00',
+        ]);
+        PlayerAchievement::factory()->create([
+            'user_id' => $user->id,
+            'achievement_id' => $parentAch2->id, // !! from parent 2
+            'unlocked_hardcore_at' => '2024-01-02 10:00:00',
+        ]);
+        PlayerAchievement::factory()->create([
+            'user_id' => $user->id,
+            'achievement_id' => $subsetAch->id, // !! from the subset itself
+            'unlocked_hardcore_at' => '2024-01-03 10:00:00',
+        ]);
+
+        // Act
+        $result = (new GetPlayerAchievementUnlocksForGameSetsAction())->execute($user, $subsetGame);
+
+        // Assert
+        $this->assertCount(3, $result);
+        $this->assertArrayHasKey($parentAch1->id, $result);
+        $this->assertArrayHasKey($parentAch2->id, $result);
+        $this->assertArrayHasKey($subsetAch->id, $result);
+    }
+}


### PR DESCRIPTION
If two games share a subset, `getUserAchievementUnlocksForGame()` only sends down unlocks for one of the parents rather than sending down unlocks for both of the siblings.

This is particularly noticeable in the bonus subset for Pokemon Red & Blue. Assuming it's linked to both games (in prod it currently isn't), when the client calls `unlocks` for game ID 11632, it'll only send unlocks for 11632 and one of the parents, but not both.