### PR TITLE
fix(manage): don't delete roles on detach

### DIFF
--- a/app/Filament/Resources/UserResource/Pages/Roles.php
+++ b/app/Filament/Resources/UserResource/Pages/Roles.php
@@ -12,7 +12,7 @@ use App\Models\User;
 use BackedEnum;
 use Filament\Actions\AttachAction;
 use Filament\Actions\BulkActionGroup;
-use Filament\Actions\DeleteAction;
+use Filament\Actions\DetachAction;
 use Filament\Forms;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables;
@@ -155,7 +155,7 @@ class Roles extends ManageRelatedRecords
             ])
             ->paginated(false)
             ->recordActions([
-                DeleteAction::make()
+                DetachAction::make()
                     ->label(__('Remove'))
                     ->authorize(fn (SpatieRole $record) => $user->can('detachRole', [$this->getRecord(), $record]))
                     ->after(function (SpatieRole $record) {


### PR DESCRIPTION
https://discord.com/channels/476211979464343552/1002695123030773790/1445549565775184055

Filament 4 has a behavior change where `DeleteAction` on a many-to-many relation now deletes actual records from the database rather than detaching relations 😱

This is the only place in the code that should be affected by this issue.