### PR TITLE
fix(hubs): add fallback for some event hub breadcrumbs

### DIFF
--- a/app/Observers/GameSetLinkObserver.php
+++ b/app/Observers/GameSetLinkObserver.php
@@ -7,6 +7,7 @@ namespace App\Observers;
 use App\Models\GameSet;
 use App\Models\GameSetLink;
 use App\Platform\Enums\GameSetType;
+use App\Support\Cache\CacheKey;
 use Illuminate\Support\Facades\Cache;
 
 class GameSetLinkObserver
@@ -40,14 +41,14 @@ class GameSetLinkObserver
         }
 
         // Clear the cache for both hubs.
-        Cache::forget("hub_breadcrumbs:{$parent->id}");
-        Cache::forget("hub_breadcrumbs:{$child->id}");
+        Cache::forget(CacheKey::buildGameSetBreadcrumbsCacheKey($parent->id));
+        Cache::forget(CacheKey::buildGameSetBreadcrumbsCacheKey($child->id));
 
         // Clear the caches for all child hubs of the child hub (they're affected too).
         $child->children()
             ->whereType(GameSetType::Hub)
             ->each(function (GameSet $grandchild) {
-                Cache::forget("hub_breadcrumbs:{$grandchild->id}");
+                Cache::forget(CacheKey::buildGameSetBreadcrumbsCacheKey($grandchild->id));
             });
     }
 }

--- a/app/Observers/GameSetObserver.php
+++ b/app/Observers/GameSetObserver.php
@@ -6,6 +6,7 @@ namespace App\Observers;
 
 use App\Models\GameSet;
 use App\Platform\Enums\GameSetType;
+use App\Support\Cache\CacheKey;
 use Illuminate\Support\Facades\Cache;
 
 class GameSetObserver
@@ -30,13 +31,13 @@ class GameSetObserver
         }
 
         // Clear the cache for this hub.
-        Cache::forget("hub_breadcrumbs:{$gameSet->id}");
+        Cache::forget(CacheKey::buildGameSetBreadcrumbsCacheKey($gameSet->id));
 
         // Clear caches for all child hubs (they include this hub in their breadcrumbs).
         $gameSet->children()
             ->whereType(GameSetType::Hub)
             ->each(function (GameSet $child) {
-                Cache::forget("hub_breadcrumbs:{$child->id}");
+                Cache::forget(CacheKey::buildGameSetBreadcrumbsCacheKey($child->id));
             });
     }
 }

--- a/app/Platform/Actions/BuildHubBreadcrumbsAction.php
+++ b/app/Platform/Actions/BuildHubBreadcrumbsAction.php
@@ -7,6 +7,7 @@ namespace App\Platform\Actions;
 use App\Models\GameSet;
 use App\Platform\Data\GameSetData;
 use App\Platform\Enums\GameSetType;
+use App\Support\Cache\CacheKey;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Spatie\LaravelData\Lazy;
@@ -98,7 +99,7 @@ class BuildHubBreadcrumbsAction
      */
     public function execute(GameSet $gameSet): array
     {
-        $cacheKey = "hub_breadcrumbs:{$gameSet->id}";
+        $cacheKey = CacheKey::buildGameSetBreadcrumbsCacheKey($gameSet->id);
 
         /** @var array[] $cachedData */
         $cachedData = Cache::flexible($cacheKey, [self::FRESH_SECONDS, self::STALE_SECONDS], function () use ($gameSet) {
@@ -446,6 +447,20 @@ class BuildHubBreadcrumbsAction
 
             if ($sameEventParent) {
                 return $sameEventParent;
+            }
+
+            // As a fallback, look for ANY parent hub that is an Events hub.
+            // This handles cases where naming is inconsistent (eg: "[RA Roulette 2022 - X]" with parent "[Events - RA Roulette (RAWR)]").
+            $anyEventParent = $gameSet->parents()
+                ->select('game_sets.*')
+                ->where('game_sets.type', GameSetType::Hub)
+                ->where('game_sets.title', 'like', '[Events - %')
+                ->whereNotIn('game_sets.id', $visited)
+                ->whereNull('game_sets.deleted_at')
+                ->first();
+
+            if ($anyEventParent) {
+                return $anyEventParent;
             }
         }
 

--- a/app/Support/Cache/CacheKey.php
+++ b/app/Support/Cache/CacheKey.php
@@ -13,6 +13,11 @@ class CacheKey
         return self::buildNormalizedCacheKey("game", $gameId, "card-data");
     }
 
+    public static function buildGameSetBreadcrumbsCacheKey(int $gameSetId): string
+    {
+        return self::buildNormalizedCacheKey("game-set", $gameSetId, "breadcrumbs");
+    }
+
     public static function buildUserLastLoginCacheKey(string $username): string
     {
         return self::buildNormalizedUserCacheKey($username, "last-login");


### PR DESCRIPTION
http://localhost:64000/hub/18379

**Before**
<img width="628" height="100" alt="Screenshot 2025-10-01 at 5 07 14 PM" src="https://github.com/user-attachments/assets/99d35cff-94b7-4d69-8df5-6ba93157ba52" />


**After**
<img width="660" height="150" alt="Screenshot 2025-10-01 at 5 06 48 PM" src="https://github.com/user-attachments/assets/9dd2eaa2-9fd1-4af8-9b16-07377d6cbd85" />
