### PR TITLE
fix: make managing achievement credit more intuitive

### DIFF
--- a/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
+++ b/app/Filament/Resources/AchievementResource/RelationManagers/AuthorshipCreditsRelationManager.php
@@ -38,7 +38,6 @@ class AuthorshipCreditsRelationManager extends RelationManager
         $dummyModel->achievement_id = $this->ownerRecord->id;
 
         $canCreate = $user->can('create', $dummyModel);
-        $canDelete = $user->can('delete', $dummyModel);
         $canUpdate = $user->can('update', $dummyModel);
 
         $earliestLogicCredit = AchievementAuthor::where('achievement_id', $this->ownerRecord->id)
@@ -156,13 +155,11 @@ class AuthorshipCreditsRelationManager extends RelationManager
                     ->visible(fn () => $canUpdate),
 
                 Tables\Actions\DeleteAction::make()
-                    ->modalHeading('Delete contribution credit')
-                    ->hidden(fn (AchievementAuthor $record) => !$canDelete || ($earliestLogicCredit && $earliestLogicCredit->id === $record->id)),
+                    ->modalHeading('Delete contribution credit'),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make()
-                        ->visible(fn () => $canDelete),
+                    Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ]);
     }

--- a/app/Policies/AchievementAuthorPolicy.php
+++ b/app/Policies/AchievementAuthorPolicy.php
@@ -19,7 +19,6 @@ class AchievementAuthorPolicy
         return $user->hasAnyRole([
             Role::DEVELOPER,
             Role::MODERATOR,
-            Role::TEAM_ACCOUNT,
             Role::ARTIST,
         ]);
     }
@@ -57,7 +56,11 @@ class AchievementAuthorPolicy
         }
 
         return $user->hasAnyRole([
+            Role::ADMINISTRATOR,
+            Role::DEV_COMPLIANCE,
+            Role::GAME_EDITOR,
             Role::MODERATOR,
+            Role::QUALITY_ASSURANCE,
             Role::TEAM_ACCOUNT,
         ]);
     }
@@ -65,7 +68,11 @@ class AchievementAuthorPolicy
     public function restore(User $user, AchievementAuthor $achievementAuthor): bool
     {
         return $user->hasAnyRole([
+            Role::ADMINISTRATOR,
+            Role::DEV_COMPLIANCE,
+            Role::GAME_EDITOR,
             Role::MODERATOR,
+            Role::QUALITY_ASSURANCE,
             Role::TEAM_ACCOUNT,
         ]);
     }

--- a/app/Policies/AchievementAuthorPolicy.php
+++ b/app/Policies/AchievementAuthorPolicy.php
@@ -51,6 +51,11 @@ class AchievementAuthorPolicy
 
     public function delete(User $user, AchievementAuthor $achievementAuthor): bool
     {
+        // Users can delete their own credit.
+        if ($user->is($achievementAuthor->user)) {
+            return true;
+        }
+
         return $user->hasAnyRole([
             Role::MODERATOR,
             Role::TEAM_ACCOUNT,


### PR DESCRIPTION
We've been receiving some feedback that managing achievement credit in Filament is unintuitive:

https://github.com/RetroAchievements/RAWeb/issues/3334
https://discord.com/channels/310192285306454017/962817919698501702/1415712675526348851

I agree with this feedback.

This PR makes it so that someone can always remove their own credit entries, as long as it isn't the earliest logic credit for the achievement.

Additionally, the roles allowed to delete and restore credit have been expanded to:
```php
return $user->hasAnyRole([
    Role::ADMINISTRATOR,
    Role::DEV_COMPLIANCE,
    Role::GAME_EDITOR,
    Role::MODERATOR,
    Role::QUALITY_ASSURANCE,
    Role::TEAM_ACCOUNT,
]);
```