### PR TITLE
feat(game): restore box art, title, and ingame images on mobile

### DIFF
--- a/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.tsx
+++ b/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.tsx
@@ -9,8 +9,10 @@ import {
 } from '@/common/components/+vendor/BaseTabs';
 import { MatureContentWarningDialog } from '@/common/components/MatureContentWarningDialog';
 import { PlayableAchievementDistribution } from '@/common/components/PlayableAchievementDistribution';
+import { PlayableBoxArtImage } from '@/common/components/PlayableBoxArtImage';
 import { PlayableCompareProgress } from '@/common/components/PlayableCompareProgress';
 import { PlayableHubsList } from '@/common/components/PlayableHubsList';
+import { PlayableMainMedia } from '@/common/components/PlayableMainMedia';
 import { PlayableTopPlayers } from '@/common/components/PlayableTopPlayers';
 import { usePageProps } from '@/common/hooks/usePageProps';
 
@@ -109,6 +111,15 @@ export const GameShowMobileRoot: FC = () => {
         </BaseTabsContent>
 
         <BaseTabsContent value="info" className="flex flex-col gap-8">
+          <div className="-mx-2.5 flex flex-col gap-6 bg-embed p-4">
+            <PlayableBoxArtImage src={game.imageBoxArtUrl} />
+
+            <PlayableMainMedia
+              imageIngameUrl={game.imageIngameUrl!}
+              imageTitleUrl={game.imageTitleUrl!}
+            />
+          </div>
+
           {hasMatureContent ? <MatureContentIndicator /> : null}
 
           <GameMetadata allMetaRowElements={allMetaRowElements} game={game} hubs={hubs} />

--- a/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.tsx
+++ b/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.tsx
@@ -111,7 +111,7 @@ export const GameShowMobileRoot: FC = () => {
         </BaseTabsContent>
 
         <BaseTabsContent value="info" className="flex flex-col gap-8">
-          <div className="-mx-2.5 flex flex-col gap-6 bg-embed p-4">
+          <div className="-mx-2.5 -my-4 flex flex-col gap-6 p-4">
             <PlayableBoxArtImage src={game.imageBoxArtUrl} />
 
             <PlayableMainMedia


### PR DESCRIPTION
Addresses the most persistent piece of feedback we're receiving about the mobile view.

No carousel - trying a different approach here. The images are all tappable just like desktop if the user wants to zoom in. This saves vertical space.

<img width="383" height="674" alt="Screenshot 2025-09-25 at 9 02 30 PM" src="https://github.com/user-attachments/assets/27faa540-04d0-454f-80e9-3888c623810f" />
