### PR TITLE
chore(TrustHosts): allow internal server-to-server requests

### DIFF
--- a/app/Http/Middleware/TrustHosts.php
+++ b/app/Http/Middleware/TrustHosts.php
@@ -18,6 +18,7 @@ class TrustHosts extends Middleware
         return [
             $this->allSubdomainsOfApplicationUrl(),
             '^(.+\.)?retroachievements\.org$',
+            '^10\.0\.0\.\d+(:\d+)?$', // private network hosts for server-to-server requests
         ];
     }
 }


### PR DESCRIPTION
This is necessary for the app server to pull the API server's logs. The `api.retroachievements.org` subdomain is being locked down at the nginx level.