### PR TITLE
test: switch from jsdom to happy-dom, increase test suite performance by ~25%

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "eslint-plugin-testing-library": "^7.7.0",
         "eslint-plugin-unicorn": "^61.0.2",
         "globals": "^15.14.0",
-        "jsdom": "^27.0.0",
+        "happy-dom": "^19.0.2",
         "laravel-echo": "^1.15.1",
         "laravel-vite-plugin": "^2.0.1",
         "postcss": "^8.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,9 +261,9 @@ importers:
       globals:
         specifier: ^15.14.0
         version: 15.15.0
-      jsdom:
-        specifier: ^27.0.0
-        version: 27.0.0(postcss@8.5.4)
+      happy-dom:
+        specifier: ^19.0.2
+        version: 19.0.2
       laravel-echo:
         specifier: ^1.15.1
         version: 1.16.1
@@ -308,7 +308,7 @@ importers:
         version: 7.1.5(@types/node@22.8.4)(jiti@1.21.6)(tsx@4.20.5)(yaml@2.6.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0)
+        version: 3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(happy-dom@19.0.2)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0)
 
 packages:
 
@@ -2208,6 +2208,9 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
+  '@types/node@20.19.19':
+    resolution: {integrity: sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==}
+
   '@types/node@22.8.4':
     resolution: {integrity: sha512-SpNNxkftTJOPk0oN+y2bIqurEXHTA2AOZ3EJDDKeJ5VzkvvORSvmQXGQarcOzWV1ac7DCaPBEdMDxBsM+d8jWw==}
 
@@ -2236,6 +2239,9 @@ packages:
 
   '@types/ua-parser-js@0.7.39':
     resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
   '@typescript-eslint/eslint-plugin@8.36.0':
     resolution: {integrity: sha512-lZNihHUVB6ZZiPBNgOQGSxUASI7UJWhT8nHyUGCnaQ28XFCw98IfrMCG3rUl1uwUWoAvodJQby2KTs79UTcrAg==}
@@ -3502,6 +3508,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  happy-dom@19.0.2:
+    resolution: {integrity: sha512-831CLbgDyjRbd2lApHZFsBDe56onuFcjsCBPodzWpzedTpeDr8CGZjs7iEIdNW1DVwSFRecfwzLpVyGBPamwGA==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -5078,6 +5088,9 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   unplugin@1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
 
@@ -5261,6 +5274,10 @@ packages:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
@@ -5380,6 +5397,7 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 11.2.1
+    optional: true
 
   '@asamuzakjp/dom-selector@6.5.4':
     dependencies:
@@ -5387,8 +5405,10 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.1.0
       is-potential-custom-element-name: 1.0.1
+    optional: true
 
-  '@asamuzakjp/nwsapi@2.3.9': {}
+  '@asamuzakjp/nwsapi@2.3.9':
+    optional: true
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -5562,12 +5582,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@csstools/color-helpers@5.1.0': {}
+  '@csstools/color-helpers@5.1.0':
+    optional: true
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
+    optional: true
 
   '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -5575,16 +5597,20 @@ snapshots:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
+    optional: true
 
   '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
+    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.4)':
     dependencies:
       postcss: 8.5.4
+    optional: true
 
-  '@csstools/css-tokenizer@3.0.4': {}
+  '@csstools/css-tokenizer@3.0.4':
+    optional: true
 
   '@csstools/selector-resolve-nested@1.1.0(postcss-selector-parser@6.1.2)':
     dependencies:
@@ -7343,6 +7369,10 @@ snapshots:
     dependencies:
       '@types/node': 22.8.4
 
+  '@types/node@20.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.8.4':
     dependencies:
       undici-types: 6.19.8
@@ -7374,6 +7404,8 @@ snapshots:
       '@types/node': 22.8.4
 
   '@types/ua-parser-js@0.7.39': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
 
   '@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.35.0(jiti@1.21.6))(typescript@5.7.3))(eslint@9.35.0(jiti@1.21.6))(typescript@5.7.3)':
     dependencies:
@@ -7601,7 +7633,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0)
+      vitest: 3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(happy-dom@19.0.2)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7612,7 +7644,7 @@ snapshots:
       eslint: 9.35.0(jiti@1.21.6)
     optionalDependencies:
       typescript: 5.7.3
