### PR TITLE
fix: add missing nav.classList.toggle to banner-scripts

### DIFF
--- a/resources/views/components/banner-scripts.blade.php
+++ b/resources/views/components/banner-scripts.blade.php
@@ -27,6 +27,7 @@
 
         navs.forEach(function(nav) {
             nav.classList.toggle('has-banner', hasBanner);
+            nav.classList.toggle('!bg-transparent', hasBanner);
             if (!hasBanner) {
                 nav.classList.remove('scrolled-past-banner');
             }
@@ -39,7 +40,8 @@
     updateNavbarOnScroll();
 
     document.addEventListener('inertia:navigate', (event) => {
-        setBannerState(event.detail.page.props?.banner?.desktopMdWebp != null);
+        const hasBanner = !!event.detail.page.props?.banner?.desktopMdWebp;
+        setBannerState(hasBanner);
     });
 
     window.addEventListener('scroll', function() {


### PR DESCRIPTION
When making a client-side navigation from a game page that has a banner to a page that doesn't have one (such as the game's official forum topic), the navbar is still transparent on scroll. This is because a class isn't correctly being toggled off in _banner-scripts.blade.php_.