### PR TITLE
feat(game-list): show 'Reset' button when user changes their sort order

### DIFF
--- a/resources/js/features/game-list/components/DataTableResetFiltersButton/DataTableResetFiltersButton.test.tsx
+++ b/resources/js/features/game-list/components/DataTableResetFiltersButton/DataTableResetFiltersButton.test.tsx
@@ -1,8 +1,9 @@
-import type { ColumnFiltersState } from '@tanstack/react-table';
+import type { ColumnFiltersState, SortingState } from '@tanstack/react-table';
 import { getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import type { FC } from 'react';
+import { useState } from 'react';
 
 import { render, screen, waitFor } from '@/test';
 import { createPaginatedData } from '@/test/factories';
@@ -11,29 +12,42 @@ import { DataTableResetFiltersButton } from './DataTableResetFiltersButton';
 
 interface DataTableResetFiltersButtonTestHarnessProps {
   columnFilters?: ColumnFiltersState;
+  sorting?: SortingState;
 }
 
 const DataTableResetFiltersButtonTestHarness: FC<DataTableResetFiltersButtonTestHarnessProps> = ({
   columnFilters = [],
+  sorting = [{ id: 'title', desc: false }],
 }) => {
+  const [currentColumnFilters, setCurrentColumnFilters] = useState(columnFilters);
+  const [currentSorting, setCurrentSorting] = useState(sorting);
+
   // eslint-disable-next-line react-hooks/incompatible-library -- https://github.com/TanStack/table/issues/5567
   const table = useReactTable({
     data: [],
     columns: [],
     state: {
-      columnFilters,
+      columnFilters: currentColumnFilters,
       pagination: { pageIndex: 0, pageSize: 25 },
+      sorting: currentSorting,
     },
+    onColumnFiltersChange: setCurrentColumnFilters,
+    onSortingChange: setCurrentSorting,
     getCoreRowModel: getCoreRowModel(),
   });
 
   return (
     <div>
-      <DataTableResetFiltersButton table={table} />
+      <DataTableResetFiltersButton
+        table={table}
+        defaultColumnFilters={[{ id: 'system', value: ['supported'] }]}
+        defaultColumnSort={{ id: 'title', desc: false }}
+      />
 
       <p data-testid="current-column-filters-state">
         {JSON.stringify(table.getState().columnFilters)}
       </p>
+      <p data-testid="current-sorting-state">{JSON.stringify(table.getState().sorting)}</p>
     </div>
   );
 };
@@ -51,7 +65,12 @@ describe('Component: DataTableResetFiltersButton', () => {
     // ARRANGE
     const getSpy = vi.spyOn(axios, 'get').mockResolvedValueOnce({ data: createPaginatedData([]) });
 
-    render(<DataTableResetFiltersButtonTestHarness />);
+    render(
+      <DataTableResetFiltersButtonTestHarness
+        columnFilters={[{ id: 'progress', value: ['mastered'] }]}
+        sorting={[{ id: 'playersTotal', desc: true }]}
+      />,
+    );
 
     // ACT
     await userEvent.hover(screen.getByRole('button', { name: /reset/i }));
@@ -63,7 +82,33 @@ describe('Component: DataTableResetFiltersButton', () => {
 
     expect(getSpy).toHaveBeenCalledWith([
       'api.game.index',
-      { 'page[number]': 1, 'page[size]': 25, sort: null },
+      {
+        'page[number]': 1,
+        'page[size]': 25,
+        'filter[system]': 'supported',
+        sort: 'title',
+      },
     ]);
+  });
+
+  it('given the user clicks the button, resets filters and sorting to their defaults', async () => {
+    // ARRANGE
+    render(
+      <DataTableResetFiltersButtonTestHarness
+        columnFilters={[{ id: 'progress', value: ['mastered'] }]}
+        sorting={[{ id: 'playersTotal', desc: true }]}
+      />,
+    );
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: /reset/i }));
+
+    // ASSERT
+    expect(screen.getByTestId('current-column-filters-state')).toHaveTextContent(
+      '[{"id":"system","value":["supported"]}]',
+    );
+    expect(screen.getByTestId('current-sorting-state')).toHaveTextContent(
+      '[{"id":"title","desc":false}]',
+    );
   });
 });

