### PR TITLE
fix: serialize beaten game leaderboard updates to a single lock

### DIFF
--- a/app/Platform/Actions/UpdateBeatenGamesLeaderboardAction.php
+++ b/app/Platform/Actions/UpdateBeatenGamesLeaderboardAction.php
@@ -24,11 +24,11 @@ class UpdateBeatenGamesLeaderboardAction
             return;
         }
 
-        // Use a Redis lock per system+kind to prevent deadlocks when
-        // multiple jobs for the same system and kind run concurrently.
-        // Different kinds can safely run in parallel since they operate on distinct rows.
-        $lockKey = 'player-stat-rankings:' . ($systemId ?? 'overall') . ':' . $kind->value;
-        Cache::lock($lockKey, 120)->block(90, function () use ($systemId, $kind, $includedTypes) {
+        // Use a single global Redis lock to serialize all leaderboard updates.
+        // Concurrent DELETE/INSERT operations on player_stat_rankings cause
+        // InnoDB auto-increment corruption (error 1467) even on different rows.
+        $lockKey = 'player-stat-rankings-update';
+        Cache::lock($lockKey, 300)->block(240, function () use ($systemId, $kind, $includedTypes) {
             $this->executeWithDirectInsert($systemId, $kind, $includedTypes);
         });
     }


### PR DESCRIPTION
Trades throughput for stability.