### PR TITLE
fix(SetSelectionTabs): don't pop tooltips on mobile taps

### DIFF
--- a/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSetsContainer.test.tsx
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSetsContainer.test.tsx
@@ -7,6 +7,7 @@ import {
   createAggregateAchievementSetCredits,
   createGame,
   createGameAchievementSet,
+  createZiggyProps,
 } from '@/test/factories';
 
 import { GameAchievementSetsContainer } from './GameAchievementSetsContainer';
@@ -14,7 +15,11 @@ import { GameAchievementSetsContainer } from './GameAchievementSetsContainer';
 describe('Component: GameAchievementSetsContainer', () => {
   it('renders without crashing', () => {
     // ARRANGE
-    const { container } = render(<GameAchievementSetsContainer game={createGame()} />);
+    const { container } = render(<GameAchievementSetsContainer game={createGame()} />, {
+      pageProps: {
+        ziggy: createZiggyProps(),
+      },
+    });
 
     // ASSERT
     expect(container).toBeTruthy();
@@ -26,7 +31,11 @@ describe('Component: GameAchievementSetsContainer', () => {
       gameAchievementSets: [],
     });
 
-    render(<GameAchievementSetsContainer game={game} />);
+    render(<GameAchievementSetsContainer game={game} />, {
+      pageProps: {
+        ziggy: createZiggyProps(),
+      },
+    });
 
     // ASSERT
     expect(screen.getByText(/aren't any achievements/i)).toBeVisible();
@@ -50,6 +59,7 @@ describe('Component: GameAchievementSetsContainer', () => {
         backingGame: game,
         selectableGameAchievementSets: [],
         targetAchievementSetId: 123,
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -73,6 +83,7 @@ describe('Component: GameAchievementSetsContainer', () => {
         aggregateCredits: createAggregateAchievementSetCredits(),
         backingGame: game,
         selectableGameAchievementSets: [],
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -99,6 +110,7 @@ describe('Component: GameAchievementSetsContainer', () => {
         backingGame: game,
         targetAchievementSetId: 123,
         selectableGameAchievementSets: [],
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -133,6 +145,7 @@ describe('Component: GameAchievementSetsContainer', () => {
           createGameAchievementSet({ title: 'Bonus Set' }),
         ],
         targetAchievementSetId: 123,
+        ziggy: createZiggyProps(),
       },
     });
 

--- a/resources/js/features/games/components/GameAchievementSetsContainer/SetSelectionTabs/SetSelectionTabs.test.tsx
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/SetSelectionTabs/SetSelectionTabs.test.tsx
@@ -2,9 +2,16 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events -- doesn't matter in a test suite */
 
 import userEvent from '@testing-library/user-event';
+import { route } from 'ziggy-js';
 
+import { currentListViewAtom } from '@/features/games/state/games.atoms';
 import { render, screen } from '@/test';
-import { createAchievementSet, createGame, createGameAchievementSet } from '@/test/factories';
+import {
+  createAchievementSet,
+  createGame,
+  createGameAchievementSet,
+  createZiggyProps,
+} from '@/test/factories';
 
 import { SetSelectionTabs } from './SetSelectionTabs';
 
@@ -34,6 +41,7 @@ describe('Component: SetSelectionTabs', () => {
       pageProps: {
         game,
         selectableGameAchievementSets,
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -49,6 +57,7 @@ describe('Component: SetSelectionTabs', () => {
       pageProps: {
         game,
         selectableGameAchievementSets: [],
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -72,11 +81,11 @@ describe('Component: SetSelectionTabs', () => {
       createGameAchievementSet({ title: 'Bonus Set', achievementSet: achievementSet2 }),
     ];
 
-    // ACT
     render(<SetSelectionTabs activeTab={null} />, {
       pageProps: {
         game,
         selectableGameAchievementSets,
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -94,11 +103,11 @@ describe('Component: SetSelectionTabs', () => {
     const game = createGame();
     const selectableGameAchievementSets = [createGameAchievementSet({ title: null })];
 
-    // ACT
     render(<SetSelectionTabs activeTab={null} />, {
       pageProps: {
         game,
         selectableGameAchievementSets,
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -119,12 +128,12 @@ describe('Component: SetSelectionTabs', () => {
       createGameAchievementSet({ achievementSet: achievementSet3, title: 'Set 3' }),
     ];
 
-    // ACT
     render(<SetSelectionTabs activeTab={200} />, {
       // !! activeTab matches second achievement set's ID
       pageProps: {
         game,
         selectableGameAchievementSets,
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -149,6 +158,7 @@ describe('Component: SetSelectionTabs', () => {
       pageProps: {
         game,
         selectableGameAchievementSets,
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -167,6 +177,7 @@ describe('Component: SetSelectionTabs', () => {
       pageProps: {
         game,
         selectableGameAchievementSets,
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -188,6 +199,7 @@ describe('Component: SetSelectionTabs', () => {
       pageProps: {
         game,
         selectableGameAchievementSets,
+        ziggy: createZiggyProps(),
       },
     });
 
@@ -197,5 +209,61 @@ describe('Component: SetSelectionTabs', () => {
 
     // ASSERT
     expect(container).toBeTruthy();
+  });
+
+  it('given the device is mobile, does not display any tooltips', async () => {
+    // ARRANGE
+    const game = createGame();
+    const achievementSet1 = createAchievementSet({ id: 10 });
+    const achievementSet2 = createAchievementSet({ id: 20 });
+    const selectableGameAchievementSets = [
+      createGameAchievementSet({ achievementSet: achievementSet1, title: 'Set 1' }),
+      createGameAchievementSet({ achievementSet: achievementSet2, title: 'Set 2' }),
+    ];
+
+    render(<SetSelectionTabs activeTab={10} />, {
+      pageProps: {
+        game,
+        selectableGameAchievementSets,
+        ziggy: createZiggyProps({ device: 'mobile' }),
+      },
+    });
+
+    // ACT
+    await userEvent.hover(screen.getByRole('link', { name: /set 1/i }));
+
+    // ASSERT
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('given the user is viewing leaderboards, respects that in the hrefs', async () => {
+    // ARRANGE
+    const game = createGame({ id: 123 });
+    const achievementSet1 = createAchievementSet({ id: 10 });
+    const achievementSet2 = createAchievementSet({ id: 20 });
+    const selectableGameAchievementSets = [
+      createGameAchievementSet({ achievementSet: achievementSet1, title: 'Set 1', type: 'core' }),
+      createGameAchievementSet({ achievementSet: achievementSet2, title: 'Set 2', type: 'bonus' }),
+    ];
+
+    render(<SetSelectionTabs activeTab={10} />, {
+      pageProps: {
+        game,
+        selectableGameAchievementSets,
+        ziggy: createZiggyProps(),
+      },
+      jotaiAtoms: [
+        [currentListViewAtom, 'leaderboards'], // !!
+        //
+      ],
+    });
+
+    // ASSERT
+    expect(route).toHaveBeenCalledWith(
+      'game2.show',
+      expect.objectContaining({
+        view: 'leaderboards',
+      }),
+    );
   });
 });

--- a/resources/js/features/games/components/GameAchievementSetsContainer/SetSelectionTabs/SetSelectionTabs.tsx
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/SetSelectionTabs/SetSelectionTabs.tsx
@@ -17,7 +17,7 @@ interface SetSelectionTabsProps {
 }
 
 export const SetSelectionTabs: FC<SetSelectionTabsProps> = ({ activeTab }) => {
-  const { game, selectableGameAchievementSets } =
+  const { game, selectableGameAchievementSets, ziggy } =
     usePageProps<App.Platform.Data.GameShowPageProps>();
 
   const currentListView = useAtomValue(currentListViewAtom);
@@ -47,7 +47,7 @@ export const SetSelectionTabs: FC<SetSelectionTabsProps> = ({ activeTab }) => {
       {/* Tabs */}
       <div className="relative flex items-center space-x-[6px]">
         {selectableGameAchievementSets.map((gas, index) => (
-          <BaseTooltip key={gas.id}>
+          <BaseTooltip key={gas.id} open={ziggy.device === 'mobile' ? false : undefined}>
             <BaseTooltipTrigger>
               <InertiaLink
                 href={route('game2.show', {


### PR DESCRIPTION
This PR fixes a bug on mobile React game pages.

The set selection tabs are currently popping tooltips on navigation taps:

https://github.com/user-attachments/assets/4b47f10a-b224-4aec-b57d-e1a516def03d


This is desirable on desktop, but undesirable on mobile.