### PR TITLE
fix(game): don't show empty 'Development' section in sidebar

### DIFF
--- a/resources/js/common/components/PlayableSidebarButtonsSection/PlayableSidebarButtonsSection.test.tsx
+++ b/resources/js/common/components/PlayableSidebarButtonsSection/PlayableSidebarButtonsSection.test.tsx
@@ -8,7 +8,7 @@ describe('Component: PlayableSidebarButtonsSection', () => {
     // ARRANGE
     const { container } = render(
       <PlayableSidebarButtonsSection headingLabel={'Test Heading' as TranslatedString}>
-        <div>Test Child</div>
+        <button onClick={vi.fn()}>Click me</button>
       </PlayableSidebarButtonsSection>,
     );
 
@@ -20,7 +20,7 @@ describe('Component: PlayableSidebarButtonsSection', () => {
     // ARRANGE
     render(
       <PlayableSidebarButtonsSection headingLabel={'My Section Title' as TranslatedString}>
-        <div>Test Child</div>
+        <button onClick={vi.fn()}>Click me</button>
       </PlayableSidebarButtonsSection>,
     );
 
@@ -32,8 +32,8 @@ describe('Component: PlayableSidebarButtonsSection', () => {
     // ARRANGE
     render(
       <PlayableSidebarButtonsSection headingLabel={'Test Heading' as TranslatedString}>
-        <button>Click me</button>
-        <button>Another button</button>
+        <button onClick={vi.fn()}>Click me</button>
+        <button onClick={vi.fn()}>Another button</button>
       </PlayableSidebarButtonsSection>,
     );
 
@@ -72,7 +72,7 @@ describe('Component: PlayableSidebarButtonsSection', () => {
     render(
       <PlayableSidebarButtonsSection headingLabel={'Test Heading' as TranslatedString}>
         {null}
-        <button>Visible button</button>
+        <button onClick={vi.fn()}>Visible button</button>
       </PlayableSidebarButtonsSection>,
     );
 
@@ -80,5 +80,17 @@ describe('Component: PlayableSidebarButtonsSection', () => {
     expect(screen.getByText(/test heading/i)).toBeVisible();
     expect(screen.getByRole('button', { name: /visible button/i })).toBeVisible();
     expect(screen.queryByRole('button', { name: /hidden/i })).not.toBeInTheDocument();
+  });
+
+  it('given children is a fragment, returns null', () => {
+    // ARRANGE
+    render(
+      <PlayableSidebarButtonsSection headingLabel={'Test Heading' as TranslatedString}>
+        <></>
+      </PlayableSidebarButtonsSection>,
+    );
+
+    // ASSERT
+    expect(screen.queryByText(/test heading/i)).not.toBeInTheDocument();
   });
 });

--- a/resources/js/common/components/PlayableSidebarButtonsSection/PlayableSidebarButtonsSection.tsx
+++ b/resources/js/common/components/PlayableSidebarButtonsSection/PlayableSidebarButtonsSection.tsx
@@ -1,5 +1,4 @@
 import type { FC, ReactNode } from 'react';
-import { Children } from 'react';
 
 import type { TranslatedString } from '@/types/i18next';
 
@@ -12,10 +11,10 @@ export const PlayableSidebarButtonsSection: FC<PlayableSidebarButtonsSectionProp
   children,
   headingLabel,
 }) => {
-  // If there aren't any buttons to render (due to children returning null),
-  // then don't render headingLabel either.
-  const hasVisibleChildren = Children.toArray(children).some((child) => child);
-  if (!hasVisibleChildren) {
+  // If there aren't any buttons or anchors in the children tree,
+  // then don't render the section.
+  const hasButtonOrAnchor = containsButtonOrAnchor(children);
+  if (!hasButtonOrAnchor) {
     return null;
   }
 
@@ -27,3 +26,27 @@ export const PlayableSidebarButtonsSection: FC<PlayableSidebarButtonsSectionProp
     </div>
   );
 };
+
+/**
+ * Recursively checks if a React element tree contains any buttons or anchors.
+ */
+function containsButtonOrAnchor(node: ReactNode): boolean {
+  if (!node) {
+    return false;
+  }
+
+  if (Array.isArray(node)) {
+    return node.some(containsButtonOrAnchor);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this is fully dynamic
+  const dynamicProps = (node as any).props as any;
+
+  // Check for interactive elements by their props.
+  if (dynamicProps?.href || dynamicProps?.onClick) {
+    return true;
+  }
+
+  // Recursively check children.
+  return containsButtonOrAnchor(dynamicProps?.children);
+}


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1420202141183901716.

**Root Cause**
The sections already have logic to not mount if `children` isn't truthy. However, when the Development section has nothing to render, it returns an empty fragment (`<></>`), which is not being properly handled by this logic.