### PR TITLE
fix: disable React Compiler in the game-list feature module

### DIFF
--- a/resources/js/features/game-list/components/GamesDataTableContainer/GameListDataTable/GameListDataTable.tsx
+++ b/resources/js/features/game-list/components/GamesDataTableContainer/GameListDataTable/GameListDataTable.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react-hooks/refs -- the use no memo directive is enabled */
-
 import type { Row, Table } from '@tanstack/react-table';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,7 +22,6 @@ interface GameListDataTableProps {
 }
 
 export function GameListDataTable({ table, isLoading = false }: GameListDataTableProps) {
-  'use no memo'; // useReactTable does not support React Compiler
   const { t } = useTranslation();
 
   const wasShowingGroups = useRef(false);

--- a/resources/js/features/game-list/components/GamesDataTableContainer/GamesDataTableContainer.tsx
+++ b/resources/js/features/game-list/components/GamesDataTableContainer/GamesDataTableContainer.tsx
@@ -83,8 +83,7 @@ export const GamesDataTableContainer: FC<GamesDataTableContainerProps> = ({
     isEnabled: ziggy.device === 'desktop',
   });
 
-  // eslint-disable-next-line react-hooks/incompatible-library -- https://github.com/TanStack/table/issues/5567
-  const tableInstance = useReactTable({
+  const table = useReactTable({
     columns: columnDefinitions,
     data: gameListQuery.data?.items ?? [],
     manualPagination: true,
@@ -94,7 +93,7 @@ export const GamesDataTableContainer: FC<GamesDataTableContainerProps> = ({
     pageCount: gameListQuery.data?.lastPage,
     onColumnVisibilityChange: setColumnVisibility,
     onColumnFiltersChange: (updateOrValue) => {
-      tableInstance.setPageIndex(0);
+      table.setPageIndex(0);
 
       setColumnFilters(updateOrValue);
     },
@@ -102,18 +101,13 @@ export const GamesDataTableContainer: FC<GamesDataTableContainerProps> = ({
       setPagination(newPaginationValue);
     },
     onSortingChange: (newSortingValue) => {
-      tableInstance.setPageIndex(0);
+      table.setPageIndex(0);
 
       setSorting(newSortingValue);
     },
     getCoreRowModel: getCoreRowModel(),
     state: { columnFilters, columnVisibility, pagination, sorting },
   });
-
-  // Spread to break the stable reference. useReactTable returns the same
-  // object identity across renders, which causes React Compiler to skip
-  // re-evaluating table.get*() calls in child components.
-  const table = { ...tableInstance } as typeof tableInstance;
 
   return (
     <div className="flex flex-col gap-3">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,7 +57,20 @@ export default defineConfig(({ mode, isSsrBuild }) => {
 
       react({
         babel: {
-          plugins: ['babel-plugin-react-compiler'],
+          plugins: [
+            [
+              'babel-plugin-react-compiler',
+              {
+                // @tanstack/react-table uses a mutable API that's incompatible with
+                // React Compiler's memoization. The useReactTable hook returns a stable
+                // object, so the compiler caches stale results from table/column/row
+                // method calls, breaking column visibility toggling and filter labels.
+                sources: (filename: string) => {
+                  return !filename.includes('features/game-list');
+                },
+              },
+            ],
+          ],
         },
       }),
 


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1481747389844033568
https://discord.com/channels/310192285306454017/1481710644129566842
https://discord.com/channels/476211979464343552/1026595325038833725/1481679993644912790

Rather than letting this devolve into whack-a-mole, I've decided to disable React Compiler where `useReactTable()` is invoked.