### PR TITLE
fix(game): don't lock mobile scrolling when starting scroll from the sort button

### DIFF
--- a/resources/js/common/components/PlayableListSortButton/PlayableListSortButton.test.tsx
+++ b/resources/js/common/components/PlayableListSortButton/PlayableListSortButton.test.tsx
@@ -243,4 +243,26 @@ describe('Component: PlayableListSortButton', () => {
     // ASSERT
     expect(onChange).toHaveBeenCalledWith('-wonBy');
   });
+
+  it('given the user selects the already-selected option, does not call onChange', async () => {
+    // ARRANGE
+    const onChange = vi.fn();
+
+    render(
+      <PlayableListSortButton
+        value="displayOrder"
+        onChange={onChange}
+        availableSortOrders={['displayOrder', 'wonBy', '-wonBy']}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(
+      screen.getByRole('menuitemcheckbox', { name: /display order \(first\)/i }),
+    );
+
+    // ASSERT
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/resources/js/common/components/PlayableListSortButton/PlayableListSortButton.tsx
+++ b/resources/js/common/components/PlayableListSortButton/PlayableListSortButton.tsx
@@ -70,8 +70,17 @@ export const PlayableListSortButton: FC<PlayableListSortButtonProps> = ({
     wonBy: { label: t('Won by (most)'), icon: LuUsers },
   };
 
+  const handleCheckedChange = (sortOrder: PlayableListSortOrder) => {
+    // If we didn't actually change the option, don't re-sort the list. Just close the dropdown.
+    if (value === sortOrder) {
+      return;
+    }
+
+    onChange(sortOrder);
+  };
+
   return (
-    <BaseDropdownMenu>
+    <BaseDropdownMenu modal={false}>
       <BaseDropdownMenuTrigger asChild>
         <BaseButton
           size="sm"
@@ -101,7 +110,7 @@ export const PlayableListSortButton: FC<PlayableListSortButtonProps> = ({
             <Fragment key={`option-item-${sortOrder}`}>
               <BaseDropdownMenuCheckboxItem
                 checked={value === sortOrder}
-                onCheckedChange={() => onChange(sortOrder)}
+                onCheckedChange={() => handleCheckedChange(sortOrder)}
                 className="gap-2"
               >
                 <SortIcon className="size-5" />

--- a/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSetToolbar/GameListViewSelectButton/GameListViewSelectButton.tsx
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSetToolbar/GameListViewSelectButton/GameListViewSelectButton.tsx
@@ -51,7 +51,7 @@ export const GameListViewSelectButton: FC = () => {
   };
 
   return (
-    <BaseDropdownMenu>
+    <BaseDropdownMenu modal={false}>
       <BaseDropdownMenuTrigger asChild>
         <BaseButton size="sm" aria-label={t('Display mode')}>
           <Icon className="size-4" />


### PR DESCRIPTION
This PR fixes numerous issues with mobile sorting on the beta game page.

The most egregious issue fixed is if the user starts scrolling the page from the scroll button position (not tapping the button), the dropdown opens and scrolling is locked. This is caused by a known issue in the underlying Radix component: https://github.com/radix-ui/primitives/issues/1912. I've made some adjustments in `BaseDropdown` to work around the problem:


https://github.com/user-attachments/assets/4ca07e28-c894-43f0-944e-e54907729ef6

Additionally, two more changes have been made:
1. If the user selects the same sort option that's already selected, the list won't re-sort anymore.
2. When opening the sort order and achievements/leaderboards view dropdowns, the body is no longer scroll locked.