### PR TITLE
refactor: extract normalizeUrl and use it on VideoEmbed

### DIFF
--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeUrl/ShortcodeUrl.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeUrl/ShortcodeUrl.tsx
@@ -2,6 +2,8 @@ import type { FC, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { route } from 'ziggy-js';
 
+import { normalizeUrl } from '@/common/utils/normalizeUrl';
+
 interface ShortcodeUrlProps {
   children: ReactNode;
   href: string;
@@ -32,24 +34,3 @@ export const ShortcodeUrl: FC<ShortcodeUrlProps> = ({ children, href }) => {
     </a>
   );
 };
-
-function normalizeUrl(href: string): string {
-  if (!href) {
-    return '';
-  }
-
-  try {
-    const url = new URL(href.startsWith('http') ? href : `https://${href}`);
-
-    // Force HTTPS for internal links.
-    if (url.hostname.endsWith('retroachievements.org') && url.protocol === 'http:') {
-      url.protocol = 'https:';
-    }
-
-    return url.toString();
-  } catch (error) {
-    console.debug('Failed to normalize URL:', href, error);
-
-    return '';
-  }
-}

--- a/resources/js/common/components/VideoEmbed/VideoEmbed.test.tsx
+++ b/resources/js/common/components/VideoEmbed/VideoEmbed.test.tsx
@@ -1,6 +1,10 @@
+import { route } from 'ziggy-js';
+
 import { render, screen } from '@/test';
 
 import { VideoEmbed } from './VideoEmbed';
+
+console.debug = vi.fn();
 
 describe('Component: VideoEmbed', () => {
   it('renders without crashing', () => {
@@ -11,7 +15,7 @@ describe('Component: VideoEmbed', () => {
     expect(container).toBeTruthy();
   });
 
-  it('given an unrecognized URL, renders a fallback link', () => {
+  it('given an unrecognized URL, renders a fallback link through the redirect route', () => {
     // ARRANGE
     render(<VideoEmbed src="https://ibb.co/9gShSmF" />);
 
@@ -19,8 +23,27 @@ describe('Component: VideoEmbed', () => {
     expect(screen.queryByTestId('video-embed')).not.toBeInTheDocument();
 
     const linkEl = screen.getByRole('link');
-    expect(linkEl).toHaveAttribute('href', 'https://ibb.co/9gShSmF');
+    expect(linkEl.getAttribute('href')).toContain(route('redirect'));
     expect(linkEl).toHaveAttribute('target', '_blank');
+    expect(linkEl).toHaveAttribute('rel', 'noreferrer noopener nofollow');
+  });
+
+  it('given a dangerous unrecognized URL, renders broken link text', () => {
+    // ARRANGE
+    render(<VideoEmbed src="javascript:alert(1)" />);
+
+    // ASSERT
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText(/broken link/i)).toBeVisible();
+  });
+
+  it('given a malformed unrecognized URL, renders broken link text', () => {
+    // ARRANGE
+    render(<VideoEmbed src="<a" />);
+
+    // ASSERT
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText(/broken link/i)).toBeVisible();
   });
 
   it('given a YouTube URL, renders a YouTube embed iframe', () => {

--- a/resources/js/common/components/VideoEmbed/VideoEmbed.tsx
+++ b/resources/js/common/components/VideoEmbed/VideoEmbed.tsx
@@ -1,5 +1,8 @@
 import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { route } from 'ziggy-js';
 
+import { normalizeUrl } from '@/common/utils/normalizeUrl';
 import { processVideoUrl } from '../../utils/shortcodes/processVideoUrl';
 
 const baseUrl = import.meta.env.VITE_BASE_URL;
@@ -9,11 +12,23 @@ interface VideoEmbedProps {
 }
 
 export const VideoEmbed: FC<VideoEmbedProps> = ({ src }) => {
+  const { t } = useTranslation();
+
   const processedVideo = processVideoUrl(src);
 
   if (!processedVideo) {
+    const normalizedSrc = normalizeUrl(src);
+
+    if (!normalizedSrc) {
+      return <span className="line-through">{t('Broken Link')}</span>;
+    }
+
     return (
-      <a href={src} target="_blank" rel="noreferrer">
+      <a
+        href={route('redirect', { url: normalizedSrc })}
+        target="_blank"
+        rel="noreferrer noopener nofollow"
+      >
         {src}
       </a>
     );

--- a/resources/js/common/components/VideoEmbed/VideoEmbed.tsx
+++ b/resources/js/common/components/VideoEmbed/VideoEmbed.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { route } from 'ziggy-js';
 
 import { normalizeUrl } from '@/common/utils/normalizeUrl';
+
 import { processVideoUrl } from '../../utils/shortcodes/processVideoUrl';
 
 const baseUrl = import.meta.env.VITE_BASE_URL;

--- a/resources/js/common/utils/normalizeUrl.test.ts
+++ b/resources/js/common/utils/normalizeUrl.test.ts
@@ -1,0 +1,38 @@
+import { normalizeUrl } from './normalizeUrl';
+
+console.debug = vi.fn();
+
+describe('Util: normalizeUrl', () => {
+  it('given an empty URL, returns an empty string', () => {
+    // ASSERT
+    expect(normalizeUrl('')).toEqual('');
+  });
+
+  it('given an HTTPS URL, returns the normalized URL', () => {
+    // ASSERT
+    expect(normalizeUrl('https://example.com')).toEqual('https://example.com/');
+  });
+
+  it('given a URL without a scheme, assumes HTTPS', () => {
+    // ASSERT
+    expect(normalizeUrl('example.com/path')).toEqual('https://example.com/path');
+  });
+
+  it('given an HTTP internal URL, upgrades it to HTTPS', () => {
+    // ASSERT
+    expect(normalizeUrl('http://retroachievements.org/game/1/top-achievers')).toEqual(
+      'https://retroachievements.org/game/1/top-achievers',
+    );
+  });
+
+  it('given a malformed URL, returns an empty string', () => {
+    // ASSERT
+    expect(normalizeUrl('<a')).toEqual('');
+  });
+
+  it('given a dangerous scheme, returns an empty string', () => {
+    // ASSERT
+    expect(normalizeUrl('javascript:alert(1)')).toEqual('');
+    expect(normalizeUrl('data:text/html,<script>alert(1)</script>')).toEqual('');
+  });
+});

--- a/resources/js/common/utils/normalizeUrl.ts
+++ b/resources/js/common/utils/normalizeUrl.ts
@@ -1,0 +1,30 @@
+export function normalizeUrl(href: string): string {
+  const trimmedHref = href.trim();
+
+  if (!trimmedHref) {
+    return '';
+  }
+
+  const explicitScheme = trimmedHref.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:/)?.[0].toLowerCase();
+  if (explicitScheme && !['http:', 'https:'].includes(explicitScheme)) {
+    return '';
+  }
+
+  try {
+    const url = new URL(explicitScheme ? trimmedHref : `https://${trimmedHref}`);
+
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      return '';
+    }
+
+    if (url.hostname.endsWith('retroachievements.org') && url.protocol === 'http:') {
+      url.protocol = 'https:';
+    }
+
+    return url.toString();
+  } catch (error) {
+    console.debug('Failed to normalize URL:', href, error);
+
+    return '';
+  }
+}


### PR DESCRIPTION
React 19.2 already guards `[video]` from XSS:
<img width="586" height="105" alt="Screenshot 2026-05-02 at 9 57 53 AM" src="https://github.com/user-attachments/assets/9704e966-c629-455d-b410-f9f0356371a6" />


But it seems risky to rely on this implicit framework-level behavior.

`[url]` was written when we were still on a version of React that didn't do this, and it uses a `normalizeUrl()` util to prevent XSS. `[video]` was modified during `achievement2` development to allow this sort of exploit to take place.

I've extracted the `normalizeUrl()` util so that `[video]` can reuse it too:
<img width="368" height="494" alt="Screenshot 2026-05-02 at 9 57 09 AM" src="https://github.com/user-attachments/assets/e3727874-7531-4a32-9083-70dd9dcc840b" />
