### PR TITLE
feat(game): show user current leaderboard position

### DIFF
--- a/app/Platform/Actions/BuildGameShowPagePropsAction.php
+++ b/app/Platform/Actions/BuildGameShowPagePropsAction.php
@@ -14,6 +14,7 @@ use App\Data\UserPermissionsData;
 use App\Enums\GameHashCompatibility;
 use App\Models\Game;
 use App\Models\GameAchievementSet;
+use App\Models\LeaderboardEntry;
 use App\Models\Role;
 use App\Models\System;
 use App\Models\Ticket;
@@ -27,6 +28,7 @@ use App\Platform\Data\GameSetData;
 use App\Platform\Data\GameSetRequestData;
 use App\Platform\Data\GameShowPagePropsData;
 use App\Platform\Data\LeaderboardData;
+use App\Platform\Data\LeaderboardEntryData;
 use App\Platform\Data\PlayerGameData;
 use App\Platform\Data\PlayerGameProgressionAwardsData;
 use App\Platform\Data\UserCreditsData;
@@ -284,8 +286,8 @@ class BuildGameShowPagePropsAction
             followedPlayerCompletions: $this->buildFollowedPlayerCompletionAction->execute($user, $backingGame),
 
             leaderboards: request()->inertia()
-                ? $this->buildLeaderboards($backingGame)
-                : Lazy::inertiaDeferred(fn () => $this->buildLeaderboards($backingGame)),
+                ? $this->buildLeaderboards($backingGame, $user)
+                : Lazy::inertiaDeferred(fn () => $this->buildLeaderboards($backingGame, $user)),
 
             playerAchievementChartBuckets: $targetAchievementFlag === AchievementFlag::OfficialCore
                 ? $this->buildGameAchievementDistributionAction->execute($backingGame, $user)
@@ -589,21 +591,59 @@ class BuildGameShowPagePropsAction
     /**
      * @return Collection<int, LeaderboardData>
      */
-    private function buildLeaderboards(Game $game): Collection
+    private function buildLeaderboards(Game $game, ?User $user = null): Collection
     {
         // Only show leaderboards if the system is active and it's not an event game.
         if (!$game->system->active || $game->system->id === System::Events) {
             return collect();
         }
 
-        return $game->leaderboards->map(fn ($leaderboard) => LeaderboardData::fromLeaderboard($leaderboard)->include(
-            'title',
-            'description',
-            'topEntry.formattedScore',
-            'topEntry.user.displayName',
-            'topEntry.user.avatarUrl',
-            'format',
-        ));
+        // If the user is authenticated, fetch all their leaderboard entries for the game.
+        $userEntriesByLeaderboardId = collect();
+        if ($user) {
+            $leaderboardIds = $game->leaderboards->pluck('ID');
+            $userEntries = LeaderboardEntry::whereIn('leaderboard_id', $leaderboardIds)
+                ->where('user_id', $user->id)
+                ->get();
+            $userEntriesByLeaderboardId = $userEntries->keyBy('leaderboard_id');
+        }
+
+        return $game->leaderboards->map(function ($leaderboard) use ($userEntriesByLeaderboardId, $user) {
+            // Build the user entry if it exists.
+            $userEntryData = null;
+            if ($user && $userEntriesByLeaderboardId->has($leaderboard->id)) {
+                $userEntry = $userEntriesByLeaderboardId->get($leaderboard->id);
+                $rank = $leaderboard->getRank($userEntry->score);
+
+                // If the user has an entry and isn't rank #1, calculate how close they are to rank #1.
+                $percentageOfTopScore = null;
+                if ($rank > 1 && $leaderboard->topEntry) {
+                    $percentageOfTopScore = $this->calculatePercentageOfLeaderboardTopScore(
+                        $userEntry->score,
+                        $leaderboard->topEntry->score,
+                        $leaderboard->rank_asc
+                    );
+                }
+
+                $userEntryData = LeaderboardEntryData::fromLeaderboardEntry(
+                    $userEntry,
+                    $leaderboard->format,
+                    $rank,
+                    $percentageOfTopScore
+                )->include('formattedScore', 'rank', 'percentageOfTopScore');
+            }
+
+            return LeaderboardData::fromLeaderboard($leaderboard, $userEntryData)->include(
+                'description',
+                'format',
+                'rankAsc',
+                'title',
+                'topEntry.formattedScore',
+                'topEntry.user.avatarUrl',
+                'topEntry.user.displayName',
+                'userEntry',
+            );
+        });
     }
 
     private function getLeaderboardsCount(Game $game): int