--- a/resources/js/features/game-list/components/DataTableResetFiltersButton/DataTableResetFiltersButton.tsx
+++ b/resources/js/features/game-list/components/DataTableResetFiltersButton/DataTableResetFiltersButton.tsx
@@ -1,4 +1,4 @@
-import type { ColumnFiltersState, Table } from '@tanstack/react-table';
+import type { ColumnFiltersState, ColumnSort, Table } from '@tanstack/react-table';
 import { useTranslation } from 'react-i18next';
 import { RxCross2 } from 'react-icons/rx';
 import type { RouteName } from 'ziggy-js';
@@ -11,6 +11,7 @@ interface DataTableResetFiltersButtonProps<TData> {
   table: Table<TData>;
 
   defaultColumnFilters?: ColumnFiltersState;
+  defaultColumnSort?: ColumnSort;
   /** The controller route name where client-side calls for this datatable are made. */
   tableApiRouteName?: RouteName;
   tableApiRouteParams?: Record<string, unknown>;
@@ -20,6 +21,7 @@ export function DataTableResetFiltersButton<TData>({
   table,
   tableApiRouteParams,
   defaultColumnFilters = [],
+  defaultColumnSort = { id: 'title', desc: false },
   tableApiRouteName = 'api.game.index',
 }: DataTableResetFiltersButtonProps<TData>) {
   const { t } = useTranslation();
@@ -27,19 +29,21 @@ export function DataTableResetFiltersButton<TData>({
   const { prefetchResetFilters } = useDataTablePrefetchResetFilters(
     table,
     defaultColumnFilters,
+    defaultColumnSort,
     tableApiRouteName,
     tableApiRouteParams,
   );
 
-  const resetFiltersToDefault = () => {
+  const resetViewToDefault = () => {
     table.setColumnFilters(defaultColumnFilters);
+    table.setSorting([defaultColumnSort]);
   };
 
   return (
     <BaseButton
       variant="ghost"
       size="sm"
-      onClick={resetFiltersToDefault}
+      onClick={resetViewToDefault}
       onMouseEnter={() => prefetchResetFilters()}
       className="px-2 text-link lg:px-3"
       data-testid="reset-all-filters"

--- a/resources/js/features/game-list/components/GamesDataTableContainer/DataTableToolbar/DataTableDesktopToolbar.tsx
+++ b/resources/js/features/game-list/components/GamesDataTableContainer/DataTableToolbar/DataTableDesktopToolbar.tsx
@@ -1,4 +1,4 @@
-import type { ColumnFiltersState, Table } from '@tanstack/react-table';
+import type { ColumnFiltersState, ColumnSort, Table } from '@tanstack/react-table';
 import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import type { RouteName } from 'ziggy-js';
@@ -10,6 +10,7 @@ import { usePageProps } from '@/common/hooks/usePageProps';
 import { isCurrentlyPersistingViewAtom } from '../../../state/game-list.atoms';
 import { doesColumnExist } from '../../../utils/doesColumnExist';
 import { getAreNonDefaultFiltersSet } from '../../../utils/getAreNonDefaultFiltersSet';
+import { getIsDefaultSorting } from '../../../utils/getIsDefaultSorting';
 import { DataTableColumnsToggle } from '../../DataTableColumnsToggle';
 import { DataTableResetFiltersButton } from '../../DataTableResetFiltersButton';
 import { DataTableSearchInput } from '../../DataTableSearchInput';
@@ -27,6 +28,7 @@ interface DataTableDesktopToolbarProps<TData> {
   unfilteredTotal: number | null;
 
   defaultColumnFilters?: ColumnFiltersState;
+  defaultColumnSort?: ColumnSort;
   isTableQueryLoading?: boolean;
   randomGameApiRouteName?: RouteName;
   tableApiRouteName?: RouteName;
@@ -38,6 +40,7 @@ export function DataTableDesktopToolbar<TData>({
   tableApiRouteParams,
   unfilteredTotal,
   defaultColumnFilters = [],
+  defaultColumnSort = { id: 'title', desc: false },
   isTableQueryLoading = false,
   randomGameApiRouteName = 'api.game.random',
   tableApiRouteName = 'api.game.index',
@@ -53,9 +56,10 @@ export function DataTableDesktopToolbar<TData>({
   );
 
   const allColumns = table.getAllColumns();
-
-  const currentFilters = table.getState().columnFilters;
+  const { columnFilters: currentFilters, sorting: currentSorting } = table.getState();
   const isFiltered = getAreNonDefaultFiltersSet(currentFilters, defaultColumnFilters);
+  const isSortedByDefault = getIsDefaultSorting(currentSorting, defaultColumnSort);
+  const shouldShowResetButton = isFiltered || !isSortedByDefault;
 
   return (
     <div className="flex w-full flex-col justify-between gap-2">
@@ -99,10 +103,11 @@ export function DataTableDesktopToolbar<TData>({
             <DataTableProgressFilter table={table} />
           ) : null}
 
-          {isFiltered ? (
+          {shouldShowResetButton ? (
             <DataTableResetFiltersButton
               table={table}
               defaultColumnFilters={defaultColumnFilters}
+              defaultColumnSort={defaultColumnSort}
               tableApiRouteName={tableApiRouteName}
               tableApiRouteParams={tableApiRouteParams}
             />

--- a/resources/js/features/game-list/components/GamesDataTableContainer/DataTableToolbar/DataTableToolbar.test.tsx
+++ b/resources/js/features/game-list/components/GamesDataTableContainer/DataTableToolbar/DataTableToolbar.test.tsx
@@ -1,8 +1,9 @@
-import type { ColumnDef, Table } from '@tanstack/react-table';
+import type { ColumnDef, ColumnFiltersState, Table } from '@tanstack/react-table';
 import { getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import type { FC } from 'react';
+import { useState } from 'react';
 import type { RouteName } from 'ziggy-js';
 
 import i18n from '@/i18n-client';
@@ -47,23 +48,34 @@ const mockData: Model[] = [
 interface DataTableToolbarHarnessProps {
   columns?: ColumnDef<Model>[];
   data?: Model[];
+  defaultColumnFilters?: ColumnFiltersState;
   tableApiRouteName?: RouteName;
   unfilteredTotal?: number;
+  initialSorting?: { id: string; desc: boolean }[];
 }
 
 const DataTableToolbarHarness: FC<DataTableToolbarHarnessProps> = ({
   columns = mockColumns,
   data = mockData,
+  defaultColumnFilters = [],
+  initialSorting = [{ id: 'title', desc: false }],
   tableApiRouteName,
   unfilteredTotal,
 }) => {
+  const [columnFilters, setColumnFilters] = useState(defaultColumnFilters);
+  const [sorting, setSorting] = useState(initialSorting);
+
   // eslint-disable-next-line react-hooks/incompatible-library -- https://github.com/TanStack/table/issues/5567
   const table = useReactTable({
     data,
     columns,
     state: {
+      columnFilters,
       pagination: { pageIndex: 0, pageSize: 25 },
+      sorting,
     },
+    onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setSorting,
     rowCount: data.length ?? 0,
     getCoreRowModel: getCoreRowModel(),
   });
@@ -71,6 +83,8 @@ const DataTableToolbarHarness: FC<DataTableToolbarHarnessProps> = ({
   return (
     <DataTableToolbar
       table={table as Table<unknown>}
+      defaultColumnFilters={defaultColumnFilters}
+      defaultColumnSort={{ id: 'title', desc: false }}
       tableApiRouteName={tableApiRouteName}
       unfilteredTotal={unfilteredTotal ?? data.length}
     />
@@ -278,9 +292,22 @@ describe('Component: DataTableToolbar', () => {
       {
         'page[number]': 1,
         'page[size]': 25,
-        sort: null,
+        sort: 'title',
       },
     ]);
+  });
+
+  it('given the user changed the sort order, shows a Reset button', () => {
+    // ARRANGE
+    render(<DataTableToolbarHarness initialSorting={[{ id: 'system', desc: false }]} />, {
+      pageProps: {
+        filterableSystemOptions: [createSystem({ name: 'Nintendo 64', nameShort: 'N64' })],
+        ziggy: createZiggyProps({ device: 'desktop' }),
+      },
+    });
+
+    // ASSERT
+    expect(screen.getByRole('button', { name: /reset/i })).toBeVisible();
   });
 
   it('given the table has no achievements published column, does not show the "Has achievements" filter', () => {

--- a/resources/js/features/game-list/components/GamesDataTableContainer/DataTableToolbar/DataTableToolbar.tsx
+++ b/resources/js/features/game-list/components/GamesDataTableContainer/DataTableToolbar/DataTableToolbar.tsx
@@ -1,4 +1,4 @@
-import type { ColumnFiltersState, Table } from '@tanstack/react-table';
+import type { ColumnFiltersState, ColumnSort, Table } from '@tanstack/react-table';
 import { lazy, Suspense } from 'react';
 import type { RouteName } from 'ziggy-js';
 
@@ -14,6 +14,7 @@ interface DataTableToolbarProps<TData> {
   unfilteredTotal: number | null;
 
   defaultColumnFilters?: ColumnFiltersState;
+  defaultColumnSort?: ColumnSort;
   isTableQueryLoading?: boolean;
   randomGameApiRouteName?: RouteName;
   tableApiRouteName?: RouteName;
@@ -25,6 +26,7 @@ export function DataTableToolbar<TData>({
   tableApiRouteParams,
   unfilteredTotal,
   defaultColumnFilters = [],
+  defaultColumnSort = { id: 'title', desc: false },
   isTableQueryLoading = false,
   randomGameApiRouteName = 'api.game.random',
   tableApiRouteName = 'api.game.index',
@@ -52,6 +54,7 @@ export function DataTableToolbar<TData>({
       table={table}
       unfilteredTotal={unfilteredTotal}
       defaultColumnFilters={defaultColumnFilters}
+      defaultColumnSort={defaultColumnSort}
       isTableQueryLoading={isTableQueryLoading}
       randomGameApiRouteName={randomGameApiRouteName}
       tableApiRouteName={tableApiRouteName}

--- a/resources/js/features/game-list/components/GamesDataTableContainer/GamesDataTableContainer.tsx
+++ b/resources/js/features/game-list/components/GamesDataTableContainer/GamesDataTableContainer.tsx
@@ -113,6 +113,7 @@ export const GamesDataTableContainer: FC<GamesDataTableContainerProps> = ({
     <div className="flex flex-col gap-3">
       <DataTableToolbar
         defaultColumnFilters={defaultColumnFilters}
+        defaultColumnSort={defaultColumnSort}
         isTableQueryLoading={gameListQuery.isLoading || gameListQuery.isFetching}
         randomGameApiRouteName={randomGameApiRouteName}
         table={table}

--- a/resources/js/features/game-list/hooks/useDataTablePrefetchResetFilters.ts
+++ b/resources/js/features/game-list/hooks/useDataTablePrefetchResetFilters.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import type { ColumnFiltersState, Table } from '@tanstack/react-table';
+import type { ColumnFiltersState, ColumnSort, SortingState, Table } from '@tanstack/react-table';
 import axios from 'axios';
 import type { RouteName } from 'ziggy-js';
 import { route } from 'ziggy-js';
@@ -16,20 +16,23 @@ import { buildGameListQuerySortParam } from '../utils/buildGameListQuerySortPara
 export function useDataTablePrefetchResetFilters<TData>(
   table: Table<TData>,
   defaultColumnFilters: ColumnFiltersState,
+  defaultColumnSort: ColumnSort,
   tableApiRouteName: RouteName,
   tableApiRouteParams?: Record<string, unknown>,
 ) {
   const queryClient = useQueryClient();
 
-  const { pagination, sorting } = table.getState();
+  const { pagination } = table.getState();
+  const resetPagination = { ...pagination, pageIndex: 0 };
+  const resetSorting: SortingState = [defaultColumnSort];
 
   const prefetchResetFilters = () => {
     queryClient.prefetchQuery({
       queryKey: [
         'data',
         tableApiRouteName,
-        pagination,
-        sorting,
+        resetPagination,
+        resetSorting,
         defaultColumnFilters,
         tableApiRouteParams,
       ],
@@ -38,8 +41,8 @@ export function useDataTablePrefetchResetFilters<TData>(
         const response = await axios.get<App.Data.PaginatedData<App.Platform.Data.GameListEntry>>(
           route(tableApiRouteName, {
             ...tableApiRouteParams,
-            sort: buildGameListQuerySortParam(sorting),
-            ...buildGameListQueryPaginationParams(pagination),
+            sort: buildGameListQuerySortParam(resetSorting),
+            ...buildGameListQueryPaginationParams(resetPagination),
             ...buildGameListQueryFilterParams(defaultColumnFilters),
           }),
         );

--- a/resources/js/features/game-list/utils/getIsDefaultSorting.test.ts
+++ b/resources/js/features/game-list/utils/getIsDefaultSorting.test.ts
@@ -1,0 +1,35 @@
+import type { SortingState } from '@tanstack/react-table';
+
+import { getIsDefaultSorting } from './getIsDefaultSorting';
+
+describe('Util: getIsDefaultSorting', () => {
+  it('returns true when the active sorting matches the default sorting', () => {
+    // ARRANGE
+    const sorting: SortingState = [{ id: 'title', desc: false }];
+
+    // ACT
+    const result = getIsDefaultSorting(sorting, { id: 'title', desc: false });
+
+    // ASSERT
+    expect(result).toEqual(true);
+  });
+
+  it('returns false when the active sorting does not match the default sorting', () => {
+    // ARRANGE
+    const sorting: SortingState = [{ id: 'playersTotal', desc: true }];
+
+    // ACT
+    const result = getIsDefaultSorting(sorting, { id: 'title', desc: false });
+
+    // ASSERT
+    expect(result).toEqual(false);
+  });
+
+  it('returns false when no sorting is active', () => {
+    // ACT
+    const result = getIsDefaultSorting([], { id: 'title', desc: false });
+
+    // ASSERT
+    expect(result).toEqual(false);
+  });
+});

--- a/resources/js/features/game-list/utils/getIsDefaultSorting.ts
+++ b/resources/js/features/game-list/utils/getIsDefaultSorting.ts
@@ -1,0 +1,12 @@
+import type { ColumnSort, SortingState } from '@tanstack/react-table';
+
+export function getIsDefaultSorting(
+  sorting: SortingState,
+  defaultColumnSort: ColumnSort,
+): boolean {
+  return (
+    sorting.length === 1 &&
+    sorting[0].id === defaultColumnSort.id &&
+    sorting[0].desc === defaultColumnSort.desc
+  );
+}

--- a/resources/js/features/game-list/utils/getIsDefaultSorting.ts
+++ b/resources/js/features/game-list/utils/getIsDefaultSorting.ts
@@ -1,9 +1,6 @@
 import type { ColumnSort, SortingState } from '@tanstack/react-table';
 
-export function getIsDefaultSorting(
-  sorting: SortingState,
-  defaultColumnSort: ColumnSort,
-): boolean {
+export function getIsDefaultSorting(sorting: SortingState, defaultColumnSort: ColumnSort): boolean {
   return (
     sorting.length === 1 &&
     sorting[0].id === defaultColumnSort.id &&

--- a/resources/js/features/game-list/utils/serializeGameListViewState.ts
+++ b/resources/js/features/game-list/utils/serializeGameListViewState.ts
@@ -6,6 +6,7 @@ import type {
 } from '@tanstack/react-table';
 
 import { buildGameListQuerySortParam } from './buildGameListQuerySortParam';
+import { getIsDefaultSorting } from './getIsDefaultSorting';
 
 interface SerializeGameListViewStateOptions {
   columnFilters: ColumnFiltersState;
@@ -68,7 +69,7 @@ function updateSorting(
     return;
   }
 
-  if (activeSort.id === defaultColumnSort.id && activeSort.desc === defaultColumnSort.desc) {
+  if (getIsDefaultSorting(sorting, defaultColumnSort)) {
     searchParams.delete('sort');
   } else {
     searchParams.set('sort', buildGameListQuerySortParam(sorting)!);


### PR DESCRIPTION
This PR makes it so if the user is viewing a game list (desktop) and changes the sort order from the default, the "Reset" button appears which can reset the sort order back to the default.


https://github.com/user-attachments/assets/f55fd672-745c-4241-be4c-4711faac5b32

