### PR TITLE
perf: resolve N+1 query issue with site navbar / systems

### DIFF
--- a/app/Support/Cache/CacheKey.php
+++ b/app/Support/Cache/CacheKey.php
@@ -6,7 +6,7 @@ namespace App\Support\Cache;
 
 class CacheKey
 {
-    public const SystemMenuList = 'ui:menu:systems:v2';
+    public const SystemMenuList = 'ui:menu:systems:v3';
 
     public static function buildGameCardDataCacheKey(int $gameId): string
     {

--- a/resources/views/components/menu/main.blade.php
+++ b/resources/views/components/menu/main.blade.php
@@ -19,6 +19,7 @@ $menuSystemsList = Cache::remember(CacheKey::SystemMenuList, Carbon::now()->addH
             'id' => $system->id,
             'manufacturer' => $system->manufacturer,
             'name' => $system->name,
+            'name_short' => $system->name_short,
         ]);
 
     $menuSystemsList = [
@@ -71,7 +72,7 @@ $menuSystemsList = Cache::remember(CacheKey::SystemMenuList, Carbon::now()->addH
                     <x-dropdown-header>{{ $manufacturer }}</x-dropdown-header>
                     @foreach ($manufacturerSystems as $system)
                         <x-dropdown-item :href="route('system.game.index', ['system' => $system['id']])">
-                            <img src="{!! getSystemIconUrl($system['id']) !!}" loading="lazy" width="16" height="16" alt='{{ $system['name'] }}'>
+                            <img src="{{ getSystemIconUrl($system['name_short']) }}" loading="lazy" width="16" height="16" alt='{{ $system['name'] }}'>
                             <span>{{ $system['name'] }}</span>
                         </x-dropdown-item>
                     @endforeach


### PR DESCRIPTION
Regression from migrating to Laravel 13, which introduced cache serialization changes. Every page right now is hitting an N+1 query problem from the navbar:
<img width="1690" height="419" alt="Screenshot 2026-04-19 at 12 35 37 PM" src="https://github.com/user-attachments/assets/12eb543b-8455-45f2-ac83-0a2b75526530" />

**Root Cause**
The cached `$menuSystemsList` payload is not storing everything we need for the component (ie: `name_short`).