### PR TITLE
fix(multiset): improve subset game select field UX in attach wizard

### DIFF
--- a/app/Filament/Resources/GameResource/RelationManagers/AchievementSetsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/AchievementSetsRelationManager.php
@@ -151,7 +151,6 @@ class AchievementSetsRelationManager extends RelationManager
                                 Select::make('game')
                                     ->label('Subset game')
                                     ->helperText('Find the current subset game in the database. For example: "Mega Man 2 [Subset - Bonus]".')
-                                    ->searchable()
                                     ->options(
                                         Game::where('Title', 'like', "%[Subset -%")
                                             ->where('ConsoleID', $game->ConsoleID)


### PR DESCRIPTION
http://localhost:64000/manage/games/2606?activeRelationManager=1

When clicking "Attach Subset", the Subset game field is currently limited to N results, even though it's fetching everything. This makes it almost appear as if games are missing from the list unless the user explicitly types for them.

Now, all results are shown.
<img width="870" height="1440" alt="Screenshot 2025-09-09 at 7 36 24 PM" src="https://github.com/user-attachments/assets/10d431a5-9eea-4aaa-8334-93e608498ef2" />
