### PR TITLE
use intersection of players for bonus subsets, only subset player count for other subsets

### DIFF
--- a/app/Platform/Actions/UpdateGamePlayerCountAction.php
+++ b/app/Platform/Actions/UpdateGamePlayerCountAction.php
@@ -18,11 +18,12 @@ class UpdateGamePlayerCountAction
 
         $coreGameAchievementSet = $game->gameAchievementSets()->core()->first();
         if ($coreGameAchievementSet) {
-            $bonusSubsetAchievementSet = GameAchievementSet::query()
+            $bonusSubsetAchievementSets = GameAchievementSet::query()
                 ->where('achievement_set_id', $coreGameAchievementSet->achievement_set_id)
                 ->where('type', AchievementSetType::Bonus)
-                ->first();
-            if ($bonusSubsetAchievementSet) {
+                ->select('game_id')
+                ->get();
+            foreach ($bonusSubsetAchievementSets as $bonusSubsetAchievementSet) {
                 // if this is a bonus subset, also include the players of the parent game
                 $gameIds[] = $bonusSubsetAchievementSet->game_id;
             }

--- a/app/Platform/Actions/UpdateGamePlayerCountAction.php
+++ b/app/Platform/Actions/UpdateGamePlayerCountAction.php
@@ -5,43 +5,49 @@ declare(strict_types=1);
 namespace App\Platform\Actions;
 
 use App\Models\Game;
+use App\Models\GameAchievementSet;
+use App\Models\PlayerGame;
+use App\Platform\Enums\AchievementSetType;
 
 // Recalculates the number of players for a game.
 class UpdateGamePlayerCountAction
 {
     public function execute(Game $game): void
     {
-        $parentGame = $game->parentGame();
-        if ($parentGame) {
-            // NOTE: This assumes everyone who plays a child set also plays the parent set.
-            //       These counts should technically be the union of users from both sets.
-            if ($parentGame->players_total > 0) {
-                $game->players_total = $parentGame->players_total;
-                $game->players_hardcore = $parentGame->players_hardcore;
-            } else {
-                $parentGame = null;
+        $gameIds = [$game->id];
+
+        $coreGameAchievementSet = $game->gameAchievementSets()->core()->first();
+        if ($coreGameAchievementSet) {
+            $bonusSubsetAchievementSet = GameAchievementSet::query()
+                ->where('achievement_set_id', $coreGameAchievementSet->achievement_set_id)
+                ->where('type', AchievementSetType::Bonus)
+                ->first();
+            if ($bonusSubsetAchievementSet) {
+                // if this is a bonus subset, also include the players of the parent game
+                $gameIds[] = $bonusSubsetAchievementSet->game_id;
             }
         }
 
-        if (!$parentGame) {
-            $game->players_total = $game->playerGames()
-                ->leftJoin('unranked_users', 'player_games.user_id', '=', 'unranked_users.user_id')
-                ->whereNull('unranked_users.id')
-                ->where('achievements_unlocked', '>', 0)
-                ->count();
+        $playersQuery = PlayerGame::whereIn('game_id', $gameIds)
+            ->leftJoin('unranked_users', 'player_games.user_id', '=', 'unranked_users.user_id')
+            ->whereNull('unranked_users.id');
 
-            $game->players_hardcore = $game->playerGames()
-                ->leftJoin('unranked_users', 'player_games.user_id', '=', 'unranked_users.user_id')
-                ->whereNull('unranked_users.id')
-                ->where('achievements_unlocked_hardcore', '>', 0)
-                ->count();
+        if (count($gameIds) > 1) {
+            $playersQuery->distinct('player_games.user_id');
         }
+
+        $game->players_total = $playersQuery->clone()
+            ->where('achievements_unlocked', '>', 0)
+            ->count();
+
+        $game->players_hardcore = $playersQuery->clone()
+            ->where('achievements_unlocked_hardcore', '>', 0)
+            ->count();
 
         if ($game->isDirty()) {
             $game->saveQuietly();
 
             // copy the new player counts to the achievement set
-            $coreGameAchievementSet = $game->gameAchievementSets()->core()->first();
             if ($coreGameAchievementSet) {
                 $coreSet = $coreGameAchievementSet->achievementSet;
                 $coreSet->players_hardcore = $game->players_hardcore;

--- a/tests/Feature/Platform/Actions/UpdateGamePlayerCountActionTests.php
+++ b/tests/Feature/Platform/Actions/UpdateGamePlayerCountActionTests.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Connect;
+
+use App\Models\AchievementSet;
+use App\Models\Game;
+use App\Models\GameAchievementSet;
+use App\Models\PlayerGame;
+use App\Models\UnrankedUser;
+use App\Models\User;
+use App\Platform\Actions\UpdateGamePlayerCountAction;
+use App\Platform\Enums\AchievementSetType;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+
+uses(LazilyRefreshDatabase::class);
+
+class UpdateGamePlayerCountActionTestHelpers
+{
+    public static function createGame(): Game
+    {
+        $game = Game::factory()->create(['players_total' => 0, 'players_hardcore' => 0]);
+        $achievementSet = AchievementSet::factory()->create(['players_total' => 0, 'players_hardcore' => 0]);
+        GameAchievementSet::create([
+            'game_id' => $game->id,
+            'achievement_set_id' => $achievementSet->id,
+            'type' => AchievementSetType::Core,
+        ]);
+
+        return $game;
+    }
+
+    public static function createSubset(Game $game, AchievementSetType $type): Game
+    {
+        $subset = UpdateGamePlayerCountActionTestHelpers::createGame();
+        GameAchievementSet::create([
+            'game_id' => $game->id,
+            'achievement_set_id' => $subset->gameAchievementSets()->core()->first()->achievement_set_id,
+            'type' => $type,
+        ]);
+
+        return $subset;
+    }
+
+    public static function addPlayers(Game $game, int $count, bool $hardcore): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $user = User::factory()->create();
+            PlayerGame::create([
+                'game_id' => $game->id,
+                'user_id' => $user->id,
+                'achievements_unlocked' => 5,
+                'achievements_unlocked_hardcore' => $hardcore ? rand(1, 5) : 0,
+            ]);
+        }
+    }
+}
+
+describe('core set', function () {
+    test('constructs player count from player games records', function () {
+        $game = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 2, true);
+
+        (new UpdateGamePlayerCountAction())->execute($game);
+
+        $game->refresh();
+        $this->assertEquals(5, $game->players_total);
+        $this->assertEquals(2, $game->players_hardcore);
+
+        $achievementSet = $game->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(5, $achievementSet->players_total);
+        $this->assertEquals(2, $achievementSet->players_hardcore);
+    });
+
+    test('ignores unranked users', function () {
+        $game = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 2, true);
+
+        // unrank one hardcore and one softcore player
+        UnrankedUser::create(['user_id' => PlayerGame::where('achievements_unlocked_hardcore', 0)->first()->user_id]);
+        UnrankedUser::create(['user_id' => PlayerGame::where('achievements_unlocked_hardcore', '!=', 0)->first()->user_id]);
+
+        (new UpdateGamePlayerCountAction())->execute($game);
+
+        $game->refresh();
+        $this->assertEquals(3, $game->players_total);
+        $this->assertEquals(1, $game->players_hardcore);
+
+        $achievementSet = $game->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(3, $achievementSet->players_total);
+        $this->assertEquals(1, $achievementSet->players_hardcore);
+    });
+
+    test('ignores bonus subset players', function () {
+        $game = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 2, true);
+
+        $subset = UpdateGamePlayerCountActionTestHelpers::createSubset($game, AchievementSetType::Bonus);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 2, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 1, false);
+
+        (new UpdateGamePlayerCountAction())->execute($game);
+
+        $game->refresh();
+        $this->assertEquals(5, $game->players_total);
+        $this->assertEquals(2, $game->players_hardcore);
+
+        $achievementSet = $game->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(5, $achievementSet->players_total);
+        $this->assertEquals(2, $achievementSet->players_hardcore);
+    });
+});
+
+describe('subset', function () {
+    test('constructs player count from game and bonus subset records', function () {
+        $game = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 2, true);
+
+        $subset = UpdateGamePlayerCountActionTestHelpers::createSubset($game, AchievementSetType::Bonus);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 2, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 1, true);
+
+        (new UpdateGamePlayerCountAction())->execute($subset);
+
+        // base game should not be updated
+        $game->refresh();
+        $this->assertEquals(0, $game->players_total);
+        $this->assertEquals(0, $game->players_hardcore);
+
+        $achievementSet = $game->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(0, $achievementSet->players_total);
+        $this->assertEquals(0, $achievementSet->players_hardcore);
+
+        // bonus subset game should include players of subset and base game
+        $subset->refresh();
+        $this->assertEquals(8, $subset->players_total);
+        $this->assertEquals(3, $subset->players_hardcore);
+
+        $achievementSet = $subset->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(8, $achievementSet->players_total);
+        $this->assertEquals(3, $achievementSet->players_hardcore);
+    });
+
+    test('constructs player count from game and challenge subset records', function () {
+        $game = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 2, true);
+
+        $subset = UpdateGamePlayerCountActionTestHelpers::createSubset($game, AchievementSetType::Challenge);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 2, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 1, true);
+
+        (new UpdateGamePlayerCountAction())->execute($subset);
+
+        // base game should not be updated
+        $game->refresh();
+        $this->assertEquals(0, $game->players_total);
+        $this->assertEquals(0, $game->players_hardcore);
+
+        $achievementSet = $game->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(0, $achievementSet->players_total);
+        $this->assertEquals(0, $achievementSet->players_hardcore);
+
+        // challenge subset game should only include players of subset
+        $subset->refresh();
+        $this->assertEquals(3, $subset->players_total);
+        $this->assertEquals(1, $subset->players_hardcore);
+
+        $achievementSet = $subset->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(3, $achievementSet->players_total);
+        $this->assertEquals(1, $achievementSet->players_hardcore);
+    });
+
+    test('constructs player count from game and specialty subset records', function () {
+        $game = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 2, true);
+
+        $subset = UpdateGamePlayerCountActionTestHelpers::createSubset($game, AchievementSetType::Specialty);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 2, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 1, true);
+
+        (new UpdateGamePlayerCountAction())->execute($subset);
+
+        // base game should not be updated
+        $game->refresh();
+        $this->assertEquals(0, $game->players_total);
+        $this->assertEquals(0, $game->players_hardcore);
+
+        $achievementSet = $game->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(0, $achievementSet->players_total);
+        $this->assertEquals(0, $achievementSet->players_hardcore);
+
+        // specialty subset game should only include players of subset
+        $subset->refresh();
+        $this->assertEquals(3, $subset->players_total);
+        $this->assertEquals(1, $subset->players_hardcore);
+
+        $achievementSet = $subset->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(3, $achievementSet->players_total);
+        $this->assertEquals(1, $achievementSet->players_hardcore);
+    });
+
+    test('constructs player count from game and exclusive subset records', function () {
+        $game = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 2, true);
+
+        $subset = UpdateGamePlayerCountActionTestHelpers::createSubset($game, AchievementSetType::Exclusive);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 2, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 1, true);
+
+        (new UpdateGamePlayerCountAction())->execute($subset);
+
+        // base game should not be updated
+        $game->refresh();
+        $this->assertEquals(0, $game->players_total);
+        $this->assertEquals(0, $game->players_hardcore);
+
+        $achievementSet = $game->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(0, $achievementSet->players_total);
+        $this->assertEquals(0, $achievementSet->players_hardcore);
+
+        // exclusive subset game should only include players of subset
+        $subset->refresh();
+        $this->assertEquals(3, $subset->players_total);
+        $this->assertEquals(1, $subset->players_hardcore);
+
+        $achievementSet = $subset->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(3, $achievementSet->players_total);
+        $this->assertEquals(1, $achievementSet->players_hardcore);
+    });
+});

