### PR TITLE
chore(deps): bump pint to 1.25, format

### DIFF
--- a/app/Actions/DeleteAvatarAction.php
+++ b/app/Actions/DeleteAvatarAction.php
@@ -9,7 +9,7 @@ use App\Models\User;
 class DeleteAvatarAction
 {
     public function __construct(
-        private LinkLatestAvatarAction $linkLatestAvatarAction
+        private LinkLatestAvatarAction $linkLatestAvatarAction,
     ) {
     }
 

--- a/app/Actions/LinkLatestAvatarAction.php
+++ b/app/Actions/LinkLatestAvatarAction.php
@@ -11,7 +11,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 class LinkLatestAvatarAction
 {
     public function __construct(
-        private Filesystem $filesystem
+        private Filesystem $filesystem,
     ) {
     }
 

--- a/app/Actions/UpdateAvatarAction.php
+++ b/app/Actions/UpdateAvatarAction.php
@@ -12,7 +12,7 @@ class UpdateAvatarAction
 {
     public function __construct(
         private AddMediaAction $addMediaAction,
-        private LinkLatestAvatarAction $linkLatestAvatarAction
+        private LinkLatestAvatarAction $linkLatestAvatarAction,
     ) {
     }
 

--- a/app/Api/Middleware/LogApiRequest.php
+++ b/app/Api/Middleware/LogApiRequest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 class LogApiRequest
 {
     public function __construct(
-        private readonly string $apiVersion = 'v2'
+        private readonly string $apiVersion = 'v2',
     ) {
     }
 

--- a/app/Auth/HeaderTokenGuard.php
+++ b/app/Auth/HeaderTokenGuard.php
@@ -19,7 +19,7 @@ class HeaderTokenGuard extends TokenGuard
         string $inputKey = 'api_key',
         string $storageKey = 'api_token',
         bool $hash = false,
-        string $headerName = 'X-API-Key'
+        string $headerName = 'X-API-Key',
     ) {
         parent::__construct($provider, $request, $inputKey, $storageKey, $hash);
 

--- a/app/Community/Actions/AddToMessageThreadAction.php
+++ b/app/Community/Actions/AddToMessageThreadAction.php
@@ -16,7 +16,7 @@ class AddToMessageThreadAction
         MessageThread $thread,
         User $userFrom,
         User $trueSenderUser,
-        string $body
+        string $body,
     ): void {
         $message = new Message([
             'thread_id' => $thread->id,

--- a/app/Community/Actions/CreateMessageThreadAction.php
+++ b/app/Community/Actions/CreateMessageThreadAction.php
@@ -17,7 +17,7 @@ class CreateMessageThreadAction
         User $trueSenderUser,
         string $title,
         string $body,
-        bool $isProxied = false
+        bool $isProxied = false,
     ): MessageThread {
         $thread = new MessageThread([
             'title' => $title,

--- a/app/Community/Actions/ForwardMessageToDiscordAction.php
+++ b/app/Community/Actions/ForwardMessageToDiscordAction.php
@@ -44,7 +44,7 @@ class ForwardMessageToDiscordAction
         User $userFrom,
         User $userTo,
         MessageThread $messageThread,
-        Message $message
+        Message $message,
     ): void {
         $inboxConfig = config('services.discord.inbox_webhook.' . $userTo->username);
 
@@ -120,7 +120,7 @@ class ForwardMessageToDiscordAction
         string $webhookUrl,
         int $color,
         bool $isForum,
-        bool $isNewThread
+        bool $isNewThread,
     ): ProcessedDiscordMessageData {
         $messageTitle = mb_strtolower($messageThread->title);
         $threadTitle = $messageThread->title;
@@ -199,7 +199,7 @@ class ForwardMessageToDiscordAction
         string $messageBody,
         int $color,
         bool $isForum,
-        ?string $existingThreadId = null
+        ?string $existingThreadId = null,
     ): void {
         if ($isForum) {
             $isNewThread = !$existingThreadId;
@@ -258,7 +258,7 @@ class ForwardMessageToDiscordAction
         User $userTo,
         MessageThread $messageThread,
         string $messageBody,
-        int $color
+        int $color,
     ): ?string {
         $isLongMessage = mb_strlen($messageBody) > self::DISCORD_EMBED_DESCRIPTION_LIMIT;
         $firstChunk = $isLongMessage
@@ -307,7 +307,7 @@ class ForwardMessageToDiscordAction
         MessageThread $messageThread,
         string $messageBody,
         int $color,
-        bool $isNewThread = false
+        bool $isNewThread = false,
     ): void {
         $threadWebhookUrl = $webhookUrl . '?thread_id=' . $discordThreadId;
 
@@ -351,7 +351,7 @@ class ForwardMessageToDiscordAction
         MessageThread $messageThread,
         string $messageBody,
         int $color,
-        bool $skipFirstChunk = false
+        bool $skipFirstChunk = false,
     ): void {
         $chunks = mb_str_split($messageBody, self::DISCORD_EMBED_DESCRIPTION_LIMIT);
         $totalParts = count($chunks);
@@ -391,7 +391,7 @@ class ForwardMessageToDiscordAction
         User $userTo,
         MessageThread $messageThread,
         string $messageBody,
-        int $color
+        int $color,
     ): void {
         $payload = $this->buildDiscordPayload(
             $userFrom,
@@ -415,7 +415,7 @@ class ForwardMessageToDiscordAction
         MessageThread $messageThread,
         string $description,
         int $color,
-        bool $includeAuthor = true
+        bool $includeAuthor = true,
     ): array {
         $embed = [
             'description' => $description,
@@ -447,7 +447,7 @@ class ForwardMessageToDiscordAction
         string $discordThreadId,
         User $userFrom,
         MessageThread $messageThread,
-        Message $message
+        Message $message,
     ): void {
         $webhookUrl = $senderInboxConfig['url'];
         $fullBody = Shortcode::stripAndClamp($message->body, self::MESSAGE_BODY_MAX_LENGTH, preserveWhitespace: true);

--- a/app/Community/Actions/LoadThinActivePlayersListAction.php
+++ b/app/Community/Actions/LoadThinActivePlayersListAction.php
@@ -23,7 +23,7 @@ class LoadThinActivePlayersListAction
      */
     public function execute(
         int $lookbackMinutes = 10,
-        int $minimumPermissions = Permissions::Registered
+        int $minimumPermissions = Permissions::Registered,
     ): array {
         return Cache::flexible(
             "all-active-players:{$lookbackMinutes}:{$minimumPermissions}",

--- a/app/Community/Commands/GenerateAnnualRecap.php
+++ b/app/Community/Commands/GenerateAnnualRecap.php
@@ -18,7 +18,7 @@ class GenerateAnnualRecap extends Command
     protected $description = 'Generates an annual summary email for the provided user';
 
     public function __construct(
-        private readonly GenerateAnnualRecapAction $generateAnnualRecapAction
+        private readonly GenerateAnnualRecapAction $generateAnnualRecapAction,
     ) {
         parent::__construct();
     }

--- a/app/Community/Components/UserProfileMeta.php
+++ b/app/Community/Components/UserProfileMeta.php
@@ -206,7 +206,7 @@ class UserProfileMeta extends Component
         array $userMassData,
         array $hardcoreRankMeta,
         array $softcoreRankMeta,
-        array $userJoinedGamesAndAwards
+        array $userJoinedGamesAndAwards,
     ): array {
         $hardcorePoints = $userMassData['TotalPoints'] ?? 0;
         $softcorePoints = $userMassData['TotalSoftcorePoints'] ?? 0;
@@ -303,7 +303,7 @@ class UserProfileMeta extends Component
     private function buildRankMetadata(
         User $user,
         int $rankType = RankType::Hardcore,
-        ?int $predefinedRank = null
+        ?int $predefinedRank = null,
     ): array {
         $rank = $predefinedRank ?? getUserRank($user->User, $rankType);
         $numRankedUsers = countRankedUsers($rankType);

--- a/app/Community/Components/UserProgressionStatus.php
+++ b/app/Community/Components/UserProgressionStatus.php
@@ -118,7 +118,7 @@ class UserProgressionStatus extends Component
         array $consoleProgress,
         array $userRecentlyPlayed,
         array $userCompletionProgress,
-        array $userSiteAwards
+        array $userSiteAwards,
     ): array {
         $validConsoleIds = getValidConsoleIds();
 

--- a/app/Community/Components/UserRecentlyPlayed.php
+++ b/app/Community/Components/UserRecentlyPlayed.php
@@ -257,7 +257,7 @@ class UserRecentlyPlayed extends Component
         array $recentlyPlayedEntity = [],
         array $achievementEntities = [],
         array $awardedEntity = [],
-        array $userAwards = []
+        array $userAwards = [],
     ): array {
         $gameInformation = $this->extractGameInformation($recentlyPlayedEntity);
         $achievementsData = $this->processAchievements($achievementEntities, $awardedEntity);

--- a/app/Community/Controllers/AchievementCommentController.php
+++ b/app/Community/Controllers/AchievementCommentController.php
@@ -67,7 +67,7 @@ class AchievementCommentController extends CommentController
     protected function update(
         StoreCommentRequest $request,
         AchievementComment $comment,
-        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction
+        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction,
     ): RedirectResponse {
         $this->authorize('update', $comment);
 

--- a/app/Community/Controllers/Api/ForumTopicApiController.php
+++ b/app/Community/Controllers/Api/ForumTopicApiController.php
@@ -20,7 +20,7 @@ class ForumTopicApiController extends Controller
     public function store(
         ForumCategory $category,
         Forum $forum,
-        StoreForumTopicRequest $request
+        StoreForumTopicRequest $request,
     ): JsonResponse {
         // The actual user making this API request.
         $requestingUser = $request->user();
@@ -58,7 +58,7 @@ class ForumTopicApiController extends Controller
 
     public function update(
         ForumTopic $topic,
-        UpdateForumTopicRequest $request
+        UpdateForumTopicRequest $request,
     ): JsonResponse {
         $this->authorize('update', $topic);
 
@@ -87,7 +87,7 @@ class ForumTopicApiController extends Controller
 
     public function gate(
         ForumTopic $topic,
-        GateForumTopicRequest $request
+        GateForumTopicRequest $request,
     ): JsonResponse {
         $this->authorize('gate', $topic);
 

--- a/app/Community/Controllers/Api/ForumTopicCommentApiController.php
+++ b/app/Community/Controllers/Api/ForumTopicCommentApiController.php
@@ -16,7 +16,7 @@ class ForumTopicCommentApiController extends Controller
 {
     public function store(
         UpsertForumTopicCommentRequest $request,
-        ForumTopic $topic
+        ForumTopic $topic,
     ): JsonResponse {
         // The actual user making this API request.
         $requestingUser = $request->user();
@@ -52,7 +52,7 @@ class ForumTopicCommentApiController extends Controller
 
     public function update(
         UpsertForumTopicCommentRequest $request,
-        ForumTopicComment $comment
+        ForumTopicComment $comment,
     ): JsonResponse {
         $this->authorize('update', $comment);
 

--- a/app/Community/Controllers/Api/ShortcodeApiController.php
+++ b/app/Community/Controllers/Api/ShortcodeApiController.php
@@ -13,7 +13,7 @@ class ShortcodeApiController extends Controller
 {
     public function preview(
         PreviewShortcodeBodyRequest $request,
-        FetchDynamicShortcodeContentAction $action
+        FetchDynamicShortcodeContentAction $action,
     ): JsonResponse {
         $entities = $action->execute(
             usernames: $request->input('usernames'),

--- a/app/Community/Controllers/Api/UnsubscribeApiController.php
+++ b/app/Community/Controllers/Api/UnsubscribeApiController.php
@@ -12,7 +12,7 @@ use Illuminate\Http\Request;
 class UnsubscribeApiController extends Controller
 {
     public function __construct(
-        private UnsubscribeService $unsubscribeService
+        private UnsubscribeService $unsubscribeService,
     ) {
     }
 

--- a/app/Community/Controllers/CommentController.php
+++ b/app/Community/Controllers/CommentController.php
@@ -13,7 +13,7 @@ class CommentController extends Controller
 {
     public function show(
         Comment $comment,
-        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction
+        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction,
     ): RedirectResponse {
         $this->authorize('view', $comment);
 

--- a/app/Community/Controllers/ForumTopicCommentController.php
+++ b/app/Community/Controllers/ForumTopicCommentController.php
@@ -33,7 +33,7 @@ class ForumTopicCommentController extends CommentController
         ForumTopicCommentRequest $request,
         ForumTopic $topic,
         AddCommentAction $addCommentAction,
-        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction
+        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction,
     ): RedirectResponse {
         $this->authorize('create', [ForumTopicComment::class, $topic]);
 
@@ -69,7 +69,7 @@ class ForumTopicCommentController extends CommentController
     protected function update(
         ForumTopicCommentRequest $request,
         ForumTopicComment $comment,
-        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction
+        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction,
     ): RedirectResponse {
         $this->authorize('update', $comment);
 

--- a/app/Community/Controllers/ForumTopicController.php
+++ b/app/Community/Controllers/ForumTopicController.php
@@ -87,7 +87,7 @@ class ForumTopicController extends Controller
 
     public function recentPosts(
         Request $request,
-        BuildAggregateRecentForumPostsDataAction $buildAggregateRecentPostsData
+        BuildAggregateRecentForumPostsDataAction $buildAggregateRecentPostsData,
     ): InertiaResponse {
         /** @var ?User $user */
         $user = Auth::user();

--- a/app/Community/Controllers/GameCommentController.php
+++ b/app/Community/Controllers/GameCommentController.php
@@ -67,7 +67,7 @@ class GameCommentController extends CommentController
     protected function update(
         StoreCommentRequest $request,
         GameComment $comment,
-        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction
+        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction,
     ): RedirectResponse {
         $this->authorize('update', $comment);
 

--- a/app/Community/Controllers/NewsCommentController.php
+++ b/app/Community/Controllers/NewsCommentController.php
@@ -32,7 +32,7 @@ class NewsCommentController extends CommentController
         StoreCommentRequest $request,
         News $news,
         AddCommentAction $addCommentAction,
-        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction
+        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction,
     ): RedirectResponse {
         $this->authorize('create', [NewsComment::class, $news]);
 
@@ -58,7 +58,7 @@ class NewsCommentController extends CommentController
     protected function update(
         StoreCommentRequest $request,
         NewsComment $comment,
-        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction
+        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction,
     ): RedirectResponse {
         $this->authorize('update', $comment);
 

--- a/app/Community/Controllers/UnsubscribeController.php
+++ b/app/Community/Controllers/UnsubscribeController.php
@@ -14,7 +14,7 @@ use Inertia\Response as InertiaResponse;
 class UnsubscribeController extends Controller
 {
     public function __construct(
-        private UnsubscribeService $unsubscribeService
+        private UnsubscribeService $unsubscribeService,
     ) {
     }
 

--- a/app/Community/Controllers/UserCommentController.php
+++ b/app/Community/Controllers/UserCommentController.php
@@ -77,7 +77,7 @@ class UserCommentController extends CommentController
     protected function update(
         StoreCommentRequest $request,
         UserComment $comment,
-        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction
+        GetUrlToCommentDestinationAction $getUrlToCommentDestinationAction,
     ): RedirectResponse {
         $this->authorize('update', $comment);
 

--- a/app/Community/Data/StoreUsernameChangeData.php
+++ b/app/Community/Data/StoreUsernameChangeData.php
@@ -10,7 +10,7 @@ use Spatie\LaravelData\Data;
 class StoreUsernameChangeData extends Data
 {
     public function __construct(
-        public string $newDisplayName
+        public string $newDisplayName,
     ) {
     }
 

--- a/app/Community/Data/SubscriptionData.php
+++ b/app/Community/Data/SubscriptionData.php
@@ -20,7 +20,7 @@ class SubscriptionData extends Data
         public string $subjectType,
         public int $subjectId,
         public bool $state,
-        public Lazy|UserData $user
+        public Lazy|UserData $user,
     ) {
     }
 

--- a/app/Community/Events/MessageCreated.php
+++ b/app/Community/Events/MessageCreated.php
@@ -17,7 +17,7 @@ class MessageCreated
     use SerializesModels;
 
     public function __construct(
-        public Message $message
+        public Message $message,
     ) {
     }
 

--- a/app/Connect/Actions/BuildClientPatchDataAction.php
+++ b/app/Connect/Actions/BuildClientPatchDataAction.php
@@ -74,7 +74,7 @@ class BuildClientPatchDataAction
     private function buildPatchData(
         Game $game,
         ?User $user,
-        ?AchievementFlag $flag
+        ?AchievementFlag $flag,
     ): array {
         $gamePlayerCount = $this->calculateGamePlayerCount($game, $user);
 

--- a/app/Connect/Actions/BuildClientPatchDataV2Action.php
+++ b/app/Connect/Actions/BuildClientPatchDataV2Action.php
@@ -343,7 +343,7 @@ class BuildClientPatchDataV2Action
      */
     private function determineLoadedHashSetType(
         GameHash $gameHash,
-        Collection $resolvedAchievementSets
+        Collection $resolvedAchievementSets,
     ): AchievementSetType {
         $loadedHashId = $gameHash->game->id;
         $loadedAchievementSetId = null;

--- a/app/Connect/Actions/ResolveAchievementSetsAction.php
+++ b/app/Connect/Actions/ResolveAchievementSetsAction.php
@@ -133,7 +133,7 @@ class ResolveAchievementSetsAction
         GameHash $gameHash,
         User $user,
         Collection $userSetPreferences,
-        GameAchievementSet $initialSet
+        GameAchievementSet $initialSet,
     ): Collection {
         // Determine if the initial set is a subset's "core" set.
         $isSubsetGame = $this->isSubsetGame($initialSet);

--- a/app/Console/Commands/CleanupAvatars.php
+++ b/app/Console/Commands/CleanupAvatars.php
@@ -16,7 +16,7 @@ class CleanupAvatars extends Command
     protected $description = 'Delete rejected avatars';
 
     public function __construct(
-        private DeleteAvatarAction $deleteAvatarAction
+        private DeleteAvatarAction $deleteAvatarAction,
     ) {
         parent::__construct();
     }

--- a/app/Console/Commands/SystemAlert.php
+++ b/app/Console/Commands/SystemAlert.php
@@ -13,7 +13,7 @@ class SystemAlert extends Command
     protected $description = 'Set system alert message';
 
     public function __construct(
-        private Settings $settings
+        private Settings $settings,
     ) {
         parent::__construct();
     }

--- a/app/Events/UserDeleted.php
+++ b/app/Events/UserDeleted.php
@@ -15,7 +15,7 @@ class UserDeleted
     use SerializesModels;
 
     public function __construct(
-        public User $user
+        public User $user,
     ) {
     }
 

--- a/app/Exceptions/ViewRedirect.php
+++ b/app/Exceptions/ViewRedirect.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 class ViewRedirect extends HttpException
 {
     public function __construct(
-        public RedirectResponse $redirect
+        public RedirectResponse $redirect,
     ) {
     }
 }

--- a/app/Helpers/database/achievement.php
+++ b/app/Helpers/database/achievement.php
@@ -27,7 +27,7 @@ function getAchievementsList(
     int $limit,
     int $offset,
     ?AchievementFlag $achievementFlag = null,
-    ?User $developer = null
+    ?User $developer = null,
 ): Collection {
     $bindings = [
         'offset' => $offset,
@@ -217,7 +217,7 @@ function UploadNewAchievement(
     ?int &$idInOut,
     string $badge,
     ?string &$errorOut,
-    ?int $gameAchievementSetID
+    ?int $gameAchievementSetID,
 ): bool {
     if (!$gameAchievementSetID && !$gameID) {
         $errorOut = "You must provide a game ID or a game achievement set ID.";

--- a/app/Helpers/database/forum.php
+++ b/app/Helpers/database/forum.php
@@ -313,7 +313,7 @@ function getRecentForumPosts(
     int $limit,
     int $numMessageChars,
     ?int $permissions = Permissions::Unregistered,
-    ?int $fromAuthorId = null
+    ?int $fromAuthorId = null,
 ): Collection {
     $bindings = [
         'fromOffset' => $offset,

--- a/app/Helpers/database/game.php
+++ b/app/Helpers/database/game.php
@@ -169,7 +169,7 @@ function getGamesListByDev(
     ?int $filter = 0,
     int $offset = 0,
     int $count = 0,
-    ?string $listType = null
+    ?string $listType = null,
 ): int {
     $dataOut = [];
     $numGamesFound = 0;

--- a/app/Helpers/database/leaderboard.php
+++ b/app/Helpers/database/leaderboard.php
@@ -157,7 +157,7 @@ function submitLBData(
     string $lbDescription,
     string $lbFormat,
     bool $lbLowerIsBetter,
-    int $lbDisplayOrder
+    int $lbDisplayOrder,
 ): bool {
     sanitize_sql_inputs($user, $lbMem, $lbTitle, $lbDescription, $lbFormat);
 
@@ -214,7 +214,7 @@ function UploadNewLeaderboard(
     string $mem,
     ?int &$idInOut,
     ?string &$errorOut,
-    ?int $gameAchievementSetID
+    ?int $gameAchievementSetID,
 ): bool {
     if (!$gameAchievementSetID && !$gameID) {
         $errorOut = "You must provide a game ID or a game achievement set ID.";

--- a/app/Helpers/database/player-achievement.php
+++ b/app/Helpers/database/player-achievement.php
@@ -126,7 +126,7 @@ function getAchievementUnlocksData(
     ?int &$numWinnersHardcore,
     ?int &$numPossibleWinners,
     int $offset = 0,
-    int $limit = 50
+    int $limit = 50,
 ): Collection {
 
     $achievement = Achievement::firstWhere('ID', $achievementId);
@@ -231,7 +231,7 @@ function getAchievementDistribution(
     int $isHardcore,
     ?string $requestedBy = null,
     AchievementFlag $flag = AchievementFlag::OfficialCore,
-    int $numPlayers = 0
+    int $numPlayers = 0,
 ): array {
     /** @var Game $game */
     $game = Game::withCount(['achievements' => fn ($query) => $query->flag($flag)])->find($gameID);

--- a/app/Helpers/database/player-history.php
+++ b/app/Helpers/database/player-history.php
@@ -109,7 +109,7 @@ function getAwardedList(
     ?int $offset = null,
     ?int $limit = null,
     ?string $dateFrom = null,
-    ?string $dateTo = null
+    ?string $dateTo = null,
 ): array {
     $retVal = [];
 

--- a/app/Helpers/database/search.php
+++ b/app/Helpers/database/search.php
@@ -24,7 +24,7 @@ function performSearch(
     int $count,
     int $permissions,
     ?array &$searchResultsOut,
-    bool $wantTotalResults = true
+    bool $wantTotalResults = true,
 ): int {
     sanitize_sql_inputs($searchQuery, $offset, $count);
 

--- a/app/Helpers/database/set-claim.php
+++ b/app/Helpers/database/set-claim.php
@@ -142,7 +142,7 @@ function getFilteredClaims(
     bool $getExpiringOnly = false,
     ?string $username = null,
     ?int $offset = null,
-    ?int $limit = null
+    ?int $limit = null,
 ): Collection {
     $primaryClaim = ($claimFilter & ClaimFilters::PrimaryClaim);
     $collaborationClaim = ($claimFilter & ClaimFilters::CollaborationClaim);

--- a/app/Helpers/database/ticket.php
+++ b/app/Helpers/database/ticket.php
@@ -26,7 +26,7 @@ function submitNewTicketsJSON(
     string $idsCSV,
     int $reportType,
     string $noteIn,
-    string $RAHash
+    string $RAHash,
 ): array {
     sanitize_sql_inputs($userSubmitter, $reportType, $noteIn, $RAHash);
 

--- a/app/Helpers/database/user-activity.php
+++ b/app/Helpers/database/user-activity.php
@@ -112,7 +112,7 @@ function getArticleComments(
     int $offset,
     int $count,
     ?array &$dataOut,
-    bool $recent = false
+    bool $recent = false,
 ): int {
     $dataOut = [];
     $numArticleComments = 0;
@@ -152,7 +152,7 @@ function getRecentArticleComments(
     int $articleTypeID,
     int $articleID,
     ?array &$dataOut,
-    int $count = 20
+    int $count = 20,
 ): int {
     $numArticleComments = getArticleComments($articleTypeID, $articleID, 0, $count, $dataOut, true);
 

--- a/app/Helpers/database/user-auth.php
+++ b/app/Helpers/database/user-auth.php
@@ -166,7 +166,7 @@ function authenticateFromCookie(
     ?string &$userOut,
     ?int &$permissionsOut,
     ?array &$userDetailsOut = null,
-    ?int $minPermissions = null
+    ?int $minPermissions = null,
 ): bool {
     $userOut = null;
     $permissionsOut = Permissions::Unregistered;
@@ -211,7 +211,7 @@ function authenticateFromCookie(
 function authenticateFromAppToken(
     ?string &$userOut,
     string $token,
-    ?int &$permissionOut
+    ?int &$permissionOut,
 ): bool {
     if (empty($userOut)) {
         return false;

--- a/app/Helpers/database/user-permission.php
+++ b/app/Helpers/database/user-permission.php
@@ -22,7 +22,7 @@ function SetAccountPermissionsJSON(
     string $actingUsername,
     int $actingUserPermissions,
     string $targetUsername,
-    int $targetUserNewPermissions
+    int $targetUserNewPermissions,
 ): array {
     $retVal = [];
 

--- a/app/Helpers/formatters.php
+++ b/app/Helpers/formatters.php
@@ -10,7 +10,7 @@ if (!function_exists('localized_date')) {
         ?string $locale = null,
         int $dateType = IntlDateFormatter::SHORT,
         int $timeType = IntlDateFormatter::SHORT,
-        ?string $timezone = 'UTC'
+        ?string $timezone = 'UTC',
     ): string {
         $dateTime ??= Carbon::now();
         $locale ??= session('date_locale');
@@ -31,7 +31,7 @@ if (!function_exists('localized_number')) {
         ?string $locale = null,
         int $format = NumberFormatter::DECIMAL,
         int $fractionDigits = 0,
-        ?string $pattern = null
+        ?string $pattern = null,
     ): string {
         $locale = $locale ?? session('number_locale', 'en_US');
 

--- a/app/Helpers/render/game.php
+++ b/app/Helpers/render/game.php
@@ -386,7 +386,7 @@ function calculateBuckets(
     bool $isDynamicBucketingEnabled,
     int $numAchievements,
     array $softcoreUnlocks,
-    array $hardcoreUnlocks
+    array $hardcoreUnlocks,
 ): array {
     $largestWonByCount = 0;
 

--- a/app/Helpers/render/ranking.php
+++ b/app/Helpers/render/ranking.php
@@ -50,7 +50,7 @@ function getGlobalRankingData(
     int $untracked = 0,
     int $offset = 0,
     int $count = 50,
-    int $info = 0
+    int $info = 0,
 ): array {
     $pointRequirement = "";
 

--- a/app/Helpers/translation.php
+++ b/app/Helpers/translation.php
@@ -10,7 +10,7 @@ if (!function_exists('__choice')) {
         string $key,
         Countable|int|array $number = 2,
         array $replace = [],
-        ?string $locale = null
+        ?string $locale = null,
     ): string {
         return trans_choice($key, $number, $replace, $locale);
     }

--- a/app/Helpers/util/database.php
+++ b/app/Helpers/util/database.php
@@ -118,7 +118,7 @@ function applyFoundRows(Builder $query): Builder
     return match (DB::getDriverName()) {
         'sqlite' => $query,
         // mysql
-        default => $query->selectRaw('SQL_CALC_FOUND_ROWS *')
+        default => $query->selectRaw('SQL_CALC_FOUND_ROWS *'),
     };
 }
 
@@ -136,7 +136,7 @@ function ifStatement(string $condition, mixed $trueValue, mixed $falseValue): st
     return match (DB::getDriverName()) {
         'sqlite' => "IIF($condition, $trueValue, $falseValue)",
         // mysql
-        default => "IF($condition, $trueValue, $falseValue)"
+        default => "IF($condition, $trueValue, $falseValue)",
     };
 }
 

--- a/app/Helpers/util/mail.php
+++ b/app/Helpers/util/mail.php
@@ -168,7 +168,7 @@ function informAllSubscribersAboutActivity(
     int $articleID,
     User $activityAuthor,
     int $commentID,
-    ?string $onBehalfOfUser = null
+    ?string $onBehalfOfUser = null,
 ): void {
     $subscribers = [];
     $subjectAuthor = null;

--- a/app/Helpers/util/media.php
+++ b/app/Helpers/util/media.php
@@ -52,7 +52,7 @@ function createImageFromExtension(array $file): GdImage
         'png' => imagecreatefrompng($file['tmp_name']),
         'jpg', 'jpeg' => imagecreatefromjpeg($file['tmp_name']),
         'gif' => imagecreatefromgif($file['tmp_name']),
-        default => null
+        default => null,
     };
     if (!$image) {
         throw new Exception('Cannot create image');

--- a/app/Helpers/util/recaptcha.php
+++ b/app/Helpers/util/recaptcha.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This is a PHP library that handles calling reCAPTCHA.
  *    - Documentation and latest version

--- a/app/Http/Controllers/Api/UserApiController.php
+++ b/app/Http/Controllers/Api/UserApiController.php
@@ -12,7 +12,7 @@ use Illuminate\Http\JsonResponse;
 class UserApiController extends Controller
 {
     public function updateForumPostPermissions(
-        UpdateForumPostPermissionsRequest $request
+        UpdateForumPostPermissionsRequest $request,
     ): JsonResponse {
         $this->authorize('manage', User::class);
 

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -15,7 +15,7 @@ class RedirectIfAuthenticated
     /**
      * Handle an incoming request.
      *
-     * @param  Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next, string ...$guards): Response
     {

--- a/app/Mail/CommunityActivityMail.php
+++ b/app/Mail/CommunityActivityMail.php
@@ -107,7 +107,7 @@ class CommunityActivityMail extends Mailable
         int $articleType,
         string $articleTitle,
         string $toUserDisplayName,
-        bool $isThreadInvolved
+        bool $isThreadInvolved,
     ): string {
         $activityDescription = $isThreadInvolved ? "a thread you've commented in" : "your latest activity";
 

--- a/app/Mail/DisplayNameChangeConfirmedMail.php
+++ b/app/Mail/DisplayNameChangeConfirmedMail.php
@@ -20,7 +20,7 @@ class DisplayNameChangeConfirmedMail extends Mailable
      */
     public function __construct(
         public User $user,
-        public string $newDisplayName
+        public string $newDisplayName,
     ) {
     }
 

--- a/app/Mail/DisplayNameChangeDeclinedMail.php
+++ b/app/Mail/DisplayNameChangeDeclinedMail.php
@@ -20,7 +20,7 @@ class DisplayNameChangeDeclinedMail extends Mailable
      */
     public function __construct(
         public User $user,
-        public string $desiredDisplayName
+        public string $desiredDisplayName,
     ) {
     }
 

--- a/app/Mail/ExpiringClaimMail.php
+++ b/app/Mail/ExpiringClaimMail.php
@@ -19,7 +19,7 @@ class ExpiringClaimMail extends Mailable
      * Create a new message instance.
      */
     public function __construct(
-        public AchievementSetClaim $claim
+        public AchievementSetClaim $claim,
     ) {
     }
 

--- a/app/Models/ApiLogEntry.php
+++ b/app/Models/ApiLogEntry.php
@@ -64,7 +64,7 @@ class ApiLogEntry extends Model
         string $ipAddress,
         ?string $userAgent,
         ?array $requestData = null,
-        ?string $errorMessage = null
+        ?string $errorMessage = null,
     ): self {
         return self::create([
             'api_version' => $apiVersion,

--- a/app/Platform/Actions/AssociateAchievementSetToGameAction.php
+++ b/app/Platform/Actions/AssociateAchievementSetToGameAction.php
@@ -45,7 +45,7 @@ class AssociateAchievementSetToGameAction
         Game $game,
         AchievementSet $achievementSet,
         AchievementSetType $type,
-        string $title
+        string $title,
     ): void {
         $game->achievementSets()->attach($achievementSet->id, [
             'type' => $type->value,

--- a/app/Platform/Actions/BuildGameListAction.php
+++ b/app/Platform/Actions/BuildGameListAction.php
@@ -227,7 +227,7 @@ class BuildGameListAction
         GameListType $listType,
         ?User $user,
         Collection $playerGames,
-        Collection $backlogGames
+        Collection $backlogGames,
     ): array {
         return $entries->map(function (Game $game) use ($listType, $user, $playerGames, $backlogGames): GameListEntryData {
             $playerGame = $playerGames->get($game->id);

--- a/app/Platform/Actions/BuildGameShowPagePropsAction.php
+++ b/app/Platform/Actions/BuildGameShowPagePropsAction.php
@@ -64,7 +64,7 @@ class BuildGameShowPagePropsAction
         ?User $user,
         AchievementFlag $targetAchievementFlag = AchievementFlag::OfficialCore,
         ?GameAchievementSet $targetAchievementSet = null,
-        GamePageListView $initialView = GamePageListView::Achievements
+        GamePageListView $initialView = GamePageListView::Achievements,
     ): GameShowPagePropsData {
         // The backing game is the legacy game that backs the target achievement set.
         // For core sets, this will be $game->id. For subsets, it'll be a different ID.

--- a/app/Platform/Actions/BuildHubBreadcrumbsAction.php
+++ b/app/Platform/Actions/BuildHubBreadcrumbsAction.php
@@ -307,7 +307,7 @@ class BuildHubBreadcrumbsAction
         string $currentType,
         string $mappedType,
         array &$visited,
-        array &$remainingPath
+        array &$remainingPath,
     ): void {
         // Detect if this is a nested Misc. hub by counting title parts.
         $titleParts = explode(' - ', trim($currentGameSet->title, '[]'));
@@ -364,7 +364,7 @@ class BuildHubBreadcrumbsAction
         string $currentType,
         string $mappedType,
         array &$visited,
-        array &$remainingPath
+        array &$remainingPath,
     ): void {
         while (isset(self::HUB_HIERARCHY[$currentType])) {
             $parentType = self::HUB_HIERARCHY[$currentType];
@@ -515,7 +515,7 @@ class BuildHubBreadcrumbsAction
         string $currentType,
         string $parentType,
         array $visited,
-        string $mappedType
+        string $mappedType,
     ): ?GameSet {
         if ($parentType === 'Central') {
             $parent = $gameSet->parents()

--- a/app/Platform/Actions/ComputeGameSearchTitlesAction.php
+++ b/app/Platform/Actions/ComputeGameSearchTitlesAction.php
@@ -26,7 +26,7 @@ class ComputeGameSearchTitlesAction
         string $gameTitle,
         string $systemName,
         string $systemNameShort,
-        array $altTitles = []
+        array $altTitles = [],
     ): array {
         $searchTitles = [];
 
@@ -254,7 +254,7 @@ class ComputeGameSearchTitlesAction
         string $gameTitle,
         array $altTitles,
         string $systemName,
-        string $systemNameShort
+        string $systemNameShort,
     ): array {
         $variations = [];
 
@@ -283,7 +283,7 @@ class ComputeGameSearchTitlesAction
     private function handleNumericSuffixAbbreviations(
         string $title,
         array $seriesAbbreviationMap,
-        array &$abbreviations
+        array &$abbreviations,
     ): void {
         if (!preg_match('/^(.+?)\s+(\d+)$/', $title, $matches)) {
             return;

--- a/app/Platform/Actions/Concerns/CalculatesPlayerPointsStats.php
+++ b/app/Platform/Actions/Concerns/CalculatesPlayerPointsStats.php
@@ -104,7 +104,7 @@ trait CalculatesPlayerPointsStats
         int $userId,
         array $hardcorePoints,
         array $softcorePoints,
-        string $period
+        string $period,
     ): array {
         $stats = [];
         $statTypes = static::PERIOD_MAP[$period];

--- a/app/Platform/Actions/IncrementDeveloperContributionYieldAction.php
+++ b/app/Platform/Actions/IncrementDeveloperContributionYieldAction.php
@@ -23,7 +23,7 @@ class IncrementDeveloperContributionYieldAction
         Achievement $achievement,
         PlayerAchievement $playerAchievement,
         bool $isUnlock = true,
-        bool $isHardcore = false
+        bool $isHardcore = false,
     ): void {
         // If we somehow made it here for an unofficial achievement, bail.
         if (!$achievement->is_published) {

--- a/app/Platform/Actions/LogGameReleaseActivityAction.php
+++ b/app/Platform/Actions/LogGameReleaseActivityAction.php
@@ -16,7 +16,7 @@ class LogGameReleaseActivityAction
         string $operation,
         GameRelease $gameRelease,
         array $original = [],
-        array $changes = []
+        array $changes = [],
     ): void {
         match ($operation) {
             'create' => $this->logCreate($gameRelease),

--- a/app/Platform/Actions/UpdatePlayerBeatenGamesStatsAction.php
+++ b/app/Platform/Actions/UpdatePlayerBeatenGamesStatsAction.php
@@ -203,7 +203,7 @@ class UpdatePlayerBeatenGamesStatsAction
         int $value,
         ?int $systemId,
         ?int $lastGameId,
-        ?string $statUpdatedAt
+        ?string $statUpdatedAt,
     ): void {
         PlayerStat::updateOrCreate(
             [

--- a/app/Platform/Commands/UpdateGameAchievementsMetrics.php
+++ b/app/Platform/Commands/UpdateGameAchievementsMetrics.php
@@ -15,7 +15,7 @@ class UpdateGameAchievementsMetrics extends Command
     protected $description = "Update game(s) metrics";
 
     public function __construct(
-        private readonly UpdateGameAchievementsMetricsAction $updateGameAchievementsMetrics
+        private readonly UpdateGameAchievementsMetricsAction $updateGameAchievementsMetrics,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdateGameBeatenMetrics.php
+++ b/app/Platform/Commands/UpdateGameBeatenMetrics.php
@@ -16,7 +16,7 @@ class UpdateGameBeatenMetrics extends Command
     protected $description = "Update beaten metrics for all games or a comma-separated list of game IDs";
 
     public function __construct(
-        private readonly UpdateGameBeatenMetricsAction $updateGameBeatenMetrics
+        private readonly UpdateGameBeatenMetricsAction $updateGameBeatenMetrics,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdateGameMetrics.php
+++ b/app/Platform/Commands/UpdateGameMetrics.php
@@ -16,7 +16,7 @@ class UpdateGameMetrics extends Command
     protected $description = "Update game metrics for all games or a comma-separated list of game IDs";
 
     public function __construct(
-        private readonly UpdateGameMetricsAction $updateGameMetrics
+        private readonly UpdateGameMetricsAction $updateGameMetrics,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdateGamePlayerCount.php
+++ b/app/Platform/Commands/UpdateGamePlayerCount.php
@@ -15,7 +15,7 @@ class UpdateGamePlayerCount extends Command
     protected $description = "Update player count metrics for all games or a comma-separated list of game IDs";
 
     public function __construct(
-        private readonly UpdateGamePlayerCountAction $updateGamePlayerCount
+        private readonly UpdateGamePlayerCountAction $updateGamePlayerCount,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdateGamePlayerGames.php
+++ b/app/Platform/Commands/UpdateGamePlayerGames.php
@@ -15,7 +15,7 @@ class UpdateGamePlayerGames extends Command
     protected $description = "Update game(s) outdated player game metrics";
 
     public function __construct(
-        private readonly UpdateGamePlayerGamesAction $updateGamePlayerGames
+        private readonly UpdateGamePlayerGamesAction $updateGamePlayerGames,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdatePlayerBeatenGamesStats.php
+++ b/app/Platform/Commands/UpdatePlayerBeatenGamesStats.php
@@ -18,7 +18,7 @@ class UpdatePlayerBeatenGamesStats extends Command
     protected $description = 'Update player beaten games stats';
 
     public function __construct(
-        private readonly UpdatePlayerBeatenGamesStatsAction $updatePlayerBeatenGamesStats
+        private readonly UpdatePlayerBeatenGamesStatsAction $updatePlayerBeatenGamesStats,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdatePlayerGameMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerGameMetrics.php
@@ -19,7 +19,7 @@ class UpdatePlayerGameMetrics extends Command
 
     public function __construct(
         private readonly UpdatePlayerGameMetricsAction $updatePlayerGameMetrics,
-        private readonly UpdatePlayerMetricsAction $updatePlayerMetrics
+        private readonly UpdatePlayerMetricsAction $updatePlayerMetrics,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdatePlayerMetrics.php
+++ b/app/Platform/Commands/UpdatePlayerMetrics.php
@@ -15,7 +15,7 @@ class UpdatePlayerMetrics extends Command
     protected $description = 'Update player metrics';
 
     public function __construct(
-        private readonly UpdatePlayerMetricsAction $updatePlayerMetrics
+        private readonly UpdatePlayerMetricsAction $updatePlayerMetrics,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdatePlayerPointsStats.php
+++ b/app/Platform/Commands/UpdatePlayerPointsStats.php
@@ -22,7 +22,7 @@ class UpdatePlayerPointsStats extends Command
     protected $description = 'Update player points stats';
 
     public function __construct(
-        private readonly UpdatePlayerPointsStatsAction $updatePlayerPointsStats
+        private readonly UpdatePlayerPointsStatsAction $updatePlayerPointsStats,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdateSearchIndexForQueuedEntities.php
+++ b/app/Platform/Commands/UpdateSearchIndexForQueuedEntities.php
@@ -15,7 +15,7 @@ class UpdateSearchIndexForQueuedEntities extends Command
     protected $description = 'Update Scout search index for queued entities';
 
     public function __construct(
-        protected readonly SearchIndexingService $searchIndexingService
+        protected readonly SearchIndexingService $searchIndexingService,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Commands/UpdateTotalGamesCount.php
+++ b/app/Platform/Commands/UpdateTotalGamesCount.php
@@ -13,7 +13,7 @@ class UpdateTotalGamesCount extends Command
     protected $description = 'Update the tracked count of total unique games';
 
     public function __construct(
-        private readonly UpdateTotalGamesCountAction $updateTotalGamesCount
+        private readonly UpdateTotalGamesCountAction $updateTotalGamesCount,
     ) {
         parent::__construct();
     }

--- a/app/Platform/Controllers/EmulatorReleaseController.php
+++ b/app/Platform/Controllers/EmulatorReleaseController.php
@@ -57,7 +57,7 @@ class EmulatorReleaseController extends Controller
         EmulatorReleaseRequest $request,
         Emulator $emulator,
         AddMediaAction $addFileToCollectionAction,
-        LinkLatestEmulatorReleaseAction $linkLatestReleaseAction
+        LinkLatestEmulatorReleaseAction $linkLatestReleaseAction,
     ): RedirectResponse {
         $this->authorize('create', $this->resourceClass());
 
@@ -95,7 +95,7 @@ class EmulatorReleaseController extends Controller
         EmulatorReleaseRequest $request,
         EmulatorRelease $release,
         AddMediaAction $addFileToCollectionAction,
-        LinkLatestEmulatorReleaseAction $linkLatestReleaseAction
+        LinkLatestEmulatorReleaseAction $linkLatestReleaseAction,
     ): RedirectResponse {
         $this->authorize('update', $release);
 
@@ -115,7 +115,7 @@ class EmulatorReleaseController extends Controller
 
     public function destroy(
         EmulatorRelease $release,
-        LinkLatestEmulatorReleaseAction $linkLatestReleaseAction
+        LinkLatestEmulatorReleaseAction $linkLatestReleaseAction,
     ): RedirectResponse {
         $this->authorize('delete', $release);
 

--- a/app/Platform/Controllers/GameController.php
+++ b/app/Platform/Controllers/GameController.php
@@ -89,7 +89,7 @@ class GameController extends Controller
         Request $request,
         Game $game,
         LoadGameWithRelationsAction $loadGameWithRelationsAction,
-        BuildGameShowPagePropsAction $buildGameShowPagePropsAction
+        BuildGameShowPagePropsAction $buildGameShowPagePropsAction,
     ): InertiaResponse|RedirectResponse {
         $this->authorize('view', $game);
 

--- a/app/Platform/Controllers/IntegrationReleaseController.php
+++ b/app/Platform/Controllers/IntegrationReleaseController.php
@@ -47,7 +47,7 @@ class IntegrationReleaseController extends Controller
     public function store(
         IntegrationReleaseRequest $request,
         AddMediaAction $addMediaAction,
-        LinkLatestIntegrationReleaseAction $linkLatestReleaseAction
+        LinkLatestIntegrationReleaseAction $linkLatestReleaseAction,
     ): RedirectResponse {
         $this->authorize('create', $this->resourceClass());
 
@@ -82,7 +82,7 @@ class IntegrationReleaseController extends Controller
         IntegrationReleaseRequest $request,
         IntegrationRelease $release,
         AddMediaAction $addMediaAction,
-        LinkLatestIntegrationReleaseAction $linkLatestReleaseAction
+        LinkLatestIntegrationReleaseAction $linkLatestReleaseAction,
     ): RedirectResponse {
         $this->authorize('update', $release);
 
@@ -100,7 +100,7 @@ class IntegrationReleaseController extends Controller
 
     public function destroy(
         IntegrationRelease $release,
-        LinkLatestIntegrationReleaseAction $linkLatestReleaseAction
+        LinkLatestIntegrationReleaseAction $linkLatestReleaseAction,
     ): RedirectResponse {
         $this->authorize('delete', $release);
 

--- a/app/Platform/Controllers/PlayerGameController.php
+++ b/app/Platform/Controllers/PlayerGameController.php
@@ -109,7 +109,7 @@ class PlayerGameController extends Controller
     public function activity(
         User $user,
         Game $game,
-        BuildPlayerGameActivityDataAction $buildPlayerGameActivityData
+        BuildPlayerGameActivityDataAction $buildPlayerGameActivityData,
     ): InertiaResponse {
         $playerGame = $user->playerGames()->whereGameId($game->id)->first();
         // TODO rename to viewSessionHistory

--- a/app/Platform/Data/AchievementSetClaimData.php
+++ b/app/Platform/Data/AchievementSetClaimData.php
@@ -38,7 +38,7 @@ class AchievementSetClaimData extends Data
     public static function fromAchievementSetClaim(
         AchievementSetClaim $claim,
         bool $isValidConsole = false,
-        bool $hasOfficialAchievements = false
+        bool $hasOfficialAchievements = false,
     ): self {
         $now = Carbon::now();
         $minutesLeft = (int) $now->diffInMinutes($claim->Finished, false);

--- a/app/Platform/Data/GameHashLabelData.php
+++ b/app/Platform/Data/GameHashLabelData.php
@@ -13,7 +13,7 @@ class GameHashLabelData extends Data
 {
     public function __construct(
         public string $label,
-        public ?string $imgSrc
+        public ?string $imgSrc,
     ) {
     }
 

--- a/app/Platform/Data/GameRecentPlayerData.php
+++ b/app/Platform/Data/GameRecentPlayerData.php
@@ -37,7 +37,7 @@ class GameRecentPlayerData extends Data
     public static function fromGameRecentPlayer(
         GameRecentPlayer $gameRecentPlayer,
         ?PlayerGame $playerGame = null,
-        ?PlayerBadge $highestAward = null
+        ?PlayerBadge $highestAward = null,
     ): self {
         $achievementsUnlocked = $playerGame?->achievements_unlocked ?? 0;
         $achievementsUnlockedHardcore = $playerGame?->achievements_unlocked_hardcore ?? 0;

--- a/app/Platform/Data/UserCreditsData.php
+++ b/app/Platform/Data/UserCreditsData.php
@@ -26,7 +26,7 @@ class UserCreditsData extends Data
     public static function fromUserWithCount(
         User $user,
         int $count,
-        ?Carbon $dateCredited = null
+        ?Carbon $dateCredited = null,
     ): self {
         $userData = UserData::fromUser($user)->include('displayName', 'avatarUrl');
 

--- a/app/Platform/Events/AchievementCreated.php
+++ b/app/Platform/Events/AchievementCreated.php
@@ -17,7 +17,7 @@ class AchievementCreated
     use SerializesModels;
 
     public function __construct(
-        public Achievement $achievement
+        public Achievement $achievement,
     ) {
     }
 

--- a/app/Platform/Events/AchievementPublished.php
+++ b/app/Platform/Events/AchievementPublished.php
@@ -17,7 +17,7 @@ class AchievementPublished
     use SerializesModels;
 
     public function __construct(
-        public Achievement $achievement
+        public Achievement $achievement,
     ) {
     }
 

--- a/app/Platform/Events/AchievementUnpublished.php
+++ b/app/Platform/Events/AchievementUnpublished.php
@@ -17,7 +17,7 @@ class AchievementUnpublished
     use SerializesModels;
 
     public function __construct(
-        public Achievement $achievement
+        public Achievement $achievement,
     ) {
     }
 

--- a/app/Platform/Events/PlayerSessionResumed.php
+++ b/app/Platform/Events/PlayerSessionResumed.php
@@ -20,7 +20,7 @@ class PlayerSessionResumed
     public function __construct(
         public User $user,
         public Game $game,
-        public ?string $message = null
+        public ?string $message = null,
     ) {
     }
 

--- a/app/Platform/Events/PlayerSessionStarted.php
+++ b/app/Platform/Events/PlayerSessionStarted.php
@@ -20,7 +20,7 @@ class PlayerSessionStarted
     public function __construct(
         public User $user,
         public Game $game,
-        public ?string $message = null
+        public ?string $message = null,
     ) {
     }
 

--- a/app/Platform/Services/BeatenGamesLeaderboardService.php
+++ b/app/Platform/Services/BeatenGamesLeaderboardService.php
@@ -263,7 +263,7 @@ class BeatenGamesLeaderboardService
     private function getUserRankingData(
         int $userId,
         array $gameKindFilterOptions,
-        ?int $targetSystemId = null
+        ?int $targetSystemId = null,
     ): ?array {
         $query = $this->buildAggregatedLeaderboardQuery($gameKindFilterOptions, $targetSystemId);
 

--- a/app/Platform/Services/GameSuggestions/GameSuggestionEngine.php
+++ b/app/Platform/Services/GameSuggestions/GameSuggestionEngine.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Collection;
 
 class GameSuggestionEngine
 {
-    /** @var array<array{0: Strategies\GameSuggestionStrategy, 1: int}> */
+    /** @var array<array{0: GameSuggestionStrategy, 1: int}> */
     private array $strategies;
 
     public function __construct(

--- a/app/Platform/Services/GameSuggestions/Strategies/WantToPlayStrategy.php
+++ b/app/Platform/Services/GameSuggestions/Strategies/WantToPlayStrategy.php
@@ -14,7 +14,7 @@ use App\Platform\Enums\GameSuggestionReason;
 class WantToPlayStrategy implements GameSuggestionStrategy
 {
     public function __construct(
-        private readonly User $user
+        private readonly User $user,
     ) {
     }
 

--- a/app/Platform/Services/PlayerCompletionProgressPageService.php
+++ b/app/Platform/Services/PlayerCompletionProgressPageService.php
@@ -15,7 +15,7 @@ class PlayerCompletionProgressPageService
     private int $pageSize = 100;
 
     public function __construct(
-        protected PlayerProgressionService $playerProgressionService
+        protected PlayerProgressionService $playerProgressionService,
     ) {
     }
 

--- a/app/Platform/Services/PlayerGameActivityService.php
+++ b/app/Platform/Services/PlayerGameActivityService.php
@@ -248,7 +248,7 @@ class PlayerGameActivityService
         Carbon $when,
         PlayerGameActivitySessionType $sessionType,
         string $description,
-        string $header = ''
+        string $header = '',
     ): void {
         $event = [
             'type' => PlayerGameActivityEventType::Custom,

--- a/app/Platform/Services/TicketViewService.php
+++ b/app/Platform/Services/TicketViewService.php
@@ -22,7 +22,7 @@ class TicketViewService
     public string $ticketNotes = '';
 
     public function __construct(
-        protected PlayerGameActivityService $activity = new PlayerGameActivityService()
+        protected PlayerGameActivityService $activity = new PlayerGameActivityService(),
     ) {
 
     }

--- a/app/Support/Cache/CacheKey.php
+++ b/app/Support/Cache/CacheKey.php
@@ -72,7 +72,7 @@ class CacheKey
         string $entityKind,
         string|int $identifier,
         string $keyKind,
-        array $params = []
+        array $params = [],
     ): string {
         $cacheKey = "$entityKind:$identifier:$keyKind";
         if (count($params) > 0) {

--- a/app/Support/MediaLibrary/PathGenerator.php
+++ b/app/Support/MediaLibrary/PathGenerator.php
@@ -10,7 +10,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 class PathGenerator implements \Spatie\MediaLibrary\Support\PathGenerator\PathGenerator
 {
     public function __construct(
-        private Optimus $optimus
+        private Optimus $optimus,
     ) {
     }
 

--- a/app/Support/Shortcode/Shortcode.php
+++ b/app/Support/Shortcode/Shortcode.php
@@ -131,7 +131,7 @@ final class Shortcode
     public static function stripAndClamp(
         string $input,
         int $previewLength = 100,
-        bool $preserveWhitespace = false
+        bool $preserveWhitespace = false,
     ): string {
         // Inject game and achievement data for shortcodes.
         // This is more desirable than showing "Game 123" or "Achievement 123".

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "larastan/larastan": "^2.7",
         "laravel-json-api/testing": "^3.1",
         "laravel/pail": "^1.2",
-        "laravel/pint": "^1.5",
+        "laravel/pint": "^1.25",
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc48f7036a47086b5a8750c3ea085fb1",
+    "content-hash": "ad6e2eca02fb85457c253ffaa15abf98",
     "packages": [
         {
             "name": "amphp/amp",
@@ -16600,16 +16600,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.17.2",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "e8a88130a25e3f9d4d5785e6a1afca98268ab110"
+                "reference": "595de38458c6b0ab4cae4bcc769c2e5c5d5b8e96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/e8a88130a25e3f9d4d5785e6a1afca98268ab110",
-                "reference": "e8a88130a25e3f9d4d5785e6a1afca98268ab110",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/595de38458c6b0ab4cae4bcc769c2e5c5d5b8e96",
+                "reference": "595de38458c6b0ab4cae4bcc769c2e5c5d5b8e96",
                 "shasum": ""
             },
             "require": {
@@ -16617,16 +16617,16 @@
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": "^8.1.0"
+                "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.61.1",
-                "illuminate/view": "^10.48.18",
-                "larastan/larastan": "^2.9.8",
-                "laravel-zero/framework": "^10.4.0",
+                "friendsofphp/php-cs-fixer": "^3.87.2",
+                "illuminate/view": "^11.46.0",
+                "larastan/larastan": "^3.7.1",
+                "laravel-zero/framework": "^11.45.0",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^1.15.1",
-                "pestphp/pest": "^2.35.0"
+                "nunomaduro/termwind": "^2.3.1",
+                "pestphp/pest": "^2.36.0"
             },
             "bin": [
                 "builds/pint"
@@ -16662,7 +16662,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2024-08-06T15:11:54+00:00"
+            "time": "2025-09-17T01:36:44+00:00"
         },
         {
             "name": "laravel/sail",

--- a/database/migrations/2025_07_28_000000_update_player_games_table.php
+++ b/database/migrations/2025_07_28_000000_update_player_games_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         Schema::table('player_games', function (Blueprint $table) {

--- a/database/migrations/2025_07_30_000000_create_api_logs_table.php
+++ b/database/migrations/2025_07_30_000000_create_api_logs_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         Schema::create('api_logs', function (Blueprint $table) {

--- a/database/migrations/2025_08_16_000000_update_forum_topic_comments_table.php
+++ b/database/migrations/2025_08_16_000000_update_forum_topic_comments_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         Schema::table('forum_topic_comments', function (Blueprint $table) {

--- a/database/migrations/2025_08_17_000000_create_discord_message_thread_mappings_table.php
+++ b/database/migrations/2025_08_17_000000_create_discord_message_thread_mappings_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         Schema::create('discord_message_thread_mappings', function (Blueprint $table) {

--- a/database/migrations/upcoming/2018_10_01_000001_create_badges_table.php
+++ b/database/migrations/upcoming/2018_10_01_000001_create_badges_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         /*

--- a/database/migrations/upcoming/2018_10_04_000001_create_user_badges_table.php
+++ b/database/migrations/upcoming/2018_10_04_000001_create_user_badges_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         /*

--- a/database/migrations/upcoming/2018_10_04_000001_create_user_triggers_table.php
+++ b/database/migrations/upcoming/2018_10_04_000001_create_user_triggers_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         /*

--- a/database/migrations/upcoming/2018_10_05_000001_create_events_table.php
+++ b/database/migrations/upcoming/2018_10_05_000001_create_events_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         Schema::create('events', function (Blueprint $table) {

--- a/database/migrations/upcoming/2023_05_01_000001_rename_tables.php
+++ b/database/migrations/upcoming/2023_05_01_000001_rename_tables.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         // TODO update metabase

--- a/database/migrations/upcoming/2023_05_01_000002_add_foreign_keys.php
+++ b/database/migrations/upcoming/2023_05_01_000002_add_foreign_keys.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         Schema::table('LeaderboardEntry', function (Blueprint $table) {

--- a/database/migrations/upcoming/2023_05_12_000000_utf8mb4.php
+++ b/database/migrations/upcoming/2023_05_12_000000_utf8mb4.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 
-return new class() extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         $this->migrateCharsetTo('utf8mb4', 'utf8mb4_unicode_ci');

--- a/tests/Feature/Community/Actions/ForwardMessageToDiscordActionTest.php
+++ b/tests/Feature/Community/Actions/ForwardMessageToDiscordActionTest.php
@@ -73,7 +73,7 @@ class ForwardMessageToDiscordActionTest extends TestCase
         bool $isForum = false,
         ?string $verifyUrl = null,
         ?string $achievementIssuesUrl = null,
-        ?string $manualUnlockUrl = null
+        ?string $manualUnlockUrl = null,
     ): void {
         config([
             'services.discord.inbox_webhook.' . $user->username => [

--- a/tests/Feature/Connect/Actions/BuildClientPatchDataV2ActionTest.php
+++ b/tests/Feature/Connect/Actions/BuildClientPatchDataV2ActionTest.php
@@ -90,7 +90,7 @@ class BuildClientPatchDataV2ActionTest extends TestCase
         array $achievementData,
         Achievement $achievement,
         float $expectedRarity,
-        float $expectedRarityHardcore
+        float $expectedRarityHardcore,
     ): void {
         $this->assertEquals($achievement->id, $achievementData['ID']);
         $this->assertEquals($achievement->title, $achievementData['Title']);

--- a/tests/Feature/Connect/Actions/ResolveAchievementSetsActionTest.php
+++ b/tests/Feature/Connect/Actions/ResolveAchievementSetsActionTest.php
@@ -49,7 +49,7 @@ class ResolveAchievementSetsActionTest extends TestCase
         System $system,
         string $title,
         int $publishedCount,
-        int $unpublishedCount = 0
+        int $unpublishedCount = 0,
     ): Game {
         $game = Game::factory()->create(['Title' => $title, 'ConsoleID' => $system->id]);
         Achievement::factory()->published()->count($publishedCount)->create(['GameID' => $game->id]);
@@ -66,7 +66,7 @@ class ResolveAchievementSetsActionTest extends TestCase
         AchievementSetType $type,
         int $gameId,
         int $publishedAchievementCount,
-        int $unpublishedAchievementCount
+        int $unpublishedAchievementCount,
     ): void {
         $this->assertEquals($type, $set->type);
         $this->assertEquals($gameId, $set->game_id);
@@ -89,7 +89,7 @@ class ResolveAchievementSetsActionTest extends TestCase
      */
     private function assertContainsAchievementSetType(
         Collection $sets,
-        AchievementSetType $type
+        AchievementSetType $type,
     ): void {
         $contains = $sets->contains(fn ($set) => $set->type === $type);
         $this->assertTrue($contains);
@@ -102,7 +102,7 @@ class ResolveAchievementSetsActionTest extends TestCase
      */
     private function assertNotContainsAchievementSetType(
         Collection $sets,
-        AchievementSetType $type
+        AchievementSetType $type,
     ): void {
         $contains = $sets->contains(fn ($set) => $set->type === $type);
         $this->assertFalse($contains);

--- a/tests/Feature/Mail/Services/UnsubscribeServiceTest.php
+++ b/tests/Feature/Mail/Services/UnsubscribeServiceTest.php
@@ -52,7 +52,7 @@ class UnsubscribeServiceTest extends TestCase
         int $userId,
         SubscriptionSubjectType $subjectType,
         int $subjectId,
-        bool $state
+        bool $state,
     ): void {
         $subscription = Subscription::where('user_id', $userId)
             ->where('subject_type', $subjectType)
@@ -69,7 +69,7 @@ class UnsubscribeServiceTest extends TestCase
     private function assertSubscriptionDoesNotExist(
         int $userId,
         SubscriptionSubjectType $subjectType,
-        int $subjectId
+        int $subjectId,
     ): void {
         $exists = Subscription::where('user_id', $userId)
             ->where('subject_type', $subjectType)

--- a/tests/Feature/Platform/Actions/UpdatePlayerBeatenGamesStatsActionTest.php
+++ b/tests/Feature/Platform/Actions/UpdatePlayerBeatenGamesStatsActionTest.php
@@ -249,7 +249,7 @@ class UpdatePlayerBeatenGamesStatsActionTest extends TestCase
         int $gameId,
         ?int $systemId,
         Carbon $expectedDate,
-        bool $isOverall = false
+        bool $isOverall = false,
     ): void {
         $query = $playerStats->where('last_game_id', $gameId);
         $query = $isOverall ? $query->whereNull('system_id') : $query->where('system_id', $systemId);

--- a/tests/Feature/Platform/Concerns/TestsPlayerBadges.php
+++ b/tests/Feature/Platform/Concerns/TestsPlayerBadges.php
@@ -18,7 +18,7 @@ trait TestsPlayerBadges
         int $type,
         int $id,
         int $extra = 0,
-        ?Carbon $awardTime = null
+        ?Carbon $awardTime = null,
     ): void {
         if ($awardTime === null) {
             $awardTime = Carbon::now();
@@ -45,7 +45,7 @@ trait TestsPlayerBadges
         User $user,
         Game $game,
         int $mode = UnlockMode::Hardcore,
-        ?Carbon $awardTime = null
+        ?Carbon $awardTime = null,
     ): void {
         $this->addPlayerBadge($user, AwardType::GameBeaten, $game->ID, $mode, $awardTime);
     }
@@ -83,7 +83,7 @@ trait TestsPlayerBadges
         User $user,
         Game $game,
         int $mode = UnlockMode::Hardcore,
-        ?Carbon $awardTime = null
+        ?Carbon $awardTime = null,
     ): void {
         $this->addPlayerBadge($user, AwardType::Mastery, $game->ID, $mode, $awardTime);
     }

--- a/tests/Feature/Support/Routing/HasSelfHealingUrlsTest.php
+++ b/tests/Feature/Support/Routing/HasSelfHealingUrlsTest.php
@@ -21,7 +21,7 @@ class HasSelfHealingUrlsTest extends TestCase
         parent::setUp();
 
         // Create a test model that uses the trait.
-        $this->testModel = new class() extends Model {
+        $this->testModel = new class extends Model {
             use HasSelfHealingUrls;
 
             protected $table = 'test_models';
@@ -65,7 +65,7 @@ class HasSelfHealingUrlsTest extends TestCase
     public function testItGeneratesSlugFromCustomField(): void
     {
         // Arrange
-        $model = new class() extends Model {
+        $model = new class extends Model {
             use HasSelfHealingUrls;
 
             protected $table = 'test_models';


### PR DESCRIPTION
This PR bumps `laravel/pint` from 1.17.2 to 1.25 (latest). No functional changes.

Pint has some new formatting rules in latest which generate a lot of noise. This is an incremental step in upgrading to Laravel 12.