### PR TITLE
fix(game): use consistent progress bar meta text

### DIFF
--- a/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
+++ b/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
@@ -172,7 +172,11 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
             </p>
 
             <p className="mb-0.5 flex gap-x-1 text-2xs md:mb-0 md:justify-center md:text-center">
-              <ProgressBarMetaText achievement={achievement} playersTotal={playersTotal} />
+              <ProgressBarMetaText
+                achievement={achievement}
+                playersTotal={playersTotal}
+                variant={eventAchievement ? 'event' : 'game'}
+              />
             </p>
 
             <BaseProgress

--- a/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.test.tsx
+++ b/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.test.tsx
@@ -14,6 +14,7 @@ describe('Component: ProgressBarMetaText', () => {
           unlockPercentage: '0.5',
         })}
         playersTotal={200}
+        variant="event"
       />,
     );
 
@@ -31,6 +32,7 @@ describe('Component: ProgressBarMetaText', () => {
           unlockPercentage: '0.5',
         })}
         playersTotal={200}
+        variant="event"
       />,
     );
 
@@ -41,22 +43,43 @@ describe('Component: ProgressBarMetaText', () => {
     expect(screen.getByText('- 50.00%')).toBeVisible();
   });
 
-  it('given hardcore unlocks equal total unlocks, hides the hardcore count with sr-only', () => {
+  it('given hardcore unlocks equal total unlocks and variant is event, hides the hardcore count with sr-only', () => {
     // ARRANGE
     render(
       <ProgressBarMetaText
         achievement={createAchievement({
           unlocksTotal: 75,
-          unlocksHardcoreTotal: 75,
+          unlocksHardcoreTotal: 75, // !! equal counts
           unlockPercentage: '0.375',
         })}
         playersTotal={200}
+        variant="event" // !!
       />,
     );
 
     // ASSERT
     const hardcoreElement = screen.getByText('(75)');
     expect(hardcoreElement).toHaveClass('sr-only');
+  });
+
+  it('given hardcore unlocks equal total unlocks and variant is game, shows the hardcore count without sr-only', () => {
+    // ARRANGE
+    render(
+      <ProgressBarMetaText
+        achievement={createAchievement({
+          unlocksTotal: 75,
+          unlocksHardcoreTotal: 75, // !! equal counts
+          unlockPercentage: '0.375',
+        })}
+        playersTotal={200}
+        variant="game" // !!
+      />,
+    );
+
+    // ASSERT
+    const hardcoreElement = screen.getByText('(75)');
+    expect(hardcoreElement).not.toHaveClass('sr-only');
+    expect(hardcoreElement).toHaveClass('font-bold');
   });
 
   it('given hardcore unlocks equal total unlocks and are greater than zero, makes the total count bold', () => {
@@ -69,6 +92,7 @@ describe('Component: ProgressBarMetaText', () => {
           unlockPercentage: '0.375',
         })}
         playersTotal={200}
+        variant="event"
       />,
     );
 
@@ -87,6 +111,7 @@ describe('Component: ProgressBarMetaText', () => {
           unlockPercentage: '0.5',
         })}
         playersTotal={200}
+        variant="event"
       />,
     );
 
@@ -105,6 +130,7 @@ describe('Component: ProgressBarMetaText', () => {
           unlockPercentage: '0.0',
         })}
         playersTotal={0}
+        variant="event"
       />,
     );
 
@@ -124,6 +150,7 @@ describe('Component: ProgressBarMetaText', () => {
           unlockPercentage: undefined,
         })}
         playersTotal={200}
+        variant="event"
       />,
     );
 

--- a/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.tsx
+++ b/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.tsx
@@ -7,11 +7,13 @@ import { formatPercentage } from '@/common/utils/l10n/formatPercentage';
 interface ProgressBarMetaTextProps {
   achievement: App.Platform.Data.Achievement;
   playersTotal: number;
+  variant: 'game' | 'event';
 }
 
 export const ProgressBarMetaText: FC<ProgressBarMetaTextProps> = ({
   achievement,
   playersTotal,
+  variant,
 }) => {
   const { t } = useTranslation();
 
@@ -23,13 +25,13 @@ export const ProgressBarMetaText: FC<ProgressBarMetaTextProps> = ({
     <Trans
       i18nKey="<1>{{totalUnlocks, number}}</1> <2>({{totalHardcoreUnlocks, number}})</2> of <3>{{totalPlayers, number}}</3> <4>- {{unlockHardcorePercentage}}</4> <5>unlock rate</5>"
       values={{
+        totalUnlocks: unlocksTotal,
+        totalHardcoreUnlocks: unlocksHardcoreTotal,
+        totalPlayers: playersTotal,
         unlockHardcorePercentage: formatPercentage(unlockPercentage, {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
         }),
-        totalUnlocks: unlocksTotal,
-        totalHardcoreUnlocks: unlocksHardcoreTotal,
-        totalPlayers: playersTotal,
       }}
       components={{
         1: (
@@ -39,6 +41,7 @@ export const ProgressBarMetaText: FC<ProgressBarMetaTextProps> = ({
               unlocksTotal === unlocksHardcoreTotal && unlocksHardcoreTotal > 0
                 ? 'font-bold'
                 : null,
+
               'cursor-help',
             )}
           />
@@ -47,7 +50,7 @@ export const ProgressBarMetaText: FC<ProgressBarMetaTextProps> = ({
         2: (
           <span
             className={cn(
-              unlocksTotal === unlocksHardcoreTotal ? 'sr-only' : null,
+              unlocksTotal === unlocksHardcoreTotal && variant !== 'game' ? 'sr-only' : null,
               'cursor-help font-bold',
             )}
             title={t('Hardcore unlocks')}


### PR DESCRIPTION
Fixes an issue on React game pages where list items alternate between how hardcore stats are showed if there are no softcore unlocks on the achievement. This results in text that can be kinda disorienting.

**Before**
<img width="867" height="364" alt="Screenshot 2025-09-25 at 5 53 02 PM" src="https://github.com/user-attachments/assets/0587689a-ba15-4e0e-ade2-895d5831f013" />


**After**
<img width="875" height="365" alt="Screenshot 2025-09-25 at 5 53 21 PM" src="https://github.com/user-attachments/assets/46b38a4b-c181-47bf-a95e-e7acf04dc4e4" />
