### PR TITLE
fix(manage): remediate audit log crash

### DIFF
--- a/resources/views/filament/pages/audit-log.blade.php
+++ b/resources/views/filament/pages/audit-log.blade.php
@@ -86,7 +86,7 @@ use \Illuminate\Support\Js;
                             @php
                                 $oldValue = data_get($changes, "old.{$field}");
                                 $newValue = data_get($changes, "attributes.{$field}");
-                                $isRelationship = method_exists($this->record, $field);
+                                $isRelationship = method_exists($this->record, $field) && (new \ReflectionMethod($this->record, $field))->isPublic();
                                 $newRelatedModels = collect();
                                 $oldRelatedModels = collect();
                                 if ($isRelationship) {


### PR DESCRIPTION
`method_exists()` is erroring due to the `Achievement::description()` mutator being protected and many log entries are pointing to ->Description or ->Title.