### PR TITLE
chore(game): relocate the 'View Unpublished Achievements' button

### DIFF
--- a/resources/js/features/games/components/GameSidebarFullWidthButtons/SidebarDevelopmentSection/SidebarDevelopmentSection.tsx
+++ b/resources/js/features/games/components/GameSidebarFullWidthButtons/SidebarDevelopmentSection/SidebarDevelopmentSection.tsx
@@ -47,20 +47,6 @@ export const SidebarDevelopmentSection: FC = () => {
 
   return (
     <>
-      <SidebarClaimButtons />
-      <SidebarToggleInReviewButton />
-
-      {isDeveloper ? (
-        <PlayableSidebarButton
-          aria-pressed={isOnWantToDevList}
-          IconComponent={isOnWantToDevList ? LuCheck : LuPlus}
-          onClick={() => toggleWantToDevelop()}
-          showSubsetIndicator={game.id !== backingGame.id}
-        >
-          {backingGame.achievementsPublished ? t('Want to Revise') : t('Want to Develop')}
-        </PlayableSidebarButton>
-      ) : null}
-
       {!isViewingPublishedAchievements || backingGame.achievementsUnpublished ? (
         <PlayableSidebarButton
           IconComponent={isViewingPublishedAchievements ? LuFolderLock : LuFolder}
@@ -75,6 +61,20 @@ export const SidebarDevelopmentSection: FC = () => {
           {isViewingPublishedAchievements
             ? t('View Unpublished Achievements')
             : t('View Published Achievements')}
+        </PlayableSidebarButton>
+      ) : null}
+
+      <SidebarClaimButtons />
+      <SidebarToggleInReviewButton />
+
+      {isDeveloper ? (
+        <PlayableSidebarButton
+          aria-pressed={isOnWantToDevList}
+          IconComponent={isOnWantToDevList ? LuCheck : LuPlus}
+          onClick={() => toggleWantToDevelop()}
+          showSubsetIndicator={game.id !== backingGame.id}
+        >
+          {backingGame.achievementsPublished ? t('Want to Revise') : t('Want to Develop')}
         </PlayableSidebarButton>
       ) : null}
     </>


### PR DESCRIPTION
For some reason, my brain is not too happy with the current placement of this button.

**Before**
<img width="363" height="161" alt="Screenshot 2025-09-14 at 5 04 41 PM" src="https://github.com/user-attachments/assets/96e43915-72cf-4c66-baf4-957e37eb2c4b" />


**After**
<img width="372" height="169" alt="Screenshot 2025-09-14 at 5 04 34 PM" src="https://github.com/user-attachments/assets/3aac56c6-344f-4ebd-a398-4f015d5094b4" />
