### PR TITLE
fix: add `$tries` to jobs that experience transient failures due to deadlocks

### DIFF
--- a/app/Platform/Jobs/UpdateBeatenGamesLeaderboardJob.php
+++ b/app/Platform/Jobs/UpdateBeatenGamesLeaderboardJob.php
@@ -21,6 +21,10 @@ class UpdateBeatenGamesLeaderboardJob implements ShouldQueue, ShouldBeUniqueUnti
     use Queueable;
     use SerializesModels;
 
+    // Retry on transient deadlocks when multiple jobs update player_stat_rankings concurrently.
+    public int $tries = 3;
+    public int $backoff = 10;
+
     public function __construct(
         private readonly ?int $systemId,
         private readonly PlayerStatRankingKind $kind,

--- a/app/Platform/Jobs/UpdateGamePlayerCountJob.php
+++ b/app/Platform/Jobs/UpdateGamePlayerCountJob.php
@@ -20,6 +20,10 @@ class UpdateGamePlayerCountJob implements ShouldQueue, ShouldBeUniqueUntilProces
     use Queueable;
     use SerializesModels;
 
+    // Retry on transient deadlocks when multiple jobs update the achievements table concurrently.
+    public int $tries = 3;
+    public int $backoff = 10;
+
     public function __construct(
         private readonly int $gameId,
     ) {


### PR DESCRIPTION
During concurrent bulk updates, these two jobs experience deadlocks in prod.