### PR TITLE
fix(hub): add missing Time to Beat and Beat % columns

### DIFF
--- a/resources/js/features/game-list/components/HubMainRoot/useColumnDefinitions.ts
+++ b/resources/js/features/game-list/components/HubMainRoot/useColumnDefinitions.ts
@@ -5,6 +5,8 @@ import type { RouteName } from 'ziggy-js';
 import { usePageProps } from '@/common/hooks/usePageProps';
 
 import { buildAchievementsPublishedColumnDef } from '../../utils/column-definitions/buildAchievementsPublishedColumnDef';
+import { buildBeatRatioColumnDef } from '../../utils/column-definitions/buildBeatRatioColumnDef';
+import { buildBeatTimeColumnDef } from '../../utils/column-definitions/buildBeatTimeColumnDef';
 import { buildHasActiveOrInReviewClaimsColumnDef } from '../../utils/column-definitions/buildHasActiveOrInReviewClaimsColumnDef';
 import { buildLastUpdatedColumnDef } from '../../utils/column-definitions/buildLastUpdatedColumnDef';
 import { buildMasteryRatioColumnDef } from '../../utils/column-definitions/buildMasteryRatioColumnDef';
@@ -50,6 +52,17 @@ export function useColumnDefinitions(options: {
       tableApiRouteParams,
       t_label: t('RetroRatio'),
       strings: { t_none: t('none') },
+    }),
+    buildBeatRatioColumnDef({
+      tableApiRouteName,
+      tableApiRouteParams,
+      t_label: t('Beat %'),
+    }),
+    buildBeatTimeColumnDef({
+      tableApiRouteName,
+      tableApiRouteParams,
+      t_label: t('Time to Beat'),
+      strings: { t_none: t('None'), t_not_enough_data: t('Not enough data') },
     }),
     buildMasteryRatioColumnDef({
       tableApiRouteName,


### PR DESCRIPTION
<img width="1314" height="585" alt="Screenshot 2026-04-29 at 7 07 39 PM" src="https://github.com/user-attachments/assets/620678b7-779f-467b-904e-b65b4e254fdf" />