@@ -614,5 +654,32 @@ class BuildGameShowPagePropsAction
         }
 
         return $game->leaderboards->count();
+    }
+
+    private function calculatePercentageOfLeaderboardTopScore(int $userScore, int $topScore, bool $rankAsc): ?float
+    {
+        if ($userScore === 0 && $topScore === 0) {
+            return 100.0;
+        }
+
+        if ($rankAsc) {
+            // Lower is better (eg: speedrun leaderboards).
+
+            if ($userScore === 0) {
+                return null;
+            }
+
+            $percentage = ($topScore / $userScore) * 100;
+        } else {
+            // Higher is better (eg: high score leaderboards).
+
+            if ($topScore === 0) {
+                return null;
+            }
+
+            $percentage = ($userScore / $topScore) * 100;
+        }
+
+        return round(min($percentage, 100.0), 1);
     }
 }

--- a/app/Platform/Data/LeaderboardData.php
+++ b/app/Platform/Data/LeaderboardData.php
@@ -13,29 +13,33 @@ use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 class LeaderboardData extends Data
 {
     public function __construct(
-        public int $id,
-        public string $title,
         public Lazy|string $description,
-        public Lazy|GameData $game,
-        public Lazy|LeaderboardEntryData|null $topEntry,
         public Lazy|string|null $format,
+        public Lazy|GameData $game,
+        public int $id,
         public Lazy|int $orderColumn,
+        public string $title,
+        public Lazy|LeaderboardEntryData|null $topEntry,
+        public Lazy|LeaderboardEntryData|null $userEntry = null,
+        public Lazy|bool|null $rankAsc = null,
     ) {
     }
 
-    public static function fromLeaderboard(Leaderboard $leaderboard): self
+    public static function fromLeaderboard(Leaderboard $leaderboard, ?LeaderboardEntryData $userEntry = null): self
     {
         return new self(
-            id: $leaderboard->id,
-            title: $leaderboard->title,
             description: Lazy::create(fn () => $leaderboard->description),
+            format: Lazy::create(fn () => $leaderboard->format),
             game: Lazy::create(fn () => GameData::fromGame($leaderboard->game)),
+            id: $leaderboard->id,
+            orderColumn: Lazy::create(fn () => $leaderboard->DisplayOrder),
+            title: $leaderboard->title,
             topEntry: Lazy::create(fn () => $leaderboard->topEntry
                 ? LeaderboardEntryData::fromLeaderboardEntry($leaderboard->topEntry, $leaderboard->format)
                 : null
             ),
-            format: Lazy::create(fn () => $leaderboard->format),
-            orderColumn: Lazy::create(fn () => $leaderboard->DisplayOrder),
+            userEntry: $userEntry,
+            rankAsc: Lazy::create(fn () => $leaderboard->rank_asc),
         );
     }
 }

--- a/app/Platform/Data/LeaderboardEntryData.php
+++ b/app/Platform/Data/LeaderboardEntryData.php
@@ -21,17 +21,25 @@ class LeaderboardEntryData extends Data
         public Lazy|string $formattedScore,
         public Lazy|Carbon $createdAt,
         public Lazy|UserData|null $user,
+        public Lazy|int|null $rank = null,
+        public Lazy|float|null $percentageOfTopScore = null,
     ) {
     }
 
-    public static function fromLeaderboardEntry(LeaderboardEntry $leaderboardEntry, ?string $format = null): self
-    {
+    public static function fromLeaderboardEntry(
+        LeaderboardEntry $leaderboardEntry,
+        ?string $format = null,
+        ?int $rank = null,
+        ?float $percentageOfTopScore = null
+    ): self {
         return new self(
             id: $leaderboardEntry->id,
             score: Lazy::create(fn () => $leaderboardEntry->score),
             formattedScore: Lazy::create(fn () => ValueFormat::format($leaderboardEntry->score, $format)),
             createdAt: Lazy::create(fn () => $leaderboardEntry->created_at),
             user: Lazy::create(fn () => $leaderboardEntry->user ? UserData::fromUser($leaderboardEntry->user) : null),
+            rank: Lazy::create(fn () => $rank),
+            percentageOfTopScore: Lazy::create(fn () => $percentageOfTopScore),
         );
     }
 }

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -1185,5 +1185,8 @@
     "Beaten Progress (Softcore)": "Beaten Progress (Softcore)",
     "Overall Set Progress": "Overall Set Progress",
     "Reset all progress": "Reset all progress",