--- a/tests/Feature/Platform/Actions/UpdateGamePlayerCountActionTests.php
+++ b/tests/Feature/Platform/Actions/UpdateGamePlayerCountActionTests.php
@@ -235,4 +235,74 @@ describe('subset', function () {
         $this->assertEquals(3, $achievementSet->players_total);
         $this->assertEquals(1, $achievementSet->players_hardcore);
     });
+
+    test('constructs player count from game and bonus subset records ignoring duplicates', function () {
+        $game = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game, 2, true);
+
+        $subset = UpdateGamePlayerCountActionTestHelpers::createSubset($game, AchievementSetType::Bonus);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 2, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 1, true);
+
+        // have one of the game players also play the subset
+        PlayerGame::create([
+            'game_id' => $subset->id,
+            'user_id' => PlayerGame::where('game_id', $game->id)->where('achievements_unlocked_hardcore', 0)->first()->user_id,
+            'achievements_unlocked' => 5,
+            'achievements_unlocked_hardcore' => 0,
+        ]);
+
+        (new UpdateGamePlayerCountAction())->execute($subset);
+
+        // base game should not be updated
+        $game->refresh();
+        $this->assertEquals(0, $game->players_total);
+        $this->assertEquals(0, $game->players_hardcore);
+
+        $achievementSet = $game->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(0, $achievementSet->players_total);
+        $this->assertEquals(0, $achievementSet->players_hardcore);
+
+        // bonus subset game should include players of subset and base game
+        $subset->refresh();
+        $this->assertEquals(8, $subset->players_total);
+        $this->assertEquals(3, $subset->players_hardcore);
+
+        $achievementSet = $subset->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(8, $achievementSet->players_total);
+        $this->assertEquals(3, $achievementSet->players_hardcore);
+    });
+
+    test('constructs player count from multiple parent games and bonus subset records', function () {
+        $game1 = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game1, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game1, 2, true);
+
+        $game2 = UpdateGamePlayerCountActionTestHelpers::createGame();
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game2, 3, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($game2, 2, true);
+
+        $subset = UpdateGamePlayerCountActionTestHelpers::createSubset($game1, AchievementSetType::Bonus);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 2, false);
+        UpdateGamePlayerCountActionTestHelpers::addPlayers($subset, 1, true);
+
+        // also associate subset to second game
+        GameAchievementSet::create([
+            'game_id' => $game2->id,
+            'achievement_set_id' => $subset->gameAchievementSets()->core()->first()->achievement_set_id,
+            'type' => AchievementSetType::Bonus,
+        ]);
+
+        (new UpdateGamePlayerCountAction())->execute($subset);
+
+        // bonus subset game should include players of subset and both base games
+        $subset->refresh();
+        $this->assertEquals(13, $subset->players_total);
+        $this->assertEquals(5, $subset->players_hardcore);
+
+        $achievementSet = $subset->gameAchievementSets()->core()->first()->achievementSet;
+        $this->assertEquals(13, $achievementSet->players_total);
+        $this->assertEquals(5, $achievementSet->players_hardcore);
+    });
 });


### PR DESCRIPTION
Any subset that requires additional effort from the user (opt-in or unique hash) should only count players who have earned achievements in that subset (and not include players from the base set). Bonus sets, which are loaded without additional effort from the user should continue to count players who have earned achievements in either the base set or the bonus set.

As discussed in this discord thread, and summarized here: https://discord.com/channels/310192285306454017/1488177530786680852/1488273598375530517
>  If bonus were truly "something in addition to what is expected" (as defined in the dictionary), then it should leverage the base player count. As soon as you start throwing in things that require playing abnormally, they should only count the players who chose to play in that manner.

Because players can still load bonus sets using a unique hash (at least for most existing bonus sets), it's possible to have players who have played only the bonus set and not the base set. As such, some bonus sets may appear to have more players than the base set. Similarly, games with multiple bonus sets may have different counts for each bonus set. The base set will still only count players who have earned achievements in the base set.

Additionally, as this is changing the bonus set behavior from "inherit player count from parent" to "intersect parent players with bonus set players", this will fix https://discord.com/channels/310192285306454017/1493357676376227983/1493357676376227983

