### PR TITLE
fix(api): don't expose future events without a policy check

### DIFF
--- a/app/Api/V2/Events/EventSchema.php
+++ b/app/Api/V2/Events/EventSchema.php
@@ -95,6 +95,7 @@ class EventSchema extends Schema
     public function indexQuery(?object $model, Builder $query): Builder
     {
         return $query
+            ->visibleTo(request()->user())
             ->join('games', 'events.legacy_game_id', '=', 'games.id')
             ->select('events.*')
             ->addSelect('games.title as title')

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -106,6 +106,24 @@ class Event extends BaseModel implements HasPermalink
         return true;
     }
 
+    // == scopes
+
+    /**
+     * @param Builder<Event> $query
+     * @return Builder<Event>
+     */
+    public function scopeVisibleTo(Builder $query, ?User $user = null): Builder
+    {
+        if ($user?->can('manage', self::class)) {
+            return $query;
+        }
+
+        return $query->where(function (Builder $query) {
+            $query->whereNull('events.active_from')
+                ->orWhere('events.active_from', '<=', now());
+        });
+    }
+
     // == accessors
 
     public function getStateAttribute(): EventState

--- a/tests/Feature/Api/V2/EventsTest.php
+++ b/tests/Feature/Api/V2/EventsTest.php
@@ -9,8 +9,10 @@ use App\Models\Event;
 use App\Models\EventAchievement;
 use App\Models\EventAward;
 use App\Models\Game;
+use App\Models\Role;
 use App\Models\System;
 use App\Models\User;
+use Database\Seeders\RolesTableSeeder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Tests\Feature\Api\V2\Concerns\TestsJsonApiIndex;
@@ -68,6 +70,86 @@ class EventsTest extends JsonApiResourceTestCase
         $response->assertFetchedMany([
             ['type' => 'events', 'id' => (string) $event->id],
         ]);
+    }
+
+    public function testItDoesNotListFutureEventsForNonEventManagers(): void
+    {
+        // Arrange
+        User::factory()->create(['web_api_key' => 'test-key']);
+        System::factory()->create(['id' => System::Events]);
+
+        $activeGame = Game::factory()->create(['system_id' => System::Events]);
+        $activeEvent = Event::factory()->create([
+            'legacy_game_id' => $activeGame->id,
+            'active_from' => Carbon::now()->subMonth(),
+        ]);
+
+        $futureGame = Game::factory()->create(['system_id' => System::Events]);
+        Event::factory()->create([
+            'legacy_game_id' => $futureGame->id,
+            'active_from' => Carbon::now()->addMonth(),
+        ]);
+
+        // Act
+        $response = $this->jsonApi('v2')
+            ->expects('events')
+            ->withHeader('X-API-Key', 'test-key')
+            ->get('/api/v2/events');
+
+        // Assert
+        $response->assertSuccessful();
+        $response->assertFetchedMany([
+            ['type' => 'events', 'id' => (string) $activeEvent->id],
+        ]);
+    }
+
+    public function testItListsFutureEventsForEventManagers(): void
+    {
+        // Arrange
+        $this->seed(RolesTableSeeder::class);
+
+        $user = User::factory()->create(['web_api_key' => 'test-key']);
+        $user->assignRole(Role::EVENT_MANAGER);
+
+        System::factory()->create(['id' => System::Events]);
+        $game = Game::factory()->create(['system_id' => System::Events]);
+        $event = Event::factory()->create([
+            'legacy_game_id' => $game->id,
+            'active_from' => Carbon::now()->addMonth(),
+        ]);
+
+        // Act
+        $response = $this->jsonApi('v2')
+            ->expects('events')
+            ->withHeader('X-API-Key', 'test-key')
+            ->get('/api/v2/events');
+
+        // Assert
+        $response->assertSuccessful();
+        $response->assertFetchedMany([
+            ['type' => 'events', 'id' => (string) $event->id],
+        ]);
+    }
+
+    public function testItPreventsAccessToFutureEventsForNonEventManagers(): void
+    {
+        // Arrange
+        User::factory()->create(['web_api_key' => 'test-key']);
+        System::factory()->create(['id' => System::Events]);
+        $game = Game::factory()->create(['system_id' => System::Events]);
+        $event = Event::factory()->create([
+            'legacy_game_id' => $game->id,
+            'active_from' => Carbon::now()->addMonth(),
+        ]);
+
+        // Act
+        $response = $this->jsonApi('v2')
+            ->expects('events')
+            ->withHeader('X-API-Key', 'test-key')
+            ->get("/api/v2/events/{$event->id}");
+
+        // Assert
+        $response->assertForbidden();
     }
 
     public function testItReturnsCorrectAttributes(): void


### PR DESCRIPTION
`EventPolicy::view()` enforces that future events should be hidden from non event manager users. The V2 API currently doesn't respect that.

This PR makes an adjustment such that, given the user is unable to manage events, they will no longer see future events in V2 API responses. This is also verified by a handful of new test cases.