### PR TITLE
fix(game): remediate Inertia.js mobile backswipe issue

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -57,7 +57,7 @@ createInertiaApp({
     /**
      * WORKAROUND: Inertia has a major bug with iOS Safari.
      * @see https://github.com/inertiajs/inertia/issues/2402
-     * iOS Safari doesn't properly restore Inetia's page component state when using
+     * iOS Safari doesn't properly restore Inertia's page component state when using
      * the back/forward buttons. The page URL changes but the content doesn't update.
      * This workaround forces a full page reload on back/forward navigation to solve the issue.
      *
@@ -69,17 +69,17 @@ createInertiaApp({
         // Store the current URL when navigating.
         let lastUrl = window.location.href;
 
-        // Listen for popstate (back/forward button).
+        // Listen for popstate (back/forward button or a swipe gesture).
         window.addEventListener('popstate', () => {
           const currentUrl = window.location.href;
-          // If the URL changed (meaning back/forward was pressed).
+          // If the URL changed (meaning back/forward was triggered).
           if (currentUrl !== lastUrl) {
-            // Force a hard reload to the new URL.
-            window.location.href = currentUrl;
+            // Use replace() instead of setting href to avoid adding a history entry.
+            window.location.replace(currentUrl);
           }
         });
 
-        // Update the last URL whenever navigation happens.
+        // Update the last URL whenever navigation happens successfully.
         router.on('success', () => {
           lastUrl = window.location.href;
         });


### PR DESCRIPTION
Backswipes on iOS Safari are creating duplicate browser history entries.

Related: https://github.com/RetroAchievements/RAWeb/pull/3946