-    "This will remove all your unlocked achievements for the game. This cannot be reversed.": "This will remove all your unlocked achievements for the game. This cannot be reversed."
+    "This will remove all your unlocked achievements for the game. This cannot be reversed.": "This will remove all your unlocked achievements for the game. This cannot be reversed.",
+    "Your Position": "Your Position",
+    "#{{rank, number}}": "#{{rank, number}}",
+    "{{percentage}} of #1": "{{percentage}} of #1"
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.1",
         "@types/ua-parser-js": "^0.7.36",
+        "@typescript-eslint/types": "^8.43.0",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^3.2.3",
         "@vitest/eslint-plugin": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@types/ua-parser-js':
         specifier: ^0.7.36
         version: 0.7.39
+      '@typescript-eslint/types':
+        specifier: ^8.43.0
+        version: 8.43.0
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.3.5(@types/node@22.8.4)(jiti@1.21.6)(tsx@4.19.3)(yaml@2.6.0))
@@ -2199,6 +2202,10 @@ packages:
 
   '@typescript-eslint/types@8.36.0':
     resolution: {integrity: sha512-xGms6l5cTJKQPZOKM75Dl9yBfNdGeLRsIyufewnxT4vZTrjC0ImQT4fj8QmtJK84F58uSh5HVBSANwcfiXxABQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.43.0':
+    resolution: {integrity: sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.24.0':
@@ -7214,7 +7221,7 @@ snapshots:
   '@typescript-eslint/project-service@8.36.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.36.0(typescript@5.7.3)
-      '@typescript-eslint/types': 8.36.0
+      '@typescript-eslint/types': 8.43.0
       debug: 4.4.1
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -7248,6 +7255,8 @@ snapshots:
   '@typescript-eslint/types@8.24.0': {}
 
   '@typescript-eslint/types@8.36.0': {}
+
+  '@typescript-eslint/types@8.43.0': {}
 
   '@typescript-eslint/typescript-estree@8.24.0(typescript@5.7.3)':
     dependencies:

--- a/resources/js/features/games/components/LeaderboardsListItem/LeaderboardsListItem.test.tsx
+++ b/resources/js/features/games/components/LeaderboardsListItem/LeaderboardsListItem.test.tsx
@@ -106,4 +106,46 @@ describe('Component: LeaderboardsListItem', () => {
     // ASSERT
     expect(container).toBeTruthy();
   });
+
+  it('given there is a user entry for the leaderboard, displays it', async () => {
+    // ARRANGE
+    const leaderboard = createLeaderboard({
+      rankAsc: false,
+      userEntry: createLeaderboardEntry({
+        rank: 2,
+        score: 200,
+        formattedScore: '200',
+      }),
+      topEntry: createLeaderboardEntry({ score: 200 }),
+    });
+
+    render(<LeaderboardsListItem index={10} isLargeList={true} leaderboard={leaderboard} />);
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText('#2')).toBeVisible();
+    });
+    expect(screen.getByText(/200/i)).toBeVisible();
+  });
+
+  it('given the user entry has a percentageOfTopScore value, displays it', async () => {
+    // ARRANGE
+    const leaderboard = createLeaderboard({
+      rankAsc: false,
+      userEntry: createLeaderboardEntry({
+        rank: 2,
+        score: 200,
+        formattedScore: '200',
+        percentageOfTopScore: 50,
+      }),
+      topEntry: createLeaderboardEntry({ score: 400 }),
+    });
+
+    render(<LeaderboardsListItem index={10} isLargeList={true} leaderboard={leaderboard} />);
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText('50% of #1')).toBeVisible();
+    });
+  });
 });

--- a/resources/js/features/games/components/LeaderboardsListItem/LeaderboardsListItem.tsx
+++ b/resources/js/features/games/components/LeaderboardsListItem/LeaderboardsListItem.tsx
@@ -1,8 +1,10 @@
 import * as motion from 'motion/react-m';
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import { LuChartBar, LuCrown } from 'react-icons/lu';
 
 import { UserAvatar } from '@/common/components/UserAvatar';
