### PR TITLE
feat(ForwardMessageToDiscordAction): also forward team replies

### DIFF
--- a/app/Community/Actions/ForwardMessageToDiscordAction.php
+++ b/app/Community/Actions/ForwardMessageToDiscordAction.php
@@ -47,7 +47,28 @@ class ForwardMessageToDiscordAction
         Message $message
     ): void {
         $inboxConfig = config('services.discord.inbox_webhook.' . $userTo->username);
+
+        // Check if this is a reply from a team account to an existing Discord thread.
+        // If it is, we'll also put the reply in the Discord thread just for the sake
+        // of continuity.
         if ($inboxConfig === null || empty($inboxConfig['url'] ?? null)) {
+            $existingMapping = DiscordMessageThreadMapping::findMapping($messageThread->id);
+            if ($existingMapping) {
+                // This thread is already being tracked in Discord.
+                // Check if the sender (team account) has a webhook config.
+                $senderInboxConfig = config('services.discord.inbox_webhook.' . $userFrom->username);
+                if ($senderInboxConfig !== null && !empty($senderInboxConfig['url'] ?? null)) {
+                    // Forward the team's reply to the existing Discord thread.
+                    $this->forwardTeamReplyToDiscord(
+                        $senderInboxConfig,
+                        $existingMapping->discord_thread_id,
+                        $userFrom,
+                        $messageThread,
+                        $message
+                    );
+                }
+            }
+
             return;
         }
 
@@ -416,6 +437,51 @@ class ForwardMessageToDiscordAction
             'avatar_url' => $userTo->avatar_url,
             'embeds' => [$embed],
         ];
+    }
+
+    /**
+     * Forward a team account's reply to an existing Discord thread.
+     */
+    private function forwardTeamReplyToDiscord(
+        array $senderInboxConfig,
+        string $discordThreadId,
+        User $userFrom,
+        MessageThread $messageThread,
+        Message $message
+    ): void {
+        $webhookUrl = $senderInboxConfig['url'];
+        $fullBody = Shortcode::stripAndClamp($message->body, self::MESSAGE_BODY_MAX_LENGTH, preserveWhitespace: true);
+
+        if (empty($fullBody)) {
+            return;
+        }
+
+        // Post the reply to the existing Discord thread.
+        $threadWebhookUrl = $webhookUrl . '?thread_id=' . $discordThreadId;
+
+        if (mb_strlen($fullBody) > self::DISCORD_EMBED_DESCRIPTION_LIMIT) {
+            // Handle long messages by chunking them.
+            $this->sendChunkedMessages(
+                $threadWebhookUrl,
+                $userFrom,
+                $userFrom, // Pass the team account (sender) as both from and to so the webhook shows "[Team] Inbox"
+                $messageThread,
+                $fullBody,
+                self::COLOR_DEFAULT,
+                false // not a new thread, this is a reply
+            );
+        } else {
+            $payload = $this->buildDiscordPayload(
+                $userFrom,
+                $userFrom, // Pass the team account (sender) as both from and to so the webhook shows "[Team] Inbox"
+                $messageThread,
+                $fullBody,
+                self::COLOR_DEFAULT,
+                true
+            );
+
+            $this->client->post($threadWebhookUrl, ['json' => $payload]);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR enhances `ForwardMessageToDiscordAction` to also forward any team account replies to the on-site DM thread for the sake of continuity.

<img width="728" height="852" alt="Screenshot 2025-09-13 at 5 55 46 PM" src="https://github.com/user-attachments/assets/a13b8bbe-6d64-440b-b389-21c7b37edbc8" />