-      vitest: 3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0)
+      vitest: 3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(happy-dom@19.0.2)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7661,7 +7693,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0)
+      vitest: 3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(happy-dom@19.0.2)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -7695,7 +7727,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  agent-base@7.1.3: {}
+  agent-base@7.1.3:
+    optional: true
 
   ajv@6.12.6:
     dependencies:
@@ -7883,6 +7916,7 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+    optional: true
 
   binary-extensions@2.3.0: {}
 
@@ -8058,6 +8092,7 @@ snapshots:
     dependencies:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
+    optional: true
 
   css.escape@1.5.1: {}
 
@@ -8070,6 +8105,7 @@ snapshots:
       css-tree: 3.1.0
     transitivePeerDependencies:
       - postcss
+    optional: true
 
   csstype@3.1.3: {}
 
@@ -8117,6 +8153,7 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.0.0
+    optional: true
 
   data-view-buffer@1.0.1:
     dependencies:
@@ -8170,7 +8207,8 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
-  decimal.js@10.6.0: {}
+  decimal.js@10.6.0:
+    optional: true
 
   deep-eql@5.0.2: {}
 
@@ -8241,7 +8279,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  entities@6.0.1: {}
+  entities@6.0.1:
+    optional: true
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -8914,6 +8953,12 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  happy-dom@19.0.2:
+    dependencies:
+      '@types/node': 20.19.19
+      '@types/whatwg-mimetype': 3.0.2
+      whatwg-mimetype: 3.0.0
+
   has-bigints@1.0.2: {}
 
   has-flag@4.0.0: {}
@@ -8947,6 +8992,7 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -8960,6 +9006,7 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -8974,6 +9021,7 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   hyphenate-style-name@1.1.0: {}
 
@@ -8988,6 +9036,7 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+    optional: true
 
   ignore@5.3.2: {}
 
@@ -9138,7 +9187,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-potential-custom-element-name@1.0.1: {}
+  is-potential-custom-element-name@1.0.1:
+    optional: true
 
   is-regex@1.1.4:
     dependencies:
@@ -9290,6 +9340,7 @@ snapshots:
       - postcss
       - supports-color
       - utf-8-validate
+    optional: true
 
   jsesc@3.0.2: {}
 
@@ -9373,7 +9424,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.1: {}
+  lru-cache@11.2.1:
+    optional: true
 
   lru-cache@5.1.1:
     dependencies:
@@ -9403,7 +9455,8 @@ snapshots:
 
   mdn-data@2.0.14: {}
 
-  mdn-data@2.12.2: {}
+  mdn-data@2.12.2:
+    optional: true
 
   merge2@1.4.1: {}
 
@@ -9588,6 +9641,7 @@ snapshots:
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
+    optional: true
 
   path-exists@4.0.0: {}
 
@@ -9994,7 +10048,8 @@ snapshots:
     dependencies:
       jsesc: 3.0.2
 
-  require-from-string@2.0.2: {}
+  require-from-string@2.0.2:
+    optional: true
 
   require-in-the-middle@7.5.2:
     dependencies:
@@ -10051,7 +10106,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.50.1
       fsevents: 2.3.3
 
-  rrweb-cssom@0.8.0: {}
+  rrweb-cssom@0.8.0:
+    optional: true
 
   rtl-css-js@1.16.1:
     dependencies:
@@ -10093,11 +10149,13 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
-  safer-buffer@2.1.2: {}
+  safer-buffer@2.1.2:
+    optional: true
 
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+    optional: true
 
   scheduler@0.26.0: {}
 
@@ -10342,7 +10400,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  symbol-tree@3.2.4: {}
+  symbol-tree@3.2.4:
+    optional: true
 
   synckit@0.11.8:
     dependencies:
@@ -10419,11 +10478,13 @@ snapshots:
 
   tinyspy@4.0.3: {}
 
-  tldts-core@7.0.14: {}
+  tldts-core@7.0.14:
+    optional: true
 
   tldts@7.0.14:
     dependencies:
       tldts-core: 7.0.14
+    optional: true
 
   to-regex-range@5.0.1:
     dependencies:
