### PR TITLE
fix(manage): remediate error on adding games to hub from game search

### DIFF
--- a/app/Filament/Resources/HubResource/RelationManagers/GamesRelationManager.php
+++ b/app/Filament/Resources/HubResource/RelationManagers/GamesRelationManager.php
@@ -152,6 +152,12 @@ class GamesRelationManager extends RelationManager
                                     ->get()
                                     ->mapWithKeys(fn ($game) => [$game->ID => "[{$game->ID}] {$game->Title}"]);
                             })
+                            ->getOptionLabelsUsing(function (array $values): array {
+                                return Game::whereIn('ID', $values)
+                                    ->get()
+                                    ->mapWithKeys(fn ($game) => [$game->ID => "[{$game->ID}] {$game->Title}"])
+                                    ->toArray();
+                            })
                             ->hidden(fn (Get $get): bool => filled($get('game_ids_csv')))
                             ->disabled(fn (Get $get): bool => filled($get('game_ids_csv')))
                             ->live()


### PR DESCRIPTION
Resolves this error:
![firefox_8cjFYT0s15](https://github.com/user-attachments/assets/1b72de1c-8dbf-474c-a2a5-a926b314d793)
