### PR TITLE
fix(GameMobileHeader): use GameTitle to render tagged titles properly

### DIFF
--- a/resources/css/tag.css
+++ b/resources/css/tag.css
@@ -9,6 +9,7 @@
   line-height: 1.1em;
   font-size: .8em;
   overflow: hidden;
+  text-shadow: none;
 }
 
 .tag > * {

--- a/resources/js/features/games/components/GameMobileHeader/GameMobileHeader.tsx
+++ b/resources/js/features/games/components/GameMobileHeader/GameMobileHeader.tsx
@@ -4,6 +4,7 @@ import { LuCheck, LuMegaphone, LuPlus } from 'react-icons/lu';
 import { route } from 'ziggy-js';
 
 import { BetaFeedbackDialog } from '@/common/components/BetaFeedbackDialog';
+import { GameTitle } from '@/common/components/GameTitle';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import { cn } from '@/common/utils/cn';
 import { useGameBacklogState } from '@/features/game-list/components/GameListItems/useGameBacklogState';
@@ -85,7 +86,7 @@ export const GameMobileHeader: FC = () => {
                 game.title.length > 60 ? 'line-clamp-2 !text-sm' : null,
               )}
             >
-              {game.title}
+              <GameTitle title={game.title} />
             </h1>
 
             {/* Chip buttons */}


### PR DESCRIPTION
**Before**
<img width="384" height="300" alt="Screenshot 2025-09-24 at 8 52 40 AM" src="https://github.com/user-attachments/assets/7588e833-3eb7-4e19-a03a-63247a21aea2" />


**After**
<img width="386" height="301" alt="Screenshot 2025-09-24 at 8 51 40 AM" src="https://github.com/user-attachments/assets/be42f5a7-66bc-41ab-9d8a-8e1fadcbbaa5" />