@@ -10436,12 +10497,14 @@ snapshots:
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.14
+    optional: true
 
   tr46@0.0.3: {}
 
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
   ts-api-utils@2.0.1(typescript@5.7.3):
     dependencies:
@@ -10573,6 +10636,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.19.8: {}
+
+  undici-types@6.21.0: {}
 
   unplugin@1.0.1:
     dependencies:
@@ -10726,7 +10791,7 @@ snapshots:
       tsx: 4.20.5
       yaml: 2.6.0
 
-  vitest@3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0):
+  vitest@3.2.4(@types/node@22.8.4)(@vitest/ui@3.2.4)(happy-dom@19.0.2)(jiti@1.21.6)(jsdom@27.0.0(postcss@8.5.4))(tsx@4.20.5)(yaml@2.6.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -10754,6 +10819,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.8.4
       '@vitest/ui': 3.2.4(vitest@3.2.4)
+      happy-dom: 19.0.2
       jsdom: 27.0.0(postcss@8.5.4)
     transitivePeerDependencies:
       - jiti
@@ -10774,10 +10840,12 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+    optional: true
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@8.0.0: {}
+  webidl-conversions@8.0.0:
+    optional: true
 
   webpack-sources@3.2.3: {}
 
@@ -10786,13 +10854,18 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
+    optional: true
 
-  whatwg-mimetype@4.0.0: {}
+  whatwg-mimetype@3.0.0: {}
+
+  whatwg-mimetype@4.0.0:
+    optional: true
 
   whatwg-url@15.0.0:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 8.0.0
+    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -10894,11 +10967,14 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
-  ws@8.18.3: {}
+  ws@8.18.3:
+    optional: true
 
-  xml-name-validator@5.0.0: {}
+  xml-name-validator@5.0.0:
+    optional: true
 
-  xmlchars@2.2.0: {}
+  xmlchars@2.2.0:
+    optional: true
 
   xtend@4.0.2: {}
 

--- a/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketMainRoot.test.tsx
+++ b/resources/js/features/achievements/components/CreateAchievementTicketMainRoot/CreateAchievementTicketMainRoot.test.tsx
@@ -725,6 +725,11 @@ describe('Component: CreateAchievementTicketMainRoot', () => {
         'Something is very wrong with this achievement. I tried many things and it just wont unlock. Help.',
       );
 
+      // ... wait for the submit button to become enabled before clicking ...
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /submit/i })).toBeEnabled();
+      });
+
       await userEvent.click(screen.getByRole('button', { name: /submit/i }));
 
       // ASSERT

