### PR TITLE
chore: bump to phpstan 2, add baseline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,9 +73,9 @@
         "barryvdh/laravel-debugbar": "^3.13.5",
         "barryvdh/laravel-ide-helper": "^3.1",
         "brianium/paratest": "^7.2",
-        "driftingly/rector-laravel": "^0.26.0",
+        "driftingly/rector-laravel": "^2.0",
         "fakerphp/faker": "^1.23",
-        "larastan/larastan": "^2.7",
+        "larastan/larastan": "^3.0",
         "laravel-json-api/testing": "^3.1",
         "laravel/pail": "^1.2",
         "laravel/pint": "^1.25",
@@ -84,7 +84,7 @@
         "nunomaduro/collision": "^8.1",
         "phpunit/phpunit": "^10.5",
         "predis/predis": "^2.0",
-        "rector/rector": "^0.18.1",
+        "rector/rector": "^2.0",
         "spatie/laravel-ignition": "^2.4",
         "worksome/envy": "^1.1"
     },
@@ -149,6 +149,7 @@
             "@php -r \"file_exists('storage/app/settings.json') || copy('storage/app/settings.dist.json', 'storage/app/settings.json');\""
         ],
         "stan": "@php vendor/bin/phpstan analyse --memory-limit 768M --ansi",
+        "stan-baseline": "@php vendor/bin/phpstan analyse --generate-baseline --memory-limit 1G",
         "stan-clear": "@php vendor/bin/phpstan clear-result-cache",
         "start": "@php artisan serve --port=64000",
         "test": "@php artisan test --env=testing",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad6e2eca02fb85457c253ffaa15abf98",
