### PR TITLE
fix(card): treat no-context type=game GET responses as user-specific for authenticated users

### DIFF
--- a/public/request/card.php
+++ b/public/request/card.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
@@ -26,9 +27,10 @@ $html = match ($type) {
     default => '?',
 };
 
-// User cards and cards with context contain user-specific data and should not be CDN-cached.
+// User cards, cards with context, and authenticated game cards contain user-specific data.
 // Other card types contain static content that can be cached at the CDN level.
-$isUserSpecific = $type === 'user' || $context !== null;
+$isGameCardForAuthenticatedUser = $type === 'game' && $context === null && Auth::check();
+$isUserSpecific = $type === 'user' || $context !== null || $isGameCardForAuthenticatedUser;
 $isCacheable = request()->isMethod('GET') && !$isUserSpecific;
 
 $cacheControl = $isCacheable


### PR DESCRIPTION
If a user is authenticated, game cards by default will display user-specific data in the card (ie: beaten / mastery state). We shouldn't cache these GET responses.

This PR treats these GET responses as user-specific data so they remain uncached.