### PR TITLE
fix(AchievementSetEmptyState): don't link player requests if unauthorized

### DIFF
--- a/resources/js/features/games/components/AchievementSetEmptyState/AchievementSetEmptyState.test.tsx
+++ b/resources/js/features/games/components/AchievementSetEmptyState/AchievementSetEmptyState.test.tsx
@@ -70,7 +70,7 @@ describe('Component: AchievementSetEmptyState', () => {
 
     render(<AchievementSetEmptyState />, {
       pageProps: {
-        auth: null,
+        auth: { user: createAuthenticatedUser() }, // !!
         backingGame: createGame({ id: 456 }),
         setRequestData,
       },
@@ -81,6 +81,24 @@ describe('Component: AchievementSetEmptyState', () => {
       'href',
       '/setRequestors.php?g=456',
     );
+  });
+
+  it('given the user is not logged in, the total requests count is not a link', () => {
+    // ARRANGE
+    const setRequestData = createGameSetRequestData({ totalRequests: 123 }); // !!
+
+    render(<AchievementSetEmptyState />, {
+      pageProps: {
+        auth: null, // !!
+        backingGame: createGame({ id: 456 }),
+        setRequestData,
+      },
+    });
+
+    // ASSERT
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText(/123 requests/i)).toBeVisible();
+    expect(screen.getByText(/from players/i)).toBeVisible();
   });
 
   it('given the user is not authenticated, does not display remaining requests', () => {

--- a/resources/js/features/games/components/AchievementSetEmptyState/AchievementSetEmptyState.tsx
+++ b/resources/js/features/games/components/AchievementSetEmptyState/AchievementSetEmptyState.tsx
@@ -44,7 +44,7 @@ export const AchievementSetEmptyState: FC = () => {
               }}
               components={{
                 // eslint-disable-next-line jsx-a11y/anchor-has-content -- this is passed in by the consumer
-                1: <a href={`/setRequestors.php?g=${backingGame.id}`} />,
+                1: auth?.user ? <a href={`/setRequestors.php?g=${backingGame.id}`} /> : <span />,
               }}
             />
           </p>


### PR DESCRIPTION
https://github.com/RetroAchievements/RAWeb/pull/3788#pullrequestreview-3126343745

If the user is unauthorized, the link to player requests will now be a span.

**Before**
<img width="865" height="410" alt="Screenshot 2025-09-14 at 5 10 45 PM" src="https://github.com/user-attachments/assets/6d86eb2e-acb1-4acb-b8d3-a14897616a15" />


**After**
<img width="858" height="420" alt="Screenshot 2025-09-14 at 5 10 37 PM" src="https://github.com/user-attachments/assets/19cda3f0-84e6-4a2b-8939-4413a05f638c" />
