### PR TITLE
maintainer should be implicitly subscribed to achievement

### DIFF
--- a/app/Community/Services/SubscriptionService.php
+++ b/app/Community/Services/SubscriptionService.php
@@ -331,6 +331,29 @@ class AchievementWallSubscriptionHandler extends CommentSubscriptionHandler
                 }
 
                 $query->union($query2);
+
+                // achievement maintainer should also be implicitly subscribed if they still have a development role
+                $includeMaintainer = false;
+                $maintainer = $achievement->getMaintainerAt(now());
+                if ($maintainer && $maintainer->hasAnyRole([Role::DEVELOPER, Role::DEVELOPER_JUNIOR])) {
+                    if ($forUserId !== null) {
+                        $includeMaintainer = $maintainer->id === $forUserId;
+                    } else {
+                        $includeMaintainer = !$ignoreUserIds || !in_array($maintainer->id, $ignoreUserIds);
+                    }
+                }
+
+                if ($includeMaintainer) {
+                    /** @var Builder<Model> $query3 */
+                    $query3 = Achievement::query()
+                        ->where('ID', $achievement->ID)
+                        ->select([
+                            DB::raw($maintainer->id . ' as user_id'),
+                            DB::raw('ID as subject_id'),
+                        ]);
+
+                    $query->union($query3);
+                }
             }
         } elseif ($forUserId !== null) {
             // If a user is subscribed to GameAchievements for a game, they're implicitly subscribed to all achievements in the game.
@@ -618,6 +641,39 @@ class UserWallSubscriptionHandler extends CommentSubscriptionHandler
                 DB::raw('IFNULL(display_name, User) as title'),
             ])
             ->orderBy('title');
+
+        return $query;
+    }
+
+    /**
+     * @return Builder<Model>
+     */
+    public function getImplicitSubscriptionQuery(?int $subjectId, ?int $forUserId, ?array $ignoreSubjectIds, ?array $ignoreUserIds): Builder
+    {
+        // find any users who have commented on the ticket
+        $query = parent::getImplicitSubscriptionQuery($subjectId, $forUserId, $ignoreSubjectIds, $ignoreUserIds);
+
+        if ($subjectId !== null) {
+            // wall owner is always implicitly subscribed
+            $includeWallOwner = false;
+            if ($forUserId !== null) {
+                $includeWallOwner = $subjectId === $forUserId;
+            } else {
+                $includeWallOwner = !$ignoreUserIds || !in_array($subjectId, $ignoreUserIds);
+            }
+
+            if ($includeWallOwner) {
+                /** @var Builder<Model> $query2 */
+                $query2 = User::query()
+                    ->where('ID', $subjectId)
+                    ->select([
+                        DB::raw('ID as user_id'),
+                        DB::raw('ID as subject_id'),
+                    ]);
+
+                $query->union($query2);
+            }
+        }
 
         return $query;
     }


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/310195377993416714/1415371794579194056

The [`authorQry` subclause](https://github.com/RetroAchievements/RAWeb/pull/3859/files#diff-71a3c3b791d5300047d57e9ae350f051dd19cf2769aa5e9078968ce3f0e4c436L178-L184) of `getSubscribedOfArticle` was misplaced in #3859.

It was provided for achievements and user walls. Both are restored in this PR, though I've opted for maintainer over author for the achievement wall, and restricted it such that the maintainer is only notified if they're still a developer. This matches the behavior for ticket comments being sent for the maintainer.