### PR TITLE
chore(UserAgentService): add exception for PCSX2 2.4.0

### DIFF
--- a/app/Platform/Services/UserAgentService.php
+++ b/app/Platform/Services/UserAgentService.php
@@ -319,9 +319,20 @@ class UserAgentService
         if ($emulatorUserAgent->minimum_allowed_version
             && UserAgentService::versionCompare($data['clientVersion'], $emulatorUserAgent->minimum_allowed_version) < 0) {
 
-            // special case: Dolphin/e5d32f273f must still be allowed as it's the most stable development build
+            // TODO allow Filament to support these special cases
+            /**
+             * special case: Dolphin/e5d32f273f must still be allowed as it's the most stable development build
+             */
             if (str_starts_with($userAgent, 'Dolphin/e5d32f273f ')) {
                 return ClientSupportLevel::Outdated;
+            }
+
+            /**
+             * special case: PCSX2 v2.4 does not have a known save state regression
+             * @see https://github.com/PCSX2/pcsx2/pull/13271
+             */
+            if (str_starts_with($userAgent, 'PCSX2 v2.4')) {
+                return ClientSupportLevel::Full;
             }
 
             return ClientSupportLevel::Blocked;


### PR DESCRIPTION
We currently don't have any way in Filament to support emulator version ranges. Some PCSX2 2.5 nightlies have a major regression. 2.4 is fine though.

For now, we'll allow all versions of 2.4.