### PR TITLE
fix(ForwardMessageToDiscordAction): add basic error handling

### DIFF
--- a/app/Community/Listeners/NotifyMessageThreadParticipants.php
+++ b/app/Community/Listeners/NotifyMessageThreadParticipants.php
@@ -12,6 +12,7 @@ use App\Mail\PrivateMessageReceivedMail;
 use App\Models\MessageThread;
 use App\Models\MessageThreadParticipant;
 use App\Models\User;
+use Exception;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
@@ -73,7 +74,7 @@ class NotifyMessageThreadParticipants
 
             try {
                 (new ForwardMessageToDiscordAction())->execute($userFrom, $userTo, $thread, $message);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 Log::warning('Discord notification failed', [
                     'thread_id' => $thread->id,
                     'user_from' => $userFrom->username,


### PR DESCRIPTION
When Discord's API explodes, users shouldn't see a "Something went wrong" message when submitting their messages.

<img width="762" height="304" alt="Screenshot 2025-09-27 at 8 29 06 AM" src="https://github.com/user-attachments/assets/56cd68b2-68f0-4d45-b8d5-06346a8359bc" />