### PR TITLE
feat: add a new 'prioritize hardcore stats' preference

### DIFF
--- a/app/Enums/UserPreference.php
+++ b/app/Enums/UserPreference.php
@@ -48,4 +48,6 @@ abstract class UserPreference
     public const Game_OptOutOfAllSubsets = 18;
 
     public const User_EnableBetaFeatures = 19;
+
+    public const Game_PrioritizeHardcoreStats = 20;
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -468,6 +468,11 @@ class User extends Authenticatable implements CommunityMember, Developer, HasLoc
         return BitSet($this->getAttribute('websitePrefs'), UserPreference::Game_OptOutOfAllSubsets);
     }
 
+    public function getIsPrioritizingHardcoreStatsAttribute(): bool
+    {
+        return BitSet($this->getAttribute('websitePrefs'), UserPreference::Game_PrioritizeHardcoreStats);
+    }
+
     public function getOnlyAllowsContactFromFollowersAttribute(): bool
     {
         return BitSet($this->getAttribute('websitePrefs'), UserPreference::User_OnlyContactFromFollowing);

--- a/app/Platform/Actions/BuildGameShowPagePropsAction.php
+++ b/app/Platform/Actions/BuildGameShowPagePropsAction.php
@@ -358,6 +358,7 @@ class BuildGameShowPagePropsAction
             isLockedOnlyFilterEnabled: $isLockedOnlyFilterEnabled,
             isMissableOnlyFilterEnabled: $isMissableOnlyFilterEnabled,
             isViewingPublishedAchievements: $targetAchievementFlag === AchievementFlag::OfficialCore,
+            shouldPrioritizeHardcoreStats: $user->is_prioritizing_hardcore_stats,
             followedPlayerCompletions: $this->buildFollowedPlayerCompletionAction->execute($user, $backingGame),
 
             playerAchievementChartBuckets: $targetAchievementFlag === AchievementFlag::OfficialCore

--- a/app/Platform/Data/GameShowPagePropsData.php
+++ b/app/Platform/Data/GameShowPagePropsData.php
@@ -70,6 +70,7 @@ class GameShowPagePropsData extends Data
         public Collection $recentVisibleComments,
         /** @var GameData[] */
         public array $similarGames,
+        public bool $shouldPrioritizeHardcoreStats,
         public Collection $topAchievers,
         public ?PlayerGameData $playerGame,
         public ?PlayerGameProgressionAwardsData $playerGameProgressionAwards,

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -1263,5 +1263,6 @@
     "Edit Subset Game Details": "Edit Subset Game Details",
     "View Subset Game Details": "View Subset Game Details",
     "Contribute": "Contribute",
-    "View Developer Interest": "View Developer Interest"
+    "View Developer Interest": "View Developer Interest",
+    "Prioritize hardcore mode statistics": "Prioritize hardcore mode statistics"
 }

--- a/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
+++ b/resources/js/common/components/AchievementsListItem/AchievementsListItem.tsx
@@ -5,6 +5,7 @@ import { route } from 'ziggy-js';
 
 import { BaseProgress } from '@/common/components/+vendor/BaseProgress';
 import { AchievementAvatar } from '@/common/components/AchievementAvatar';
+import { calculateUnlockPercentage } from '@/common/utils/calculateUnlockPercentage';
 import { formatPercentage } from '@/common/utils/l10n/formatPercentage';
 
 import { UserAvatar } from '../UserAvatar';
