### PR TITLE
fix(manage): remediate more form errors related to hubs

### DIFF
--- a/app/Filament/Resources/EventResource/RelationManagers/HubsRelationManager.php
+++ b/app/Filament/Resources/EventResource/RelationManagers/HubsRelationManager.php
@@ -93,6 +93,12 @@ class HubsRelationManager extends RelationManager
                                     ->get()
                                     ->mapWithKeys(fn ($gameSet) => [$gameSet->id => "[{$gameSet->id} {$gameSet->title}]"]);
                             })
+                            ->getOptionLabelsUsing(function (array $values): array {
+                                return GameSet::whereIn('id', $values)
+                                    ->get()
+                                    ->mapWithKeys(fn ($gameSet) => [$gameSet->id => "[{$gameSet->id} {$gameSet->title}]"])
+                                    ->toArray();
+                            })
                             ->required(),
                     ])
                     ->modalHeading('Add event to related hub')

--- a/app/Filament/Resources/HubResource/RelationManagers/ParentHubsRelationManager.php
+++ b/app/Filament/Resources/HubResource/RelationManagers/ParentHubsRelationManager.php
@@ -112,6 +112,12 @@ class ParentHubsRelationManager extends RelationManager
                                     ->get()
                                     ->mapWithKeys(fn ($gameSet) => [$gameSet->id => "[{$gameSet->id} {$gameSet->title}]"]);
                             })
+                            ->getOptionLabelsUsing(function (array $values): array {
+                                return GameSet::whereIn('id', $values)
+                                    ->get()
+                                    ->mapWithKeys(fn ($gameSet) => [$gameSet->id => "[{$gameSet->id} {$gameSet->title}]"])
+                                    ->toArray();
+                            })
                             ->hidden(fn (Get $get): bool => filled($get('hub_ids_csv')))
                             ->disabled(fn (Get $get): bool => filled($get('hub_ids_csv')))
                             ->live()


### PR DESCRIPTION
Related to https://github.com/RetroAchievements/RAWeb/pull/4187. This is happening elsewhere too in prod.

![firefox_f4ctk5Jcq3](https://github.com/user-attachments/assets/2e283173-1599-4259-8fa3-61edd3e27efd)
