### PR TITLE
fix: properly sync the unranked_users table against users.unranked_at

### DIFF
--- a/app/Filament/Resources/UserResource/Pages/Edit.php
+++ b/app/Filament/Resources/UserResource/Pages/Edit.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
-use App\Models\UnrankedUser;
 use App\Models\User;
 use Carbon\Carbon;
 use Filament\Resources\Pages\EditRecord;
@@ -30,12 +29,6 @@ class Edit extends EditRecord
 
         if ($wasUnranked !== $isNowUnranked) {
             $data['unranked_at'] = $isNowUnranked ? Carbon::now() : null;
-
-            if ($data['unranked_at'] !== null) {
-                UnrankedUser::firstOrCreate(['user_id' => $record->id]);
-            } else {
-                UnrankedUser::where('user_id', $record->id)->delete();
-            }
         }
 
         // Remove the Filament form's virtual field before saving.

--- a/app/Helpers/database/player-rank.php
+++ b/app/Helpers/database/player-rank.php
@@ -2,7 +2,6 @@
 
 use App\Community\Enums\Rank;
 use App\Community\Enums\RankType;
-use App\Models\UnrankedUser;
 use App\Models\User;
 use App\Platform\Events\PlayerRankedStatusChanged;
 use App\Support\Cache\CacheKey;
@@ -13,12 +12,6 @@ function SetUserUntrackedStatus(User $user, bool $isUntracked): void
 {
     $user->unranked_at = $isUntracked ? now() : null;
     $user->save();
-
-    if ($isUntracked) {
-        UnrankedUser::firstOrCreate(['user_id' => $user->id]);
-    } else {
-        UnrankedUser::where('user_id', $user->id)->delete();
-    }
 
     PlayerRankedStatusChanged::dispatch($user);
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -223,13 +223,6 @@ class User extends Authenticatable implements CommunityMember, Developer, HasLoc
                     ->log('pivotDetached');
             }
         });
-
-        // When a user is restored, check if they should remain unranked.
-        static::restored(function (User $user) {
-            if ($user->unranked_at === null) {
-                UnrankedUser::where('user_id', $user->id)->delete();
-            }
-        });
     }
 
     protected static function newFactory(): UserFactory

--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -35,6 +35,7 @@ use App\Platform\Commands\RebuildAllSearchIndexes;
 use App\Platform\Commands\ResetPlayerAchievement;
 use App\Platform\Commands\RevertManualUnlocks;
 use App\Platform\Commands\SyncEvents;
+use App\Platform\Commands\SyncUnrankedUsersTable;
 use App\Platform\Commands\UnlockPlayerAchievement;
 use App\Platform\Commands\UpdateAwardsStaticData;
 use App\Platform\Commands\UpdateBeatenGamesLeaderboard;
@@ -118,6 +119,7 @@ class AppServiceProvider extends ServiceProvider
 
                 // Sync
                 SyncEvents::class,
+                SyncUnrankedUsersTable::class,
             ]);
         }
 

--- a/app/Platform/Commands/SyncUnrankedUsersTable.php
+++ b/app/Platform/Commands/SyncUnrankedUsersTable.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class SyncUnrankedUsersTable extends Command
+{
+    protected $signature = 'ra:sync:unranked-users';
+    protected $description = 'Rebuild the unranked_users table from users.unranked_at';
+
+    public function handle(): void
+    {
+        $this->info('Rebuilding unranked_users table...');
+
+        DB::table('unranked_users')->truncate();
+
+        $userIds = User::withTrashed()->whereNotNull('unranked_at')->pluck('id');
+
+        $inserted = 0;
+        foreach ($userIds->chunk(1000) as $chunk) {
+            DB::table('unranked_users')->insert(
+                $chunk->map(fn ($id) => ['user_id' => $id])->toArray()
+            );
+            $inserted += $chunk->count();
+        }
+
+        $this->info("Inserted {$inserted} entries from users.unranked_at.");
+        $this->info('Done.');
+    }
+}


### PR DESCRIPTION
Discovered while iterating through feedback in #4357. The `unranked_users` table we use for efficient filtering in our queries is actually out of sync with `users.unranked_at`.

In prod, 241 banned users have `unranked_at` set but no entry in `unranked_users`. This PR migrates writing these records to `UserObserver` and adds an Artisan command to resync the table.

```
sail artisan ra:sync:unranked-users
```