### PR TITLE
fix(BuildGameShowPagePropsAction): use backingGame for recent players

### DIFF
--- a/app/Platform/Actions/BuildGameShowPagePropsAction.php
+++ b/app/Platform/Actions/BuildGameShowPagePropsAction.php
@@ -312,7 +312,7 @@ class BuildGameShowPagePropsAction
             numLeaderboards: $this->getLeaderboardsCount($backingGame),
             numMasters: $numMasters,
             numOpenTickets: Ticket::forGame($backingGame)->unresolved()->count(),
-            recentPlayers: $this->loadGameRecentPlayersAction->execute($game),
+            recentPlayers: $this->loadGameRecentPlayersAction->execute($backingGame),
             recentVisibleComments: Collection::make(array_reverse(CommentData::fromCollection($backingGame->visibleComments))),
             topAchievers: $topAchievers,
             playerGame: $playerGame ? PlayerGameData::fromPlayerGame($playerGame) : null,


### PR DESCRIPTION
Currently, all recent players are shown from the root game rather than a selected subset. With this PR, the right players (and RP strings) appear.