### PR TITLE
fix: change tableFilters to just filters for leaderboards

### DIFF
--- a/resources/views/pages-legacy/leaderboardinfo.blade.php
+++ b/resources/views/pages-legacy/leaderboardinfo.blade.php
@@ -137,7 +137,7 @@ $pageTitle = "$lbTitle in $gameTitle ($consoleName)";
 
             echo "<ul>";
             $manageLeaderboardsRoute = route('filament.admin.resources.leaderboards.index', [
-                'tableFilters[game][id]' => $gameID,
+                'filters[game][id]' => $gameID,
                 'tableSortColumn' => 'order_column',
                 'tableSortDirection' => 'asc',
             ]);


### PR DESCRIPTION
Seems like the Filament v4 upgrade had a lingering issue. Fixes the "Leaderboard Management for [game]" link to properly filter again. Seems that `?tableFilters` changed to just `?filters` right under our noses.