### PR TITLE
fix(AnonymousCacheProfile): don't cache 'Invalid token.' flash state

### DIFF
--- a/app/Http/ResponseCache/AnonymousCacheProfile.php
+++ b/app/Http/ResponseCache/AnonymousCacheProfile.php
@@ -39,7 +39,14 @@ class AnonymousCacheProfile extends BaseCacheProfile
         // Don't cache responses that carry flash data. Otherwise a flash
         // message (eg "your email has been verified") gets baked into the
         // cached page and shown to every subsequent anonymous visitor.
-        if (session()->has('_flash.new') && filled(session()->get('_flash.new'))) {
+        // We check both _flash.new and _flash.old because Laravel's
+        // ageFlashData() runs at session start, moving new to old before
+        // the response is built. The rendered page still displays the
+        // old flash data, so we must catch it here too.
+        if (
+            (session()->has('_flash.new') && filled(session()->get('_flash.new')))
+            || (session()->has('_flash.old') && filled(session()->get('_flash.old')))
+        ) {
             return false;
         }
 

--- a/tests/Feature/Http/ResponseCache/AnonymousCacheProfileTest.php
+++ b/tests/Feature/Http/ResponseCache/AnonymousCacheProfileTest.php
@@ -78,14 +78,31 @@ describe('shouldCacheResponse', function () {
         'application/json',
     ]);
 
-    it('rejects responses when the session has flash data', function (string $key) {
+    it('rejects responses when the session has fresh flash data', function (string $key) {
+        // ARRANGE
         session()->flash($key, 'Some message.');
         $response = new Response('OK', 200, ['Content-Type' => 'text/html']);
 
+        // ACT
         $result = $this->profile->shouldCacheResponse($response);
 
+        // ASSERT
         expect($result)->toBeFalse();
     })->with(['message', 'success', 'error', 'status']);
+
+    it('rejects responses when the session has aged flash data', function () {
+        // ARRANGE
+        session()->flash('error', 'Invalid token.');
+        session()->ageFlashData();
+
+        $response = new Response('OK', 200, ['Content-Type' => 'text/html']);
+
+        // ACT
+        $result = $this->profile->shouldCacheResponse($response);
+
+        // ASSERT
+        expect($result)->toBeFalse();
+    });
 
     it('rejects redirects, errors, and binary responses', function (int $status, string $contentType) {
         // ARRANGE


### PR DESCRIPTION
"Invalid token." responses are stored in `_flash.old`, so sometimes unauthenticated users are seeing those messages on the home page even if it's the first time they've ever hit the site.