@@ -29,6 +30,8 @@ interface AchievementsListItemProps {
    */
   eventAchievement?: App.Platform.Data.EventAchievement;
 
+  shouldPrioritizeHardcoreStats?: boolean;
+
   /**
    * When truthy, shows who created this achievement.
    * This is mainly intended for internal use, such as when the user is viewing
@@ -45,16 +48,21 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
   index,
   isLargeList,
   playersTotal,
+  shouldPrioritizeHardcoreStats = false,
   shouldShowAuthor = false,
 }) => {
   const { t } = useTranslation();
 
   const { description, game, title, type, decorator } = achievement;
 
-  const unlockPercentage = achievement.unlockPercentage ? Number(achievement.unlockPercentage) : 0;
-
   const unlocksHardcoreTotal = achievement.unlocksHardcoreTotal ?? 0;
   const unlocksTotal = achievement.unlocksTotal ?? 0;
+  const unlockPercentage = calculateUnlockPercentage(
+    shouldPrioritizeHardcoreStats,
+    unlocksHardcoreTotal,
+    playersTotal,
+    achievement.unlockPercentage,
+  );
 
   return (
     <motion.li
@@ -175,6 +183,7 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
               <ProgressBarMetaText
                 achievement={achievement}
                 playersTotal={playersTotal}
+                shouldPrioritizeHardcoreStats={shouldPrioritizeHardcoreStats}
                 variant={eventAchievement ? 'event' : 'game'}
               />
             </p>
@@ -188,7 +197,7 @@ export const AchievementsListItem: FC<AchievementsListItemProps> = ({
                   className: 'bg-gradient-to-r from-amber-500 to-[gold]',
                 },
                 {
-                  value: unlocksTotal - unlocksHardcoreTotal,
+                  value: shouldPrioritizeHardcoreStats ? 0 : unlocksTotal - unlocksHardcoreTotal,
                   className: 'bg-neutral-500',
                 },
               ]}

--- a/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.test.tsx
+++ b/resources/js/common/components/AchievementsListItem/ProgressBarMetaText/ProgressBarMetaText.test.tsx
@@ -159,4 +159,83 @@ describe('Component: ProgressBarMetaText', () => {
     expect(screen.getByText('(0)')).toBeVisible();
     expect(screen.getByText('200')).toBeVisible();
   });
+
+  it('given shouldPrioritizeHardcoreStats is true, displays the hardcore unlock count as the main count', () => {
+    // ARRANGE
+    render(
+      <ProgressBarMetaText
+        achievement={createAchievement({
+          unlocksTotal: 100,
+          unlocksHardcoreTotal: 50, // !! should show this as the main count
+          unlockPercentage: '0.5',
+        })}
+        playersTotal={200}
+        variant="game"
+        shouldPrioritizeHardcoreStats={true} // !!
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByText('50')).toBeVisible();
+    expect(screen.queryByText('100')).not.toBeInTheDocument(); // !! total count not shown
+  });
+
+  it('given shouldPrioritizeHardcoreStats is true, hides the hardcore count in parentheses', () => {
+    // ARRANGE
+    render(
+      <ProgressBarMetaText
+        achievement={createAchievement({
+          unlocksTotal: 100,
+          unlocksHardcoreTotal: 50,
+          unlockPercentage: '0.5',
+        })}
+        playersTotal={200}
+        variant="game"
+        shouldPrioritizeHardcoreStats={true} // !!
+      />,
+    );
+
+    // ASSERT
+    const hardcoreElement = screen.getByText('(50)');
+    expect(hardcoreElement).toHaveClass('sr-only');
+  });
+
+  it('given shouldPrioritizeHardcoreStats is true, calculates the percentage from hardcore unlocks divided by total players', () => {
+    // ARRANGE
+    render(
+      <ProgressBarMetaText
+        achievement={createAchievement({
+          unlocksTotal: 100,
+          unlocksHardcoreTotal: 50, // 50/200 = 0.25 = 25%
+          unlockPercentage: '0.5', // this should be ignored
+        })}
+        playersTotal={200} // !!
+        variant="game"
+        shouldPrioritizeHardcoreStats={true} // !!
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByText('- 25.00%')).toBeVisible(); // !! 50/200
+  });
+
+  it('given shouldPrioritizeHardcoreStats is false, displays total unlock count as the main count', () => {
+    // ARRANGE
+    render(
+      <ProgressBarMetaText
+        achievement={createAchievement({
+          unlocksTotal: 100, // should show this as main count
+          unlocksHardcoreTotal: 50,
+          unlockPercentage: '0.5',
+        })}
+        playersTotal={200}
+        variant="game"
+        shouldPrioritizeHardcoreStats={false} // !!
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByText('100')).toBeVisible();
+    expect(screen.getByText('(50)')).toBeVisible();
+  });
 });

--- a/resources/js/common/utils/calculateUnlockPercentage.test.ts
+++ b/resources/js/common/utils/calculateUnlockPercentage.test.ts
@@ -1,0 +1,137 @@
+import { calculateUnlockPercentage } from './calculateUnlockPercentage';
+
+describe('Util: calculateUnlockPercentage', () => {
+  it('is defined', () => {
+    // ASSERT
+    expect(calculateUnlockPercentage).toBeDefined();
+  });
+
+  it('given hardcore stats are prioritized and we have a valid player total, calculates percentage from hardcore unlocks', () => {
+    // ARRANGE
+    const shouldPrioritizeHardcoreStats = true;
+    const unlocksHardcoreTotal = 50;
+    const playersTotal = 200; // !! 50/200 = 0.25
+
+    // ACT
+    const result = calculateUnlockPercentage(
+      shouldPrioritizeHardcoreStats,
+      unlocksHardcoreTotal,
+      playersTotal,
+      10.5,
+    );
+
+    // ASSERT
+    expect(result).toEqual(0.25);
+  });
+
+  it('given hardcore stats are prioritized but players total is zero, returns zero', () => {
+    // ARRANGE
+    const shouldPrioritizeHardcoreStats = true;
+    const unlocksHardcoreTotal = 50;
+    const playersTotal = 0; // !!
+
+    // ACT
+    const result = calculateUnlockPercentage(
+      shouldPrioritizeHardcoreStats,
+      unlocksHardcoreTotal,
+      playersTotal,
+      10.5,
+    );
+
+    // ASSERT
+    expect(result).toEqual(0);
+  });
+
+  it('given hardcore stats are prioritized but players total is null, returns zero', () => {
+    // ARRANGE
+    const shouldPrioritizeHardcoreStats = true;
+    const unlocksHardcoreTotal = 50;
+    const playersTotal = null; // !!
+
+    // ACT
+    const result = calculateUnlockPercentage(
+      shouldPrioritizeHardcoreStats,
+      unlocksHardcoreTotal,
+      playersTotal,
+      10.5,
+    );
+
+    // ASSERT
+    expect(result).toEqual(0);
+  });
+
+  it('given hardcore stats are not prioritized and a default unlock percentage is provided, returns the default percentage', () => {
+    // ARRANGE
+    const shouldPrioritizeHardcoreStats = false;
+    const unlocksHardcoreTotal = 50;
+    const playersTotal = 200;
+    const defaultUnlockPercentage = 15.75; // !! should return this value
+
+    // ACT
+    const result = calculateUnlockPercentage(
+      shouldPrioritizeHardcoreStats,
+      unlocksHardcoreTotal,
+      playersTotal,
+      defaultUnlockPercentage,
+    );
+
+    // ASSERT
+    expect(result).toEqual(defaultUnlockPercentage);
+  });
+
+  it('given hardcore stats are not prioritized and the default unlock percentage is null, returns zero', () => {
+    // ARRANGE
+    const shouldPrioritizeHardcoreStats = false;
+    const unlocksHardcoreTotal = 50;
+    const playersTotal = 200;
+    const defaultUnlockPercentage = null; // !!
+
+    // ACT
+    const result = calculateUnlockPercentage(
+      shouldPrioritizeHardcoreStats,
+      unlocksHardcoreTotal,
+      playersTotal,
+      defaultUnlockPercentage,
+    );
+
+    // ASSERT
+    expect(result).toEqual(0);
+  });
+
+  it('given hardcore stats are not prioritized and default unlock percentage is undefined, returns zero', () => {
+    // ARRANGE
+    const shouldPrioritizeHardcoreStats = false;
+    const unlocksHardcoreTotal = 50;
+    const playersTotal = 200;
+    const defaultUnlockPercentage = undefined; // !!
+
+    // ACT
+    const result = calculateUnlockPercentage(
+      shouldPrioritizeHardcoreStats,
+      unlocksHardcoreTotal,
+      playersTotal,
+      defaultUnlockPercentage,
+    );
+
+    // ASSERT
+    expect(result).toEqual(0);
+  });
+
+  it('given hardcore stats are prioritized and there are zero hardcore unlocks, returns zero', () => {
+    // ARRANGE
+    const shouldPrioritizeHardcoreStats = true;
+    const unlocksHardcoreTotal = 0; // !!
+    const playersTotal = 200;
+
+    // ACT
+    const result = calculateUnlockPercentage(
+      shouldPrioritizeHardcoreStats,
+      unlocksHardcoreTotal,
+      playersTotal,
+      10.5,
+    );
+
+    // ASSERT
+    expect(result).toEqual(0);
+  });
+});

--- a/resources/js/common/utils/calculateUnlockPercentage.ts
+++ b/resources/js/common/utils/calculateUnlockPercentage.ts
@@ -1,0 +1,17 @@
+/**
+ * Calculates the unlock percentage for an achievement.
+ * When prioritizing hardcore stats, it calculates hardcore unlocks as a percentage of total players.
+ * Otherwise, it uses the pre-calculated unlock percentage from the achievement.
+ */
+export function calculateUnlockPercentage(
+  shouldPrioritizeHardcoreStats: boolean,
+  unlocksHardcoreTotal: number,
+  playersTotal: number | null,
+  defaultUnlockPercentage?: string | number | null,
+): number {
+  if (shouldPrioritizeHardcoreStats) {
+    return playersTotal && playersTotal > 0 ? unlocksHardcoreTotal / playersTotal : 0;
+  }
+
+  return defaultUnlockPercentage ? Number(defaultUnlockPercentage) : 0;
+}

--- a/resources/js/common/utils/generatedAppConstants.ts
+++ b/resources/js/common/utils/generatedAppConstants.ts
@@ -33,6 +33,7 @@ export const UserPreference = {
     User_OnlyContactFromFollowing: 17,
     Game_OptOutOfAllSubsets: 18,
     User_EnableBetaFeatures: 19,
+    Game_PrioritizeHardcoreStats: 20,
 } as const;
 
 
@@ -57,6 +58,7 @@ export const StringifiedUserPreference = {
     User_OnlyContactFromFollowing: '17',
     Game_OptOutOfAllSubsets: '18',
     User_EnableBetaFeatures: '19',
+    Game_PrioritizeHardcoreStats: '20',
 } as const;
 
 

--- a/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSet.tsx
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/GameAchievementSet/GameAchievementSet.tsx
@@ -33,8 +33,13 @@ export const GameAchievementSet: FC<GameAchievementSetProps> = ({
   achievements,
   gameAchievementSet,
 }) => {
-  const { allLeaderboards, auth, isViewingPublishedAchievements, numLeaderboards } =
-    usePageProps<App.Platform.Data.GameShowPageProps>();
+  const {
+    allLeaderboards,
+    auth,
+    isViewingPublishedAchievements,
+    numLeaderboards,
+    shouldPrioritizeHardcoreStats,
+  } = usePageProps<App.Platform.Data.GameShowPageProps>();
 
   const currentAchievementSort = useAtomValue(currentPlayableListSortAtom);
   const currentListView = useAtomValue(currentListViewAtom);
@@ -127,6 +132,7 @@ export const GameAchievementSet: FC<GameAchievementSetProps> = ({
                     beatenDialogContent={<BeatenCreditDialog />}
                     index={index}
                     isLargeList={isLargeAchievementsList}
+                    shouldPrioritizeHardcoreStats={shouldPrioritizeHardcoreStats}
                     shouldShowAuthor={!isViewingPublishedAchievements}
                     playersTotal={gameAchievementSet.achievementSet.playersTotal}
                   />

--- a/resources/js/features/settings/components/PreferencesSectionCard/PreferencesSectionCard.test.tsx
+++ b/resources/js/features/settings/components/PreferencesSectionCard/PreferencesSectionCard.test.tsx
@@ -108,4 +108,24 @@ describe('Component: PreferencesSectionCard', () => {
     // ASSERT
     expect(screen.getByRole('switch', { name: /enable beta features/i })).not.toBeChecked();
   });
+
+  it('given the user has hardcore stats prioritized, shows the prioritize hardcore stats toggle as checked', () => {
+    // ARRANGE
+    render(<PreferencesSectionCard currentWebsitePrefs={1048576} />);
+
+    // ASSERT
+    expect(
+      screen.getByRole('switch', { name: /prioritize hardcore mode statistics/i }),
+    ).toBeChecked();
+  });
+
+  it('given the user does not have hardcore stats prioritized, shows the prioritize hardcore stats toggle as unchecked', () => {
+    // ARRANGE
+    render(<PreferencesSectionCard currentWebsitePrefs={0} />);
+
+    // ASSERT
+    expect(
+      screen.getByRole('switch', { name: /prioritize hardcore mode statistics/i }),
+    ).not.toBeChecked();
+  });
 });

--- a/resources/js/features/settings/components/PreferencesSectionCard/PreferencesSectionCard.tsx
+++ b/resources/js/features/settings/components/PreferencesSectionCard/PreferencesSectionCard.tsx
@@ -51,6 +51,12 @@ export const PreferencesSectionCard: FC<PreferencesSectionCardProps> = ({
         />
 
         <PreferencesSwitchField
+          t_label={t('Prioritize hardcore mode statistics')}
+          fieldName={StringifiedUserPreference.Game_PrioritizeHardcoreStats}
+          control={form.control}
+        />
+
+        <PreferencesSwitchField
           t_label={t('Enable beta features')}
           fieldName={StringifiedUserPreference.User_EnableBetaFeatures}
           control={form.control}

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -460,7 +460,8 @@ declare namespace App.Enums {
     | 16
     | 17
     | 18
-    | 19;
+    | 19
+    | 20;
 }
 declare namespace App.Http.Data {
   export type AchievementOfTheWeekProps = {
@@ -848,6 +849,7 @@ declare namespace App.Platform.Data {
     recentPlayers: Array<App.Platform.Data.GameRecentPlayer>;
     recentVisibleComments: Array<App.Community.Data.Comment>;
     similarGames: Array<App.Platform.Data.Game>;
+    shouldPrioritizeHardcoreStats: boolean;
     topAchievers: Array<App.Platform.Data.GameTopAchiever>;
     playerGame: App.Platform.Data.PlayerGame | null;
     playerGameProgressionAwards: App.Platform.Data.PlayerGameProgressionAwards | null;


### PR DESCRIPTION
This PR implements a longstanding user feature request. Related: https://github.com/RetroAchievements/RAWeb/pull/2787

A new (disabled by default) setting has been added:
<img width="359" height="55" alt="Screenshot 2025-11-09 at 12 39 51 PM" src="https://github.com/user-attachments/assets/182d9c05-f908-48d0-958e-9ed0e4c365c8" />

When this setting is enabled, on React game pages, hardcore unlock rates are prioritized and softcore chunks are hidden in the achievement list item progress bars. Other components on the page remain unaffected:
<img width="845" height="94" alt="Screenshot 2025-11-09 at 12 40 58 PM" src="https://github.com/user-attachments/assets/c668b1b2-5eb7-4dd6-af22-b930651f83cc" />
