### PR TITLE
docs: fix translations guide link in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -100,4 +100,4 @@ Route keys for route model binding should be validated in the respective RouteSe
 
 ## Translating the Application
 
-We welcome contributions to translate the RetroAchievements website into different languages. To get started, please refer to our [translations guide](TRANSLATIONS.md) for detailed instructions on how to add or update translations.
+We welcome contributions to translate the RetroAchievements website into different languages. To get started, please refer to our [translations guide](https://github.com/RetroAchievements/RAWeb/blob/master/docs/TRANSLATIONS.md) for detailed instructions on how to add or update translations.


### PR DESCRIPTION
Currently, opening translation link using contributing file from the root (https://github.com/RetroAchievements/RAWeb?tab=contributing-ov-file) results in non-existing page (https://github.com/RetroAchievements/RAWeb/blob/master/TRANSLATIONS.md).

This PR fixes wrong behavior using absolute path to the file, similar to how `README.md` file is referenced:
```
**PHP CS Fixer** comes as a dev dependency. Use it before you commit. See the [README](https://github.com/RetroAchievements/RAWeb/blob/master/README.md).
```