### PR TITLE
fix(game): sort unlocked achievements by timestamp correctly

### DIFF
--- a/resources/js/common/utils/sortAchievements.test.ts
+++ b/resources/js/common/utils/sortAchievements.test.ts
@@ -41,7 +41,54 @@ describe('Util: sortAchievements', () => {
       expect(result.map((a) => a.id)).toEqual([2, 1]);
     });
 
-    it('given same unlock status, sorts by orderColumn ascending', () => {
+    it('given unlocked achievements, sorts by the most recent unlock time first', () => {
+      // ARRANGE
+      const baseAchievement = createAchievement();
+      const achievements = [
+        { ...baseAchievement, id: 1, unlockedAt: '2023-01-01' }, // !! oldest unlock
+        { ...baseAchievement, id: 2, unlockedAt: '2023-01-03' }, // !! most recent unlock
+        { ...baseAchievement, id: 3, unlockedAt: '2023-01-02' }, // !! middle unlock
+      ];
+
+      // ACT
+      const result = sortAchievements(achievements, 'normal');
+
+      // ASSERT
+      expect(result.map((a) => a.id)).toEqual([2, 3, 1]);
+    });
+
+    it('given unlocked achievements, uses the most recent of unlockedAt or unlockedHardcoreAt', () => {
+      // ARRANGE
+      const baseAchievement = createAchievement();
+      const achievements = [
+        { ...baseAchievement, id: 1, unlockedAt: '2023-01-03', unlockedHardcoreAt: '2023-01-01' }, // !! unlockedAt is more recent
+        { ...baseAchievement, id: 2, unlockedAt: '2023-01-01', unlockedHardcoreAt: '2023-01-05' }, // !! unlockedHardcoreAt is more recent
+        { ...baseAchievement, id: 3, unlockedAt: '2023-01-02' }, // !! only unlockedAt
+      ];
+
+      // ACT
+      const result = sortAchievements(achievements, 'normal');
+
+      // ASSERT
+      expect(result.map((a) => a.id)).toEqual([2, 1, 3]);
+    });
+
+    it('given unlocked achievements with the same unlock time, sorts by orderColumn ascending', () => {
+      // ARRANGE
+      const baseAchievement = createAchievement();
+      const achievements = [
+        { ...baseAchievement, id: 1, unlockedAt: '2023-01-01', orderColumn: 2 }, // !! higher orderColumn
+        { ...baseAchievement, id: 2, unlockedAt: '2023-01-01', orderColumn: 1 }, // !! same unlock time, lower orderColumn
+      ];
+
+      // ACT
+      const result = sortAchievements(achievements, 'normal');
+
+      // ASSERT
+      expect(result.map((a) => a.id)).toEqual([2, 1]);
+    });
+
+    it('given locked achievements, sorts by orderColumn ascending', () => {
       // ARRANGE
       const baseAchievement = createAchievement();
       const achievements = [
@@ -56,7 +103,7 @@ describe('Util: sortAchievements', () => {
       expect(result.map((a) => a.id)).toEqual([2, 1]);
     });
 
-    it('given same orderColumn, sorts by createdAt ascending', () => {
+    it('given locked achievements with same orderColumn, sorts by createdAt ascending', () => {
       // ARRANGE
       const baseAchievement = createAchievement();
       const achievements = [

--- a/resources/js/common/utils/sortAchievements.ts
+++ b/resources/js/common/utils/sortAchievements.ts
@@ -41,13 +41,20 @@ export function sortAchievements(
       const multiplier = sortOrder === 'normal' ? 1 : -1;
 
       return sortedAchievements.sort((a, b) => {
-        // For 'normal' sort, the unlocked status is affected by direction.
         const unlockedResult = compareUnlockStatus(a, b);
         if (unlockedResult !== 0) {
           return unlockedResult * multiplier;
         }
 
-        // Then sort by orderColumn within each group (unlocked and not unlocked).
+        // If both are unlocked, sort by most recent unlock time.
+        if (getIsAchievementUnlocked(a)) {
+          const timeDiff = getMostRecentUnlock(b) - getMostRecentUnlock(a);
+          if (timeDiff !== 0) {
+            return timeDiff * multiplier;
+          }
+        }
+
+        // For both locked and unlocked (with same unlock time), sort by orderColumn.
         const orderDiff = (a.orderColumn as number) - (b.orderColumn as number);
         if (orderDiff !== 0) {
           return orderDiff * multiplier;
@@ -219,4 +226,13 @@ export function sortAchievements(
     default:
       return sortedAchievements;
   }
+}
+
+function getMostRecentUnlock(achievement: App.Platform.Data.Achievement): number {
+  const unlockedAt = achievement.unlockedAt ? new Date(achievement.unlockedAt).valueOf() : 0;
+  const unlockedHardcoreAt = achievement.unlockedHardcoreAt
+    ? new Date(achievement.unlockedHardcoreAt).valueOf()
+    : 0;
+
+  return Math.max(unlockedAt, unlockedHardcoreAt);
 }


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1026595325038833725/1434044496215277650.

**Before**
<img width="862" height="429" alt="Screenshot 2025-11-01 at 7 56 35 AM" src="https://github.com/user-attachments/assets/74619f07-8f03-4da4-bad6-4467409d5ce2" />


**After**
<img width="878" height="494" alt="Screenshot 2025-11-01 at 7 56 25 AM" src="https://github.com/user-attachments/assets/4029db57-84a0-4d82-81c9-977fad7e8d9f" />
