### PR TITLE
show tooltips for addresses in the middle of a 'N bytes' note

### DIFF
--- a/tests/Feature/Platform/Services/TriggerDecoderServiceTest.php
+++ b/tests/Feature/Platform/Services/TriggerDecoderServiceTest.php
@@ -383,4 +383,25 @@ class TriggerDecoderServiceTest extends TestCase
         $this->assertConditionTargetTooltip($condition, '16');
         $this->assertConditionHitTarget($condition, '0');
     }
+
+    public function testMergeCodeNotesInRange(): void
+    {
+        $service = new TriggerDecoderService();
+        $groups = $service->decode("0xH1240=6");
+        $service->mergeCodeNotes($groups, [
+            0x001234 => "[128 bytes] Inventory",
+        ]);
+
+        $this->assertEquals(1, count($groups));
+        $this->assertEquals(1, count($groups[0]['Conditions']));
+
+        $condition = $groups[0]['Conditions'][0];
+        $this->assertConditionFlag($condition, '');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001240');
+        $this->assertConditionSourceTooltip($condition, "[0x001234 + 12]\n[128 bytes] Inventory");
+        $this->assertConditionOperator($condition, '=');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000006');
+        $this->assertConditionTargetTooltip($condition, '6');
+        $this->assertConditionHitTarget($condition, '0');
+    }
 }


### PR DESCRIPTION
Some examples:
http://localhost:64000/achievement/117890
http://localhost:64000/achievement/106667
http://localhost:64000/achievement/187964

<img width="924" height="348" alt="image" src="https://github.com/user-attachments/assets/0f4521ff-81e7-4378-9f15-c5ed38d61217" />
