### PR TITLE
fix(site-award): sanitize dynamic values

### DIFF
--- a/app/Helpers/render/site-award.php
+++ b/app/Helpers/render/site-award.php
@@ -293,6 +293,9 @@ function RenderAward(
                 $tooltipDescription = "Awarded for earning at least {$actualEventAward->points_required} {$pointsLabel}";
             }
 
+            $tooltipTitle = e($tooltipTitle);
+            $tooltipDescription = e($tooltipDescription);
+
             echo avatar('event', $event->id,
                 link: route('event.show', $event->id),
                 tooltip: "<div class='p-2 max-w-[320px] text-pretty text-menu-link flex flex-col gap-1'><p class='font-bold'>{$tooltipTitle}</p><span>{$tooltipDescription}</span><p class='italic'>{$awardDate}</p></div>",
@@ -311,7 +314,7 @@ function RenderAward(
             return;
         }
 
-        $tierLine = $awardGameTitle ? "<span>{$awardGameTitle}</span>" : '';
+        $tierLine = $awardGameTitle ? '<span>' . e($awardGameTitle) . '</span>' : '';
 
         echo avatar('playtestAward', $awardData,
             tooltip: "<div class='p-2 max-w-[320px] text-pretty text-menu-link flex flex-col gap-1'><p class='font-bold'>Playtester Award</p>{$tierLine}<p class='italic'>{$awardDate}</p></div>",


### PR DESCRIPTION
At the risk of going too in-depth, it's possible to meticulously craft a site award in such a way it injects raw JavaScript into the browser. This PR adds a few safeguards against this.

<img width="1174" height="468" alt="Screenshot 2026-05-02 at 10 25 46 AM" src="https://github.com/user-attachments/assets/19c6631a-6767-42ac-a322-cf348e0fb306" />
