### PR TITLE
fix(GlobalSearch): manually build /search url instead of using ziggy route

### DIFF
--- a/resources/js/common/components/GlobalSearch/GlobalSearch.tsx
+++ b/resources/js/common/components/GlobalSearch/GlobalSearch.tsx
@@ -3,7 +3,6 @@ import { AnimatePresence, motion } from 'motion/react';
 import { type FC, type KeyboardEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LuChevronRight, LuLoaderCircle, LuSearch } from 'react-icons/lu';
-import { route } from 'ziggy-js';
 
 import {
   BaseCommand,
@@ -29,6 +28,7 @@ import { SearchResultsSkeleton } from './components/SearchResultsSkeleton';
 import { useGlobalSearchDebounce } from './hooks/useGlobalSearchDebounce';
 import { useGlobalSearchHotkey } from './hooks/useGlobalSearchHotkey';
 import { useScrollToTopOnSearchResults } from './hooks/useScrollToTopOnSearchResults';
+import { buildSearchUrl } from './utils/buildSearchUrl';
 
 interface GlobalSearchProps {
   isOpen: boolean;
@@ -168,13 +168,7 @@ export const GlobalSearch: FC<GlobalSearchProps> = ({ isOpen, onOpenChange }) =>
             />
 
             {/* Because this is a React island, we can't use InertiaLink. */}
-            <a
-              href={route('search', {
-                query: rawQuery || undefined,
-                scope: searchMode !== 'all' ? searchMode : undefined,
-              })}
-              className="hidden items-center sm:flex"
-            >
+            <a href={buildSearchUrl(rawQuery, searchMode)} className="hidden items-center sm:flex">
               {t('Browse')} <LuChevronRight className="size-4" />
             </a>
           </div>

--- a/resources/js/common/components/GlobalSearch/components/SearchModeSelector/SearchModeSelector.tsx
+++ b/resources/js/common/components/GlobalSearch/components/SearchModeSelector/SearchModeSelector.tsx
@@ -2,10 +2,11 @@ import { motion } from 'motion/react';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LuChevronRight } from 'react-icons/lu';
-import { route } from 'ziggy-js';
 
 import { SelectableChip } from '@/common/components/SelectableChip';
 import type { SearchMode } from '@/common/models';
+
+import { buildSearchUrl } from '../../utils/buildSearchUrl';
 
 interface SearchModeSelectorProps {
   onChange: (value: SearchMode) => void;
@@ -62,10 +63,7 @@ export const SearchModeSelector: FC<SearchModeSelectorProps> = ({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.15, delay: (modes.length + 1) * 0.02 }}
-        href={route('search', {
-          query: rawQuery || undefined,
-          scope: selectedMode !== 'all' ? selectedMode : undefined,
-        })}
+        href={buildSearchUrl(rawQuery, selectedMode)}
         className="flex items-center sm:hidden"
       >
         {t('Browse')} <LuChevronRight className="size-4" />

--- a/resources/js/common/components/GlobalSearch/utils/buildSearchUrl.ts
+++ b/resources/js/common/components/GlobalSearch/utils/buildSearchUrl.ts
@@ -1,0 +1,21 @@
+import type { SearchMode } from '@/common/models';
+
+/**
+ * Builds a URL for the search page with optional query and scope parameters.
+ * We use this instead of Ziggy's route() helper because that doesn't work in React islands.
+ */
+export const buildSearchUrl = (query: string, scope: SearchMode): string => {
+  const params = new URLSearchParams();
+
+  if (query) {
+    params.set('query', query);
+  }
+
+  if (scope !== 'all') {
+    params.set('scope', scope);
+  }
+
+  const queryString = params.toString();
+
+  return queryString ? `/search?${queryString}` : '/search';
+};


### PR DESCRIPTION
`route()` throws a JS error in an island context.