### PR TITLE
ci: add 'merge-php-test-reports' fan-in job

### DIFF
--- a/tests/Feature/Connect/Actions/ResolveAchievementSetsActionTest.php
+++ b/tests/Feature/Connect/Actions/ResolveAchievementSetsActionTest.php
@@ -69,7 +69,7 @@ class ResolveAchievementSetsActionTest extends TestCase
         int $unpublishedAchievementCount,
     ): void {
         $this->assertEquals($type, $set->type);
-        $this->assertEquals($gameId, 1231231);
+        $this->assertEquals($gameId, $set->game_id);
 
         $this->assertNotNull($set->achievementSet);
 


### PR DESCRIPTION
To easily support a required check without making all the individual shards required.