### PR TITLE
fix(InertiaLink): generate prefetch cache keys correctly

### DIFF
--- a/resources/js/common/components/InertiaLink/InertiaLink.test.tsx
+++ b/resources/js/common/components/InertiaLink/InertiaLink.test.tsx
@@ -134,6 +134,42 @@ describe('Component: InertiaLink', () => {
     expect(prefetchSpy).toHaveBeenCalled();
   });
 
+  it('given navigation options are provided, includes them in the prefetch call', async () => {
+    // ARRANGE
+    const prefetchSpy = vi.spyOn(router, 'prefetch');
+
+    const navigationOptions = {
+      data: { foo: 'bar' },
+      preserveScroll: true,
+      preserveState: true,
+      only: ['users'],
+      except: ['posts'],
+      headers: { 'X-Custom': 'header' },
+      replace: true,
+    };
+
+    render(
+      <InertiaLink href="/test" prefetch="desktop-hover-only" {...navigationOptions}>
+        Link Text
+      </InertiaLink>,
+      {
+        pageProps: { ziggy: createZiggyProps({ device: 'desktop' }) },
+      },
+    );
+
+    // ACT
+    await userEvent.hover(screen.getByRole('link', { name: /link text/i }));
+
+    // ASSERT
+    await waitFor(() => {
+      expect(prefetchSpy).toHaveBeenCalledWith(
+        '/test',
+        { method: 'get', ...navigationOptions },
+        { cacheFor: '30s' },
+      );
+    });
+  });
+
   it('given the user stops hovering over a link before the prefetch delay, cancels the prefetch', async () => {
     // ARRANGE
     const prefetchSpy = vi.spyOn(router, 'prefetch');

--- a/resources/js/common/components/InertiaLink/InertiaLink.tsx
+++ b/resources/js/common/components/InertiaLink/InertiaLink.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports -- this component wraps Inertia's <Link /> */
 
+import type { Visit, VisitCallbacks } from '@inertiajs/core';
 import type { InertiaLinkProps as OriginalInertiaLinkProps } from '@inertiajs/react';
 import { Link, router } from '@inertiajs/react';
 import { type FC, useRef } from 'react';
@@ -36,7 +37,34 @@ export const InertiaLink: FC<InertiaLinkProps> = ({ href, prefetch = 'never', ..
   });
 
   const handlePrefetch = () => {
-    router.prefetch(safeHref, { method: 'get' }, { cacheFor: '30s' });
+    // Inertia uses navigation options to generate cache keys for prefetched requests.
+    // If we don't pass the same options during prefetch that the Link will use during
+    // actual navigation, the cache keys won't match and the prefetched data won't be used.
+    // This defeats the purpose of prefetching. To fix this, we extract all navigation
+    // options from the Link props and pass them to the prefetch call.
+    const {
+      data,
+      preserveScroll,
+      preserveState,
+      only,
+      except,
+      headers,
+      replace,
+      method = 'get',
+    } = rest;
+    const options: Partial<Visit & VisitCallbacks> = { method };
+
+    // Only include defined navigation options to avoid passing undefined values
+    // which could cause issues with Inertia's comparison logic.
+    if (data !== undefined) options.data = data;
+    if (except !== undefined) options.except = except;
+    if (headers !== undefined) options.headers = headers;
+    if (only !== undefined) options.only = only;
+    if (preserveScroll !== undefined) options.preserveScroll = preserveScroll;
+    if (preserveState !== undefined) options.preserveState = preserveState;
+    if (replace !== undefined) options.replace = replace;
+
+    router.prefetch(safeHref, options, { cacheFor: '30s' });
   };
 
   /**


### PR DESCRIPTION
http://localhost:64000/game2/668

When using tabs to navigate between the achievement sets, Inertia is currently making two identical HTTP requests: a prefetch call and then a navigation call.

<img width="921" height="85" alt="Screenshot 2025-09-14 at 6 50 36 PM" src="https://github.com/user-attachments/assets/1c86a820-3c80-441c-8aab-cc97019f5689" />

The navigation call shouldn't be made. What's returned from the prefetch call should be reused in order to make the page transition a bit snappier. However, Inertia is discarding the prefetch and fetching all the props for the navigation again.

**Root Cause**
`router.prefetch()` uses a bunch of navigation options to build prefetch cache keys, and if any are missing, it can't cache stuff properly. The `preserveScroll` prop on these links is causing a cache miss to occur.

With the changes in this PR, you should only see one network call made on hover+click (assuming the prefetch has enough time to resolve).