### PR TITLE
feat(hash): add breadcrumb and title to game hash audit log

### DIFF
--- a/app/Filament/Resources/GameHashResource/Pages/AuditLog.php
+++ b/app/Filament/Resources/GameHashResource/Pages/AuditLog.php
@@ -4,8 +4,33 @@ namespace App\Filament\Resources\GameHashResource\Pages;
 
 use App\Filament\Pages\ResourceAuditLog;
 use App\Filament\Resources\GameHashResource;
+use App\Models\GameHash;
+use Illuminate\Contracts\Support\Htmlable;
 
 class AuditLog extends ResourceAuditLog
 {
     protected static string $resource = GameHashResource::class;
+
+    public function getTitle(): string|Htmlable
+    {
+        /** @var GameHash $gameHash */
+        $gameHash = $this->getRecord();
+
+        return "{$gameHash->name} - Audit Log";
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        /** @var GameHash $gameHash */
+        $gameHash = $this->record;
+        $game = $gameHash->game;
+
+        return [
+            route('filament.admin.resources.games.index') => 'Games',
+            route('filament.admin.resources.games.view', $game) => $game->title,
+            route('filament.admin.resources.games.hashes', $game) => 'Hashes',
+            $gameHash->name,
+            'Audit Log',
+        ];
+    }
 }


### PR DESCRIPTION
Before:
<img width="361" height="80" alt="image" src="https://github.com/user-attachments/assets/8af5a251-bf0e-44a3-b969-05218ab921d4" />

After:
<img width="1032" height="90" alt="image" src="https://github.com/user-attachments/assets/79973cc6-6f94-467b-a23d-5f34fa2943cc" />
