### PR TITLE
don't convert newlines to brs for daily digest mail

### DIFF
--- a/app/Community/Actions/SendDailyDigestAction.php
+++ b/app/Community/Actions/SendDailyDigestAction.php
@@ -122,8 +122,8 @@ class SendDailyDigestAction
                 $post = $posts[$type][$delayedSubscription->subject_id] ?? null;
                 if ($post) {
                     $summary = match ($type) {
-                        SubscriptionSubjectType::ForumTopic->value => nl2br(Shortcode::stripAndClamp($post->latestComment->body, previewLength: 200, preserveWhitespace: true)),
-                        default => nl2br(mb_strlen($post->Payload) > 200 ? mb_substr($post->Payload, 0, 200) . '...' : $post->Payload),
+                        SubscriptionSubjectType::ForumTopic->value => Shortcode::stripAndClamp($post->latestComment->body, previewLength: 200, preserveWhitespace: true),
+                        default => mb_strlen($post->Payload) > 200 ? mb_substr($post->Payload, 0, 200) . '...' : $post->Payload,
                     };
                     $displayName = match ($type) {
                         SubscriptionSubjectType::ForumTopic->value => $post->latestComment->user->display_name,


### PR DESCRIPTION
It doesn't seem to be necessary (or desirable):
<img width="524" height="149" alt="image" src="https://github.com/user-attachments/assets/e878690f-0fd1-49ca-a907-76202c8805ff" />
