### PR TITLE
fix(individualdevstats): use consistent pie chart sorting

### DIFF
--- a/app/Helpers/database/achievement-creator.php
+++ b/app/Helpers/database/achievement-creator.php
@@ -25,9 +25,10 @@ function getUserAchievementsPerConsole(User $user): array
                 'AchievementCount' => $achievements->count(),
             ];
         })
-        ->sortBy(function ($item) {
-            return [-$item['AchievementCount'], $item['ConsoleName']];
-        }, SORT_REGULAR, true)
+        ->sortBy([
+            ['AchievementCount', 'desc'],
+            ['ConsoleName'],
+        ])
         ->values()
         ->toArray();
 }


### PR DESCRIPTION
For #4572 
Updates the developer stats for Achievements Created per Console data so it sorts consistently with Games Developed per Console.

**Before** 
<img width="1956" height="652" alt="before" src="https://github.com/user-attachments/assets/1a42bd70-d956-4cbe-b1a9-64073d7a6c7c" />

**After**
<img width="1988" height="646" alt="after" src="https://github.com/user-attachments/assets/eed5b89c-527f-4ff6-ada5-bd0aa2a169bc" />
