### PR TITLE
fix(users): show untracked users if they are jrdevs, devs, or moderators

### DIFF
--- a/resources/views/pages-legacy/userList.blade.php
+++ b/resources/views/pages-legacy/userList.blade.php
@@ -12,9 +12,11 @@ $perms = (int) request()->query('p', '1');
 
 authenticateFromCookie($user, $permissions, $userDetails);
 
-$showUntracked = false;
+// Automatically show untracked users when viewing junior devs, full devs, and moderators.
+$showUntracked = ($perms >= Permissions::JuniorDeveloper && $perms <= Permissions::Moderator);
 if (isset($user) && $permissions >= Permissions::Moderator) {
-    $showUntracked = requestInputSanitized('u', null, 'boolean');
+    // Moderators can override the default behavior.
+    $showUntracked = requestInputSanitized('u', $showUntracked, 'boolean');
 } elseif ($perms < Permissions::Unregistered || $perms > Permissions::Moderator) {
     $perms = 1;
 }


### PR DESCRIPTION
Resolves #3884.

Currently on pages like http://localhost:64000/userList.php?s=0&p=4, untracked users are hidden from view. If a jrdev, dev, or mod is untracked, it's a voluntary untrack. It's desirable to show these users.