### PR TITLE
fix(game): on mobile, navigate to 'Achievements' tab when selecting View Unpublished Achievements

### DIFF
--- a/resources/js/common/components/PlayableSidebarButton/PlayableSidebarButton.tsx
+++ b/resources/js/common/components/PlayableSidebarButton/PlayableSidebarButton.tsx
@@ -44,7 +44,7 @@ export const PlayableSidebarButton: FC<PlayableSidebarButtonProps> = ({
     className: cn('items-center justify-between gap-2 relative overflow-hidden', className),
   });
 
-  if (onClick) {
+  if (onClick && !href) {
     return (
       <button onClick={onClick} className={finalClassName} {...rest}>
         <ButtonContent
@@ -63,6 +63,7 @@ export const PlayableSidebarButton: FC<PlayableSidebarButtonProps> = ({
   return (
     <Comp
       href={href as string}
+      onClick={onClick}
       className={finalClassName}
       prefetch={isInertiaLink ? 'desktop-hover-only' : undefined}
       target={target}

--- a/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.test.tsx
+++ b/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.test.tsx
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker';
+import userEvent from '@testing-library/user-event';
 
 import { render, screen } from '@/test';
 import {
@@ -509,5 +510,43 @@ describe('Component: GameShowMobileRoot', () => {
 
     // ASSERT
     expect(screen.queryByTestId('playable-compare-progress')).not.toBeInTheDocument();
+  });
+
+  it('given the user changes tabs, does not crash', async () => {
+    // ARRANGE
+    const game = createGame({
+      badgeUrl: 'badge.jpg', // !!
+      gameAchievementSets: [createGameAchievementSet({ achievementSet: createAchievementSet() })],
+      imageBoxArtUrl: faker.internet.url(),
+      imageTitleUrl: faker.internet.url(),
+      imageIngameUrl: faker.internet.url(),
+      system: createSystem({
+        iconUrl: 'icon.jpg', // !!
+      }),
+    });
+
+    const { container } = render(<GameShowMobileRoot />, {
+      pageProps: {
+        game,
+        achievementSetClaims: [],
+        aggregateCredits: createAggregateAchievementSetCredits(),
+        backingGame: game,
+        can: {},
+        hubs: [],
+        selectableGameAchievementSets: [],
+        isViewingPublishedAchievements: true,
+        playerAchievementChartBuckets: [],
+        recentPlayers: [],
+        recentVisibleComments: [],
+        topAchievers: [],
+        ziggy: createZiggyProps(),
+      },
+    });
+
+    // ACT
+    await userEvent.click(screen.getByRole('tab', { name: /info/i }));
+
+    // ASSERT
+    expect(container).toBeTruthy();
   });
 });

--- a/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.test.tsx
+++ b/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.test.tsx
@@ -515,13 +515,13 @@ describe('Component: GameShowMobileRoot', () => {
   it('given the user changes tabs, does not crash', async () => {
     // ARRANGE
     const game = createGame({
-      badgeUrl: 'badge.jpg', // !!
+      badgeUrl: 'badge.jpg',
       gameAchievementSets: [createGameAchievementSet({ achievementSet: createAchievementSet() })],
       imageBoxArtUrl: faker.internet.url(),
       imageTitleUrl: faker.internet.url(),
       imageIngameUrl: faker.internet.url(),
       system: createSystem({
-        iconUrl: 'icon.jpg', // !!
+        iconUrl: 'icon.jpg',
       }),
     });
 

--- a/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.tsx
+++ b/resources/js/features/games/components/+show-mobile/GameShowMobileRoot.tsx
@@ -18,6 +18,7 @@ import { usePageProps } from '@/common/hooks/usePageProps';
 
 import { useAllMetaRowElements } from '../../hooks/useAllMetaRowElements';
 import { useGameShowTabs } from '../../hooks/useGameShowTabs';
+import type { GameShowTab } from '../../models';
 import { getAllPageAchievements } from '../../utils/getAllPageAchievements';
 import { getSidebarExcludedHubIds } from '../../utils/getSidebarExcludedHubIds';
 import { AchievementSetEmptyState } from '../AchievementSetEmptyState';
@@ -74,7 +75,7 @@ export const GameShowMobileRoot: FC = () => {
 
       <GameMobileHeader />
 
-      <BaseTabs value={currentTab} onValueChange={setCurrentTab}>
+      <BaseTabs value={currentTab} onValueChange={(value) => setCurrentTab(value as GameShowTab)}>
         {/* Tabs list */}
         <div className="-mx-2.5 -mt-3 overflow-x-auto">
           <BaseTabsList className="mb-3 flex w-max min-w-full justify-between rounded-none border-b border-neutral-600 bg-embed py-0 light:bg-white light:pt-1">

--- a/resources/js/features/games/components/GameSidebarFullWidthButtons/SidebarDevelopmentSection/SidebarDevelopmentSection.test.tsx
+++ b/resources/js/features/games/components/GameSidebarFullWidthButtons/SidebarDevelopmentSection/SidebarDevelopmentSection.test.tsx
@@ -38,6 +38,10 @@ describe('Component: SidebarDevelopmentSection', () => {
     mockRemoveFromGameList.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('renders without crashing', () => {
     // ARRANGE
     const game = createGame({ gameAchievementSets: [] });
@@ -344,5 +348,38 @@ describe('Component: SidebarDevelopmentSection', () => {
 
     // ASSERT
     expect(screen.getByRole('link', { name: /view unpublished achievements/i })).toBeVisible();
+  });
+
+  it('given the user taps the link to view unpublished achievements, scrolls to the top of the screen', async () => {
+    // ARRANGE
+    const game = createGame({ id: 1, gameAchievementSets: [] });
+    const backingGame = createGame({
+      id: 2,
+      achievementsPublished: 50,
+      achievementsUnpublished: 10,
+    });
+    const pageProps = {
+      backingGame,
+      game,
+      achievementSetClaims: [],
+      can: {},
+      isOnWantToDevList: false,
+      isViewingPublishedAchievements: true,
+      ziggy: createZiggyProps(),
+    };
+
+    const scrollToSpy = vi.spyOn(window, 'scrollTo');
+
+    render(<SidebarDevelopmentSection />, { pageProps });
+
+    // ACT
+    await userEvent.click(screen.getByRole('link', { name: /view unpublished achievements/i }));
+
+    // ASSERT
+    expect(scrollToSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        top: 0,
+      }),
+    );
   });
 });

--- a/resources/js/features/games/components/GameSidebarFullWidthButtons/SidebarDevelopmentSection/SidebarDevelopmentSection.tsx
+++ b/resources/js/features/games/components/GameSidebarFullWidthButtons/SidebarDevelopmentSection/SidebarDevelopmentSection.tsx
@@ -6,6 +6,7 @@ import { route } from 'ziggy-js';
 import { PlayableSidebarButton } from '@/common/components/PlayableSidebarButton';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import { useGameBacklogState } from '@/features/game-list/components/GameListItems/useGameBacklogState';
+import { useGameShowTabs } from '@/features/games/hooks/useGameShowTabs';
 
 import { SidebarClaimButtons } from './SidebarClaimButtons';
 import { SidebarToggleInReviewButton } from './SidebarToggleInReviewButton';
@@ -27,6 +28,8 @@ export const SidebarDevelopmentSection: FC = () => {
       userGameListType: 'develop',
     });
 
+  const { setCurrentTab } = useGameShowTabs();
+
   const isDeveloper = auth?.user.roles.includes('developer');
 
   // Build the query parameters for toggling between published and unpublished achievements.
@@ -44,12 +47,21 @@ export const SidebarDevelopmentSection: FC = () => {
     return route('game2.show', { game: game.id, _query: queryParams });
   };
 
+  const handleTogglePublishedAchievementsClick = () => {
+    setCurrentTab('achievements');
+    window.scrollTo({
+      top: 0,
+      behavior: 'instant',
+    });
+  };
+
   return (
     <>
       {!isViewingPublishedAchievements || backingGame.achievementsUnpublished ? (
         <PlayableSidebarButton
           IconComponent={isViewingPublishedAchievements ? LuFolderLock : LuFolder}
           href={buildToggleHref()}
+          onClick={handleTogglePublishedAchievementsClick}
           isInertiaLink={true}
           showSubsetIndicator={game.id !== backingGame.id}
           count={

--- a/resources/js/features/games/hooks/useGameShowTabs.ts
+++ b/resources/js/features/games/hooks/useGameShowTabs.ts
@@ -6,12 +6,11 @@ import { currentTabAtom } from '../state/games.atoms';
 export function useGameShowTabs() {
   const [currentTab, internal_setCurrentTab] = useAtom(currentTabAtom);
 
-  const setCurrentTab = (value: string) => {
-    const safeValue = value as GameShowTab;
-    internal_setCurrentTab(safeValue);
+  const setCurrentTab = (value: GameShowTab) => {
+    internal_setCurrentTab(value);
 
     const searchParams = new URLSearchParams(window.location.search);
-    if (safeValue !== 'achievements') {
+    if (value !== 'achievements') {
       searchParams.set('tab', value);
     } else {
       searchParams.delete('tab');


### PR DESCRIPTION
This PR fixes a bug that affects mobile only.

When selecting the "View Unpublished Achievements" link in the Info tab, the tab isn't being reset to "Achievements". This PR fixes the issue.