### PR TITLE
Add clarification to UWC report alert

### DIFF
--- a/resources/views/components/message/template-kind-alert.blade.php
+++ b/resources/views/components/message/template-kind-alert.blade.php
@@ -24,6 +24,10 @@
                             consult the docs.
                         </a>
                     </p>
+
+                    <p>
+                        Please note that DevCompliance does not rescore or rebalance achievements. If the concept is fine but the difficulty or reward is not, please suggest a change in the forum thread instead.
+                    </p>
                 </div>
                 @break
 


### PR DESCRIPTION
DevCompliance gets a lot of Unwelcome Concept reports from players who don't think it is an unwelcome concept, but would like to see the achievement award more points, or be made easier.

I'd like to adjust the alert that appears when making an UWC report to clarify that those changes should be suggested in the forum thread, rather than to DevComp, as we can only reject those.