### PR TITLE
fix(achievement): remediate active tab selection issue

### DIFF
--- a/resources/js/features/achievements/components/+show/AchievementShowRoot.test.tsx
+++ b/resources/js/features/achievements/components/+show/AchievementShowRoot.test.tsx
@@ -168,9 +168,7 @@ describe('Component: AchievementShowRoot', () => {
       .filter((tab) => tab.className.includes('relative z-10'));
 
     expect(desktopTabs.find((tab) => tab.textContent === 'Comments')).toHaveClass('text-link');
-    expect(desktopTabs.find((tab) => tab.textContent === 'Changelog')).not.toHaveClass(
-      'text-link',
-    );
+    expect(desktopTabs.find((tab) => tab.textContent === 'Changelog')).not.toHaveClass('text-link');
   });
 
   it('allows switching to the unlocks tab', async () => {

--- a/resources/js/features/achievements/components/+show/AchievementShowRoot.test.tsx
+++ b/resources/js/features/achievements/components/+show/AchievementShowRoot.test.tsx
@@ -12,6 +12,7 @@ import {
   createSystem,
 } from '@/test/factories';
 
+import { currentTabAtom } from '../../state/achievements.atoms';
 import { AchievementShowRoot } from './AchievementShowRoot';
 
 describe('Component: AchievementShowRoot', () => {
@@ -130,6 +131,46 @@ describe('Component: AchievementShowRoot', () => {
 
     // ASSERT
     expect(screen.getByText(/great achievement!/i)).toBeVisible();
+  });
+
+  it('given stale tab state from a previous achievement, syncs the active tab indicator to comments', async () => {
+    // ARRANGE
+    const achievement = createAchievement({
+      game: createGame({ playersTotal: 1000, system: createSystem() }),
+      unlocksTotal: 250,
+      unlocksHardcore: 150,
+    });
+
+    render(<AchievementShowRoot />, {
+      jotaiAtoms: [[currentTabAtom, 'changelog']],
+      pageProps: {
+        achievement,
+        backingGame: null,
+        gameAchievementSet: null,
+        can: { createAchievementComments: false },
+        changelog: [],
+        initialTab: 'comments',
+        isSubscribedToComments: false,
+        numComments: 1,
+        recentVisibleComments: [createComment({ payload: 'Fresh comment for this achievement.' })],
+      },
+    });
+
+    // ASSERT
+    await waitFor(() => {
+      expect(screen.getByText(/fresh comment for this achievement/i)).toBeVisible();
+    });
+
+    expect(screen.queryByText(/no changelog entries found/i)).not.toBeInTheDocument();
+
+    const desktopTabs = screen
+      .getAllByRole('tab')
+      .filter((tab) => tab.className.includes('relative z-10'));
+
+    expect(desktopTabs.find((tab) => tab.textContent === 'Comments')).toHaveClass('text-link');
+    expect(desktopTabs.find((tab) => tab.textContent === 'Changelog')).not.toHaveClass(
+      'text-link',
+    );
   });
 
   it('allows switching to the unlocks tab', async () => {

--- a/resources/js/features/achievements/hooks/useAnimatedTabIndicator.test.ts
+++ b/resources/js/features/achievements/hooks/useAnimatedTabIndicator.test.ts
@@ -29,6 +29,22 @@ describe('Hook: useAnimatedTabIndicator', () => {
     expect(result.current.activeIndex).toEqual(2);
   });
 
+  it('given the initial index changes, syncs the active index', () => {
+    // ARRANGE
+    const { rerender, result } = renderHook(
+      ({ initialIndex }) => useAnimatedTabIndicator(initialIndex),
+      {
+        initialProps: { initialIndex: 2 },
+      },
+    );
+
+    // ACT
+    rerender({ initialIndex: 0 });
+
+    // ASSERT
+    expect(result.current.activeIndex).toEqual(0);
+  });
+
   it('given a negative initial index, sets the active index to 0', () => {
     // ARRANGE
     const { result } = renderHook(() => useAnimatedTabIndicator(-3));

--- a/resources/js/features/achievements/hooks/useAnimatedTabIndicator.ts
+++ b/resources/js/features/achievements/hooks/useAnimatedTabIndicator.ts
@@ -34,6 +34,10 @@ export function useAnimatedTabIndicator(initialIndex: number = 0) {
   const hoverLeaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { width: windowWidth } = useWindowSize();
 
+  useEffect(() => {
+    setActiveIndex(safeIndex);
+  }, [safeIndex]);
+
   // Debounce null values so moving between tabs doesn't
   // briefly reset the hover state and break the slide animation.
   const setHoveredIndexDebounced = (index: number | null) => {


### PR DESCRIPTION
This PR resolves the following bug:
```
1) Open an achievement
2) Select the changelog tab
3) Click on the breadcrumb back to the game
4) Open another achievement
Observe: the changelog tab is still selected, but comments are shown.
```