### PR TITLE
feat(achsets): capture achievement set versions

### DIFF
--- a/app/Community/Actions/UpdateGameClaimAction.php
+++ b/app/Community/Actions/UpdateGameClaimAction.php
@@ -18,6 +18,7 @@ use App\Models\User;
 use App\Models\UserGameListEntry;
 use App\Notifications\Achievement\SetAchievementsPublishedNotification;
 use App\Notifications\Achievement\SetRevisionNotification;
+use App\Platform\Actions\CheckForAchievementSetChangesAction;
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Auth;
@@ -134,6 +135,12 @@ class UpdateGameClaimAction
                     $setRequest->user->notify(new SetAchievementsPublishedNotification($game));
                 }
             }
+        }
+
+        // create a new AchievementSetVersion
+        $achievementSet = $game->gameAchievementSets()->core()->first()?->achievementSet;
+        if ($achievementSet) {
+            (new CheckForAchievementSetChangesAction())->execute($achievementSet);
         }
 
         $webhookUrl = config('services.discord.webhook.claims');

--- a/app/Models/AchievementSet.php
+++ b/app/Models/AchievementSet.php
@@ -215,7 +215,7 @@ class AchievementSet extends BaseModel
     }
 
     /**
-     * @return HasMany<GameAchievementSet, $this>
+     * @return HasMany<AchievementSetVersion, $this>
      */
     public function versions(): HasMany
     {

--- a/app/Models/AchievementSet.php
+++ b/app/Models/AchievementSet.php
@@ -214,6 +214,14 @@ class AchievementSet extends BaseModel
         return $this->belongsTo(User::class, 'user_id');
     }
 
+    /**
+     * @return HasMany<GameAchievementSet, $this>
+     */
+    public function versions(): HasMany
+    {
+        return $this->hasMany(AchievementSetVersion::class);
+    }
+
     // == scopes
 
     // == helpers

