### PR TITLE
fix(messages): forward replies to reports correctly

### DIFF
--- a/app/Community/Actions/ForwardMessageToDiscordAction.php
+++ b/app/Community/Actions/ForwardMessageToDiscordAction.php
@@ -523,11 +523,19 @@ class ForwardMessageToDiscordAction
         MessageThread $messageThread,
         Message $message,
     ): void {
+        // Check if this thread is associated with a moderation report.
+        // If so, we need to use reports_url to post to the reports forum.
+        $isReportThread = UserModerationReport::where('message_thread_id', $messageThread->id)->exists();
+
         $webhookUrl = '';
-        foreach (['url', 'reports_url', 'verify_url', 'manual_unlock_url'] as $key) {
-            if (!empty($senderInboxConfig[$key])) {
-                $webhookUrl = $senderInboxConfig[$key];
-                break;
+        if ($isReportThread && !empty($senderInboxConfig['reports_url'])) {
+            $webhookUrl = $senderInboxConfig['reports_url'];
+        } else {
+            foreach (['url', 'reports_url', 'verify_url', 'manual_unlock_url'] as $key) {
+                if (!empty($senderInboxConfig[$key])) {
+                    $webhookUrl = $senderInboxConfig[$key];
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Resolves https://discord.com/channels/476211979464343552/1002689485005406249/1442916366075301951.

This didn't emerge locally because I'm missing an environment variable that is configured on prod.