### PR TITLE
fix(LegacyRedirector): remediate server error on search page redirect

### DIFF
--- a/app/Support/Redirector/LegacyRedirector.php
+++ b/app/Support/Redirector/LegacyRedirector.php
@@ -70,7 +70,7 @@ class LegacyRedirector implements Redirector
             // remove remaining, unused markers
             $parsedRedirectUrl = Url::fromString($redirectUrl);
             foreach ($parsedRedirectUrl->getAllQueryParameters() as $queryParameter => $queryParameterValue) {
-                if (str_starts_with($queryParameterValue, '{')) {
+                if (is_string($queryParameterValue) && str_starts_with($queryParameterValue, '{')) {
                     $parsedRedirectUrl = $parsedRedirectUrl->withoutQueryParameter($queryParameter);
                 }
             }


### PR DESCRIPTION
<img width="796" height="190" alt="Screenshot 2025-12-31 at 12 47 39 PM" src="https://github.com/user-attachments/assets/cfabf4f0-6d10-4a98-8c21-ee94a91a6720" />

This has been a latent bug in the codebase for ~2 years that is only surfacing with our new searchresults.php redirects.