### PR TITLE
bugfix(connect): junior dev should not need an active claim to update their own unpromoted achievements

### DIFF
--- a/app/Connect/Actions/SubmitAchievementAction.php
+++ b/app/Connect/Actions/SubmitAchievementAction.php
@@ -148,11 +148,6 @@ class SubmitAchievementAction extends BaseAuthenticatedApiAction
                 return $this->mustBeDeveloper();
             }
 
-            // A junior developer must have a claim on the game.
-            if (!$this->user->hasActiveClaimOnGameId($achievement->game_id)) {
-                return $this->mustHaveClaim();
-            }
-
             // A junior developer is not allowed to modify logic of promoted achievements.
             if ($this->isPromoted && $this->triggerDefinition !== $achievement->trigger_definition) {
                 return $this->mustBeDeveloper();

--- a/tests/Feature/Connect/UploadAchievementTest.php
+++ b/tests/Feature/Connect/UploadAchievementTest.php
@@ -874,7 +874,7 @@ describe('junior developer', function () {
         $game = UploadAchievementTestHelpers::createGame();
         $achievement = UploadAchievementTestHelpers::createUnpromotedAchievement($game, $this->user);
         $triggerVersion = $achievement->trigger_id;
-        UploadAchievementTestHelpers::addClaim($game, $this->user);
+        // NOTE: junior developer does not need active claim to update their own existing unpromoted achievements
 
         $this->get(UploadAchievementTestHelpers::apiUrlWithChecksum($this->apiParams('uploadachievement', [
             'a' => $achievement->id,


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1494345591520628827/1494348166882000926
https://discord.com/channels/310192285306454017/1494383602899619982/1494393260498747432

Looking at the previous implementation, the jr.dev logic did not require a claim for updates, only for creates. Jr. dev updates should only be limited to unpromoted achievements they have written.

When the tests were converted to pest in #4702, the "junior developer can modify their own achievement" test was written to provide a claim because the previous test had one leftover from an earlier assertion. Then, when the code was refactored, since the test was providing a claim, it didn't fail when the claim logic made its way into the update path.