+import { useFormatPercentage } from '@/common/hooks/useFormatPercentage';
 
 interface LeaderboardsListItemProps {
   index: number;
@@ -15,6 +17,10 @@ export const LeaderboardsListItem: FC<LeaderboardsListItemProps> = ({
   isLargeList,
   leaderboard,
 }) => {
+  const { t } = useTranslation();
+
+  const { formatPercentage } = useFormatPercentage();
+
   return (
     <motion.li
       className="flex w-full gap-x-3.5 px-2 py-3 odd:bg-[rgba(50,50,50,0.4)] light:odd:bg-neutral-100 md:gap-x-3 md:py-1"
@@ -38,8 +44,8 @@ export const LeaderboardsListItem: FC<LeaderboardsListItemProps> = ({
         </a>
       </div>
 
-      <div className="grid w-full gap-x-5 gap-y-1.5 pb-2.5 leading-4 md:grid-cols-6">
-        <div className="md:col-span-4 md:mt-1">
+      <div className="grid w-full gap-x-5 gap-y-1.5 pb-2.5 leading-4 sm:grid-cols-6">
+        <div className="sm:col-span-4 md:mt-1">
           {/* Title */}
           <div className="mb-0.5 md:mt-0">
             <span className="mr-2">
@@ -53,7 +59,7 @@ export const LeaderboardsListItem: FC<LeaderboardsListItemProps> = ({
           <p className="leading-4">{leaderboard.description}</p>
 
           {/* Top entry */}
-          <div className="mt-3">
+          <div className="mt-2.5">
             {leaderboard.topEntry?.user ? (
               <div className="flex items-center gap-3">
                 <LuCrown className="size-4 text-yellow-400 light:text-amber-600" />
@@ -67,6 +73,34 @@ export const LeaderboardsListItem: FC<LeaderboardsListItemProps> = ({
             ) : null}
           </div>
         </div>
+
+        {/* User entry */}
+        {leaderboard.userEntry ? (
+          <div className="flex flex-col gap-1 sm:col-span-2 sm:mt-1 sm:items-end sm:justify-center">
+            <div className="flex items-center justify-between sm:flex-col sm:items-end sm:justify-normal">
+              <p className="text-neutral-400 light:text-neutral-700">{t('Your Position')}</p>
+
+              <p className="sm:text-lg">
+                <span className="text-neutral-300 light:text-neutral-700">
+                  {t('#{{rank, number}}', { rank: leaderboard.userEntry.rank })}
+                </span>
+                {' / '}
+                {leaderboard.userEntry.formattedScore}
+              </p>
+            </div>
+
+            {leaderboard.userEntry.percentageOfTopScore ? (
+              <p className="mt-0.5 hidden text-xs text-neutral-500 sm:block">
+                {t('{{percentage}} of #1', {
+                  percentage: formatPercentage(leaderboard.userEntry.percentageOfTopScore / 100, {
+                    maximumFractionDigits: 0,
+                    minimumFractionDigits: 0,
+                  }),
+                })}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     </motion.li>
   );

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -862,13 +862,15 @@ declare namespace App.Platform.Data {
     defaultDesktopPageSize: number;
   };
   export type Leaderboard = {
-    id: number;
-    title: string;
     description?: string;
-    game?: App.Platform.Data.Game;
-    topEntry?: App.Platform.Data.LeaderboardEntry | null;
     format?: string | null;
+    game?: App.Platform.Data.Game;
+    id: number;
     orderColumn?: number;
+    title: string;
+    topEntry?: App.Platform.Data.LeaderboardEntry | null;
+    userEntry?: App.Platform.Data.LeaderboardEntry | null;
+    rankAsc?: boolean | null;
   };
   export type LeaderboardEntry = {
     id: number;
@@ -876,6 +878,8 @@ declare namespace App.Platform.Data {
     formattedScore?: string;
     createdAt?: string;
     user?: App.Data.User | null;
+    rank?: number | null;
+    percentageOfTopScore?: number | null;
   };
   export type ParsedUserAgent = {
     client: string;


### PR DESCRIPTION
This PR enhances the leaderboards display on React game pages to show the user's current leaderboard positions (if they have any):

<img width="861" height="375" alt="Screenshot 2025-09-13 at 5 31 32 PM" src="https://github.com/user-attachments/assets/ec839f22-46ae-4bf6-9119-cff8c1f8f2b0" />
