### PR TITLE
fix(game): show unlock percentages correctly on mobile

### DIFF
--- a/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
+++ b/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
@@ -172,7 +172,11 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
             </p>
 
             <p className="mb-0.5 flex gap-x-1 text-2xs md:mb-0 md:justify-center md:text-center">
-              <ProgressBarMetaText achievement={achievement} playersTotal={playersTotal} />
+              <ProgressBarMetaText
+                achievement={achievement}
+                playersTotal={playersTotal}
+                unlockPercentage={unlockPercentage}
+              />
             </p>
 
             <BaseProgress

--- a/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.test.tsx
+++ b/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.test.tsx
@@ -11,9 +11,9 @@ describe('Component: ProgressBarMetaText', () => {
         achievement={createAchievement({
           unlocksTotal: 100,
           unlocksHardcoreTotal: 50,
-          unlockHardcorePercentage: '0.5',
         })}
         playersTotal={200}
+        unlockPercentage={0.5}
       />,
     );
 
@@ -28,9 +28,9 @@ describe('Component: ProgressBarMetaText', () => {
         achievement={createAchievement({
           unlocksTotal: 100,
           unlocksHardcoreTotal: 50,
-          unlockHardcorePercentage: '0.5',
         })}
         playersTotal={200}
+        unlockPercentage={0.5}
       />,
     );
 
@@ -48,9 +48,9 @@ describe('Component: ProgressBarMetaText', () => {
         achievement={createAchievement({
           unlocksTotal: 75,
           unlocksHardcoreTotal: 75,
-          unlockHardcorePercentage: '0.375',
         })}
         playersTotal={200}
+        unlockPercentage={0.375}
       />,
     );
 
@@ -66,9 +66,9 @@ describe('Component: ProgressBarMetaText', () => {
         achievement={createAchievement({
           unlocksTotal: 75,
           unlocksHardcoreTotal: 75,
-          unlockHardcorePercentage: '0.375',
         })}
         playersTotal={200}
+        unlockPercentage={0.375}
       />,
     );
 
@@ -84,9 +84,9 @@ describe('Component: ProgressBarMetaText', () => {
         achievement={createAchievement({
           unlocksTotal: 100,
           unlocksHardcoreTotal: 50,
-          unlockHardcorePercentage: '0.5',
         })}
         playersTotal={200}
+        unlockPercentage={0.5}
       />,
     );
 
@@ -102,9 +102,9 @@ describe('Component: ProgressBarMetaText', () => {
         achievement={createAchievement({
           unlocksTotal: 0,
           unlocksHardcoreTotal: 0,
-          unlockHardcorePercentage: '0.0',
         })}
         playersTotal={0}
+        unlockPercentage={0}
       />,
     );
 
@@ -121,9 +121,9 @@ describe('Component: ProgressBarMetaText', () => {
         achievement={createAchievement({
           unlocksTotal: undefined,
           unlocksHardcoreTotal: undefined,
-          unlockHardcorePercentage: undefined,
         })}
         playersTotal={200}
+        unlockPercentage={0}
       />,
     );
 
@@ -131,5 +131,6 @@ describe('Component: ProgressBarMetaText', () => {
     expect(screen.getByText('0')).toBeVisible();
     expect(screen.getByText('(0)')).toBeVisible();
     expect(screen.getByText('200')).toBeVisible();
+    expect(screen.getByText('- 0.00%')).toBeVisible();
   });
 });

--- a/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.tsx
+++ b/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.tsx
@@ -7,23 +7,24 @@ import { formatPercentage } from '@/common/utils/l10n/formatPercentage';
 interface ProgressBarMetaTextProps {
   achievement: App.Platform.Data.Achievement;
   playersTotal: number;
+  unlockPercentage: number;
 }
 
 export const ProgressBarMetaText: FC<ProgressBarMetaTextProps> = ({
   achievement,
   playersTotal,
+  unlockPercentage,
 }) => {
   const { t } = useTranslation();
 
   const unlocksHardcoreTotal = achievement.unlocksHardcoreTotal ?? 0;
   const unlocksTotal = achievement.unlocksTotal ?? 0;
-  const unlockHardcorePercentage = achievement.unlockHardcorePercentage ?? 0;
 
   return (
     <Trans
       i18nKey="<1>{{totalUnlocks, number}}</1> <2>({{totalHardcoreUnlocks, number}})</2> of <3>{{totalPlayers, number}}</3> <4>- {{unlockHardcorePercentage}}</4> <5>unlock rate</5>"
       values={{
-        unlockHardcorePercentage: formatPercentage(Number(unlockHardcorePercentage), {
+        unlockHardcorePercentage: formatPercentage(unlockPercentage, {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
         }),


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1420440601123487827.

Unlock percentages are not currently displaying on achievement items on mobile.

**Before**
<img width="368" height="100" alt="Screenshot 2025-09-24 at 5 24 57 PM" src="https://github.com/user-attachments/assets/e063fa7e-90a6-4a8a-a806-3f6dce1d6b55" />


**After**

<img width="372" height="107" alt="Screenshot 2025-09-24 at 5 24 20 PM" src="https://github.com/user-attachments/assets/5bf4f570-50dd-4881-acbe-7d23186751f0" />