--- a/app/Models/AchievementSetVersion.php
+++ b/app/Models/AchievementSetVersion.php
@@ -5,7 +5,107 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Support\Database\Eloquent\BaseModel;
+use Database\Factories\AchievementSetVersionFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class AchievementSetVersion extends BaseModel
 {
+    /** @use HasFactory<AchievementSetVersionFactory> */
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'achievement_set_id',
+        'version',
+        'parent_id',
+        'definition',
+        'players_total',
+        'players_hardcore',
+        'achievements_published',
+        'achievements_unpublished',
+        'points_total',
+        'points_weighted',
+        'created_at',
+    ];
+
+    protected static function newFactory(): AchievementSetVersionFactory
+    {
+        return AchievementSetVersionFactory::new();
+    }
+
+    // == accessors
+
+    public function getIsInitialVersionAttribute(): bool
+    {
+        return $this->parent_id === null;
+    }
+
+    public function getIsLatestVersionAttribute(): bool
+    {
+        return !$this->nextVersion()->exists();
+    }
+
+    // == mutators
+
+    // == relations
+
+    /**
+     * @return HasOne<AchievementSetVersion, $this>
+     */
+    public function nextVersion(): HasOne
+    {
+        return $this->hasOne(AchievementSetVersion::class, 'parent_id');
+    }
+
+    /**
+     * @return BelongsTo<AchievementSetVersion, $this>
+     */
+    public function previousVersion(): BelongsTo
+    {
+        return $this->belongsTo(AchievementSetVersion::class, 'parent_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function achievementSet(): BelongsTo
+    {
+        return $this->belongsTo(AchievementSet::class, 'achievement_set_id', 'id')->withTrashed();
+    }
+
+    // == scopes
+
+    /**
+     * @param Builder<AchievementSetVersion> $query
+     * @return Builder<AchievementSetVersion>
+     */
+    public function scopeLatestVersion(Builder $query): Builder
+    {
+        return $query->whereNotExists(function ($query) {
+            $query->from('achievement_set_versions', 'asv2')
+                ->whereColumn('asv2.parent_id', 'achievement_set_versions.id');
+        });
+    }
+
+    /**
+     * @param Builder<AchievementSetVersion> $query
+     * @return Builder<AchievementSetVersion>
+     */
+    public function scopeInitialVersion(Builder $query): Builder
+    {
+        return $query->whereNull('parent_id');
+    }
+
+    /**
+     * @param Builder<AchievementSetVersion> $query
+     * @return Builder<AchievementSetVersion>
+     */
+    public function scopeVersion(Builder $query, int $version): Builder
+    {
+        return $query->whereVersion($version);
+    }
 }

--- a/app/Models/AchievementSetVersion.php
+++ b/app/Models/AchievementSetVersion.php
@@ -70,7 +70,7 @@ class AchievementSetVersion extends BaseModel
     }
 
     /**
-     * @return BelongsTo<User, $this>
+     * @return BelongsTo<AchievementSet, $this>
      */
     public function achievementSet(): BelongsTo
     {

--- a/app/Platform/Actions/CheckForAchievementSetChangesAction.php
+++ b/app/Platform/Actions/CheckForAchievementSetChangesAction.php
@@ -10,7 +10,7 @@ class CheckForAchievementSetChangesAction
 {
     public function execute(AchievementSet $achievementSet): void
     {
-        $latestVersion = $achievementSet->versions()->latest()->first();
+        $latestVersion = $achievementSet->versions()->orderByDesc('version')->first();
 
         if ($latestVersion) {
             // update the volatile metrics so they're accurate at the point where a new version is created

--- a/app/Platform/Actions/CheckForAchievementSetChangesAction.php
+++ b/app/Platform/Actions/CheckForAchievementSetChangesAction.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Actions;
+
+use App\Models\AchievementSet;
+
+class CheckForAchievementSetChangesAction
+{
+    public function execute(AchievementSet $achievementSet): void
+    {
+        $latestVersion = $achievementSet->versions()->latest()->first();
+
+        if ($latestVersion) {
+            // update the volatile metrics so they're accurate at the point where a new version is created
+            $latestVersion->players_total = $achievementSet->players_total ?? 0;
+            $latestVersion->players_hardcore = $achievementSet->players_hardcore ?? 0;
+            $latestVersion->achievements_unpublished = $achievementSet->achievements_unpublished ?? 0;
+
+            if ($latestVersion->points_total === $achievementSet->points_total) {
+                // if the points_total changed, the points_weighted value will have changed too,
+                // and we don't want that reflected in the existing version - only in the new one.
+                $latestVersion->points_weighted = $achievementSet->points_weighted ?? 0;
+            }
+
+            $latestVersion->save();
+
+            if ($latestVersion->achievements_published === $achievementSet->achievements_published
+                && $latestVersion->points_total === $achievementSet->points_total) {
+                // no change to number of published achievements or points, just update the other fields.
+                return;
+            }
+
+            // change detected, create a new version
+        } elseif (!$achievementSet->achievements_published) {
+            // don't bother versioning anything without published achievements
+            return;
+        }
+
+        $achievementSet->versions()->create([
+            'version' => $latestVersion ? $latestVersion->version + 1 : 1,
+            'parent_id' => $latestVersion?->id,
+            'players_total' => $achievementSet->players_total ?? 0,
+            'players_hardcore' => $achievementSet->players_hardcore ?? 0,
+            'achievements_published' => $achievementSet->achievements_published ?? 0,
+            'achievements_unpublished' => $achievementSet->achievements_unpublished ?? 0,
+            'points_total' => $achievementSet->points_total ?? 0,
+            'points_weighted' => $achievementSet->points_weighted ?? 0,
+            'created_at' => $achievementSet->updated_at,
+        ]);
+    }
+}

--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -25,6 +25,7 @@ use App\Models\PlayerBadgeStage;
 use App\Models\PlayerSession;
 use App\Models\System;
 use App\Platform\Commands\BackfillAuthorYieldUnlocks;
+use App\Platform\Commands\CheckForAchievementSetChanges;
 use App\Platform\Commands\ConvertGameToEvent;
 use App\Platform\Commands\CrawlPlayerWeightedPoints;
 use App\Platform\Commands\CreateAchievementOfTheWeek;
@@ -80,10 +81,11 @@ class AppServiceProvider extends ServiceProvider
                 RecalculateAchievementWeightedPoints::class,
 
                 // Games
-                RegenerateGameScreenshotConversions::class,
+                CheckForAchievementSetChanges::class,
                 ConvertGameToEvent::class,
                 PruneDuplicateSubsetNotes::class,
                 PruneGameRecentPlayers::class,
+                RegenerateGameScreenshotConversions::class,
                 UpdateGameAchievementsMetrics::class,
                 UpdateGameBeatenMetrics::class,
                 UpdateGameMetrics::class,

--- a/app/Platform/AppServiceProvider.php
+++ b/app/Platform/AppServiceProvider.php
@@ -154,6 +154,7 @@ class AppServiceProvider extends ServiceProvider
                 $schedule->command(ProcessExpiringClaims::class)->hourly();
                 $schedule->command(UpdateDeveloperContributionYield::class)->weeklyOn(2, '10:00'); // Tuesdays at 10AM UTC
                 $schedule->command(CrawlPlayerWeightedPoints::class)->weeklyOn(3, '10:00'); // Wednesdays at 10AM UTC
+                $schedule->command(CheckForAchievementSetChanges::class)->daily();
             }
         });
 

--- a/app/Platform/Commands/CheckForAchievementSetChanges.php
+++ b/app/Platform/Commands/CheckForAchievementSetChanges.php
@@ -43,7 +43,10 @@ class CheckForAchievementSetChanges extends Command
             }
         } else {
             if ($this->option('full')) {
-                $achievementSets = AchievementSet::where('achievements_published', '>', 0)->get();
+                $achievementSets = AchievementSet::query()
+                    ->where('achievements_published', '>', 0)
+                    ->orWhereHas('versions')
+                    ->get();
             } else {
                 $achievementSets = AchievementSet::where('updated_at', '>', Carbon::now()->subHours(25))->get();
             }

--- a/app/Platform/Commands/CheckForAchievementSetChanges.php
+++ b/app/Platform/Commands/CheckForAchievementSetChanges.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Platform\Commands;
 
 use App\Models\AchievementSet;
-use App\Models\AchievementSetVersion;
 use App\Models\GameAchievementSet;
 use App\Platform\Actions\CheckForAchievementSetChangesAction;
 use Carbon\Carbon;
@@ -15,8 +14,9 @@ use Illuminate\Console\Command;
 class CheckForAchievementSetChanges extends Command
 {
     protected $signature = 'ra:platform:game:check-for-changes
-                            {gameId? : Process a single game by ID}';
-    protected $description = 'Detects and versions achievement set changes';
+                            {gameId? : Process a single game by ID}
+                            {--full : Check all games}';
+    protected $description = 'Detects any versions achievement set changes';
 
     public function __construct(
         private readonly CheckForAchievementSetChangesAction $checkForChangesAction,
@@ -42,7 +42,7 @@ class CheckForAchievementSetChanges extends Command
                 $this->error("Unknown game");
             }
         } else {
-            if (!AchievementSetVersion::exists()) {
+            if ($this->option('full')) {
                 $achievementSets = AchievementSet::where('achievements_published', '>', 0)->get();
             } else {
                 $achievementSets = AchievementSet::where('updated_at', '>', Carbon::now()->subHours(25))->get();

--- a/app/Platform/Commands/CheckForAchievementSetChanges.php
+++ b/app/Platform/Commands/CheckForAchievementSetChanges.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Commands;
+
+use App\Models\AchievementSet;
+use App\Models\AchievementSetVersion;
+use App\Models\GameAchievementSet;
+use App\Platform\Actions\CheckForAchievementSetChangesAction;
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Console\Command;
+
+class CheckForAchievementSetChanges extends Command
+{
+    protected $signature = 'ra:platform:game:check-for-changes
+                            {gameId? : Process a single game by ID}';
+    protected $description = 'Detects and versions achievement set changes';
+
+    public function __construct(
+        private readonly CheckForAchievementSetChangesAction $checkForChangesAction,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function handle(): void
+    {
+        $singleGameId = $this->argument('gameId');
+        if ($singleGameId) {
+            $gameAchievementSet = GameAchievementSet::query()
+                ->where('game_id', (int) $singleGameId)
+                ->core()
+                ->first();
+            if ($gameAchievementSet) {
+                $this->checkForChangesAction->execute($gameAchievementSet->achievementSet);
+                $this->info('Done');
+            } else {
+                $this->error("Unknown game");
+            }
+        } else {
+            if (!AchievementSetVersion::exists()) {
+                $achievementSets = AchievementSet::where('achievements_published', '>', 0)->get();
+            } else {
+                $achievementSets = AchievementSet::where('updated_at', '>', Carbon::now()->subHours(25))->get();
+            }
+
+            $this->info("Processing {$achievementSets->count()} achievement sets...");
+
+            $bar = $this->output->createProgressBar($achievementSets->count());
+            $bar->start();
+
+            foreach ($achievementSets as $achievementSet) {
+                $this->checkForChangesAction->execute($achievementSet);
+                $bar->advance();
+            }
+
+            $bar->finish();
+            $this->newLine();
+        }
+    }
+}

--- a/database/factories/AchievementSetVersionFactory.php
+++ b/database/factories/AchievementSetVersionFactory.php
@@ -19,7 +19,7 @@ class AchievementSetVersionFactory extends Factory
     {
         $achievementSet = AchievementSet::factory()->create();
         $playersTotal = rand(0, $achievementSet->players_total);
-        $playersHardcore = min(rand(0, $achievementSet->playersHardcore), $playersTotal);
+        $playersHardcore = min(rand(0, $achievementSet->players_hardcore), $playersTotal);
 
         return [
             'version' => 1,

--- a/database/factories/AchievementSetVersionFactory.php
+++ b/database/factories/AchievementSetVersionFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Models\AchievementSet;
 use App\Models\AchievementSetVersion;
 use Illuminate\Database\Eloquent\Factories\Factory;
 

--- a/database/factories/AchievementSetVersionFactory.php
+++ b/database/factories/AchievementSetVersionFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\AchievementSetVersion;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AchievementSetVersion>
+ */
+class AchievementSetVersionFactory extends Factory
+{
+    protected $model = AchievementSetVersion::class;
+
+    public function definition(): array
+    {
+        $achievementSet = AchievementSet::factory()->create();
+        $playersTotal = rand(0, $achievementSet->players_total);
+        $playersHardcore = min(rand(0, $achievementSet->playersHardcore), $playersTotal);
+
+        return [
+            'version' => 1,
+            'parent_id' => null,
+            'achievement_set_id' => $achievementSet->id,
+            'players_total' => $playersTotal,
+            'players_hardcore' => $playersHardcore,
+            'achievements_published' => $achievementSet->achievements_published,
+            'achievements_unpublished' => $achievementSet->achievements_unpublished,
+            'points_total' => $achievementSet->points_total,
+            'points_weighted' => $achievementSet->points_weighted,
+        ];
+    }
+}

--- a/database/migrations/2026_04_26_000000_update_achievement_set_versions_table.php
+++ b/database/migrations/2026_04_26_000000_update_achievement_set_versions_table.php
@@ -10,6 +10,9 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('achievement_set_versions', function (Blueprint $table) {
+            $table->dropIndex(['players_total']);
+            $table->dropIndex(['players_hardcore']);
+
             $table->unsignedBigInteger('parent_id')->nullable()->after('version');
 
             $table->unsignedInteger('version')->nullable(false)->default(1)->change();
@@ -40,6 +43,9 @@ return new class extends Migration {
             $table->unsignedInteger('achievements_unpublished')->nullable()->change();
             $table->unsignedInteger('points_total')->nullable()->change();
             $table->unsignedInteger('points_weighted')->nullable()->change();
+
+            $table->index(['players_total']);
+            $table->index(['players_hardcore']);
         });
     }
 };

--- a/database/migrations/2026_04_26_000000_update_achievement_set_versions_table.php
+++ b/database/migrations/2026_04_26_000000_update_achievement_set_versions_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('achievement_set_versions', function (Blueprint $table) {
+            $table->unsignedBigInteger('parent_id')->nullable()->after('version');
+
+            $table->unsignedInteger('version')->nullable(false)->default(1)->change();
+            $table->unsignedInteger('players_total')->nullable(false)->default(0)->change();
+            $table->unsignedInteger('players_hardcore')->nullable(false)->default(0)->change();
+            $table->unsignedInteger('achievements_published')->nullable(false)->default(0)->change();
+            $table->unsignedInteger('achievements_unpublished')->nullable(false)->default(0)->change();
+            $table->unsignedInteger('points_total')->nullable(false)->default(0)->change();
+            $table->unsignedInteger('points_weighted')->nullable(false)->default(0)->change();
+
+            $table->foreign('parent_id')
+                ->references('id')
+                ->on('achievement_set_versions')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('achievement_set_versions', function (Blueprint $table) {
+            $table->dropForeign(['parent_id']);
+            $table->dropColumn(['parent_id']);
+
+            $table->unsignedInteger('version')->nullable()->change();
+            $table->unsignedInteger('players_total')->nullable()->change();
+            $table->unsignedInteger('players_hardcore')->nullable()->change();
+            $table->unsignedInteger('achievements_published')->nullable()->change();
+            $table->unsignedInteger('achievements_unpublished')->nullable()->change();
+            $table->unsignedInteger('points_total')->nullable()->change();
+            $table->unsignedInteger('points_weighted')->nullable()->change();
+        });
+    }
+};

--- a/tests/Feature/Platform/Actions/CheckForAchievementSetChangesActionTest.php
+++ b/tests/Feature/Platform/Actions/CheckForAchievementSetChangesActionTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Connect;
+
+use App\Models\AchievementSet;
+use App\Models\AchievementSetVersion;
+use App\Platform\Actions\CheckForAchievementSetChangesAction;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+
+uses(LazilyRefreshDatabase::class);
+
+class CheckForAchievementSetChangesActionTestHelpers
+{
+    public static function createInitialVersion(): AchievementSetVersion
+    {
+        $achievementSet = AchievementSet::factory()->create([
+            'achievements_published' => 12,
+            'achievements_unpublished' => 0,
+            'players_total' => 0,
+            'players_hardcore' => 0,
+            'points_total' => 75,
+            'points_weighted' => 177,
+        ]);
+
+        return $achievementSet->versions()->create([
+            'version' => 1,
+            'achievements_published' => 12,
+            'achievements_unpublished' => 0,
+            'players_total' => 0,
+            'players_hardcore' => 0,
+            'points_total' => 75,
+            'points_weighted' => 177,
+        ]);
+    }
+}
+
+describe('unversioned', function () {
+    test('does not create version if no achievements exist', function () {
+        $achievementSet = AchievementSet::factory()->create([
+            'achievements_published' => 0,
+            'achievements_unpublished' => 0,
+        ]);
+
+        (new CheckForAchievementSetChangesAction())->execute($achievementSet);
+
+        $this->assertEquals(0, $achievementSet->versions()->count());
+    });
+
+    test('does not create version if only unpublished achievements exist', function () {
+        $achievementSet = AchievementSet::factory()->create([
+            'achievements_published' => 0,
+            'achievements_unpublished' => 8,
+        ]);
+
+        (new CheckForAchievementSetChangesAction())->execute($achievementSet);
+
+        $this->assertEquals(0, $achievementSet->versions()->count());
+    });
+
+    test('creates first version if achievements published', function () {
+        $achievementSet = AchievementSet::factory()->create([
+            'achievements_published' => 12,
+            'achievements_unpublished' => 0,
+            'players_total' => 0,
+            'players_hardcore' => 0,
+            'points_total' => 75,
+            'points_weighted' => 177,
+        ]);
+
+        (new CheckForAchievementSetChangesAction())->execute($achievementSet);
+
+        $this->assertEquals(1, $achievementSet->versions()->count());
+        $version = $achievementSet->versions()->first();
+        $this->assertEquals(1, $version->version);
+        $this->assertNull($version->parent_id);
+        $this->assertEquals(12, $version->achievements_published);
+        $this->assertEquals(0, $version->achievements_unpublished);
+        $this->assertEquals(0, $version->players_total);
+        $this->assertEquals(0, $version->players_hardcore);
+        $this->assertEquals(75, $version->points_total);
+        $this->assertEquals(177, $version->points_weighted);
+    });
+});
+
+describe('versioned', function () {
+    test('updates existing version if no changes to published achievements', function () {
+        $firstVersion = CheckForAchievementSetChangesActionTestHelpers::createInitialVersion();
+        $achievementSet = $firstVersion->achievementSet;
+
+        $achievementSet->players_total = 5;
+        $achievementSet->players_hardcore = 3;
+        $achievementSet->points_weighted = 172;
+
+        (new CheckForAchievementSetChangesAction())->execute($achievementSet);
+
+        $this->assertEquals(1, $achievementSet->versions()->count());
+        $firstVersion->refresh();
+        $this->assertEquals(1, $firstVersion->version);
+        $this->assertNull($firstVersion->parent_id);
+        $this->assertEquals(12, $firstVersion->achievements_published);
+        $this->assertEquals(0, $firstVersion->achievements_unpublished);
+        $this->assertEquals(5, $firstVersion->players_total);
+        $this->assertEquals(3, $firstVersion->players_hardcore);
+        $this->assertEquals(75, $firstVersion->points_total);
+        $this->assertEquals(172, $firstVersion->points_weighted);
+    });
+
+    test('updates existing version if unpublished achievement added', function () {
+        $firstVersion = CheckForAchievementSetChangesActionTestHelpers::createInitialVersion();
+        $achievementSet = $firstVersion->achievementSet;
+
+        $achievementSet->players_total = 5;
+        $achievementSet->players_hardcore = 3;
+        $achievementSet->points_weighted = 172;
+        $achievementSet->achievements_unpublished = 1;
+
+        (new CheckForAchievementSetChangesAction())->execute($achievementSet);
+
+        $this->assertEquals(1, $achievementSet->versions()->count());
+        $firstVersion->refresh();
+        $this->assertEquals(1, $firstVersion->version);
+        $this->assertNull($firstVersion->parent_id);
+        $this->assertEquals(12, $firstVersion->achievements_published);
+        $this->assertEquals(1, $firstVersion->achievements_unpublished);
+        $this->assertEquals(5, $firstVersion->players_total);
+        $this->assertEquals(3, $firstVersion->players_hardcore);
+        $this->assertEquals(75, $firstVersion->points_total);
+        $this->assertEquals(172, $firstVersion->points_weighted);
+    });
+
+    test('creates new version if points change', function () {
+        $firstVersion = CheckForAchievementSetChangesActionTestHelpers::createInitialVersion();
+        $achievementSet = $firstVersion->achievementSet;
+
+        $achievementSet->players_total = 5;
+        $achievementSet->players_hardcore = 3;
+        $achievementSet->achievements_published = 12;
+        $achievementSet->points_total = 70;
+        $achievementSet->points_weighted = 167;
+
+        (new CheckForAchievementSetChangesAction())->execute($achievementSet);
+
+        $this->assertEquals(2, $achievementSet->versions()->count());
+
+        // player stats on first version should update
+        $firstVersion->refresh();
+        $this->assertEquals(1, $firstVersion->version);
+        $this->assertNull($firstVersion->parent_id);
+        $this->assertEquals(12, $firstVersion->achievements_published);
+        $this->assertEquals(0, $firstVersion->achievements_unpublished);
+        $this->assertEquals(5, $firstVersion->players_total);
+        $this->assertEquals(3, $firstVersion->players_hardcore);
+        $this->assertEquals(75, $firstVersion->points_total);
+        $this->assertEquals(177, $firstVersion->points_weighted); // weighted points not updated on old version
+
+        // new version should inclue points changes
+        $newVersion = $achievementSet->versions()->skip(1)->first();
+        $this->assertEquals(2, $newVersion->version);
+        $this->assertEquals($firstVersion->id, $newVersion->parent_id);
+        $this->assertEquals(12, $newVersion->achievements_published);
+        $this->assertEquals(0, $newVersion->achievements_unpublished);
+        $this->assertEquals(5, $newVersion->players_total);
+        $this->assertEquals(3, $newVersion->players_hardcore);
+        $this->assertEquals(70, $newVersion->points_total);
+        $this->assertEquals(167, $newVersion->points_weighted);
+    });
+
+    test('creates new version if achievement demoted', function () {
+        $firstVersion = CheckForAchievementSetChangesActionTestHelpers::createInitialVersion();
+        $achievementSet = $firstVersion->achievementSet;
+
+        $achievementSet->players_total = 5;
+        $achievementSet->players_hardcore = 3;
+        $achievementSet->achievements_published = 11;
+        $achievementSet->points_total = 70;
+        $achievementSet->points_weighted = 167;
+
+        (new CheckForAchievementSetChangesAction())->execute($achievementSet);
+
+        $this->assertEquals(2, $achievementSet->versions()->count());
+
+        // player stats on first version should update
+        $firstVersion->refresh();
+        $this->assertEquals(1, $firstVersion->version);
+        $this->assertNull($firstVersion->parent_id);
+        $this->assertEquals(12, $firstVersion->achievements_published);
+        $this->assertEquals(0, $firstVersion->achievements_unpublished);
+        $this->assertEquals(5, $firstVersion->players_total);
+        $this->assertEquals(3, $firstVersion->players_hardcore);
+        $this->assertEquals(75, $firstVersion->points_total);
+        $this->assertEquals(177, $firstVersion->points_weighted); // weighted points not updated on old version
+
+        // new version should inclue points changes
+        $newVersion = $achievementSet->versions()->skip(1)->first();
+        $this->assertEquals(2, $newVersion->version);
+        $this->assertEquals($firstVersion->id, $newVersion->parent_id);
+        $this->assertEquals(11, $newVersion->achievements_published);
+        $this->assertEquals(0, $newVersion->achievements_unpublished);
+        $this->assertEquals(5, $newVersion->players_total);
+        $this->assertEquals(3, $newVersion->players_hardcore);
+        $this->assertEquals(70, $newVersion->points_total);
+        $this->assertEquals(167, $newVersion->points_weighted);
+    });
+
+    test('creates new version if achievement added', function () {
+        $firstVersion = CheckForAchievementSetChangesActionTestHelpers::createInitialVersion();
+        $achievementSet = $firstVersion->achievementSet;
+
+        $achievementSet->players_total = 5;
+        $achievementSet->players_hardcore = 3;
+        $achievementSet->achievements_published = 13;
+        $achievementSet->points_total = 80;
+        $achievementSet->points_weighted = 183;
+
+        (new CheckForAchievementSetChangesAction())->execute($achievementSet);
+
+        $this->assertEquals(2, $achievementSet->versions()->count());
+
+        // player stats on first version should update
+        $firstVersion->refresh();
+        $this->assertEquals(1, $firstVersion->version);
+        $this->assertNull($firstVersion->parent_id);
+        $this->assertEquals(12, $firstVersion->achievements_published);
+        $this->assertEquals(0, $firstVersion->achievements_unpublished);
+        $this->assertEquals(5, $firstVersion->players_total);
+        $this->assertEquals(3, $firstVersion->players_hardcore);
+        $this->assertEquals(75, $firstVersion->points_total);
+        $this->assertEquals(177, $firstVersion->points_weighted); // weighted points not updated on old version
+
+        // new version should inclue points changes
+        $newVersion = $achievementSet->versions()->skip(1)->first();
+        $this->assertEquals(2, $newVersion->version);
+        $this->assertEquals($firstVersion->id, $newVersion->parent_id);
+        $this->assertEquals(13, $newVersion->achievements_published);
+        $this->assertEquals(0, $newVersion->achievements_unpublished);
+        $this->assertEquals(5, $newVersion->players_total);
+        $this->assertEquals(3, $newVersion->players_hardcore);
+        $this->assertEquals(80, $newVersion->points_total);
+        $this->assertEquals(183, $newVersion->points_weighted);
+    });
+
+    test('creates new version if entire set demoted', function () {
+        $firstVersion = CheckForAchievementSetChangesActionTestHelpers::createInitialVersion();
+        $achievementSet = $firstVersion->achievementSet;
+
+        $achievementSet->players_total = 5;
+        $achievementSet->players_hardcore = 3;
+        $achievementSet->achievements_published = 0;
+        $achievementSet->points_total = 0;
+        $achievementSet->points_weighted = 0;
+
+        (new CheckForAchievementSetChangesAction())->execute($achievementSet);
+
+        $this->assertEquals(2, $achievementSet->versions()->count());
+
+        // player stats on first version should update
+        $firstVersion->refresh();
+        $this->assertEquals(1, $firstVersion->version);
+        $this->assertNull($firstVersion->parent_id);
+        $this->assertEquals(12, $firstVersion->achievements_published);
+        $this->assertEquals(0, $firstVersion->achievements_unpublished);
+        $this->assertEquals(5, $firstVersion->players_total);
+        $this->assertEquals(3, $firstVersion->players_hardcore);
+        $this->assertEquals(75, $firstVersion->points_total);
+        $this->assertEquals(177, $firstVersion->points_weighted); // weighted points not updated on old version
+
+        // new version should inclue points changes
+        $newVersion = $achievementSet->versions()->skip(1)->first();
+        $this->assertEquals(2, $newVersion->version);
+        $this->assertEquals($firstVersion->id, $newVersion->parent_id);
+        $this->assertEquals(0, $newVersion->achievements_published);
+        $this->assertEquals(0, $newVersion->achievements_unpublished);
+        $this->assertEquals(5, $newVersion->players_total);
+        $this->assertEquals(3, $newVersion->players_hardcore);
+        $this->assertEquals(0, $newVersion->points_total);
+        $this->assertEquals(0, $newVersion->points_weighted);
+    });
+});


### PR DESCRIPTION
Achievement sets will now be versioned immediately upon claim completion and periodically if changes to the number of published achievements or published points are detected.

This could be used to drive the #core-set-log lists, and serves as data to derive "missing points" history (see  https://discord.com/channels/310192285306454017/1370440692874088622/1370440692874088622 and https://discord.com/channels/310192285306454017/1387686580415758509/1387686580415758509)