### PR TITLE
perf: enable useScriptElementForInitialPage inertia setting

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -35,6 +35,12 @@ Sentry.init({
 });
 
 createInertiaApp({
+  defaults: {
+    future: {
+      useScriptElementForInitialPage: true,
+    },
+  },
+
   title: (title) => (title && title !== appName ? `${title} · ${appName}` : appName),
 
   resolve: (name) =>

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -38,6 +38,12 @@ createServer(
 
       render: ReactDOMServer.renderToString,
 
+      defaults: {
+        future: {
+          useScriptElementForInitialPage: true,
+        },
+      },
+
       title: (title) => (title && title !== appName ? `${title} · ${appName}` : appName),
 
       resolve: (name) =>


### PR DESCRIPTION
https://laravel.com/docs/changelog#:~:text=Optimize%20Page%20Data%20Size%20and%20Parsing

> Opt-in support was added for loading the initial Inertia page data from a <script type="application/json"> element instead of the body tag. This results in a greatly reduced initial page data size, faster parsing, and makes the initial page data a breeze to inspect with your browser's dev tools.

<img width="405" height="141" alt="Screenshot 2026-01-09 at 5 59 15 PM" src="https://github.com/user-attachments/assets/54b04188-fc88-4e91-a7f7-c83be72df393" />
