### PR TITLE
fix: update collapsible height on content changes via ResizeObserver

### DIFF
--- a/resources/js/common/hooks/useAnimatedCollapse.test.tsx
+++ b/resources/js/common/hooks/useAnimatedCollapse.test.tsx
@@ -1,0 +1,61 @@
+import userEvent from '@testing-library/user-event';
+import type { FC } from 'react';
+import { useState } from 'react';
+
+import { render, screen } from '@/test';
+
+import { useAnimatedCollapse } from './useAnimatedCollapse';
+
+const TestComponent: FC = () => {
+  const { contentHeight, contentRef, isOpen, setIsOpen } = useAnimatedCollapse();
+  const [extraContent, setExtraContent] = useState(false);
+
+  return (
+    <div>
+      <button onClick={() => setIsOpen(!isOpen)} data-testid="toggle">
+        Toggle
+      </button>
+      <p data-testid="height">{contentHeight}</p>
+
+      {isOpen ? (
+        <div ref={contentRef} data-testid="content">
+          <p>Content</p>
+          {extraContent ? <p>Extra content that makes the container taller</p> : null}
+        </div>
+      ) : null}
+
+      <button onClick={() => setExtraContent(true)} data-testid="add-content">
+        Add Content
+      </button>
+    </div>
+  );
+};
+
+describe('Hook: useAnimatedCollapse', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const { container } = render(<TestComponent />);
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('starts in the closed state', () => {
+    // ARRANGE
+    render(<TestComponent />);
+
+    // ASSERT
+    expect(screen.queryByTestId('content')).not.toBeInTheDocument();
+  });
+
+  it('opens when toggled', async () => {
+    // ARRANGE
+    render(<TestComponent />);
+
+    // ACT
+    await userEvent.click(screen.getByTestId('toggle'));
+
+    // ASSERT
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+});

--- a/resources/js/common/hooks/useAnimatedCollapse.ts
+++ b/resources/js/common/hooks/useAnimatedCollapse.ts
@@ -6,10 +6,29 @@ export function useAnimatedCollapse() {
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentHeight, setContentHeight] = useState(0);
 
+  // Recalculate height when the collapsible is opened.
   useEffect(() => {
     if (contentRef.current) {
       setContentHeight(contentRef.current.offsetHeight);
     }
+  }, [isOpen]);
+
+  // Observe content size changes so the height stays in sync
+  // when children are dynamically added or removed (eg: after claiming a game).
+  useEffect(() => {
+    if (!isOpen || !contentRef.current) {
+      return;
+    }
+
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) {
+        setContentHeight(entry.target.scrollHeight);
+      }
+    });
+
+    observer.observe(contentRef.current);
+
+    return () => observer.disconnect();
   }, [isOpen]);
 
   return {


### PR DESCRIPTION
## Description

When the Contribute menu content changes dynamically (e.g., after claiming a game), the animated collapsible height was not recalculated, causing the 'Subscribe: Tickets' button to be cropped/cut off.

## Changes

- Added a `ResizeObserver` to the `useAnimatedCollapse` hook that watches for content size changes while the collapsible is open, keeping the animated height in sync with the actual content height.
- Added tests for the `useAnimatedCollapse` hook.

Fixes #4517