--- a/resources/js/tall-stack/alpine/toggleAchievementRowsComponent/toggleAchievementRowsComponent.test.ts
+++ b/resources/js/tall-stack/alpine/toggleAchievementRowsComponent/toggleAchievementRowsComponent.test.ts
@@ -11,15 +11,16 @@ import {
 import { toggleAchievementRowsComponent } from './toggleAchievementRowsComponent';
 
 function render() {
-  (document as any).updateRowsVisibility = toggleAchievementRowsComponent().updateRowsVisibility;
-  (document as any).toggleUnlockedRows = toggleAchievementRowsComponent().toggleUnlockedRows;
-  (document as any).toggleNonMissableRows = toggleAchievementRowsComponent().toggleNonMissableRows;
-  (document as any).toggleInactiveRows = toggleAchievementRowsComponent().toggleInactiveRows;
+  const component = toggleAchievementRowsComponent();
+  (window as any).updateRowsVisibility = component.updateRowsVisibility.bind(component);
+  (window as any).toggleUnlockedRows = component.toggleUnlockedRows.bind(component);
+  (window as any).toggleNonMissableRows = component.toggleNonMissableRows.bind(component);
+  (window as any).toggleInactiveRows = component.toggleInactiveRows.bind(component);
 
   document.body.innerHTML = /** @html */ `
     <div>
       <label class="flex items-center gap-x-1">
-        <input 
+        <input
           type="checkbox"
           name="toggleUnlocked"
           onchange="toggleUnlockedRows()"
@@ -29,7 +30,7 @@ function render() {
       </label>
 
       <label class="flex items-center gap-x-1">
-        <input 
+        <input
           type="checkbox"
           name="toggleMissables"
           onchange="toggleNonMissableRows()"
@@ -39,7 +40,7 @@ function render() {
       </label>
 
       <label class="flex items-center gap-x-1">
-        <input 
+        <input
           type="checkbox"
           name="toggleInactive"
           onchange="toggleInactiveRows()"
@@ -97,6 +98,7 @@ describe('Component: toggleAchievementRowsComponent', () => {
     it('given the checkbox is unchecked, makes unlocked achievements visible again', async () => {
       // ACT
       await userEvent.click(screen.getByRole('checkbox', { name: /unlocked/i }));
+      await userEvent.click(screen.getByRole('checkbox', { name: /unlocked/i }));
 
       // ASSERT
       const allRows = screen.getAllByRole('listitem');
@@ -119,6 +121,7 @@ describe('Component: toggleAchievementRowsComponent', () => {
     it('given the checkbox is unchecked, makes non-missable achievements visible again', async () => {
       // ACT
       await userEvent.click(screen.getByRole('checkbox', { name: /missable/i }));
+      await userEvent.click(screen.getByRole('checkbox', { name: /missable/i }));
 
       // ASSERT
       const allRows = screen.getAllByRole('listitem');
@@ -140,6 +143,7 @@ describe('Component: toggleAchievementRowsComponent', () => {
 
     it('given the checkbox is unchecked, makes inactive achievements visible again', async () => {
       // ACT
+      await userEvent.click(screen.getByRole('checkbox', { name: /inactive/i }));
       await userEvent.click(screen.getByRole('checkbox', { name: /inactive/i }));
 
       // ASSERT

--- a/resources/js/tall-stack/utils/autoExpandTextInput.test.ts
+++ b/resources/js/tall-stack/utils/autoExpandTextInput.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { autoExpandTextInput } from './autoExpandTextInput';
 
 function render() {
-  (document as any).autoExpandTextInput = autoExpandTextInput;
+  (window as any).autoExpandTextInput = autoExpandTextInput;
 
   document.body.innerHTML = /** @html */ `
     <textarea

--- a/resources/js/tall-stack/utils/toggleUserCompletedSetsVisibility.test.ts
+++ b/resources/js/tall-stack/utils/toggleUserCompletedSetsVisibility.test.ts
@@ -6,7 +6,7 @@ import * as CookieModule from './cookie';
 import { cookieName, toggleUserCompletedSetsVisibility } from './toggleUserCompletedSetsVisibility';
 
 function render() {
-  (document as any).toggleUserCompletedSetsVisibility = toggleUserCompletedSetsVisibility;
+  (window as any).toggleUserCompletedSetsVisibility = toggleUserCompletedSetsVisibility;
 
   document.body.innerHTML = /** @html */ `
     <div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -90,13 +90,28 @@ export default defineConfig(({ mode, isSsrBuild }) => {
     },
 
     test: {
-      environment: 'jsdom',
+      environment: 'happy-dom',
       setupFiles: ['resources/js/setupTests.ts'],
       include: ['resources/js/**/*.{test,spec}.{ts,tsx}'],
       globals: true,
 
       /** @see https://vitest.dev/guide/improving-performance.html#pool */
       pool: 'threads',
+
+      // Filter out harmless happy-dom iframe fetch abort errors from stderr.
+      onConsoleLog(log, type) {
+        if (
+          type === 'stderr' &&
+          log.includes('DOMException') &&
+          (log.includes('AbortError') || log.includes('NetworkError')) &&
+          (log.includes('Fetch') ||
+            log.includes('iframe') ||
+            log.includes('youtube') ||
+            log.includes('twitch'))
+        ) {
+          return false;
+        }
+      },
 
       coverage: {
         provider: 'v8',
@@ -138,7 +153,7 @@ export default defineConfig(({ mode, isSsrBuild }) => {
   };
 });
 
-function detectServerConfig(env) {
+function detectServerConfig(env: Record<string, string>) {
   const watch = {
     // Explicitly ignore large volume directories to prevent running into system-level limits
     // See https://vitejs.dev/config/server-options.html#server-watch


### PR DESCRIPTION
This PR switches Vitest's simulated DOM environment from `jsdom` to `happy-dom`, which is known to be more optimized.

On my local machine, running the full test suite with `jsdom` takes ~75 seconds. With `happy-dom`, it takes ~55 seconds.