### PR TITLE
fix uninitialized out parameter

### DIFF
--- a/resources/views/pages-legacy/codenotes.blade.php
+++ b/resources/views/pages-legacy/codenotes.blade.php
@@ -16,6 +16,7 @@ if ($user) {
     $userModel = User::find($userDetails['ID']);
 }
 
+$codeNotes = [];
 getCodeNotes($gameID, $codeNotes);
 $codeNoteCount = count(array_filter($codeNotes, function ($x) { return $x['Note'] !== "" && $x['Note'] !== "''"; }));
 


### PR DESCRIPTION
fixes
> getCodeNotes(): Argument #2 ($codeNotesOut) must be of type array, null given

error introduced by https://github.com/RetroAchievements/RAWeb/commit/4b6389bebf939eb8c70ca2d259d51fd57eb46608#diff-3d674a2841a5e6715ec8c8e24b159c3b8f5115dc5426a4168bb85c8587a940cfL27

when trying to view code notes for a game.

The only other reference to `getCodeNotes` I saw was in achievementinspector.blade.php, which already initiaizes the out variable.