### PR TITLE
fix(PlayerGameProgressBar): remediate controlled/uncontrolled tooltip regression

### DIFF
--- a/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.tsx
+++ b/resources/js/common/components/PlayerGameProgressBar/PlayerGameProgressBar.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import utc from 'dayjs/plugin/utc';
 import type { FC } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { route } from 'ziggy-js';
 
@@ -80,6 +81,8 @@ export const PlayerGameProgressBar: FC<PlayerGameProgressBarProps> = ({
 
   const { formatPercentage } = useFormatPercentage();
 
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+
   const achievementsPublished = game?.achievementsPublished ?? 0;
   const pointsTotal = game.pointsTotal ?? 0;
   const achievementsUnlocked = playerGame?.achievementsUnlocked ?? 0;
@@ -122,7 +125,7 @@ export const PlayerGameProgressBar: FC<PlayerGameProgressBarProps> = ({
   const isTooltipDisabled = achievementsUnlocked === 0 || !isTooltipEnabled;
 
   return (
-    <BaseTooltip open={!achievementsUnlocked ? false : undefined}>
+    <BaseTooltip open={isTooltipDisabled ? false : isTooltipOpen} onOpenChange={setIsTooltipOpen}>
       <BaseTooltipTrigger
         className={cn(
           'group',


### PR DESCRIPTION
Fixes a regression caused by #3910.

Progress bars are back to flooding the Sentry logs with:
<img width="919" height="39" alt="Screenshot 2025-09-27 at 8 49 17 AM" src="https://github.com/user-attachments/assets/32e23de9-e43e-41e0-98e0-676569b48720" />

Now, these bars are _always_ controlled.

"Controlled" vs "uncontrolled" is React terminology for whether or not `open` is explicitly set or implied.