### PR TITLE
feat(mail): add more implicit subscriber filtering for forum notifications

### DIFF
--- a/app/Helpers/database/forum.php
+++ b/app/Helpers/database/forum.php
@@ -236,14 +236,12 @@ function notifyUsersAboutForumActivity(ForumTopic $topic, User $author, ForumTop
     }
 
     /**
-     * For larger threads (90+ posts), we'll filter out implicit subscribers who
-     * haven't posted in the thread for 90+ days, unless they're the OP.
-     *
-     * Explicit subscribers and implicit subscribers in smaller threads always receive email notifications.
+     * For threads with many subscribers (200+), we filter out implicit subscribers
+     * who haven't posted recently, unless they explicitly subscribed or are the OP.
+     * This targets high-volume threads where each comment triggers hundreds of emails.
      */
-    $topicCommentCount = ForumTopicComment::where('forum_topic_id', $topic->id)->count();
-    if ($topicCommentCount >= 90) {
-        $threadActivityCutoff = now()->subDays(90);
+    if ($subscribers->count() >= 200) {
+        $threadActivityCutoff = now()->subDays(45);
 
         $explicitSubscriberIds = Subscription::where('subject_type', SubscriptionSubjectType::ForumTopic)
             ->where('subject_id', $topic->id)


### PR DESCRIPTION
This PR adds a few more community email notification filters to bring email rates down another notch.

~~Now, for forum threads with at least 6 pages (90 comments), if the user is implicitly subscribed, hasn't replied in 90+ days, and isn't the OP, they no longer receive an automatic email.~~

For threads with 200+ subscribers, implicit subscribers who haven't posted in the last 45 days will no longer receive email notifications. This targets threads where each new comment triggers hundreds of emails. Most normal threads are completely unaffected.