### PR TITLE
fix(game): have the Series Hub link respect user cookie prefs

### DIFF
--- a/app/Platform/Controllers/HubController.php
+++ b/app/Platform/Controllers/HubController.php
@@ -23,9 +23,7 @@ use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 
-// TODO mature hub needs to be age gated
 // TODO on rename hub, make sure it's always wrapped in square brackets
-// TODO play around on mobile
 
 class HubController extends Controller
 {

--- a/resources/js/features/games/components/SeriesHubDisplay/SeriesHubDisplay.tsx
+++ b/resources/js/features/games/components/SeriesHubDisplay/SeriesHubDisplay.tsx
@@ -3,9 +3,10 @@ import { Trans, useTranslation } from 'react-i18next';
 import { FaGamepad } from 'react-icons/fa';
 import { ImTrophy } from 'react-icons/im';
 import { PiMedalFill } from 'react-icons/pi';
-import { route } from 'ziggy-js';
 
 import { cleanHubTitle } from '@/common/utils/cleanHubTitle';
+
+import { useSeriesHubHref } from '../../hooks/useSeriesHubHref';
 
 /**
  * Hub links are intentionally not using <InertiaLink />.
@@ -20,11 +21,7 @@ interface SeriesHubDisplayProps {
 export const SeriesHubDisplay: FC<SeriesHubDisplayProps> = ({ seriesHub }) => {
   const { t } = useTranslation();
 
-  const hubHref = route('hub.show', {
-    gameSet: seriesHub.hub.id,
-    sort: '-playersTotal',
-    'filter[subsets]': 'only-games',
-  });
+  const { href } = useSeriesHubHref(seriesHub.hub.id);
 
   return (
     <div data-testid="series-hub">
@@ -33,7 +30,7 @@ export const SeriesHubDisplay: FC<SeriesHubDisplayProps> = ({ seriesHub }) => {
       <div className="rounded-lg bg-embed p-1 light:border light:border-neutral-200 light:bg-white">
         <div className="flex flex-col gap-3 rounded-lg bg-[rgba(50,50,50,0.3)] p-2 light:bg-neutral-50">
           <div className="flex items-center gap-3">
-            <a href={hubHref}>
+            <a href={href}>
               <img
                 src={seriesHub.hub.badgeUrl!}
                 alt={seriesHub.hub.title!}
@@ -42,7 +39,7 @@ export const SeriesHubDisplay: FC<SeriesHubDisplayProps> = ({ seriesHub }) => {
             </a>
 
             <div className="flex-1">
-              <a href={hubHref}>{cleanHubTitle(seriesHub.hub.title!, true)}</a>
+              <a href={href}>{cleanHubTitle(seriesHub.hub.title!, true)}</a>
 
               <div className="flex items-center gap-1.5 text-xs">
                 <FaGamepad className="size-4 text-neutral-400" />

--- a/resources/js/features/games/hooks/useSeriesHubHref.test.ts
+++ b/resources/js/features/games/hooks/useSeriesHubHref.test.ts
@@ -1,0 +1,44 @@
+import * as ReactUse from 'react-use';
+
+import { renderHook } from '@/test';
+
+import { useSeriesHubHref } from './useSeriesHubHref';
+
+describe('Hook: useSeriesHubHref', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const { result } = renderHook(() => useSeriesHubHref(123));
+
+    // ASSERT
+    expect(result.current.href).toBeTruthy();
+  });
+
+  it('given no preferences cookie exists, returns the href with default params', () => {
+    // ARRANGE
+    vi.spyOn(ReactUse, 'useCookie').mockReturnValue([null, vi.fn(), vi.fn()]);
+
+    // ACT
+    const { result } = renderHook(() => useSeriesHubHref(123));
+
+    // ASSERT
+    expect(result.current.href).toEqual([
+      'hub.show',
+      {
+        gameSet: 123,
+        sort: '-playersTotal',
+        'filter[subsets]': 'only-games',
+      },
+    ]);
+  });
+
+  it('given a preferences cookie exists, returns the href without params after the effect runs', async () => {
+    // ARRANGE
+    vi.spyOn(ReactUse, 'useCookie').mockReturnValue(['some-preference-value', vi.fn(), vi.fn()]);
+
+    // ACT
+    const { result } = renderHook(() => useSeriesHubHref(123));
+
+    // ASSERT
+    expect(result.current.href).toEqual(['hub.show', { gameSet: 123 }]);
+  });
+});

--- a/resources/js/features/games/hooks/useSeriesHubHref.ts
+++ b/resources/js/features/games/hooks/useSeriesHubHref.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { useCookie } from 'react-use';
+import { route } from 'ziggy-js';
+
+/**
+ * Users can persist their datatable preferences, which are stored in a cookie.
+ * If the user has hub datatable preferences, we don't want to tack on query
+ * params to this URL, as those params override whatever prefs the user has set.
+ */
+export function useSeriesHubHref(gameSetId: number) {
+  const [rawViewPreferences] = useCookie('datatable_view_preference_hub_games');
+
+  const [href, setHref] = useState(() =>
+    // Start with default params for SSR and the initial render.
+    route('hub.show', {
+      gameSet: gameSetId,
+      sort: '-playersTotal',
+      'filter[subsets]': 'only-games',
+    }),
+  );
+
+  useEffect(() => {
+    // Check for persisted preferences during the initial client-side render.
+    if (rawViewPreferences) {
+      // User has preferences - remove the default params.
+      setHref(route('hub.show', { gameSet: gameSetId }));
+    }
+    // If no preferences, keep the default params.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional
+  }, [gameSetId]);
+
+  return { href };
+}


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1420648984472457226

The Series Hub URL should not tack on query params if the user has cookie settings for the datatable persisted.