### PR TITLE
fix(game): add another layer of release deduplication

### DIFF
--- a/resources/js/features/games/components/GameMetadata/GameReleaseDatesRow/GameReleaseDatesRow.tsx
+++ b/resources/js/features/games/components/GameMetadata/GameReleaseDatesRow/GameReleaseDatesRow.tsx
@@ -8,6 +8,7 @@ import {
   BaseTooltipTrigger,
 } from '@/common/components/+vendor/BaseTooltip';
 import { formatGameReleasedAt } from '@/common/utils/formatGameReleasedAt';
+import { useDeduplicatedReleases } from '@/features/games/hooks/useDeduplicatedReleases';
 
 interface GameReleaseDatesRowProps {
   releases: App.Platform.Data.GameRelease[];
@@ -16,15 +17,17 @@ interface GameReleaseDatesRowProps {
 export const GameReleaseDatesRow: FC<GameReleaseDatesRowProps> = ({ releases }) => {
   const { t } = useTranslation();
 
+  const uniqueReleases = useDeduplicatedReleases(releases);
+
   return (
     <BaseTableRow className="first:rounded-t-lg last:rounded-b-lg">
       <BaseTableHead scope="row" className="h-auto text-right align-top text-text">
-        {t('metaRelease', { count: releases.length })}
+        {t('metaRelease', { count: uniqueReleases.length })}
       </BaseTableHead>
 
       <BaseTableCell>
         <span className="flex flex-col">
-          {releases.map((release) => {
+          {uniqueReleases.map((release) => {
             // Treat "other" and null as "Worldwide" for now.
             const displayRegion =
               !release.region || release.region === 'other' || release.region === 'worldwide'
@@ -32,7 +35,7 @@ export const GameReleaseDatesRow: FC<GameReleaseDatesRowProps> = ({ releases }) 
                 : release.region;
 
             // Hide the region if there's only one release and it's worldwide.
-            const shouldShowRegion = !(releases.length === 1 && displayRegion === 'WW');
+            const shouldShowRegion = !(uniqueReleases.length === 1 && displayRegion === 'WW');
 
             return (
               <span key={release.id}>

--- a/resources/js/features/games/hooks/useDeduplicatedReleases.test.ts
+++ b/resources/js/features/games/hooks/useDeduplicatedReleases.test.ts
@@ -1,0 +1,144 @@
+import { renderHook } from '@/test';
+import { createGameRelease } from '@/test/factories';
+
+import { useDeduplicatedReleases } from './useDeduplicatedReleases';
+
+describe('Hook: useDeduplicatedReleases', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const releases: App.Platform.Data.GameRelease[] = [];
+
+    // ACT
+    const { result } = renderHook(() => useDeduplicatedReleases(releases));
+
+    // ASSERT
+    expect(result.current).toEqual([]);
+  });
+
+  it('given releases with different regions and dates, returns all releases', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({ region: 'na', releasedAt: '2024-01-01T00:00:00Z' }),
+      createGameRelease({ region: 'jp', releasedAt: '2024-01-01T00:00:00Z' }),
+      createGameRelease({ region: 'na', releasedAt: '2024-02-01T00:00:00Z' }),
+    ];
+
+    // ACT
+    const { result } = renderHook(() => useDeduplicatedReleases(releases));
+
+    // ASSERT
+    expect(result.current).toHaveLength(3);
+    expect(result.current).toEqual(releases);
+  });
+
+  it('given releases with the same region and date, keeps only the first occurrence', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({ region: 'na', releasedAt: '2024-01-01T00:00:00Z', title: 'First' }),
+      createGameRelease({ region: 'na', releasedAt: '2024-01-01T12:00:00Z', title: 'Second' }),
+      createGameRelease({ region: 'na', releasedAt: '2024-01-01T23:59:59Z', title: 'Third' }),
+    ];
+
+    // ACT
+    const { result } = renderHook(() => useDeduplicatedReleases(releases));
+
+    // ASSERT
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].title).toEqual('First');
+  });
+
+  it('given releases with "worldwide" region, treats them as "WW"', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({ region: 'worldwide', releasedAt: '2024-01-01T00:00:00Z' }),
+      createGameRelease({ region: 'other', releasedAt: '2024-01-01T00:00:00Z' }),
+    ];
+
+    // ACT
+    const { result } = renderHook(() => useDeduplicatedReleases(releases));
+
+    // ASSERT
+    // ... both are treated as WW with the same date, so only one should remain ...
+    expect(result.current).toHaveLength(1);
+  });
+
+  it('given releases with "other" region, treats them as "WW"', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({ region: 'other', releasedAt: '2024-01-01T00:00:00Z', title: 'First' }),
+      createGameRelease({ region: undefined, releasedAt: '2024-01-01T00:00:00Z', title: 'Second' }),
+    ];
+
+    // ACT
+    const { result } = renderHook(() => useDeduplicatedReleases(releases));
+
+    // ASSERT
+    // ... both are treated as WW with the same date, so only one should remain ...
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].title).toEqual('First');
+  });
+
+  it('given releases with a null or undefined region, treats them as "WW"', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({ region: null, releasedAt: '2024-01-01T00:00:00Z' }),
+      createGameRelease({ region: undefined, releasedAt: '2024-01-01T00:00:00Z' }),
+      createGameRelease({ region: 'worldwide', releasedAt: '2024-01-01T00:00:00Z' }),
+    ];
+
+    // ACT
+    const { result } = renderHook(() => useDeduplicatedReleases(releases));
+
+    // ASSERT
+    // ... all three are treated as WW with same date, so only one should remain ...
+    expect(result.current).toHaveLength(1);
+  });
+
+  it('given releases with null dates, groups them together', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({ region: 'na', releasedAt: null, title: 'First' }),
+      createGameRelease({ region: 'na', releasedAt: undefined, title: 'Second' }),
+    ];
+
+    // ACT
+    const { result } = renderHook(() => useDeduplicatedReleases(releases));
+
+    // ASSERT
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].title).toEqual('First');
+  });
+
+  it('given releases with different times on the same date, deduplicates based on date only', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({ region: 'jp', releasedAt: '2024-01-01T00:00:00Z' }),
+      createGameRelease({ region: 'jp', releasedAt: '2024-01-01T23:59:59Z' }),
+    ];
+
+    // ACT
+    const { result } = renderHook(() => useDeduplicatedReleases(releases));
+
+    // ASSERT
+    // ... same region and date (ignoring time), so only one should remain ..
+    expect(result.current).toHaveLength(1);
+  });
+
+  it('given a mix of duplicate and unique releases, filters out only the duplicates', () => {
+    // ARRANGE
+    const releases = [
+      createGameRelease({ region: 'na', releasedAt: '2024-01-01T00:00:00Z' }),
+      createGameRelease({ region: 'jp', releasedAt: '2024-01-01T00:00:00Z' }),
+      createGameRelease({ region: 'na', releasedAt: '2024-01-01T12:00:00Z' }), // duplicate
+      createGameRelease({ region: 'eu', releasedAt: '2024-01-02T00:00:00Z' }),
+      createGameRelease({ region: 'worldwide', releasedAt: '2024-01-03T00:00:00Z' }),
+      createGameRelease({ region: 'other', releasedAt: '2024-01-03T00:00:00Z' }), // duplicate (both WW)
+    ];
+
+    // ACT
+    const { result } = renderHook(() => useDeduplicatedReleases(releases));
+
+    // ASSERT
+    expect(result.current).toHaveLength(4);
+  });
+});

