### PR TITLE
fix(game): keep prefix for Rollout Sets hubs in metadata

### DIFF
--- a/resources/js/features/games/hooks/useAllMetaRowElements.ts
+++ b/resources/js/features/games/hooks/useAllMetaRowElements.ts
@@ -212,7 +212,7 @@ export function useAllMetaRowElements(
   const miscRowElements = useMemo(
     () =>
       buildMiscRowElements(allGameHubs, usedHubIdsFromOtherCategories, {
-        keepPrefixFor: ['Clones', 'Fangames'],
+        keepPrefixFor: ['Clones', 'Fangames', 'Rollout Sets'],
       }),
     [allGameHubs, usedHubIdsFromOtherCategories],
   );


### PR DESCRIPTION
**Before**
<img width="510" height="183" alt="Screenshot 2025-09-24 at 8 10 13 AM" src="https://github.com/user-attachments/assets/5d4db498-127d-4c44-be9f-0534bfc6e570" />


**After**
<img width="525" height="226" alt="Screenshot 2025-09-24 at 8 12 28 AM" src="https://github.com/user-attachments/assets/7008bcbb-1034-4c39-bc11-2b681bc6e505" />
