### PR TITLE
fix(SeriesHubDisplay): rename bad prop

### DIFF
--- a/resources/js/features/games/components/SeriesHubDisplay/SeriesHubDisplay.tsx
+++ b/resources/js/features/games/components/SeriesHubDisplay/SeriesHubDisplay.tsx
@@ -84,7 +84,7 @@ export const SeriesHubDisplay: FC<SeriesHubDisplayProps> = ({ seriesHub }) => {
               <span>
                 <Trans
                   i18nKey="<1>{{val, number}}</1> points"
-                  val={seriesHub.pointsTotal}
+                  count={seriesHub.pointsTotal}
                   values={{ val: seriesHub.pointsTotal }}
                   components={{ 1: <span className="font-semibold" /> }}
                 />


### PR DESCRIPTION
Typo fix. Renames a prop that's causing i18next to throw a "missing key" warning in the browser devtools console:
<img width="769" height="35" alt="Screenshot 2025-09-14 at 6 15 56 PM" src="https://github.com/user-attachments/assets/075839a8-0a29-41b1-bc50-84be8b530db0" />
