### PR TITLE
fix(game): show the set selection tabs indicator even during SSR

### DIFF
--- a/resources/js/features/games/components/GameAchievementSetsContainer/SetSelectionControl/SetSelectionTabs/useTabIndicator.test.ts
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/SetSelectionControl/SetSelectionTabs/useTabIndicator.test.ts
@@ -52,15 +52,15 @@ describe('Hook: useTabIndicator', () => {
     expect(result.current.isAnimationReady).toEqual(false);
   });
 
-  it('given the hook is initialized, returns initial indicator styles with zero opacity', () => {
+  it('given the hook is initialized, returns SSR-friendly default indicator styles', () => {
     // ARRANGE
     const { result } = renderHook(() => useTabIndicator(0));
 
     // ASSERT
     expect(result.current.indicatorStyles).toEqual({
-      transform: 'translateX(0px) translateY(0px)',
-      width: '0px',
-      opacity: 0,
+      transform: 'translateX(0px) translateY(40px)',
+      width: '48px',
+      opacity: 1,
       contain: 'layout',
     });
   });
@@ -123,17 +123,20 @@ describe('Hook: useTabIndicator', () => {
 
   it('given no width is available, sets opacity to 0', () => {
     // ARRANGE
-    const { result } = renderHook(() => useTabIndicator(0));
+    const { result } = renderHook(() => useTabIndicator(1)); // !! start at index 1
 
-    const mockElement = {
-      offsetLeft: 50,
-      offsetWidth: 0, // !!
-    } as HTMLDivElement;
+    const mockElements = [
+      { offsetLeft: 50, offsetWidth: 0, offsetTop: 0, offsetHeight: 30 } as HTMLDivElement,
+      { offsetLeft: 100, offsetWidth: 60, offsetTop: 0, offsetHeight: 30 } as HTMLDivElement,
+    ];
+
+    act(() => {
+      result.current.tabRefs.current = mockElements;
+    });
 
     // ACT
     act(() => {
-      result.current.tabRefs.current[0] = mockElement;
-      result.current.setActiveIndex(0);
+      result.current.setActiveIndex(0); // !! change to index 0 which has width 0
     });
 
     // ASSERT

--- a/resources/js/features/games/components/GameAchievementSetsContainer/SetSelectionControl/SetSelectionTabs/useTabIndicator.ts
+++ b/resources/js/features/games/components/GameAchievementSetsContainer/SetSelectionControl/SetSelectionTabs/useTabIndicator.ts
@@ -1,11 +1,29 @@
 import { useEffect, useRef, useState } from 'react';
 import { useWindowSize } from 'react-use';
 
+/**
+ * These constants match the tab styling in SetSelectionTabs.tsx.
+ * They're used to provide reasonable SSR defaults so the indicator is
+ * actually visible before hydration, otherwise it's obvious when hydration/JS
+ * have actually kicked in due to a tiny flash of unstyled content.
+ */
+const TAB_IMAGE_SIZE = 32; // size-8
+const TAB_PADDING_X = 8; // px-2
+const TAB_GAP = 6; // gap-x-[6px] between tabs
+const DEFAULT_WIDTH = TAB_IMAGE_SIZE + TAB_PADDING_X * 2; // 48px
+const DEFAULT_TOP = 40; // offsetHeight (~34px) + TAB_GAP
+
 export function useTabIndicator(initialIndex: number) {
-  const [activeIndex, setActiveIndex] = useState(Math.max(0, initialIndex));
-  const [indicatorWidth, setIndicatorWidth] = useState(0);
-  const [indicatorPosition, setIndicatorPosition] = useState(0);
-  const [indicatorTop, setIndicatorTop] = useState(0);
+  const safeIndex = Math.max(0, initialIndex);
+
+  // Estimate the X position for any tab based on index.
+  // Each tab is ~48px wide with 6px gap, so the position is index * (48 + 6).
+  const estimatedPosition = safeIndex * (DEFAULT_WIDTH + TAB_GAP);
+
+  const [activeIndex, setActiveIndex] = useState(safeIndex);
+  const [indicatorWidth, setIndicatorWidth] = useState(DEFAULT_WIDTH);
+  const [indicatorPosition, setIndicatorPosition] = useState(estimatedPosition);
+  const [indicatorTop, setIndicatorTop] = useState(DEFAULT_TOP);
   const [isAnimationReady, setIsAnimationReady] = useState(false);
 
   const tabRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -21,7 +39,7 @@ export function useTabIndicator(initialIndex: number) {
 
       setIndicatorPosition(currentLeft);
       setIndicatorWidth(currentWidth);
-      setIndicatorTop(currentTop + currentHeight + 6); // position the indicator at bottom of the tab plus a 6px gap
+      setIndicatorTop(currentTop + currentHeight + TAB_GAP);
 
       // Enable transitions after first position is set.
       if (!isAnimationReady) {


### PR DESCRIPTION
```bash
pnpm build && sail artisan inertia:start-ssr
```

This PR fixes a bug where the set selection tabs indicator (the white line under the set badge image) currently does not render during SSR, visibly showing when hydration actually kicks in on a page load or refresh.

**Before**

https://github.com/user-attachments/assets/47a17850-917a-416b-91b4-4e7d01ab4716



**After**

https://github.com/user-attachments/assets/d85f0def-3fa7-407a-bf7b-587d33a72043

