### PR TITLE
fix unitialized out patameter (tickets)

### DIFF
--- a/resources/views/pages/ticket/[Ticket].blade.php
+++ b/resources/views/pages/ticket/[Ticket].blade.php
@@ -60,6 +60,7 @@ use Illuminate\Support\Carbon;
 
 $user = Auth::user();
 $permissions = $user->getAttribute('Permissions');
+$commentData = [];
 
 @endphp
 


### PR DESCRIPTION
fixes
> getRecentArticleComments(): Argument #3 ($dataOut) must be of type array, null given

error introduced by https://github.com/RetroAchievements/RAWeb/commit/4b6389bebf939eb8c70ca2d259d51fd57eb46608#diff-4eb28129e711e17b32a464138654fc22cd98c92b7c74d5413a64cea0786e79b8L154

when trying to view individual tickets

I did not see any other references to `getRecentArticleComments`.