### PR TITLE
fix(GameScreenshotsRelationManager): remediate lazy load server error

### DIFF
--- a/app/Filament/Resources/GameResource/RelationManagers/GameScreenshotsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/GameScreenshotsRelationManager.php
@@ -10,7 +10,6 @@ use App\Models\User;
 use App\Platform\Actions\AddGameScreenshotAction;
 use App\Platform\Enums\GameScreenshotStatus;
 use App\Platform\Enums\ScreenshotType;
-use App\Platform\Services\ScreenshotResolutionService;
 use App\Rules\DisallowAnimatedImageRule;
 use App\Rules\ValidScreenshotResolutionRule;
 use BackedEnum;
@@ -64,8 +63,6 @@ class GameScreenshotsRelationManager extends RelationManager
     {
         /** @var Game $game */
         $game = $this->getOwnerRecord();
-        $system = $game->system;
-        $resolutionService = new ScreenshotResolutionService();
 
         return $table
             ->headerActions([
@@ -145,7 +142,7 @@ class GameScreenshotsRelationManager extends RelationManager
             ])
             ->modifyQueryUsing(function (Builder $query) {
                 /** @var Builder<GameScreenshot> $query */
-                $query->with('media')
+                $query->with(['media', 'game.system'])
                     ->orderByType()
                     ->orderBy('order_column');
             })
@@ -202,20 +199,10 @@ class GameScreenshotsRelationManager extends RelationManager
 
                 Tables\Columns\TextColumn::make('resolution')
                     ->label('Resolution')
-                    ->getStateUsing(function (GameScreenshot $record) use ($system, $resolutionService): ?string {
-                        if (!$record->width || !$record->height) {
-                            return null;
-                        }
-
-                        // Stash validity so the color/icon closures
-                        // don't need to recompute it per row.
-                        $record->setAttribute('has_wrong_resolution',
-                            !empty($system?->screenshot_resolutions)
-                            && !$resolutionService->isValidResolution($record->width, $record->height, $system)
-                        );
-
-                        return "{$record->width}x{$record->height}";
-                    })
+                    ->state(fn (GameScreenshot $record): ?string => ($record->width && $record->height)
+                        ? "{$record->width}x{$record->height}"
+                        : null
+                    )
                     ->color(fn (GameScreenshot $record): ?string => $record->has_wrong_resolution ? 'danger' : null)
                     ->icon(fn (GameScreenshot $record): ?string => $record->has_wrong_resolution ? 'heroicon-o-exclamation-triangle' : null),
             ])

--- a/tests/Feature/Filament/RelationManagers/GameScreenshotsRelationManagerTest.php
+++ b/tests/Feature/Filament/RelationManagers/GameScreenshotsRelationManagerTest.php
@@ -2,19 +2,13 @@
 
 declare(strict_types=1);
 
-use App\Filament\Resources\GameResource\Pages\Media as MediaPage;
-use App\Filament\Resources\GameResource\RelationManagers\GameScreenshotsRelationManager;
 use App\Models\Game;
 use App\Models\GameScreenshot;
-use App\Models\Role;
 use App\Models\System;
-use App\Models\User;
 use App\Platform\Enums\GameScreenshotStatus;
 use App\Platform\Enums\ScreenshotType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
-use Illuminate\Support\Facades\DB;
-use Livewire\Livewire;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 uses(RefreshDatabase::class);

--- a/tests/Feature/Filament/RelationManagers/GameScreenshotsRelationManagerTest.php
+++ b/tests/Feature/Filament/RelationManagers/GameScreenshotsRelationManagerTest.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-use App\Filament\Resources\GameResource;
+use App\Filament\Resources\GameResource\Pages\Media as MediaPage;
+use App\Filament\Resources\GameResource\RelationManagers\GameScreenshotsRelationManager;
 use App\Models\Game;
 use App\Models\GameScreenshot;
 use App\Models\Role;
@@ -12,6 +13,8 @@ use App\Platform\Enums\GameScreenshotStatus;
 use App\Platform\Enums\ScreenshotType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 uses(RefreshDatabase::class);
@@ -215,39 +218,4 @@ it('given a primary screenshot of a type already exists, subsequent uploads stay
 
     // ASSERT
     expect($second->fresh()->is_primary)->toBeFalse();
-});
-
-it('does not crash when screenshot resolution badges are shown', function () {
-    // ARRANGE
-    Role::query()->firstOrCreate([
-        'name' => Role::GAME_EDITOR,
-        'guard_name' => 'web',
-    ], [
-        'display' => 1,
-    ]);
-
-    $user = User::factory()->create();
-    $user->assignRole(Role::GAME_EDITOR);
-
-    $system = System::factory()->create([
-        'screenshot_resolutions' => [
-            ['width' => 256, 'height' => 224],
-        ],
-    ]);
-    $game = Game::factory()->create(['system_id' => $system->id]);
-
-    $media = createScreenshotMedia($game);
-
-    GameScreenshot::factory()->for($game)->ingame()->create([
-        'media_id' => $media->id,
-        'width' => 256,
-        'height' => 224,
-    ]);
-
-    // ACT
-    $response = $this->actingAs($user)->get(GameResource::getUrl('media', ['record' => $game->id]));
-
-    // ASSERT
-    $response->assertOk();
-    $response->assertSeeText('256x224');
 });

--- a/tests/Feature/Filament/RelationManagers/GameScreenshotsRelationManagerTest.php
+++ b/tests/Feature/Filament/RelationManagers/GameScreenshotsRelationManagerTest.php
@@ -2,9 +2,12 @@
 
 declare(strict_types=1);
 
+use App\Filament\Resources\GameResource;
 use App\Models\Game;
 use App\Models\GameScreenshot;
+use App\Models\Role;
 use App\Models\System;
+use App\Models\User;
 use App\Platform\Enums\GameScreenshotStatus;
 use App\Platform\Enums\ScreenshotType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -212,4 +215,39 @@ it('given a primary screenshot of a type already exists, subsequent uploads stay
 
     // ASSERT
     expect($second->fresh()->is_primary)->toBeFalse();
+});
+
+it('does not crash when screenshot resolution badges are shown', function () {
+    // ARRANGE
+    Role::query()->firstOrCreate([
+        'name' => Role::GAME_EDITOR,
+        'guard_name' => 'web',
+    ], [
+        'display' => 1,
+    ]);
+
+    $user = User::factory()->create();
+    $user->assignRole(Role::GAME_EDITOR);
+
+    $system = System::factory()->create([
+        'screenshot_resolutions' => [
+            ['width' => 256, 'height' => 224],
+        ],
+    ]);
+    $game = Game::factory()->create(['system_id' => $system->id]);
+
+    $media = createScreenshotMedia($game);
+
+    GameScreenshot::factory()->for($game)->ingame()->create([
+        'media_id' => $media->id,
+        'width' => 256,
+        'height' => 224,
+    ]);
+
+    // ACT
+    $response = $this->actingAs($user)->get(GameResource::getUrl('media', ['record' => $game->id]));
+
+    // ASSERT
+    $response->assertOk();
+    $response->assertSeeText('256x224');
 });


### PR DESCRIPTION
Resolves a regression from #4789. The media tab is throwing a lazy loading error.