### PR TITLE
fix(ui): update collapsible height on dynamic content changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ nbproject
 lang/php_*.json
 npm-debug.log
 yarn-error.log
+resources/js/ziggy.ts

--- a/resources/js/common/hooks/useAnimatedCollapse.ts
+++ b/resources/js/common/hooks/useAnimatedCollapse.ts
@@ -6,10 +6,28 @@ export function useAnimatedCollapse() {
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentHeight, setContentHeight] = useState(0);
 
+  // Recalculate height when the collapsible is opened.
   useEffect(() => {
     if (contentRef.current) {
       setContentHeight(contentRef.current.offsetHeight);
     }
+  }, [isOpen]);
+
+  // Watch for dynamic content changes while the collapsible is open.
+  useEffect(() => {
+    if (!isOpen || !contentRef.current) {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContentHeight(entry.target.clientHeight);
+      }
+    });
+
+    observer.observe(contentRef.current);
+
+    return () => observer.disconnect();
   }, [isOpen]);
 
   return {


### PR DESCRIPTION
## Problem

When content inside the "Contribute" menu changes dynamically (e.g., after claiming a game), the animated collapsible height was not recalculated. This caused buttons like "Subscribe: Tickets" to be partially clipped/cropped.

## Solution

Added a `ResizeObserver` to the `useAnimatedCollapse` hook that watches for content size changes while the collapsible is open, automatically updating the animated height.

## Testing

- Open a game page with the "Contribute" menu
- Claim/unclaim a game to trigger dynamic button changes
- Verify all buttons are fully visible without clipping

Fixes #4517