--- a/resources/js/features/games/hooks/useDeduplicatedReleases.ts
+++ b/resources/js/features/games/hooks/useDeduplicatedReleases.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+export function useDeduplicatedReleases(
+  releases: App.Platform.Data.GameRelease[],
+): App.Platform.Data.GameRelease[] {
+  return useMemo(() => {
+    const seen = new Set<string>();
+
+    return releases.filter((release) => {
+      const region =
+        !release.region || release.region === 'other' || release.region === 'worldwide'
+          ? 'WW'
+          : release.region;
+      const date = release.releasedAt?.split('T')[0] ?? 'no-date';
+      const key = `${region}_${date}`;
+
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+
+      return true;
+    });
+  }, [releases]);
+}


### PR DESCRIPTION
http://localhost:64000/game2/7212

The UI needs a thin layer of deduplication for game releases, in addition to the deduplication already happening in the back-end. The front-end deduplication layer ensures unique titles aren't discarded on identical regions and dates.

**Before**
<img width="369" height="392" alt="Screenshot 2025-09-25 at 6 09 41 PM" src="https://github.com/user-attachments/assets/d270d600-8056-4a56-a24f-9a10fc574a3e" />


**After**
<img width="369" height="240" alt="Screenshot 2025-09-25 at 6 09 34 PM" src="https://github.com/user-attachments/assets/1dd36768-aafe-4727-bdaf-f45500c9d931" />