+    "content-hash": "5c63621966399633fb4649acd41f70ec",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1289,25 +1289,25 @@
         },
         {
             "name": "brick/math",
-            "version": "0.12.3",
+            "version": "0.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba"
+                "reference": "113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/866551da34e9a618e64a819ee1e01c20d8a588ba",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba",
+                "url": "https://api.github.com/repos/brick/math/zipball/113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2",
+                "reference": "113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.2"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^10.1",
-                "vimeo/psalm": "6.8.8"
+                "phpstan/phpstan": "2.1.22",
+                "phpunit/phpunit": "^11.5"
             },
             "type": "library",
             "autoload": {
@@ -1337,7 +1337,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.12.3"
+                "source": "https://github.com/brick/math/tree/0.14.0"
             },
             "funding": [
                 {
@@ -1345,7 +1345,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-28T13:11:00+00:00"
+            "time": "2025-08-29T12:40:03+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -3368,22 +3368,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.3",
+            "version": "7.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
-                "guzzlehttp/psr7": "^2.7.0",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -3474,7 +3474,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
             },
             "funding": [
                 {
@@ -3490,20 +3490,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:37:11+00:00"
+            "time": "2025-08-23T22:36:01+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
                 "shasum": ""
             },
             "require": {
@@ -3511,7 +3511,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "type": "library",
             "extra": {
@@ -3557,7 +3557,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.2.0"
+                "source": "https://github.com/guzzle/promises/tree/2.3.0"
             },
             "funding": [
                 {
@@ -3573,20 +3573,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:27:01+00:00"
+            "time": "2025-08-22T14:34:08+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
+                "reference": "21dc724a0583619cd1652f673303492272778051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
+                "reference": "21dc724a0583619cd1652f673303492272778051",
                 "shasum": ""
             },
             "require": {
@@ -3602,7 +3602,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -3673,7 +3673,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
             },
             "funding": [
                 {
@@ -3689,20 +3689,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T12:30:47+00:00"
+            "time": "2025-08-23T21:21:41+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.4",
+            "version": "v1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "30e286560c137526eccd4ce21b2de477ab0676d2"
+                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/30e286560c137526eccd4ce21b2de477ab0676d2",
-                "reference": "30e286560c137526eccd4ce21b2de477ab0676d2",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
                 "shasum": ""
             },
             "require": {
@@ -3711,7 +3711,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.36 || ^9.6.15",
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -3759,7 +3759,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.4"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
             },
             "funding": [
                 {
@@ -3775,7 +3775,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-03T10:55:03+00:00"
+            "time": "2025-08-22T14:27:06+00:00"
         },
         {
             "name": "http-interop/http-factory-guzzle",
@@ -5124,20 +5124,20 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v11.45.2",
+            "version": "v11.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "d134bf11e2208c0c5bd488cf19e612ca176b820a"
+                "reference": "2c6d85f22d08123ad45aa3a6726b16f06e68eecd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/d134bf11e2208c0c5bd488cf19e612ca176b820a",
-                "reference": "d134bf11e2208c0c5bd488cf19e612ca176b820a",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/2c6d85f22d08123ad45aa3a6726b16f06e68eecd",
+                "reference": "2c6d85f22d08123ad45aa3a6726b16f06e68eecd",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12",
+                "brick/math": "^0.9.3|^0.10.2|^0.11|^0.12|^0.13|^0.14",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
@@ -5241,7 +5241,7 @@
                 "league/flysystem-read-only": "^3.25.1",
                 "league/flysystem-sftp-v3": "^3.25.1",
                 "mockery/mockery": "^1.6.10",
-                "orchestra/testbench-core": "^9.16.0",
+                "orchestra/testbench-core": "^9.16.1",
                 "pda/pheanstalk": "^5.0.6",
                 "php-http/discovery": "^1.15",
                 "phpstan/phpstan": "^2.0",
@@ -5335,7 +5335,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-08-13T20:28:00+00:00"
+            "time": "2025-09-08T21:54:34+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -7656,16 +7656,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.10.2",
+            "version": "3.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "76b5c07b8a9d2025ed1610e14cef1f3fd6ad2c24"
+                "reference": "8e3643dcd149ae0fe1d2ff4f2c8e4bbfad7c165f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/76b5c07b8a9d2025ed1610e14cef1f3fd6ad2c24",
-                "reference": "76b5c07b8a9d2025ed1610e14cef1f3fd6ad2c24",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/8e3643dcd149ae0fe1d2ff4f2c8e4bbfad7c165f",
+                "reference": "8e3643dcd149ae0fe1d2ff4f2c8e4bbfad7c165f",
                 "shasum": ""
             },
             "require": {
@@ -7683,13 +7683,13 @@
             "require-dev": {
                 "doctrine/dbal": "^3.6.3 || ^4.0",
                 "doctrine/orm": "^2.15.2 || ^3.0",
-                "friendsofphp/php-cs-fixer": "^3.75.0",
+                "friendsofphp/php-cs-fixer": "^v3.87.1",
                 "kylekatarnls/multi-tester": "^2.5.3",
                 "phpmd/phpmd": "^2.15.0",
                 "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^2.1.17",
-                "phpunit/phpunit": "^10.5.46",
-                "squizlabs/php_codesniffer": "^3.13.0"
+                "phpstan/phpstan": "^2.1.22",
+                "phpunit/phpunit": "^10.5.53",
+                "squizlabs/php_codesniffer": "^3.13.4"
             },
             "bin": [
                 "bin/carbon"
@@ -7757,7 +7757,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-02T09:36:06+00:00"
+            "time": "2025-09-06T13:39:36+00:00"
         },
         {
             "name": "nette/schema",
@@ -8867,16 +8867,16 @@
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.9.3",
+            "version": "1.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54"
+                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/e3fac8b24f56113f7cb96af14958c0dd16330f54",
-                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
                 "shasum": ""
             },
             "require": {
@@ -8884,7 +8884,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25 || ^10.5.53 || ^11.5.34"
             },
             "type": "library",
             "extra": {
@@ -8926,7 +8926,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.3"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.4"
             },
             "funding": [
                 {
@@ -8938,7 +8938,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:41:07+00:00"
+            "time": "2025-08-21T11:53:16+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -9811,20 +9811,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.9.0",
+            "version": "4.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "4e0e23cc785f0724a0e838279a9eb03f28b092a0"
+                "reference": "81f941f6f729b1e3ceea61d9d014f8b6c6800440"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/4e0e23cc785f0724a0e838279a9eb03f28b092a0",
-                "reference": "4e0e23cc785f0724a0e838279a9eb03f28b092a0",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/81f941f6f729b1e3ceea61d9d014f8b6c6800440",
+                "reference": "81f941f6f729b1e3ceea61d9d014f8b6c6800440",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -9883,9 +9883,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.9.0"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.1"
             },
-            "time": "2025-06-25T14:20:11+00:00"
+            "time": "2025-09-04T20:59:21+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -12496,16 +12496,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5f360ebc65c55265a74d23d7fe27f957870158a1"
+                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5f360ebc65c55265a74d23d7fe27f957870158a1",
-                "reference": "5f360ebc65c55265a74d23d7fe27f957870158a1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
+                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
                 "shasum": ""
             },
             "require": {
@@ -12570,7 +12570,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.2"
+                "source": "https://github.com/symfony/console/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -12590,7 +12590,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-30T17:13:41+00:00"
+            "time": "2025-08-25T06:35:40+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -12807,16 +12807,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.3.0",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d"
+                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/497f73ac996a598c92409b44ac43b6690c4f666d",
-                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b7dc69e71de420ac04bc9ab830cf3ffebba48191",
+                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191",
                 "shasum": ""
             },
             "require": {
@@ -12867,7 +12867,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -12879,11 +12879,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-22T09:11:45+00:00"
+            "time": "2025-08-13T11:49:31+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -13166,16 +13170,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "6877c122b3a6cc3695849622720054f6e6fa5fa6"
+                "reference": "7475561ec27020196c49bb7c4f178d33d7d3dc00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6877c122b3a6cc3695849622720054f6e6fa5fa6",
-                "reference": "6877c122b3a6cc3695849622720054f6e6fa5fa6",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/7475561ec27020196c49bb7c4f178d33d7d3dc00",
+                "reference": "7475561ec27020196c49bb7c4f178d33d7d3dc00",
                 "shasum": ""
             },
             "require": {
@@ -13225,7 +13229,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.3.2"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -13245,20 +13249,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:47:49+00:00"
+            "time": "2025-08-20T08:04:18+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "6ecc895559ec0097e221ed2fd5eb44d5fede083c"
+                "reference": "72c304de37e1a1cec6d5d12b81187ebd4850a17b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/6ecc895559ec0097e221ed2fd5eb44d5fede083c",
-                "reference": "6ecc895559ec0097e221ed2fd5eb44d5fede083c",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/72c304de37e1a1cec6d5d12b81187ebd4850a17b",
+                "reference": "72c304de37e1a1cec6d5d12b81187ebd4850a17b",
                 "shasum": ""
             },
             "require": {
@@ -13343,7 +13347,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.3.2"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -13363,20 +13367,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-31T10:45:04+00:00"
+            "time": "2025-08-29T08:23:45+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "d43e84d9522345f96ad6283d5dfccc8c1cfc299b"
+                "reference": "a32f3f45f1990db8c4341d5122a7d3a381c7e575"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/d43e84d9522345f96ad6283d5dfccc8c1cfc299b",
-                "reference": "d43e84d9522345f96ad6283d5dfccc8c1cfc299b",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/a32f3f45f1990db8c4341d5122a7d3a381c7e575",
+                "reference": "a32f3f45f1990db8c4341d5122a7d3a381c7e575",
                 "shasum": ""
             },
             "require": {
@@ -13427,7 +13431,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.3.2"
+                "source": "https://github.com/symfony/mailer/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -13447,7 +13451,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:36:08+00:00"
+            "time": "2025-08-13T11:49:31+00:00"
         },
         {
             "name": "symfony/mime",
@@ -14275,16 +14279,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.3.0",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af"
+                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
-                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
+                "url": "https://api.github.com/repos/symfony/process/zipball/32241012d521e2e8a9d713adb0812bb773b907f1",
+                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1",
                 "shasum": ""
             },
             "require": {
@@ -14316,7 +14320,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.3.0"
+                "source": "https://github.com/symfony/process/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -14328,11 +14332,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-17T09:11:12+00:00"
+            "time": "2025-08-18T09:42:54+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -14587,16 +14595,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "42f505aff654e62ac7ac2ce21033818297ca89ca"
+                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/42f505aff654e62ac7ac2ce21033818297ca89ca",
-                "reference": "42f505aff654e62ac7ac2ce21033818297ca89ca",
+                "url": "https://api.github.com/repos/symfony/string/zipball/17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
+                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
                 "shasum": ""
             },
             "require": {
@@ -14654,7 +14662,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.2"
+                "source": "https://github.com/symfony/string/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -14674,20 +14682,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:47:49+00:00"
+            "time": "2025-08-25T06:35:40+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "81b48f4daa96272efcce9c7a6c4b58e629df3c90"
+                "reference": "e0837b4cbcef63c754d89a4806575cada743a38d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/81b48f4daa96272efcce9c7a6c4b58e629df3c90",
-                "reference": "81b48f4daa96272efcce9c7a6c4b58e629df3c90",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/e0837b4cbcef63c754d89a4806575cada743a38d",
+                "reference": "e0837b4cbcef63c754d89a4806575cada743a38d",
                 "shasum": ""
             },
             "require": {
@@ -14754,7 +14762,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.3.2"
+                "source": "https://github.com/symfony/translation/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -14774,7 +14782,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-30T17:31:46+00:00"
+            "time": "2025-08-01T21:02:37+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -14930,16 +14938,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "53205bea27450dc5c65377518b3275e126d45e75"
+                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/53205bea27450dc5c65377518b3275e126d45e75",
-                "reference": "53205bea27450dc5c65377518b3275e126d45e75",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
+                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
                 "shasum": ""
             },
             "require": {
@@ -14993,7 +15001,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.2"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -15013,7 +15021,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-29T20:02:46+00:00"
+            "time": "2025-08-13T11:49:31+00:00"
         },
         {
             "name": "thunderer/shortcode",
@@ -16075,20 +16083,21 @@
         },
         {
             "name": "driftingly/rector-laravel",
-            "version": "0.26.2",
+            "version": "2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/driftingly/rector-laravel.git",
-                "reference": "cf6d0a7c8e2dc33b6e2bb8ccb4638f44a5c09671"
+                "reference": "625dc02cee08d47ecf0ac86de2f02a55026cf34e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/driftingly/rector-laravel/zipball/cf6d0a7c8e2dc33b6e2bb8ccb4638f44a5c09671",
-                "reference": "cf6d0a7c8e2dc33b6e2bb8ccb4638f44a5c09671",
+                "url": "https://api.github.com/repos/driftingly/rector-laravel/zipball/625dc02cee08d47ecf0ac86de2f02a55026cf34e",
+                "reference": "625dc02cee08d47ecf0ac86de2f02a55026cf34e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0",
+                "rector/rector": "^2.0"
             },
             "type": "rector-extension",
             "autoload": {
@@ -16103,9 +16112,9 @@
             "description": "Rector upgrades rules for Laravel Framework",
             "support": {
                 "issues": "https://github.com/driftingly/rector-laravel/issues",
-                "source": "https://github.com/driftingly/rector-laravel/tree/0.26.2"
+                "source": "https://github.com/driftingly/rector-laravel/tree/2.0.7"
             },
-            "time": "2023-10-11T21:42:53+00:00"
+            "time": "2025-08-19T20:49:47+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -16354,51 +16363,95 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
-            "name": "larastan/larastan",
-            "version": "v2.9.8",
+            "name": "iamcal/sql-parser",
+            "version": "v0.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/larastan/larastan.git",
-                "reference": "340badd89b0eb5bddbc503a4829c08cf9a2819d7"
+                "url": "https://github.com/iamcal/SQLParser.git",
+                "reference": "947083e2dca211a6f12fb1beb67a01e387de9b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/340badd89b0eb5bddbc503a4829c08cf9a2819d7",
-                "reference": "340badd89b0eb5bddbc503a4829c08cf9a2819d7",
+                "url": "https://api.github.com/repos/iamcal/SQLParser/zipball/947083e2dca211a6f12fb1beb67a01e387de9b62",
+                "reference": "947083e2dca211a6f12fb1beb67a01e387de9b62",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.0",
+                "phpunit/phpunit": "^5|^6|^7|^8|^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "iamcal\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cal Henderson",
+                    "email": "cal@iamcal.com"
+                }
+            ],
+            "description": "MySQL schema parser",
+            "support": {
+                "issues": "https://github.com/iamcal/SQLParser/issues",
+                "source": "https://github.com/iamcal/SQLParser/tree/v0.6"
+            },
+            "time": "2025-03-17T16:59:46+00:00"
+        },
+        {
+            "name": "larastan/larastan",
+            "version": "v3.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "a761859a7487bd7d0cb8b662a7538a234d5bb5ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/a761859a7487bd7d0cb8b662a7538a234d5bb5ae",
+                "reference": "a761859a7487bd7d0cb8b662a7538a234d5bb5ae",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "illuminate/console": "^9.52.16 || ^10.28.0 || ^11.0",
-                "illuminate/container": "^9.52.16 || ^10.28.0 || ^11.0",
-                "illuminate/contracts": "^9.52.16 || ^10.28.0 || ^11.0",
-                "illuminate/database": "^9.52.16 || ^10.28.0 || ^11.0",
-                "illuminate/http": "^9.52.16 || ^10.28.0 || ^11.0",
-                "illuminate/pipeline": "^9.52.16 || ^10.28.0 || ^11.0",
-                "illuminate/support": "^9.52.16 || ^10.28.0 || ^11.0",
-                "php": "^8.0.2",
-                "phpmyadmin/sql-parser": "^5.9.0",
-                "phpstan/phpstan": "^1.11.2"
+                "iamcal/sql-parser": "^0.6.0",
+                "illuminate/console": "^11.44.2 || ^12.4.1",
+                "illuminate/container": "^11.44.2 || ^12.4.1",
+                "illuminate/contracts": "^11.44.2 || ^12.4.1",
+                "illuminate/database": "^11.44.2 || ^12.4.1",
+                "illuminate/http": "^11.44.2 || ^12.4.1",
+                "illuminate/pipeline": "^11.44.2 || ^12.4.1",
+                "illuminate/support": "^11.44.2 || ^12.4.1",
+                "php": "^8.2",
+                "phpstan/phpstan": "^2.1.28"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^12.0",
-                "nikic/php-parser": "^4.19.1",
-                "orchestra/canvas": "^7.11.1 || ^8.11.0 || ^9.0.2",
-                "orchestra/testbench": "^7.33.0 || ^8.13.0 || ^9.0.3",
-                "phpunit/phpunit": "^9.6.13 || ^10.5.16"
+                "doctrine/coding-standard": "^13",
+                "laravel/framework": "^11.44.2 || ^12.7.2",
+                "mockery/mockery": "^1.6.12",
+                "nikic/php-parser": "^5.4",
+                "orchestra/canvas": "^v9.2.2 || ^10.0.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15"
             },
             "suggest": {
                 "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
             },
             "type": "phpstan-extension",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                },
                 "phpstan": {
                     "includes": [
                         "extension.neon"
                     ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -16414,13 +16467,9 @@
                 {
                     "name": "Can Vural",
                     "email": "can9119@gmail.com"
-                },
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
                 }
             ],
-            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan wrapper for Laravel",
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
             "keywords": [
                 "PHPStan",
                 "code analyse",
@@ -16433,27 +16482,15 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v2.9.8"
+                "source": "https://github.com/larastan/larastan/tree/v3.7.2"
             },
             "funding": [
                 {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
                     "url": "https://github.com/canvural",
                     "type": "github"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
                 }
             ],
-            "time": "2024-07-06T17:46:02+00:00"
+            "time": "2025-09-19T09:03:05+00:00"
         },
         {
             "name": "laravel-json-api/testing",
@@ -17154,108 +17191,21 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpmyadmin/sql-parser",
-            "version": "5.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpmyadmin/sql-parser.git",
-                "reference": "91d980ab76c3f152481e367f62b921adc38af451"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/91d980ab76c3f152481e367f62b921adc38af451",
-                "reference": "91d980ab76c3f152481e367f62b921adc38af451",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-mbstring": "^1.3",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "conflict": {
-                "phpmyadmin/motranslator": "<3.0"
-            },
-            "require-dev": {
-                "phpbench/phpbench": "^1.1",
-                "phpmyadmin/coding-standard": "^3.0",
-                "phpmyadmin/motranslator": "^4.0 || ^5.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.9.12",
-                "phpstan/phpstan-phpunit": "^1.3.3",
-                "phpunit/phpunit": "^8.5 || ^9.6",
-                "psalm/plugin-phpunit": "^0.16.1",
-                "vimeo/psalm": "^4.11",
-                "zumba/json-serializer": "~3.0.2"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance",
-                "phpmyadmin/motranslator": "Translate messages to your favorite locale"
-            },
-            "bin": [
-                "bin/highlight-query",
-                "bin/lint-query",
-                "bin/sql-parser",
-                "bin/tokenize-query"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PhpMyAdmin\\SqlParser\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "The phpMyAdmin Team",
-                    "email": "developers@phpmyadmin.net",
-                    "homepage": "https://www.phpmyadmin.net/team/"
-                }
-            ],
-            "description": "A validating SQL lexer and parser with a focus on MySQL dialect.",
-            "homepage": "https://github.com/phpmyadmin/sql-parser",
-            "keywords": [
-                "analysis",
-                "lexer",
-                "parser",
-                "query linter",
-                "sql",
-                "sql lexer",
-                "sql linter",
-                "sql parser",
-                "sql syntax highlighter",
-                "sql tokenizer"
-            ],
-            "support": {
-                "issues": "https://github.com/phpmyadmin/sql-parser/issues",
-                "source": "https://github.com/phpmyadmin/sql-parser"
-            },
-            "funding": [
-                {
-                    "url": "https://www.phpmyadmin.net/donate/",
-                    "type": "other"
-                }
-            ],
-            "time": "2024-08-29T20:56:34+00:00"
-        },
-        {
             "name": "phpstan/phpstan",
-            "version": "1.12.0",
+            "version": "2.1.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1"
+                "reference": "578fa296a166605d97b94091f724f1257185d278"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/384af967d35b2162f69526c7276acadce534d0e1",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578fa296a166605d97b94091f724f1257185d278",
+                "reference": "578fa296a166605d97b94091f724f1257185d278",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -17296,7 +17246,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-27T09:18:05+00:00"
+            "time": "2025-09-19T08:58:49+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -17783,27 +17733,30 @@
         },
         {
             "name": "rector/rector",
-            "version": "0.18.13",
+            "version": "2.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "f8011a76d36aa4f839f60f3b4f97707d97176618"
+                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/f8011a76d36aa4f839f60f3b4f97707d97176618",
-                "reference": "f8011a76d36aa4f839f60f3b4f97707d97176618",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/c34cc07c4698f007a20dc5c99ff820089ae413ce",
+                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.10.35"
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.18"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
                 "rector/rector-downgrade-php": "*",
                 "rector/rector-phpunit": "*",
                 "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
             },
             "bin": [
                 "bin/rector"
@@ -17819,6 +17772,7 @@
                 "MIT"
             ],
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
             "keywords": [
                 "automation",
                 "dev",
@@ -17827,7 +17781,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.18.13"
+                "source": "https://github.com/rectorphp/rector/tree/2.1.7"
             },
             "funding": [
                 {
@@ -17835,7 +17789,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-20T16:08:01+00:00"
+            "time": "2025-09-10T11:13:58+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,3007 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\LeaderboardEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\LeaderboardEntry, ''ld\.author_id'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Community/Actions/BuildDeveloperFeedDataAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''Achievements\.Flags'' given\.$#'
+			identifier: argument.type
+			count: 4
+			path: app/Community/Actions/GenerateAnnualRecapAction.php
+
+		-
+			message: '#^Parameter \#1 \$array \(array\{highlight\: non\-falsy\-string\}\) to function array_filter does not contain falsy values, the array will always stay the same\.$#'
+			identifier: arrayFilter.same
+			count: 1
+			path: app/Community/Actions/GetUrlToCommentDestinationAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\GameRecentPlayer\>\:\:where\(\) expects array\<int\|model property of App\\Models\\GameRecentPlayer, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\GameRecentPlayer\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\GameRecentPlayer\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\GameRecentPlayer\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\GameRecentPlayer, ''UserAccounts…'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Community/Actions/LoadThinActivePlayersListAction.php
+
+		-
+			message: '#^Offset 1 on array\{list\<string\>, list\<numeric\-string\>\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: app/Community/Actions/ReplaceUserShortcodesWithUsernamesAction.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between mixed and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Community/Components/UserProfileMeta.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\:\:pluck\(\) expects Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\UserGameListEntry, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Community/Controllers/UserGameListController.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\:\:pluck\(\) expects Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\UserGameListEntry, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Community/Controllers/UserSetRequestListController.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\User\>\:\:pluck\(\) expects Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\User, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Community/Services/MessageThreadService.php
+
+		-
+			message: '#^Parameter \#1 \$columns of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\MessageThreadParticipant\>\:\:get\(\) expects array\<int, Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\MessageThreadParticipant\>\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\MessageThreadParticipant, array\<int, string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Community/Services/MessageThreadService.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\User\>\:\:where\(\) expects array\<int\|model property of App\\Models\\User, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\User\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\User\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\User\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\User, ''UserAccounts…'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Connect/Actions/GetFriendListAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\GameHash\>\:\:where\(\) expects array\<int\|model property of App\\Models\\GameHash, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\GameHash\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\GameHash\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\GameHash\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\GameHash, ''gd\.ConsoleID'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Connect/Actions/GetHashLibraryAction.php
+
+		-
+			message: '#^Parameter \#1 \$relations of static method Illuminate\\Database\\Eloquent\\Model\:\:with\(\) expects array\<int\|string, array\<int\|string, string\>\|Closure\|string\>\|string, array\{achievementSet\: array\{achievements\: Closure\(mixed\)\: mixed, 0\: ''incompatibleGameHas…''\}\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Connect/Actions/ResolveAchievementSetsAction.php
+
+		-
+			message: '#^Method App\\Data\\PaginatedData\:\:fromLengthAwarePaginator\(\) has parameter \$paginator with generic class Illuminate\\Pagination\\LengthAwarePaginator but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Data/PaginatedData.php
+
+		-
+			message: '#^Method App\\Filament\\Pages\\ResourceAuditLog\:\:getAuditLog\(\) return type with generic class Illuminate\\Pagination\\LengthAwarePaginator does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Filament/Pages/ResourceAuditLog.php
+
+		-
+			message: '#^Method App\\Filament\\Pages\\ResourceAuditLog\:\:getAuditLog\(\) should return Illuminate\\Pagination\\LengthAwarePaginator&iterable\<Illuminate\\Database\\Eloquent\\Model\> but returns Illuminate\\Contracts\\Pagination\\CursorPaginator\|Illuminate\\Contracts\\Pagination\\Paginator\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Filament/Pages/ResourceAuditLog.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:orWhere\(\) expects array\<int\|model property of Illuminate\\Database\\Eloquent\\Model, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\)\: Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of Illuminate\\Database\\Eloquent\\Model, ''GameData\.Title'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/Resources/AchievementSetResource.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:where\(\) expects array\<int\|model property of Illuminate\\Database\\Eloquent\\Model, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\)\: Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of Illuminate\\Database\\Eloquent\\Model, ''GameData\.ID'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/Resources/AchievementSetResource.php
+
+		-
+			message: '#^Non\-static access to static property Filament\\Resources\\RelationManagers\\RelationManager\:\:\$badge\.$#'
+			identifier: staticProperty.nonStaticAccess
+			count: 1
+			path: app/Filament/Resources/AchievementSetResource/RelationManagers/GameHashesRelationManager.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:where\(\) expects array\<int\|model property of Illuminate\\Database\\Eloquent\\Model, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: Illuminate\\Database\\Eloquent\\Builder\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of Illuminate\\Database\\Eloquent\\Model, ''Console\.ID'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/Resources/EmulatorResource/RelationManagers/SystemsRelationManager.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:where\(\) expects array\<int\|model property of Illuminate\\Database\\Eloquent\\Model, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: Illuminate\\Database\\Eloquent\\Builder\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of Illuminate\\Database\\Eloquent\\Model, ''Console\.name_full'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/Resources/EmulatorResource/RelationManagers/SystemsRelationManager.php
+
+		-
+			message: '#^Method App\\Filament\\Resources\\GameResource\:\:getGlobalSearchResultDetails\(\) should return array\<string, string\> but returns array\<string, int\|string\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Filament/Resources/GameResource.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:where\(\) expects array\<int\|model property of Illuminate\\Database\\Eloquent\\Model, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: Illuminate\\Database\\Eloquent\\Builder\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of Illuminate\\Database\\Eloquent\\Model, ''GameData\.ID'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/Resources/GameResource/Pages/SimilarGames.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:where\(\) expects array\<int\|model property of Illuminate\\Database\\Eloquent\\Model, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: Illuminate\\Database\\Eloquent\\Builder\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of Illuminate\\Database\\Eloquent\\Model, ''GameData\.Title'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/Resources/GameResource/Pages/SimilarGames.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:core\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Filament/Resources/GameResource/RelationManagers/AchievementSetsRelationManager.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData\.id'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/Resources/GameResource/RelationManagers/AchievementSetsRelationManager.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:where\(\) expects array\<int\|model property of Illuminate\\Database\\Eloquent\\Model, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: Illuminate\\Database\\Eloquent\\Builder\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of Illuminate\\Database\\Eloquent\\Model, ''GameData\.ID'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Filament/Resources/HubResource/RelationManagers/GamesRelationManager.php
+
+		-
+			message: '#^Function getCodeNotes\(\) never assigns null to &\$codeNotesOut so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/database/code-note.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between array and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Helpers/database/code-note.php
+
+		-
+			message: '#^Function getGameMetadata\(\) never assigns null to &\$achievementDataOut so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/database/game.php
+
+		-
+			message: '#^Function getGamesList\(\) never assigns null to &\$dataOut so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/database/game.php
+
+		-
+			message: '#^Function getGamesListByDev\(\) never assigns null to &\$dataOut so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/database/game.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:pluck\(\) expects Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Helpers/database/game.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData\.ConsoleID'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Helpers/database/game.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData…'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Helpers/database/game.php
+
+		-
+			message: '#^Parameter &\$lbIDOut by\-ref type of function SubmitNewLeaderboard\(\) expects int\|null, int\|string given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: app/Helpers/database/leaderboard.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:orWhere\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''UserAccounts\.User'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Helpers/database/player-achievement.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''Achievements\.Flags'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Helpers/database/player-achievement.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''Achievements\.GameID'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Helpers/database/player-achievement.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''UserAccounts…'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Helpers/database/player-achievement.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''sub\.hardcore_unlocks''\|''sub\.softcore_unlocks'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Helpers/database/player-achievement.php
+
+		-
+			message: '#^Function getArticleComments\(\) never assigns null to &\$dataOut so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/database/user-activity.php
+
+		-
+			message: '#^Function getRecentlyPlayedGames\(\) never assigns null to &\$dataOut so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/database/user-activity.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between Illuminate\\Support\\Collection and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Helpers/database/user-activity.php
+
+		-
+			message: '#^Parameter &\$permissionOut by\-ref type of function authenticateFromAppToken\(\) expects int\|null, Illuminate\\Database\\Eloquent\\Collection\<int, Illuminate\\Database\\Eloquent\\Model\> given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: app/Helpers/database/user-auth.php
+
+		-
+			message: '#^Parameter &\$user by\-ref type of function validateEmailVerificationToken\(\) expects string\|null, App\\Models\\User\|null given\.$#'
+			identifier: parameterByRef.type
+			count: 2
+			path: app/Helpers/database/user-email-verify.php
+
+		-
+			message: '#^Parameter \#1 \$array \(list\) of array_values is already a list, call has no effect\.$#'
+			identifier: arrayValues.list
+			count: 3
+			path: app/Helpers/render/site-award.php
+
+		-
+			message: '#^Function sanitize_sql_inputs\(\) never assigns int to &\$inputs so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/util/database.php
+
+		-
+			message: '#^Function sanitize_sql_inputs\(\) never assigns null to &\$inputs so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/util/database.php
+
+		-
+			message: '#^Function sanitize_sql_inputs\(\) never assigns string to &\$inputs so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/util/database.php
+
+		-
+			message: '#^Function sanitize_outputs\(\) never assigns int to &\$outputs so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/util/string.php
+
+		-
+			message: '#^Function sanitize_outputs\(\) never assigns null to &\$outputs so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/util/string.php
+
+		-
+			message: '#^Function sanitize_outputs\(\) never assigns string to &\$outputs so it can be removed from the by\-ref type\.$#'
+			identifier: parameterByRef.unusedType
+			count: 1
+			path: app/Helpers/util/string.php
+
+		-
+			message: '#^Unable to resolve the template type TMapWithKeysKey in call to method Illuminate\\Support\\Collection\:\:mapWithKeys\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Http/Controllers/DownloadsController.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementAuthor\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementMaintainer\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 3
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EventAchievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Ticket\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\AchievementMaintainer\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EventAchievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:achievementSets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\AchievementSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\AchievementSet, \$this\(App\\Models\\Achievement\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:activeMaintainer\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\AchievementMaintainer\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\AchievementMaintainer, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:authorshipCredits\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementAuthor\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementAuthor, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:comments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:currentTrigger\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, App\\Models\\Achievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:developer\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Achievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:eventAchievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EventAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EventAchievement, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:eventData\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EventAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EventAchievement, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\Achievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:legacyComments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:maintainers\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementMaintainer\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementMaintainer, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:playerAchievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:playerUsers\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, \$this\(App\\Models\\Achievement\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:tickets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Ticket, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:trigger\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphOne\<App\\Models\\Trigger\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphOne\<App\\Models\\Trigger, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\Achievement\:\:triggers\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\Trigger\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\Trigger, \$this\(App\\Models\\Achievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User,\$this\(App\\Models\\Achievement\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\AchievementSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User,\$this\(App\\Models\\Achievement\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/Achievement.php
+
+		-
+			message: '#^Method App\\Models\\AchievementAuthor\:\:achievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, App\\Models\\AchievementAuthor\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, \$this\(App\\Models\\AchievementAuthor\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementAuthor.php
+
+		-
+			message: '#^Method App\\Models\\AchievementAuthor\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\AchievementAuthor\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\AchievementAuthor\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementAuthor.php
+
+		-
+			message: '#^Method App\\Models\\AchievementMaintainer\:\:achievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, App\\Models\\AchievementMaintainer\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, \$this\(App\\Models\\AchievementMaintainer\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementMaintainer.php
+
+		-
+			message: '#^Method App\\Models\\AchievementMaintainer\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\AchievementMaintainer\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\AchievementMaintainer\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementMaintainer.php
+
+		-
+			message: '#^Method App\\Models\\AchievementMaintainerUnlock\:\:achievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, App\\Models\\AchievementMaintainerUnlock\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, \$this\(App\\Models\\AchievementMaintainerUnlock\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementMaintainerUnlock.php
+
+		-
+			message: '#^Method App\\Models\\AchievementMaintainerUnlock\:\:maintainer\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\AchievementMaintainerUnlock\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\AchievementMaintainerUnlock\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementMaintainerUnlock.php
+
+		-
+			message: '#^Method App\\Models\\AchievementMaintainerUnlock\:\:playerAchievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\PlayerAchievement, App\\Models\\AchievementMaintainerUnlock\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\PlayerAchievement, \$this\(App\\Models\\AchievementMaintainerUnlock\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementMaintainerUnlock.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementSetAuthor\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameAchievementSet\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSet\:\:achievementSetAuthors\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementSetAuthor\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementSetAuthor, \$this\(App\\Models\\AchievementSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSet\:\:achievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Achievement, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Achievement, \$this\(App\\Models\\AchievementSet\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSet\:\:gameAchievementSets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameAchievementSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameAchievementSet, \$this\(App\\Models\\AchievementSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSet\:\:games\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, \$this\(App\\Models\\AchievementSet\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSet\:\:incompatibleGameHashes\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHash, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHash, \$this\(App\\Models\\AchievementSet\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSet\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\AchievementSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\AchievementSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Achievement, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHash, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/AchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSetAuthor\:\:achievementSet\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\AchievementSet, App\\Models\\AchievementSetAuthor\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\AchievementSet, \$this\(App\\Models\\AchievementSetAuthor\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSetAuthor.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSetAuthor\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\AchievementSetAuthor\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\AchievementSetAuthor\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSetAuthor.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSetClaim\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\AchievementSetClaim\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\AchievementSetClaim\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSetClaim.php
+
+		-
+			message: '#^Method App\\Models\\AchievementSetClaim\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\AchievementSetClaim\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\AchievementSetClaim\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/AchievementSetClaim.php
+
+		-
+			message: '#^Method App\\Models\\ApiLogEntry\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\ApiLogEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\ApiLogEntry\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ApiLogEntry.php
+
+		-
+			message: '#^Method App\\Models\\Badge\:\:badgeable\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphTo\<Illuminate\\Database\\Eloquent\\Model, App\\Models\\Badge\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphTo\<Illuminate\\Database\\Eloquent\\Model, \$this\(App\\Models\\Badge\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Badge.php
+
+		-
+			message: '#^Method App\\Models\\Comment\:\:commentable\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphTo\<Illuminate\\Database\\Eloquent\\Model, App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphTo\<Illuminate\\Database\\Eloquent\\Model, \$this\(App\\Models\\Comment\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Comment.php
+
+		-
+			message: '#^Method App\\Models\\Comment\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Comment\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Comment.php
+
+		-
+			message: '#^Method App\\Models\\Comment\:\:userWithTrashed\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Comment\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Comment.php
+
+		-
+			message: '#^Method App\\Models\\DiscordMessageThreadMapping\:\:messageThread\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\MessageThread, App\\Models\\DiscordMessageThreadMapping\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\MessageThread, \$this\(App\\Models\\DiscordMessageThreadMapping\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/DiscordMessageThreadMapping.php
+
+		-
+			message: '#^Method App\\Models\\EmailConfirmation\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\EmailConfirmation\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\EmailConfirmation\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EmailConfirmation.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorDownload\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorRelease\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorUserAgent\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EmulatorRelease\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 3
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Method App\\Models\\Emulator\:\:downloads\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorDownload\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorDownload, \$this\(App\\Models\\Emulator\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Method App\\Models\\Emulator\:\:latestBetaRelease\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EmulatorRelease\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EmulatorRelease, \$this\(App\\Models\\Emulator\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Method App\\Models\\Emulator\:\:latestRelease\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EmulatorRelease\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EmulatorRelease, \$this\(App\\Models\\Emulator\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Method App\\Models\\Emulator\:\:minimumSupportedRelease\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EmulatorRelease\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\EmulatorRelease, \$this\(App\\Models\\Emulator\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Method App\\Models\\Emulator\:\:platforms\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Platform, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Platform, \$this\(App\\Models\\Emulator\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Method App\\Models\\Emulator\:\:releases\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorRelease\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorRelease, \$this\(App\\Models\\Emulator\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Method App\\Models\\Emulator\:\:systems\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\System, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\System, \$this\(App\\Models\\Emulator\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Method App\\Models\\Emulator\:\:userAgents\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorUserAgent\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorUserAgent, \$this\(App\\Models\\Emulator\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Platform,\$this\(App\\Models\\Emulator\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\System,\$this\(App\\Models\\Emulator\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Platform, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\System, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Platform,\$this\(App\\Models\\Emulator\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\System,\$this\(App\\Models\\Emulator\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/Emulator.php
+
+		-
+			message: '#^Method App\\Models\\EmulatorDownload\:\:emulator\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Emulator, App\\Models\\EmulatorDownload\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Emulator, \$this\(App\\Models\\EmulatorDownload\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EmulatorDownload.php
+
+		-
+			message: '#^Method App\\Models\\EmulatorDownload\:\:platform\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Platform, App\\Models\\EmulatorDownload\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Platform, \$this\(App\\Models\\EmulatorDownload\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EmulatorDownload.php
+
+		-
+			message: '#^Method App\\Models\\EmulatorRelease\:\:emulator\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Emulator, App\\Models\\EmulatorRelease\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Emulator, \$this\(App\\Models\\EmulatorRelease\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EmulatorRelease.php
+
+		-
+			message: '#^Method App\\Models\\EmulatorUserAgent\:\:emulator\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Emulator, App\\Models\\EmulatorUserAgent\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Emulator, \$this\(App\\Models\\EmulatorUserAgent\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EmulatorUserAgent.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EventAward\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Event.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\EventAchievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\: TRelatedModel, TIntermediateModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/Event.php
+
+		-
+			message: '#^Method App\\Models\\Event\:\:achievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\EventAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\EventAchievement, App\\Models\\Achievement, \$this\(App\\Models\\Event\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Event.php
+
+		-
+			message: '#^Method App\\Models\\Event\:\:awards\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EventAward\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EventAward, \$this\(App\\Models\\Event\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Event.php
+
+		-
+			message: '#^Method App\\Models\\Event\:\:legacyGame\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\Event\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\Event\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Event.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/Event.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:published\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Models/EventAchievement.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOneThrough\<App\\Models\\Event\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOneThrough\: TRelatedModel, TIntermediateModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/EventAchievement.php
+
+		-
+			message: '#^Method App\\Models\\EventAchievement\:\:achievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, App\\Models\\EventAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, \$this\(App\\Models\\EventAchievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EventAchievement.php
+
+		-
+			message: '#^Method App\\Models\\EventAchievement\:\:event\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOneThrough\<App\\Models\\Event\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOneThrough\<App\\Models\\Event, App\\Models\\Achievement, \$this\(App\\Models\\EventAchievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EventAchievement.php
+
+		-
+			message: '#^Method App\\Models\\EventAchievement\:\:sourceAchievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, App\\Models\\EventAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, \$this\(App\\Models\\EventAchievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EventAchievement.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:tracked\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Models/EventAward.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/EventAward.php
+
+		-
+			message: '#^Method App\\Models\\EventAward\:\:awardedUsers\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, \$this\(App\\Models\\EventAward\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EventAward.php
+
+		-
+			message: '#^Method App\\Models\\EventAward\:\:event\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Event, App\\Models\\EventAward\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Event, \$this\(App\\Models\\EventAward\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EventAward.php
+
+		-
+			message: '#^Method App\\Models\\EventAward\:\:playerBadges\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge, \$this\(App\\Models\\EventAward\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/EventAward.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User,\$this\(App\\Models\\EventAward\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/EventAward.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/EventAward.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User,\$this\(App\\Models\\EventAward\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/EventAward.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\ForumTopic\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Forum.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\ForumTopicComment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\: TRelatedModel, TIntermediateModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Forum.php
+
+		-
+			message: '#^Method App\\Models\\Forum\:\:category\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\ForumCategory, App\\Models\\Forum\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\ForumCategory, \$this\(App\\Models\\Forum\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Forum.php
+
+		-
+			message: '#^Method App\\Models\\Forum\:\:comments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\ForumTopicComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\ForumTopicComment, App\\Models\\ForumTopic, \$this\(App\\Models\\Forum\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Forum.php
+
+		-
+			message: '#^Method App\\Models\\Forum\:\:topics\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\ForumTopic\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\ForumTopic, \$this\(App\\Models\\Forum\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Forum.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Forum\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/ForumCategory.php
+
+		-
+			message: '#^Method App\\Models\\ForumCategory\:\:forums\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Forum\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Forum, \$this\(App\\Models\\ForumCategory\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ForumCategory.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\ForumTopicComment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/ForumTopic.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\ForumTopicComment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/ForumTopic.php
+
+		-
+			message: '#^Method App\\Models\\ForumTopic\:\:comments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\ForumTopicComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\ForumTopicComment, \$this\(App\\Models\\ForumTopic\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ForumTopic.php
+
+		-
+			message: '#^Method App\\Models\\ForumTopic\:\:forum\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Forum, App\\Models\\ForumTopic\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Forum, \$this\(App\\Models\\ForumTopic\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ForumTopic.php
+
+		-
+			message: '#^Method App\\Models\\ForumTopic\:\:latestComment\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\ForumTopicComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\ForumTopicComment, \$this\(App\\Models\\ForumTopic\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ForumTopic.php
+
+		-
+			message: '#^Method App\\Models\\ForumTopic\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\ForumTopic\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\ForumTopic\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ForumTopic.php
+
+		-
+			message: '#^Method App\\Models\\ForumTopicComment\:\:editedBy\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\ForumTopicComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\ForumTopicComment\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ForumTopicComment.php
+
+		-
+			message: '#^Method App\\Models\\ForumTopicComment\:\:forumTopic\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\ForumTopic, App\\Models\\ForumTopicComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\ForumTopic, \$this\(App\\Models\\ForumTopicComment\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ForumTopicComment.php
+
+		-
+			message: '#^Method App\\Models\\ForumTopicComment\:\:sentBy\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\ForumTopicComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\ForumTopicComment\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ForumTopicComment.php
+
+		-
+			message: '#^Method App\\Models\\ForumTopicComment\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\ForumTopicComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\ForumTopicComment\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/ForumTopicComment.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementSetClaim\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 8
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameAchievementSet\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameHash\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameHashSet\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameRelease\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Leaderboard\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MemoryNote\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerGame\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerSession\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserGameListEntry\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\AchievementSetAuthor\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\: TRelatedModel, TIntermediateModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\Ticket\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\: TRelatedModel, TIntermediateModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\Achievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\Event\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:achievementSetClaims\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementSetClaim\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementSetClaim, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:achievementSets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\AchievementSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\AchievementSet, \$this\(App\\Models\\Game\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:achievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:claimsComments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:comments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:coreSetAuthorshipCredits\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\AchievementSetAuthor\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\AchievementSetAuthor, App\\Models\\GameAchievementSet, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:currentTrigger\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, App\\Models\\Game\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:event\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\Event\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\Event, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:gameAchievementSets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameAchievementSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameAchievementSet, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:gameHashSets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameHashSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameHashSet, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:gameListEntries\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserGameListEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserGameListEntry, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:gameSets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameSet, \$this\(App\\Models\\Game\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:hashes\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameHash\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameHash, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:hashesComments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:lastAchievementUpdate\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\Achievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\Achievement, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:leaderboards\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Leaderboard\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Leaderboard, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:memoryNotes\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MemoryNote\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MemoryNote, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:modificationsComments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:playerBadges\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:playerGames\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerGame\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerGame, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:playerSessions\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerSession\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerSession, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:playerUsers\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, \$this\(App\\Models\\Game\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:releases\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameRelease\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\GameRelease, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:similarGamesList\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, \$this\(App\\Models\\Game\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:system\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\System, App\\Models\\Game\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\System, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:tickets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\Ticket, App\\Models\\Achievement, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:trigger\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphOne\<App\\Models\\Trigger\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphOne\<App\\Models\\Trigger, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\Game\:\:triggers\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\Trigger\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\Trigger, \$this\(App\\Models\\Game\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User,\$this\(App\\Models\\Game\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\AchievementSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 3
+			path: app/Models/Game.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User,\$this\(App\\Models\\Game\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/Game.php
+
+		-
+			message: '#^Method App\\Models\\GameAchievementSet\:\:achievementSet\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\AchievementSet, App\\Models\\GameAchievementSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\AchievementSet, \$this\(App\\Models\\GameAchievementSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameAchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\GameAchievementSet\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\GameAchievementSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\GameAchievementSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameAchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\GameHash\:\:compatibilityTester\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\GameHash\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\GameHash\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Method App\\Models\\GameHash\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\GameHash\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\GameHash\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Method App\\Models\\GameHash\:\:gameHashSets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHashSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHashSet, \$this\(App\\Models\\GameHash\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Method App\\Models\\GameHash\:\:incompatibleAchievementSets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\AchievementSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\AchievementSet, \$this\(App\\Models\\GameHash\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Method App\\Models\\GameHash\:\:system\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\System, App\\Models\\GameHash\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\System, \$this\(App\\Models\\GameHash\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Method App\\Models\\GameHash\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\GameHash\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\GameHash\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHashSet,\$this\(App\\Models\\GameHash\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\AchievementSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHashSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHashSet,\$this\(App\\Models\\GameHash\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/GameHash.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MemoryNote\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/GameHashSet.php
+
+		-
+			message: '#^Method App\\Models\\GameHashSet\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\GameHashSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\GameHashSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameHashSet.php
+
+		-
+			message: '#^Method App\\Models\\GameHashSet\:\:hashes\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHash, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHash, \$this\(App\\Models\\GameHashSet\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameHashSet.php
+
+		-
+			message: '#^Method App\\Models\\GameHashSet\:\:memoryNotes\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MemoryNote\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MemoryNote, \$this\(App\\Models\\GameHashSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameHashSet.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHash,\$this\(App\\Models\\GameHashSet\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/GameHashSet.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHash, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/GameHashSet.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameHash,\$this\(App\\Models\\GameHashSet\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/GameHashSet.php
+
+		-
+			message: '#^Method App\\Models\\GameRecentPlayer\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\GameRecentPlayer\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\GameRecentPlayer\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameRecentPlayer.php
+
+		-
+			message: '#^Method App\\Models\\GameRecentPlayer\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\GameRecentPlayer\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\GameRecentPlayer\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameRecentPlayer.php
+
+		-
+			message: '#^Method App\\Models\\GameRelease\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\GameRelease\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\GameRelease\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameRelease.php
+
+		-
+			message: '#^Method App\\Models\\GameSet\:\:children\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameSet, \$this\(App\\Models\\GameSet\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Method App\\Models\\GameSet\:\:forumTopic\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\ForumTopic, App\\Models\\GameSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\ForumTopic, \$this\(App\\Models\\GameSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Method App\\Models\\GameSet\:\:games\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, \$this\(App\\Models\\GameSet\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Method App\\Models\\GameSet\:\:parents\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameSet, \$this\(App\\Models\\GameSet\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Method App\\Models\\GameSet\:\:updateRoles\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Role, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Role, \$this\(App\\Models\\GameSet\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Method App\\Models\\GameSet\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\GameSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\GameSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Method App\\Models\\GameSet\:\:viewRoles\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Role, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Role, \$this\(App\\Models\\GameSet\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\GameSet, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 2
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Role, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 2
+			path: app/Models/GameSet.php
+
+		-
+			message: '#^Method App\\Models\\GameSetGame\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\GameSetGame\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\GameSetGame\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSetGame.php
+
+		-
+			message: '#^Method App\\Models\\GameSetGame\:\:gameSet\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameSet, App\\Models\\GameSetGame\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameSet, \$this\(App\\Models\\GameSetGame\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSetGame.php
+
+		-
+			message: '#^Method App\\Models\\GameSetLink\:\:childGameSet\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameSet, App\\Models\\GameSetLink\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameSet, \$this\(App\\Models\\GameSetLink\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSetLink.php
+
+		-
+			message: '#^Method App\\Models\\GameSetLink\:\:parentGameSet\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameSet, App\\Models\\GameSetLink\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameSet, \$this\(App\\Models\\GameSetLink\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/GameSetLink.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\LeaderboardEntry\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Method App\\Models\\Leaderboard\:\:comments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment, \$this\(App\\Models\\Leaderboard\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Method App\\Models\\Leaderboard\:\:currentTrigger\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, App\\Models\\Leaderboard\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, \$this\(App\\Models\\Leaderboard\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Method App\\Models\\Leaderboard\:\:developer\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Leaderboard\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Leaderboard\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Method App\\Models\\Leaderboard\:\:entries\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\LeaderboardEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\LeaderboardEntry, \$this\(App\\Models\\Leaderboard\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Method App\\Models\\Leaderboard\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\Leaderboard\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\Leaderboard\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Method App\\Models\\Leaderboard\:\:topEntry\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\LeaderboardEntry, App\\Models\\Leaderboard\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\LeaderboardEntry, \$this\(App\\Models\\Leaderboard\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Method App\\Models\\Leaderboard\:\:trigger\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphOne\<App\\Models\\Trigger\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphOne\<App\\Models\\Trigger, \$this\(App\\Models\\Leaderboard\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Method App\\Models\\Leaderboard\:\:triggers\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\Trigger\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\Trigger, \$this\(App\\Models\\Leaderboard\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Leaderboard.php
+
+		-
+			message: '#^Method App\\Models\\LeaderboardEntry\:\:leaderboard\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Leaderboard, App\\Models\\LeaderboardEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Leaderboard, \$this\(App\\Models\\LeaderboardEntry\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/LeaderboardEntry.php
+
+		-
+			message: '#^Method App\\Models\\LeaderboardEntry\:\:playerSession\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\PlayerSession, App\\Models\\LeaderboardEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\PlayerSession, \$this\(App\\Models\\LeaderboardEntry\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/LeaderboardEntry.php
+
+		-
+			message: '#^Method App\\Models\\LeaderboardEntry\:\:trigger\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, App\\Models\\LeaderboardEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, \$this\(App\\Models\\LeaderboardEntry\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/LeaderboardEntry.php
+
+		-
+			message: '#^Method App\\Models\\LeaderboardEntry\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\LeaderboardEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\LeaderboardEntry\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/LeaderboardEntry.php
+
+		-
+			message: '#^Method App\\Models\\MemoryNote\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\MemoryNote\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\MemoryNote\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/MemoryNote.php
+
+		-
+			message: '#^Method App\\Models\\MemoryNote\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\MemoryNote\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\MemoryNote\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/MemoryNote.php
+
+		-
+			message: '#^Method App\\Models\\Message\:\:author\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Message\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Message\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Message.php
+
+		-
+			message: '#^Method App\\Models\\Message\:\:sentBy\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Message\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Message\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Message.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Message\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/MessageThread.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\User\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\: TRelatedModel, TIntermediateModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/MessageThread.php
+
+		-
+			message: '#^Method App\\Models\\MessageThread\:\:lastMessage\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Message, App\\Models\\MessageThread\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Message, \$this\(App\\Models\\MessageThread\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/MessageThread.php
+
+		-
+			message: '#^Method App\\Models\\MessageThread\:\:messages\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Message\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Message, \$this\(App\\Models\\MessageThread\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/MessageThread.php
+
+		-
+			message: '#^Method App\\Models\\MessageThread\:\:participants\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, \$this\(App\\Models\\MessageThread\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/MessageThread.php
+
+		-
+			message: '#^Method App\\Models\\MessageThread\:\:users\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\User\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\User, App\\Models\\MessageThreadParticipant, \$this\(App\\Models\\MessageThread\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/MessageThread.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/MessageThread.php
+
+		-
+			message: '#^Method App\\Models\\MessageThreadParticipant\:\:thread\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\MessageThread, App\\Models\\MessageThreadParticipant\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\MessageThread, \$this\(App\\Models\\MessageThreadParticipant\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/MessageThreadParticipant.php
+
+		-
+			message: '#^Method App\\Models\\MessageThreadParticipant\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\MessageThreadParticipant\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\MessageThreadParticipant\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/MessageThreadParticipant.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\NewsComment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\MorphMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/News.php
+
+		-
+			message: '#^Method App\\Models\\News\:\:comments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\NewsComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\NewsComment, \$this\(App\\Models\\News\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/News.php
+
+		-
+			message: '#^Method App\\Models\\News\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\News\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\News\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/News.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorDownload\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Platform.php
+
+		-
+			message: '#^Method App\\Models\\Platform\:\:emulatorDownloads\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorDownload\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmulatorDownload, \$this\(App\\Models\\Platform\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Platform.php
+
+		-
+			message: '#^Method App\\Models\\Platform\:\:emulators\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator, \$this\(App\\Models\\Platform\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Platform.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator,\$this\(App\\Models\\Platform\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/Platform.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/Platform.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator,\$this\(App\\Models\\Platform\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/Platform.php
+
+		-
+			message: '#^Method App\\Models\\PlayerAchievement\:\:achievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, App\\Models\\PlayerAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, \$this\(App\\Models\\PlayerAchievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerAchievement.php
+
+		-
+			message: '#^Method App\\Models\\PlayerAchievement\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\PlayerAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\PlayerAchievement\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerAchievement.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/PlayerAchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\PlayerAchievementSet\:\:achievementSet\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\AchievementSet, App\\Models\\PlayerAchievementSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\AchievementSet, \$this\(App\\Models\\PlayerAchievementSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerAchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\PlayerAchievementSet\:\:playerAchievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement, \$this\(App\\Models\\PlayerAchievementSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerAchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\PlayerAchievementSet\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\PlayerAchievementSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\PlayerAchievementSet\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerAchievementSet.php
+
+		-
+			message: '#^Method App\\Models\\PlayerBadge\:\:gameIfApplicable\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\PlayerBadge\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\PlayerBadge\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerBadge.php
+
+		-
+			message: '#^Method App\\Models\\PlayerBadge\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\PlayerBadge\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\PlayerBadge\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerBadge.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/PlayerGame.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/PlayerGame.php
+
+		-
+			message: '#^Method App\\Models\\PlayerGame\:\:achievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement, \$this\(App\\Models\\PlayerGame\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerGame.php
+
+		-
+			message: '#^Method App\\Models\\PlayerGame\:\:badges\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge, \$this\(App\\Models\\PlayerGame\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerGame.php
+
+		-
+			message: '#^Method App\\Models\\PlayerGame\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\PlayerGame\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\PlayerGame\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerGame.php
+
+		-
+			message: '#^Method App\\Models\\PlayerGame\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\PlayerGame\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\PlayerGame\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerGame.php
+
+		-
+			message: '#^Method App\\Models\\PlayerProgressReset\:\:achievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, App\\Models\\PlayerProgressReset\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, \$this\(App\\Models\\PlayerProgressReset\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerProgressReset.php
+
+		-
+			message: '#^Method App\\Models\\PlayerProgressReset\:\:achievementSet\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\AchievementSet, App\\Models\\PlayerProgressReset\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\AchievementSet, \$this\(App\\Models\\PlayerProgressReset\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerProgressReset.php
+
+		-
+			message: '#^Method App\\Models\\PlayerProgressReset\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\PlayerProgressReset\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\PlayerProgressReset\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerProgressReset.php
+
+		-
+			message: '#^Method App\\Models\\PlayerProgressReset\:\:initiatedByUser\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\PlayerProgressReset\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\PlayerProgressReset\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerProgressReset.php
+
+		-
+			message: '#^Method App\\Models\\PlayerProgressReset\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\PlayerProgressReset\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\PlayerProgressReset\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerProgressReset.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/PlayerSession.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/PlayerSession.php
+
+		-
+			message: '#^Method App\\Models\\PlayerSession\:\:achievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement, \$this\(App\\Models\\PlayerSession\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerSession.php
+
+		-
+			message: '#^Method App\\Models\\PlayerSession\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\PlayerSession\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\PlayerSession\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerSession.php
+
+		-
+			message: '#^Method App\\Models\\PlayerSession\:\:gameHash\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameHash, App\\Models\\PlayerSession\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameHash, \$this\(App\\Models\\PlayerSession\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerSession.php
+
+		-
+			message: '#^Method App\\Models\\PlayerSession\:\:playerAchievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement, \$this\(App\\Models\\PlayerSession\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerSession.php
+
+		-
+			message: '#^Method App\\Models\\PlayerSession\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\PlayerSession\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\PlayerSession\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerSession.php
+
+		-
+			message: '#^Method App\\Models\\PlayerStat\:\:system\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\System, App\\Models\\PlayerStat\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\System, \$this\(App\\Models\\PlayerStat\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerStat.php
+
+		-
+			message: '#^Method App\\Models\\PlayerStat\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\PlayerStat\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\PlayerStat\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/PlayerStat.php
+
+		-
+			message: '#^Method App\\Models\\StaticData\:\:lastRegisteredUser\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\StaticData\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\StaticData\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/StaticData.php
+
+		-
+			message: '#^Method App\\Models\\Subscription\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Subscription\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Subscription\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Subscription.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Game\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/System.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\Achievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\: TRelatedModel, TIntermediateModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/System.php
+
+		-
+			message: '#^Method App\\Models\\System\:\:achievementGames\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Game\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Game, \$this\(App\\Models\\System\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/System.php
+
+		-
+			message: '#^Method App\\Models\\System\:\:achievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\Achievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasManyThrough\<App\\Models\\Achievement, App\\Models\\Game, \$this\(App\\Models\\System\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/System.php
+
+		-
+			message: '#^Method App\\Models\\System\:\:emulators\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator, \$this\(App\\Models\\System\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/System.php
+
+		-
+			message: '#^Method App\\Models\\System\:\:games\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Game\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Game, \$this\(App\\Models\\System\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/System.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator,\$this\(App\\Models\\System\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/System.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/System.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Emulator,\$this\(App\\Models\\System\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/System.php
+
+		-
+			message: '#^Method App\\Models\\Ticket\:\:achievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, \$this\(App\\Models\\Ticket\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Ticket.php
+
+		-
+			message: '#^Method App\\Models\\Ticket\:\:author\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Ticket\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Ticket.php
+
+		-
+			message: '#^Method App\\Models\\Ticket\:\:emulator\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Emulator, App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Emulator, \$this\(App\\Models\\Ticket\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Ticket.php
+
+		-
+			message: '#^Method App\\Models\\Ticket\:\:gameHash\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameHash, App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\GameHash, \$this\(App\\Models\\Ticket\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Ticket.php
+
+		-
+			message: '#^Method App\\Models\\Ticket\:\:reporter\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Ticket\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Ticket.php
+
+		-
+			message: '#^Method App\\Models\\Ticket\:\:resolver\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\Ticket\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Ticket.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\Trigger\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/Trigger.php
+
+		-
+			message: '#^Method App\\Models\\Trigger\:\:nextVersion\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\Trigger\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\Trigger, \$this\(App\\Models\\Trigger\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Trigger.php
+
+		-
+			message: '#^Method App\\Models\\Trigger\:\:previousVersion\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, App\\Models\\Trigger\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Trigger, \$this\(App\\Models\\Trigger\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Trigger.php
+
+		-
+			message: '#^Method App\\Models\\Trigger\:\:triggerable\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphTo\<Illuminate\\Database\\Eloquent\\Model, App\\Models\\Trigger\> but returns Illuminate\\Database\\Eloquent\\Relations\\MorphTo\<Illuminate\\Database\\Eloquent\\Model, \$this\(App\\Models\\Trigger\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/Trigger.php
+
+		-
+			message: '#^Method App\\Models\\UnrankedUser\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\UnrankedUser\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\UnrankedUser\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UnrankedUser.php
+
+		-
+			message: '#^Cannot access property \$Friendship on string\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementAuthor\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementSetClaim\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmailConfirmation\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\ForumTopicComment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Leaderboard\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\LeaderboardEntry\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MemoryNote\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MessageThreadParticipant\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievementSet\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerGame\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerSession\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerStat\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Subscription\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Ticket\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserActivity\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserComment\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserConnection\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 2
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserGameListEntry\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserUsername\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:achievementCredits\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementAuthor\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementAuthor, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:achievementSetClaims\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementSetClaim\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\AchievementSetClaim, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:achievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Achievement, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Achievement, \$this\(App\\Models\\User\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:activities\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserActivity\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserActivity, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:authoredAchievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Achievement, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:authoredCodeNotes\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MemoryNote\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MemoryNote, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:authoredLeaderboards\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Leaderboard\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Leaderboard, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:comments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserComment, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:connections\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserConnection\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserConnection, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:emailConfirmations\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmailConfirmation\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\EmailConfirmation, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:forumPosts\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\ForumTopicComment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\ForumTopicComment, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:gameListEntries\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserGameListEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserGameListEntry, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:games\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, \$this\(App\\Models\\User\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:inverseRelatedUsers\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, \$this\(App\\Models\\User\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:lastGame\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\User\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:leaderboardEntries\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\LeaderboardEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\LeaderboardEntry, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:messageThreadParticipations\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MessageThreadParticipant\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\MessageThreadParticipant, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:moderationComments\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Comment, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:playerAchievementSets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievementSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievementSet, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:playerAchievements\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerAchievement, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:playerBadges\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerBadge, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:playerGames\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerGame\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerGame, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:playerSessions\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerSession\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerSession, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:playerStats\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerStat\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\PlayerStat, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:relatedUsers\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, \$this\(App\\Models\\User\), Illuminate\\Database\\Eloquent\\Relations\\Pivot, ''pivot''\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:reportedTickets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Ticket, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:resolvedTickets\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Ticket\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Ticket, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:subscriptions\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Subscription\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\Subscription, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:usernameRequests\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserUsername\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasMany\<App\\Models\\UserUsername, \$this\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\User\:\:whereName\(\) should return Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\User\> but returns Illuminate\\Database\\Eloquent\\Builder\<static\(App\\Models\\User\)\>\.$#'
+			identifier: return.type
+			count: 2
+			path: app/Models/User.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Achievement,\$this\(App\\Models\\User\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Parameter \#1 \$class of method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game,\$this\(App\\Models\\User\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\) expects class\-string\<Illuminate\\Database\\Eloquent\\Relations\\Pivot\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\UserGameListEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\UserGameListEntry, ''SetRequest\.type'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Achievement, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\User, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 4
+			path: app/Models/User.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<Spatie\\Permission\\Models\\Role, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @return is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Type string in generic type Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<Spatie\\Permission\\Models\\Role, Illuminate\\Database\\Eloquent\\Relations\\Pivot, string\> in PHPDoc tag @var is not subtype of template type TPivotModel of Illuminate\\Database\\Eloquent\\Relations\\Pivot \= Illuminate\\Database\\Eloquent\\Relations\\Pivot of class Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Achievement,\$this\(App\\Models\\User\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Unable to resolve the template type TNewPivotModel in call to method Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\<App\\Models\\Game,\$this\(App\\Models\\User\),Illuminate\\Database\\Eloquent\\Relations\\Pivot,string\>\:\:using\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: app/Models/User.php
+
+		-
+			message: '#^Method App\\Models\\UserActivity\:\:achievement\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, App\\Models\\UserActivity\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Achievement, \$this\(App\\Models\\UserActivity\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UserActivity.php
+
+		-
+			message: '#^Method App\\Models\\UserActivity\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\UserActivity\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\UserActivity\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UserActivity.php
+
+		-
+			message: '#^Method App\\Models\\UserActivity\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\UserActivity\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\UserActivity\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UserActivity.php
+
+		-
+			message: '#^Method App\\Models\\UserConnection\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\UserConnection\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\UserConnection\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UserConnection.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\GameAchievementSet\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/UserGameAchievementSetPreference.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\User\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\HasOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Models/UserGameAchievementSetPreference.php
+
+		-
+			message: '#^Method App\\Models\\UserGameAchievementSetPreference\:\:gameAchievementSet\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\GameAchievementSet\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\GameAchievementSet, \$this\(App\\Models\\UserGameAchievementSetPreference\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UserGameAchievementSetPreference.php
+
+		-
+			message: '#^Method App\\Models\\UserGameAchievementSetPreference\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\User\> but returns Illuminate\\Database\\Eloquent\\Relations\\HasOne\<App\\Models\\User, \$this\(App\\Models\\UserGameAchievementSetPreference\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UserGameAchievementSetPreference.php
+
+		-
+			message: '#^Method App\\Models\\UserGameListEntry\:\:game\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, App\\Models\\UserGameListEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\Game, \$this\(App\\Models\\UserGameListEntry\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UserGameListEntry.php
+
+		-
+			message: '#^Method App\\Models\\UserGameListEntry\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\UserGameListEntry\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\UserGameListEntry\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UserGameListEntry.php
+
+		-
+			message: '#^Method App\\Models\\UserUsername\:\:user\(\) should return Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, App\\Models\\UserUsername\> but returns Illuminate\\Database\\Eloquent\\Relations\\BelongsTo\<App\\Models\\User, \$this\(App\\Models\\UserUsername\)\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Models/UserUsername.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserRelation\>\:\:where\(\) expects array\<int\|model property of App\\Models\\UserRelation, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserRelation\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserRelation\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserRelation\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\UserRelation, ''Friends\.Friendship'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/BuildFollowedPlayerCompletionAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserRelation\>\:\:where\(\) expects array\<int\|model property of App\\Models\\UserRelation, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserRelation\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserRelation\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserRelation\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\UserRelation, ''Friends\.user_id'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/BuildFollowedPlayerCompletionAction.php
+
+		-
+			message: '#^PHPDoc tag @var for variable \$entries contains generic class Illuminate\\Pagination\\LengthAwarePaginator but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Platform/Actions/BuildGameListAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData\.ConsoleID'' given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Platform/Actions/BuildGameListAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData\.Title'' given\.$#'
+			identifier: argument.type
+			count: 3
+			path: app/Platform/Actions/BuildGameListAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData…'' given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Platform/Actions/BuildGameListAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Leaderboard\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Leaderboard, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Leaderboard\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Leaderboard\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Leaderboard\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Leaderboard, ''LeaderboardDef…'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/BuildGameListAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Ticket, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Ticket, ''Achievements\.Flags'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/BuildGameListAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\UserGameListEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\UserGameListEntry, ''SetRequest\.type'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/BuildGameListAction.php
+
+		-
+			message: '#^PHPDoc tag @var with type array\<int, array\{achievement\?\: array\}\> is not subtype of native type array\<int, array\{achievement\?\: array\{ID\: int, Title\: string, Description\: string, Points\: int, TrueRatio\: float, BadgeName\: string, Flags\: int\}\}\>\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: app/Platform/Actions/BuildPlayerGameActivityDataAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData\.Title'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/BuildSeriesHubDataAction.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: app/Platform/Actions/ComputeGameSortTitleAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData\.ConsoleID'' given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Platform/Actions/GetRandomGameAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData\.Title'' given\.$#'
+			identifier: argument.type
+			count: 3
+			path: app/Platform/Actions/GetRandomGameAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData…'' given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Platform/Actions/GetRandomGameAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Leaderboard\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Leaderboard, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Leaderboard\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Leaderboard\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Leaderboard\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Leaderboard, ''LeaderboardDef…'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/GetRandomGameAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Ticket, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Ticket, ''Achievements\.Flags'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/GetRandomGameAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\UserGameListEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\UserGameListEntry, ''SetRequest\.type'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/GetRandomGameAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''Achievements\.Flags'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/ResetPlayerProgressAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''Achievements\.GameID'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/ResetPlayerProgressAction.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\:\:tracked\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Platform/Actions/UpdateAchievementMetricsAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerBadge\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerBadge, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerBadge\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerBadge\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerBadge\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerBadge, ''GameData\.Title'' given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Platform/Actions/UpdatePlayerBeatenGamesStatsAction.php
+
+		-
+			message: '#^Parameter \#2 \$syncData of method App\\Platform\\Actions\\UpsertGameCoreAchievementSetFromLegacyFlagsAction\:\:syncAchievementSetAchievements\(\) expects Illuminate\\Support\\Collection\<int, array\{created_at\: Carbon\\Carbon\|string, updated_at\: Carbon\\Carbon\|string, order_column\: int\}\>, Illuminate\\Support\\Collection\<int, array\{created_at\: mixed, updated_at\: mixed, order_column\: mixed\}\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Actions/UpsertGameCoreAchievementSetFromLegacyFlagsAction.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Achievement\>\:\:pluck\(\) expects Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Achievement, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: app/Platform/Commands/VerifyAchievementSetIntegrity.php
+
+		-
+			message: '#^Generic type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator\<Illuminate\\Database\\Eloquent\\Model\> in PHPDoc tag @return does not specify all template types of interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator\: TKey, TValue$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Platform/Components/PlayersActive.php
+
+		-
+			message: '#^Type Illuminate\\Database\\Eloquent\\Model in generic type Illuminate\\Contracts\\Pagination\\LengthAwarePaginator\<Illuminate\\Database\\Eloquent\\Model\> in PHPDoc tag @return is not subtype of template type TKey of \(int\|string\) of interface Illuminate\\Contracts\\Pagination\\LengthAwarePaginator\.$#'
+			identifier: generics.notSubtype
+			count: 1
+			path: app/Platform/Components/PlayersActive.php
+
+		-
+			message: '#^Trait App\\Platform\\Concerns\\UsesWebApi is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: app/Platform/Concerns/UsesWebApi.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\MorphMany\<App\\Models\\Trigger\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\MorphMany\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Platform/Contracts/HasVersionedTrigger.php
+
+		-
+			message: '#^Generic type Illuminate\\Database\\Eloquent\\Relations\\MorphOne\<App\\Models\\Trigger\> in PHPDoc tag @return does not specify all template types of class Illuminate\\Database\\Eloquent\\Relations\\MorphOne\: TRelatedModel, TDeclaringModel$#'
+			identifier: generics.lessTypes
+			count: 1
+			path: app/Platform/Contracts/HasVersionedTrigger.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:pluck\(\) expects Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Controllers/HubController.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Ticket, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Ticket, ''Achievements\.user_id'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Services/DeveloperSetsService.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Ticket, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Ticket\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Ticket, ''Achievements\.Flags'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Platform/Services/GameListService.php
+
+		-
+			message: '#^Instanceof between App\\Models\\Leaderboard and App\\Models\\Leaderboard will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: app/Policies/TriggerTicketPolicy.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\:\:where\(\) expects array\<int\|model property of App\\Models\\Game, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Game\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\Game, ''GameData\.ConsoleID'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Support/Shortcode/Shortcode.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\AchievementFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Achievement, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Achievement\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/AchievementFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\AchievementSetClaimFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\AchievementSetClaim, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\AchievementSetClaim\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/AchievementSetClaimFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\EmulatorFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Emulator, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Emulator\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/EmulatorFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\EventAchievementFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\EventAchievement, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\EventAchievement\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/EventAchievementFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\EventFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Event, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Event\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/EventFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\ForumCategoryFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\ForumCategory, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\ForumCategory\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/ForumCategoryFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\ForumFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Forum, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Forum\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/ForumFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\ForumTopicCommentFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\ForumTopicComment, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\ForumTopicComment\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/ForumTopicCommentFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\ForumTopicFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\ForumTopic, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\ForumTopic\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/ForumTopicFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\GameFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Game, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Game\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/GameFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\GameHashFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\GameHash, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\GameHash\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/GameHashFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\GameRecentPlayerFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\GameRecentPlayer, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\GameRecentPlayer\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/GameRecentPlayerFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\GameReleaseFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\GameRelease, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\GameRelease\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/GameReleaseFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\GameSetFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\GameSet, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\GameSet\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/GameSetFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\GameSetGameFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\GameSetGame, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\GameSetGame\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/GameSetGameFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\LeaderboardEntryFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\LeaderboardEntry, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\LeaderboardEntry\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/LeaderboardEntryFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\LeaderboardFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Leaderboard, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Leaderboard\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/LeaderboardFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\MessageFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Message, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Message\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/MessageFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\MessageThreadFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\MessageThread, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\MessageThread\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/MessageThreadFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\MessageThreadParticipantFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\MessageThreadParticipant, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\MessageThreadParticipant\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/MessageThreadParticipantFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\NewsFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\News, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\News\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/NewsFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\PlatformFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Platform, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Platform\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/PlatformFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\PlayerAchievementFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\PlayerAchievement, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\PlayerAchievement\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/PlayerAchievementFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\PlayerBadgeFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\PlayerBadge, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\PlayerBadge\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/PlayerBadgeFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\PlayerGameFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\PlayerGame, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\PlayerGame\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/PlayerGameFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\PlayerSessionFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\PlayerSession, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\PlayerSession\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/PlayerSessionFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\PlayerStatFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\PlayerStat, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\PlayerStat\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/PlayerStatFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\StaticDataFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\StaticData, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\StaticData\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/StaticDataFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\SystemFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\System, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\System\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/SystemFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\TicketFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Ticket, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Ticket\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/TicketFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\TriggerFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\Trigger, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\Trigger\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/TriggerFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\UserActivityFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\UserActivity, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\UserActivity\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/UserActivityFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\UserFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\User, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\User\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/UserFactory.php
+
+		-
+			message: '#^Return type \(array\<string, mixed\>\) of method Database\\Factories\\UserRelationFactory\:\:definition\(\) should be compatible with return type \(array\<model property of App\\Models\\UserRelation, mixed\>\) of method Illuminate\\Database\\Eloquent\\Factories\\Factory\<App\\Models\\UserRelation\>\:\:definition\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: database/factories/UserRelationFactory.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between array and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: public/API/API_GetRecentGameAwards.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\LeaderboardEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\LeaderboardEntry, ''LeaderboardDef…'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: public/API/API_GetUserGameLeaderboards.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\LeaderboardEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\LeaderboardEntry, ''UserAccounts…'' given\.$#'
+			identifier: argument.type
+			count: 3
+			path: public/API/API_GetUserGameLeaderboards.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\LeaderboardEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\LeaderboardEntry, ''entries_rank_calc…'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: public/API/API_GetUserGameLeaderboards.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\LeaderboardEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\LeaderboardEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\LeaderboardEntry, ''leaderboard_rank…'' given\.$#'
+			identifier: argument.type
+			count: 3
+			path: public/API/API_GetUserGameLeaderboards.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\UserGameListEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\UserGameListEntry, ''GameData…'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: public/API/API_GetUserSetRequests.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\:\:where\(\) expects array\<int\|model property of App\\Models\\UserGameListEntry, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\UserGameListEntry\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\UserGameListEntry, ''SetRequest\.user_id'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: public/API/API_GetUserSetRequests.php
+
+		-
+			message: '#^Trait Tests\\Feature\\Concerns\\TestsMail is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: tests/Feature/Concerns/TestsMail.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertEmpty\(\) with Illuminate\\Support\\Collection will always evaluate to false\.$#'
+			identifier: method.impossibleType
+			count: 1
+			path: tests/Feature/Legacy/DatabaseTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsIterable\(\) with Illuminate\\Support\\Collection will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 2
+			path: tests/Feature/Legacy/DatabaseTest.php
+
+		-
+			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+			identifier: larastan.noEnvCallsOutsideOfConfig
+			count: 1
+			path: tests/Feature/Platform/Actions/BuildGameListActionTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 2
+			path: tests/Feature/Platform/Actions/BuildPlayerGameActivityDataActionTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with App\\Platform\\Data\\PlayerGameActivitySummaryData will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Feature/Platform/Actions/BuildPlayerGameActivityDataActionTest.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/Feature/Platform/Actions/ProcessGameReleasesForViewActionTest.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''Achievements\.Flags'' given\.$#'
+			identifier: argument.type
+			count: 3
+			path: tests/Feature/Platform/Actions/ResetPlayerProgressActionTest.php
+
+		-
+			message: '#^Parameter \#1 \$column of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\:\:where\(\) expects array\<int\|model property of App\\Models\\PlayerAchievement, mixed\>\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\|\(Closure\(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\PlayerAchievement\>\)\: void\)\|Illuminate\\Contracts\\Database\\Query\\Expression\|model property of App\\Models\\PlayerAchievement, ''Achievements\.GameID'' given\.$#'
+			identifier: argument.type
+			count: 3
+			path: tests/Feature/Platform/Actions/ResetPlayerProgressActionTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,41 +1,52 @@
 includes:
-    - ./vendor/larastan/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
+    - vendor/nesbot/carbon/extension.neon
+    - phpstan-baseline.neon
+
 parameters:
+
     paths:
         - app
         - database
         - public
-        - resources/views
         - tests
+        # - resources/views -- excluded, the UI is primarily written in Inertia/React going forward
     level: 6
     tmpDir: tmp
     treatPhpDocTypesAsCertain: false
+
+    # Larastan-specific settings for better Laravel/Eloquent understanding.
+    checkModelProperties: true
+    checkOctaneCompatibility: true
+
+    # Be less aggressive about nullsafe operators when relationships might be null.
+    earlyTerminatingMethodCalls: []
+    universalObjectCratesClasses:
+        - Illuminate\Database\Eloquent\Model
+        - Illuminate\Http\Request
+
     # TODO figure out why github actions phpstan does not find the same
     reportUnmatchedIgnoredErrors: false
+
     ignoreErrors:
         - identifier: missingType.iterableValue # replaces deprecated `checkMissingIterableValueType: false`
+        # Eager loading with with() doesn't guarantee relationships are non-null.
+        - identifier: nullsafe.neverNull
         - '#Return type of call to method .+::map\(\) contains unresolvable type#'
         - '#Unsafe usage of new static#'
         # accessors to polymorphic relationships
         - '#Access to an undefined property [a-zA-Z0-9\&\\_]+::\$[trigger\|subject]#'
         - '#Access to an undefined property [a-zA-Z0-9\&\\_]+::\$[a-zA-Z0-9\&\\_]+[_count]#'
-        - '#Access to an undefined property App\\Models\\.*#'
-        # Builder::exists() is not private
-        #- '#Call to private method exists\(\) of parent class Illuminate\\Database\\Eloquent\\Builder<Illuminate\\Database\\Eloquent\\Model>.#'
-        - '#Parameter (.*) of function htmlentities expects#'
         # TODO views have been removed
         - '#Parameter (.*) \$view of function view expects view-string\|null, string given.#'
         # lib/database/user-activity.php
         - '#Offset (.*) does not exist on#'
-        # TODO check if still an issue with Laravel 10
-        - '#Call to an undefined method Database\\Factories#'
-        - '#Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$#'
         - '#Unable to resolve the template type TMapWithKeysValue in call to method Illuminate\\Support\\Collection<\*NEVER\*,\*NEVER\*>::mapWithKeys\(\)#'
-        - '#Command "ra:sync:(.*)" does not have argument "(.*)"#'
+
     excludePaths:
         # unrelated directories
         - public/storage
-        - public/tmp
+        - public/tmp (?)
         # disabled features
         - public/API/API_GetFeed.php
         # third party


### PR DESCRIPTION
Successor to https://github.com/RetroAchievements/RAWeb/pull/3921.

This PR bumps RAWeb to the latest version of PHPStan/Larastan and adds a [baseline file](https://phpstan.org/user-guide/baseline).

Baseline files are used to upgrade to the next version of PHPStan while existing errors are in place. They crystalize the existing errors while preventing new ones from forming.

Subsequent PRs will chip away errors in the baseline file until the file itself can be removed.

`composer stan-baseline` can be used to regenerate the baseline file in these subsequent PRs.