### PR TITLE
chore: suppress doupload.php GD image driver warnings

### DIFF
--- a/app/Helpers/util/media.php
+++ b/app/Helpers/util/media.php
@@ -52,9 +52,9 @@ function validateFile(array $file): bool
 function createImageFromExtension(array $file): GdImage
 {
     $image = match (pathinfo($file['name'], PATHINFO_EXTENSION)) {
-        'png' => imagecreatefrompng($file['tmp_name']),
-        'jpg', 'jpeg' => imagecreatefromjpeg($file['tmp_name']),
-        'gif' => imagecreatefromgif($file['tmp_name']),
+        'png' => @imagecreatefrompng($file['tmp_name']),
+        'jpg', 'jpeg' => @imagecreatefromjpeg($file['tmp_name']),
+        'gif' => @imagecreatefromgif($file['tmp_name']),
         default => null,
     };
     if (!$image) {


### PR DESCRIPTION
<img width="928" height="305" alt="Screenshot 2026-02-23 at 7 51 56 PM" src="https://github.com/user-attachments/assets/3f2a300d-491d-4341-b807-b74887e75620" />

These error logs are actually caused by network issues between the server and client. The GD image driver is emitting PHP errors when it tries to process corrupt image data, even though our code gracefully handles that already.