### PR TITLE
fix(ScrollToTopButton): reposition and restyle

### DIFF
--- a/resources/js/features/games/components/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/resources/js/features/games/components/ScrollToTopButton/ScrollToTopButton.tsx
@@ -23,12 +23,15 @@ export const ScrollToTopButton: FC = () => {
           transition={{ duration: 0.1 }}
           onClick={handleClick}
           className={cn(
-            'fixed left-1/2 top-12 z-50 mx-[-18px] flex size-10 -translate-x-1/2',
-            'items-center justify-center rounded-full bg-neutral-950 shadow-xl transition-colors hover:bg-black/80',
+            'fixed bottom-8 right-8 z-50 mx-[-18px] flex size-12',
+            'sm:bottom-6 sm:right-6',
+            'items-center justify-center rounded-full bg-neutral-700 shadow-xl',
+            'light:border light:border-neutral-400 light:bg-neutral-300',
+            'transition-colors hover:bg-black/80',
           )}
           aria-label="scroll to top"
         >
-          <LuArrowUp className="size-5 text-white" />
+          <LuArrowUp className="size-5 text-white light:text-neutral-600" />
         </motion.button>
       ) : null}
     </AnimatePresence>


### PR DESCRIPTION
This PR repositions and slightly restyles the mobile scroll-to-top button. I made sure these changes were research-backed before opening this PR.

Summary of changes:
* The button is now slightly larger at 48x48 px, which aligns with Google's human interface guidelines for this sort of button.
* The button colors are now different for dark and light modes.
* The button now appears on the bottom right, which is Google's recommended placement for floating action buttons.

Reminder: the button only appears when scrolling up.

**Before**
<img width="384" height="667" alt="Screenshot 2025-09-27 at 1 40 26 PM" src="https://github.com/user-attachments/assets/4722af4e-7e03-45b4-a0e8-e60e6c9f37c4" />


**After**
<img width="379" height="674" alt="Screenshot 2025-09-27 at 1 40 03 PM" src="https://github.com/user-attachments/assets/3b07f523-6ad7-4435-b13f-e88ed566e5dc" />
