### PR TITLE
fix: don't cache page responses that contain flash data

### DIFF
--- a/app/Http/ResponseCache/AnonymousCacheProfile.php
+++ b/app/Http/ResponseCache/AnonymousCacheProfile.php
@@ -39,7 +39,7 @@ class AnonymousCacheProfile extends BaseCacheProfile
         // Don't cache responses that carry flash data. Otherwise a flash
         // message (eg "your email has been verified") gets baked into the
         // cached page and shown to every subsequent anonymous visitor.
-        if (session('message') || session('success') || session('error') || session('status')) {
+        if (session()->has('_flash.new') && filled(session()->get('_flash.new'))) {
             return false;
         }
 

--- a/tests/Feature/Http/ResponseCache/AnonymousCacheProfileTest.php
+++ b/tests/Feature/Http/ResponseCache/AnonymousCacheProfileTest.php
@@ -78,17 +78,14 @@ describe('shouldCacheResponse', function () {
         'application/json',
     ]);
 
-    it('rejects responses when the session has flash data', function () {
-        // ARRANGE
-        session()->flash('success', 'Your email has been verified.');
+    it('rejects responses when the session has flash data', function (string $key) {
+        session()->flash($key, 'Some message.');
         $response = new Response('OK', 200, ['Content-Type' => 'text/html']);
 
-        // ACT
         $result = $this->profile->shouldCacheResponse($response);
 
-        // ASSERT
         expect($result)->toBeFalse();
-    });
+    })->with(['message', 'success', 'error', 'status']);
 
     it('rejects redirects, errors, and binary responses', function (int $status, string $contentType) {
         // ARRANGE


### PR DESCRIPTION
Page responses with flash state (eg: "go verify your email", etc) are being cached and shown to guests that have never interacted with auth. This PR allows `AnonymousCacheProfile::shouldCacheResponse()` to bail during these scenarios.