### PR TITLE
fix(BeatenCreditDialog): remediate a layout bug

### DIFF
--- a/resources/js/features/games/components/BeatenCreditDialog/BeatenCreditDialog.tsx
+++ b/resources/js/features/games/components/BeatenCreditDialog/BeatenCreditDialog.tsx
@@ -35,7 +35,7 @@ export const BeatenCreditDialog: FC = () => {
   );
 
   return (
-    <BaseDialogContent className="h-full max-w-[52rem] overflow-auto sm:max-h-[60vh]">
+    <BaseDialogContent className="flex h-full max-w-[52rem] flex-col overflow-auto sm:max-h-[60vh]">
       <BaseDialogHeader>
         <BaseDialogTitle>{t('Beaten Game Credit')}</BaseDialogTitle>
         <BaseDialogDescription className="sr-only" />


### PR DESCRIPTION
http://localhost:64000/game2/14402

If the beaten credit dialog doesn't have much content, right now the browser is trying to fill in as much empty space as it can. This is undesirable.

**Before**
<img width="873" height="822" alt="Screenshot 2025-09-09 at 9 27 32 PM" src="https://github.com/user-attachments/assets/1d46989d-4d8e-4d9c-8e47-9ba81d1a5fb0" />

**After**
<img width="883" height="829" alt="Screenshot 2025-09-09 at 9 26 51 PM" src="https://github.com/user-attachments/assets/f629c51b-0cc3-445f-93fd-86e3b1147637" />
