### PR TITLE
feat(SubmitGameTitleAction): auto-attach new 'subset games' to their parent game

### DIFF
--- a/app/Connect/Actions/SubmitGameTitleAction.php
+++ b/app/Connect/Actions/SubmitGameTitleAction.php
@@ -160,7 +160,7 @@ class SubmitGameTitleAction extends BaseAuthenticatedApiAction
      * achievement set would normally be orphaned and only accessible via /game/{subsetGameId}.
      *
      * This method automatically attaches the subset to its parent game so users can access
-     * it via /game/{parentGameId}?set={achievementSetId} instead. We use WillBeExclusive as
+     * it via /game/{parentGameId}?set={achievementSetId} instead. We use Exclusive as
      * the default type since subset requirements are unknown at creation time, and Exclusive
      * is the safest assumption (requires unique hash, doesn't load with core achievements).
      *
@@ -184,8 +184,8 @@ class SubmitGameTitleAction extends BaseAuthenticatedApiAction
         $subsetName = trim($matches[2]);
 
         // Now, try to find the parent game by an exact title match on the same system.
-        $parentGame = Game::where('Title', $parentTitle)
-            ->where('ConsoleID', $this->systemId)
+        $parentGame = Game::where('title', $parentTitle)
+            ->where('system_id', $this->systemId)
             ->first();
 
         if (!$parentGame) {
@@ -195,7 +195,7 @@ class SubmitGameTitleAction extends BaseAuthenticatedApiAction
         (new AssociateAchievementSetToGameAction())->execute(
             targetGame: $parentGame,
             sourceGame: $subsetGame,
-            type: AchievementSetType::WillBeExclusive,
+            type: AchievementSetType::Exclusive,
             title: $subsetName
         );
     }

--- a/tests/Feature/Connect/SubmitGameTitleTest.php
+++ b/tests/Feature/Connect/SubmitGameTitleTest.php
@@ -361,8 +361,8 @@ class SubmitGameTitleTest extends TestCase
         // create the parent game first with its core achievement set
         /** @var Game $parentGame */
         $parentGame = Game::factory()->create([
-            'Title' => 'Mega Man 2',
-            'ConsoleID' => $system->id,
+            'title' => 'Mega Man 2',
+            'system_id' => $system->id,
         ]);
         (new UpsertGameCoreAchievementSetFromLegacyFlagsAction())->execute($parentGame);
 
@@ -388,22 +388,22 @@ class SubmitGameTitleTest extends TestCase
             ]);
 
         // verify the subset game was created
-        $subsetGame = Game::where('Title', $subsetTitle)->first();
+        $subsetGame = Game::where('title', $subsetTitle)->first();
         $this->assertNotNull($subsetGame);
         $this->assertEquals($subsetTitle, $subsetGame->title);
-        $this->assertEquals($system->id, $subsetGame->ConsoleID);
+        $this->assertEquals($system->id, $subsetGame->system_id);
 
         // verify the subset game has its own core achievement set
         $this->assertEquals(1, $subsetGame->gameAchievementSets()->count());
         $subsetCoreSet = $subsetGame->gameAchievementSets()->first();
         $this->assertEquals(AchievementSetType::Core, $subsetCoreSet->type);
 
-        // verify the parent game now has the subset's achievement set attached as WillBeExclusive
+        // verify the parent game now has the subset's achievement set attached as Exclusive
         $parentGame->refresh();
         $parentGameSets = $parentGame->gameAchievementSets()->get();
         $this->assertEquals(2, $parentGameSets->count());
 
-        $attachedSet = $parentGameSets->firstWhere('type', AchievementSetType::WillBeExclusive);
+        $attachedSet = $parentGameSets->firstWhere('type', AchievementSetType::Exclusive);
         $this->assertNotNull($attachedSet);
         $this->assertEquals('Bonus', $attachedSet->title);
         $this->assertEquals($subsetCoreSet->achievement_set_id, $attachedSet->achievement_set_id);
@@ -438,7 +438,7 @@ class SubmitGameTitleTest extends TestCase
             ]);
 
         // verify the subset game was created
-        $subsetGame = Game::where('Title', $subsetTitle)->first();
+        $subsetGame = Game::where('title', $subsetTitle)->first();
         $this->assertNotNull($subsetGame);
         $this->assertEquals($subsetTitle, $subsetGame->title);
 


### PR DESCRIPTION
This PR makes an enhancement to `SubmitGameTitleAction`.

When a developer adds a new "subset game" to the database (a game with a title like 'Some Game [Subset - Bonus]'), the new game's achievement set will automatically be attached to the parent game (if found) with a type of `Exclusive`.

We intentionally make no attempt whatsoever to try to discern what the set type is, even if the given title for the subset is "Bonus". This is purely meant to make navigation for players on the website less confusing (currently, they're seeing the same game across two game pages because the subset game is commonly orphaned).