### PR TITLE
feat(game): add sorting to Beaten Game Credit dialog, make some css updates

### DIFF
--- a/resources/js/features/games/components/BeatenCreditDialog/BeatenCreditAchievementList/BeatenCreditAchievementList.test.tsx
+++ b/resources/js/features/games/components/BeatenCreditDialog/BeatenCreditAchievementList/BeatenCreditAchievementList.test.tsx
@@ -63,7 +63,7 @@ describe('Component: BeatenCreditAchievementList', () => {
     render(<BeatenCreditAchievementList achievements={[unlockedAchievement]} type="progression" />);
 
     // ASSERT
-    const unlockedContainer = screen.getByText(/unlocked achievement/i).closest('div.rounded-lg');
+    const unlockedContainer = screen.getByText(/unlocked achievement/i).closest('div.rounded');
     expect(unlockedContainer).toHaveClass('border-green-700/30', 'bg-green-900/20');
   });
 
@@ -80,7 +80,7 @@ describe('Component: BeatenCreditAchievementList', () => {
     );
 
     // ASSERT
-    const unlockedContainer = screen.getByText(/unlocked achievement/i).closest('div.rounded-lg');
+    const unlockedContainer = screen.getByText(/unlocked achievement/i).closest('div.rounded');
     expect(unlockedContainer).toHaveClass('border-amber-700/30', 'bg-amber-900/20');
   });
 

--- a/resources/js/features/games/components/BeatenCreditDialog/BeatenCreditAchievementList/BeatenCreditAchievementList.tsx
+++ b/resources/js/features/games/components/BeatenCreditDialog/BeatenCreditAchievementList/BeatenCreditAchievementList.tsx
@@ -6,6 +6,7 @@ import { AchievementAvatar } from '@/common/components/AchievementAvatar';
 import { RaProgression } from '@/common/components/RaProgression';
 import { RaWinCondition } from '@/common/components/RaWinCondition';
 import { cn } from '@/common/utils/cn';
+import { sortAchievements } from '@/common/utils/sortAchievements';
 
 interface BeatenCreditAchievementListProps {
   achievements: App.Platform.Data.Achievement[];
@@ -19,6 +20,9 @@ export const BeatenCreditAchievementList: FC<BeatenCreditAchievementListProps> =
   const { t } = useTranslation();
 
   const Icon = type === 'progression' ? RaProgression : RaWinCondition;
+
+  // Show unlocked achievements at the top of the list.
+  const sortedAchievements = sortAchievements(achievements, 'normal');
 
   return (
     <div className="flex flex-col gap-2">
@@ -43,8 +47,8 @@ export const BeatenCreditAchievementList: FC<BeatenCreditAchievementListProps> =
         </p>
       </div>
 
-      <div className="grid gap-2 sm:grid-cols-2">
-        {achievements.map((achievement) => (
+      <div className="flex flex-col gap-2">
+        {sortedAchievements.map((achievement) => (
           <div
             key={`${type}-${achievement.id}`}
             className={getAchievementCardClassName(type, !!achievement.unlockedAt)}
@@ -76,7 +80,7 @@ function getAchievementCardClassName(
   type: 'progression' | 'win_condition',
   isUnlocked: boolean,
 ): string {
-  const baseClasses = 'flex items-center gap-4 rounded-lg border p-3';
+  const baseClasses = 'flex items-center gap-4 rounded border p-3';
 
   if (type === 'progression') {
     return cn(

--- a/resources/js/features/games/components/BeatenCreditDialog/BeatenCreditDialog.tsx
+++ b/resources/js/features/games/components/BeatenCreditDialog/BeatenCreditDialog.tsx
@@ -71,13 +71,18 @@ export const BeatenCreditDialog: FC = () => {
         ) : null}
       </div>
 
-      {progressionAchievements?.length ? (
-        <BeatenCreditAchievementList type="progression" achievements={progressionAchievements} />
-      ) : null}
+      <div className="flex flex-col gap-8">
+        {progressionAchievements?.length ? (
+          <BeatenCreditAchievementList type="progression" achievements={progressionAchievements} />
+        ) : null}
 
-      {winConditionAchievements?.length ? (
-        <BeatenCreditAchievementList type="win_condition" achievements={winConditionAchievements} />
-      ) : null}
+        {winConditionAchievements?.length ? (
+          <BeatenCreditAchievementList
+            type="win_condition"
+            achievements={winConditionAchievements}
+          />
+        ) : null}
+      </div>
     </BaseDialogContent>
   );
 };

--- a/resources/js/features/games/components/BeatenCreditDialog/JumboTypeMetric/JumboTypeMetric.tsx
+++ b/resources/js/features/games/components/BeatenCreditDialog/JumboTypeMetric/JumboTypeMetric.tsx
@@ -17,7 +17,7 @@ export const JumboTypeMetric: FC<JumboTypeMetricProps> = ({ current, total, type
   const Icon = type === 'progression' ? RaProgression : RaWinCondition;
 
   return (
-    <div className="rounded-lg border border-neutral-700 bg-neutral-800 p-4">
+    <div className="rounded border border-neutral-700 bg-neutral-800 p-4">
       <div className="flex flex-col gap-2">
         <p className="flex items-center justify-between text-neutral-400">
           <span>


### PR DESCRIPTION
This PR:
* Applies the "normal" sort order to achievements so the unlocked ones appear before locked ones.
* Updates the layout (no more 2 column grid) and applies a consistent border radius to all elements.

**Before**
<img width="867" height="815" alt="Screenshot 2025-09-25 at 6 27 49 PM" src="https://github.com/user-attachments/assets/2c1d1452-fad6-4bfe-9a51-29111c7f4f7f" />


**After**
<img width="868" height="810" alt="Screenshot 2025-09-25 at 6 27 39 PM" src="https://github.com/user-attachments/assets/6d6c0f14-cc2f-4481-b22c-11681925b7dc" />
