### PR TITLE
fix: add query param validation to GameController and AchievementController

### DIFF
--- a/app/Platform/Controllers/AchievementController.php
+++ b/app/Platform/Controllers/AchievementController.php
@@ -121,7 +121,10 @@ class AchievementController extends Controller
             }
         }
 
-        $initialTab = AchievementPageTab::tryFrom($request->query('tab', '')) ?? AchievementPageTab::Comments;
+        $tabParam = $request->query('tab');
+        $initialTab =
+            (is_string($tabParam) ? AchievementPageTab::tryFrom($tabParam) : null)
+            ?? AchievementPageTab::Comments;
 
         // Safeguard: event achievement pages don't have the Changelog tab.
         // Fall back to comments as the initial tab.

--- a/app/Platform/Controllers/GameController.php
+++ b/app/Platform/Controllers/GameController.php
@@ -165,10 +165,14 @@ class GameController extends Controller
         }
 
         // Get the initial view from query params.
-        $initialView = GamePageListView::tryFrom($request->query('view', '')) ?? GamePageListView::Achievements;
+        $viewParam = $request->query('view');
+        $initialView =
+            (is_string($viewParam) ? GamePageListView::tryFrom($viewParam) : null)
+            ?? GamePageListView::Achievements;
 
         // Get the initial sort from query params.
-        $initialSort = $request->query('sort') ? GamePageListSort::tryFrom($request->query('sort')) : null;
+        $sortParam = $request->query('sort');
+        $initialSort = is_string($sortParam) ? GamePageListSort::tryFrom($sortParam) : null;
 
         $game = $loadGameWithRelationsAction->execute($game, $isPromoted, $targetAchievementSet);
         $props = $buildGameShowPagePropsAction->execute(

--- a/tests/Feature/Platform/Controllers/AchievementControllerTest.php
+++ b/tests/Feature/Platform/Controllers/AchievementControllerTest.php
@@ -184,6 +184,21 @@ describe('Basic Rendering', function () {
         );
     });
 
+    it('given an array tab query param, falls back to comments without erroring', function () {
+        // ARRANGE
+        $system = System::factory()->create();
+        [, $achievement] = createGameWithAchievementAndSet($system);
+
+        // ACT
+        $response = get(route('achievement.show', ['achievement' => $achievement]) . '?tab[]=foo');
+
+        // ASSERT
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->where('initialTab', 'comments')
+        );
+    });
+
     it('given no tab query param, defaults initialTab to comments', function () {
         // ARRANGE
         $system = System::factory()->create();

--- a/tests/Feature/Platform/Controllers/GameControllerShowTest.php
+++ b/tests/Feature/Platform/Controllers/GameControllerShowTest.php
@@ -322,6 +322,36 @@ describe('Basic Rendering', function () {
         );
     });
 
+    it('given an array view query param, falls back to achievements without erroring', function () {
+        // ARRANGE
+        $system = System::factory()->create();
+        $game = createGameWithAchievements($system, 'Test Game');
+
+        // ACT
+        $response = get(route('game.show', ['game' => $game]) . '?view[]=foo');
+
+        // ASSERT
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->where('initialView', 'achievements')
+        );
+    });
+
+    it('given an array sort query param, falls back to display order without erroring', function () {
+        // ARRANGE
+        $system = System::factory()->create();
+        $game = createGameWithAchievements($system, 'Test Game');
+
+        // ACT
+        $response = get(route('game.show', ['game' => $game]) . '?sort[]=foo');
+
+        // ASSERT
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page) => $page
+            ->where('initialSort', 'displayOrder')
+        );
+    });
+
     it('given a sort query param, sets the initial sort', function () {
         // ARRANGE
         $system = System::factory()->create();


### PR DESCRIPTION
Resolves this issue that occurs with array-based expected query params:
http://localhost:64000/achievement/9?tab[]=foo,bar

The game page is similarly affected.