### PR TITLE
feat(connect): add explicit support for offline submission clients

### DIFF
--- a/app/Connect/Actions/AwardAchievementAction.php
+++ b/app/Connect/Actions/AwardAchievementAction.php
@@ -28,8 +28,13 @@ class AwardAchievementAction extends BaseAuthenticatedApiAction
     protected ?GameHash $gameHash = null;
     protected Carbon $when;
 
-    public function execute(User $user, Achievement $achievement, bool $hardcore, ?GameHash $gameHash = null, ?Carbon $when = null): array
-    {
+    public function execute(
+        User $user,
+        Achievement $achievement,
+        bool $hardcore,
+        ?GameHash $gameHash = null,
+        ?Carbon $when = null,
+    ): array {
         $this->user = $user;
         $this->achievement = $achievement;
         $this->hardcore = $hardcore;
@@ -239,10 +244,14 @@ class AwardAchievementAction extends BaseAuthenticatedApiAction
                 // if active event achievements are associated to this achievement, dispatch
                 // unlock requests for them.
                 foreach ($this->achievement->eventAchievements()->active($this->when)->get() as $eventAchievement) {
-                    dispatch(new UnlockPlayerAchievementJob($this->user->id, $eventAchievement->achievement->id, true,
-                                                            gameHashId: $this->gameHash?->id,
-                                                            timestamp: $this->when))
-                            ->onQueue('player-achievements');
+                    dispatch(new UnlockPlayerAchievementJob(
+                        $this->user->id,
+                        $eventAchievement->achievement->id,
+                        true,
+                        gameHashId: $this->gameHash?->id,
+                        timestamp: $this->when,
+                        userAgent: $this->userAgent
+                    ))->onQueue('player-achievements');
 
                     // if at least one active event achievement was found, report the request as successful.
                     $retVal['Success'] = true;
@@ -271,10 +280,14 @@ class AwardAchievementAction extends BaseAuthenticatedApiAction
 
             // this job actually unlocks the achievement and updates all the associated metrics
             // asynchronously in the background so we can respond to the client as quickly as possible.
-            dispatch(new UnlockPlayerAchievementJob($this->user->id, $this->achievement->id, $this->hardcore,
-                                                    gameHashId: $this->gameHash?->id,
-                                                    timestamp: $this->when))
-                    ->onQueue('player-achievements');
+            dispatch(new UnlockPlayerAchievementJob(
+                $this->user->id,
+                $this->achievement->id,
+                $this->hardcore,
+                gameHashId: $this->gameHash?->id,
+                timestamp: $this->when,
+                userAgent: $this->userAgent
+            ))->onQueue('player-achievements');
         }
 
         return $retVal;

--- a/app/Models/ConnectOfflineSubmissionClient.php
+++ b/app/Models/ConnectOfflineSubmissionClient.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Support\Database\Eloquent\BaseModel;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class ConnectOfflineSubmissionClient extends BaseModel
+{
+    use LogsActivity {
+        LogsActivity::activities as auditLog;
+    }
+
+    protected $table = 'connect_offline_submission_clients';
+
+    protected $fillable = [
+        'client',
+    ];
+
+    // audit activity log
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['client'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
+    }
+
+    // == accessors
+
+    // == mutators
+
+    // == relations
+
+    // == scopes
+}

--- a/app/Platform/Actions/UnlockPlayerAchievementAction.php
+++ b/app/Platform/Actions/UnlockPlayerAchievementAction.php
@@ -23,6 +23,7 @@ class UnlockPlayerAchievementAction
         ?Carbon $timestamp = null,
         ?User $unlockedBy = null,
         ?GameHash $gameHash = null,
+        ?string $userAgent = null,
     ): void {
         $timestamp ??= Carbon::now();
 
@@ -38,7 +39,7 @@ class UnlockPlayerAchievementAction
         // also unlock active event achievements associated to the achievement being unlocked
         if ($hardcore && $user->isRanked()) {
             foreach ($achievement->eventAchievements()->active($timestamp)->get() as $eventAchievement) {
-                dispatch(new UnlockPlayerAchievementJob($user->id, $eventAchievement->achievement_id, true, $timestamp, $unlockedBy?->id, $gameHash?->id))
+                dispatch(new UnlockPlayerAchievementJob($user->id, $eventAchievement->achievement_id, true, $timestamp, $unlockedBy?->id, $gameHash?->id, $userAgent))
                     ->onQueue('player-achievements');
             }
         }
@@ -52,7 +53,13 @@ class UnlockPlayerAchievementAction
         } else {
             // make sure to resume the player session which will attach the game to the player, too
             $playerSession = app()->make(ResumePlayerSessionAction::class)
-                ->execute($user, $gameHash?->game ?? $achievement->game, gameHash: $gameHash, timestamp: $timestamp);
+                ->execute(
+                    $user,
+                    $gameHash?->game ?? $achievement->game,
+                    gameHash: $gameHash,
+                    timestamp: $timestamp,
+                    userAgent: $userAgent
+                );
 
             // if the gameHash isn't associated with the achievement game, make sure a player_games record
             // exists for the achievement game so points for unlocking the achievement can be captured.

--- a/app/Platform/Jobs/UnlockPlayerAchievementJob.php
+++ b/app/Platform/Jobs/UnlockPlayerAchievementJob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Platform\Jobs;
 
 use App\Models\Achievement;
@@ -30,6 +32,7 @@ class UnlockPlayerAchievementJob implements ShouldQueue
         private ?Carbon $timestamp = null,
         private readonly ?int $unlockedByUserId = null,
         private readonly ?int $gameHashId = null,
+        private readonly ?string $userAgent = null,
     ) {
         $this->timestamp ??= Carbon::now();
     }
@@ -55,6 +58,7 @@ class UnlockPlayerAchievementJob implements ShouldQueue
             $this->timestamp,
             $this->unlockedByUserId ? User::findOrFail($this->unlockedByUserId) : null,
             $this->gameHashId ? GameHash::find($this->gameHashId) : null,
+            $this->userAgent,
         );
     }
 }

--- a/app/Platform/Services/UserAgentService.php
+++ b/app/Platform/Services/UserAgentService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Platform\Services;
 
 use App\Enums\ClientSupportLevel;
+use App\Models\ConnectOfflineSubmissionClient;
 use App\Models\EmulatorCoreRestriction;
 use App\Models\EmulatorUserAgent;
 
@@ -341,7 +342,7 @@ class UserAgentService
         // Ordering matters: minimum_allowed_version still blocks ancient
         // clients above, and core restrictions below are intentionally
         // bypassed because softcore_only is a blanket emulator-wide flag.
-        if ($isSoftcoreOnly) {
+        if ($isSoftcoreOnly || $this->hasOfflineSubmissionClient($data)) {
             return [ClientSupportLevel::SoftcoreOnly, null];
         }
 
@@ -435,5 +436,10 @@ class UserAgentService
         }
 
         return null;
+    }
+
+    private function hasOfflineSubmissionClient(array $data): bool
+    {
+        return ConnectOfflineSubmissionClient::whereIn('client', array_keys($data['extra'] ?? []))->exists();
     }
 }

--- a/database/migrations/2026_05_09_000000_create_connect_offline_submission_clients_table.php
+++ b/database/migrations/2026_05_09_000000_create_connect_offline_submission_clients_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('connect_offline_submission_clients', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('client')->unique();
+            $table->timestamps();
+        });
+
+        DB::table('connect_offline_submission_clients')->insert([
+            'client' => 'RAOfflineProxy',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('connect_offline_submission_clients');
+    }
+};

--- a/tests/Feature/Connect/AwardAchievementTest.php
+++ b/tests/Feature/Connect/AwardAchievementTest.php
@@ -962,6 +962,58 @@ describe('normal unlock', function () {
         $this->assertEquals(0, ConnectWarning::count());
     });
 
+    test('offline submission client marker downgrades hardcore unlock and is captured on player session', function () {
+        $data = AwardAchievementTestHelpers::createGame();
+        $game = $data['game'];
+        $achievement1 = $data['achievements'][0];
+        $achievement3 = $data['achievements'][2];
+        $gameHash = $data['gameHash'];
+        $now = Carbon::now();
+        $offlineSubmissionUserAgent = $this->userAgentValid . ' RAOfflineProxy/1.0.0-alpha1';
+
+        $unlock1Date = $now->clone()->subMinutes(65);
+        $this->addHardcoreUnlock($this->user, $achievement1, $unlock1Date, $gameHash);
+
+        $validationHash = AwardAchievementTestHelpers::buildValidationHash($achievement3, $this->user, 1);
+        $scoreBefore = $this->user->points_hardcore;
+        $softcoreScoreBefore = $this->user->points;
+
+        $this->withHeaders(['User-Agent' => $offlineSubmissionUserAgent])
+            ->get($this->apiUrl('awardachievement', [
+                'a' => $achievement3->id,
+                'h' => 1,
+                'm' => $gameHash->md5,
+                'v' => $validationHash,
+            ]))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'AchievementID' => $achievement3->id,
+                'AchievementsRemaining' => 4,
+                'Score' => $scoreBefore,
+                'SoftcoreScore' => $softcoreScoreBefore + $achievement3->points,
+            ]);
+        $this->user->refresh();
+
+        $playerAchievement = PlayerAchievement::where([
+            'user_id' => $this->user->id,
+            'achievement_id' => $achievement3->id,
+        ])->first();
+        $this->assertModelExists($playerAchievement);
+        $this->assertNotNull($playerAchievement->unlocked_at);
+        $this->assertNull($playerAchievement->unlocked_hardcore_at);
+
+        $playerSession = PlayerSession::find($playerAchievement->player_session_id);
+        $this->assertModelExists($playerSession);
+        $this->assertEquals($offlineSubmissionUserAgent, $playerSession->user_agent);
+
+        $user1 = User::whereName($this->user->username)->first();
+        $this->assertEquals($scoreBefore, $user1->points_hardcore);
+        $this->assertEquals($softcoreScoreBefore + $achievement3->points, $user1->points);
+
+        $this->assertEquals(0, ConnectWarning::count());
+    });
+
     test('repeated softcore unlock', function () {
         $data = AwardAchievementTestHelpers::createGame();
         $game = $data['game'];

--- a/tests/Feature/Platform/Services/UserAgentServiceClientSupportLevelTest.php
+++ b/tests/Feature/Platform/Services/UserAgentServiceClientSupportLevelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Platform\Services;
 
 use App\Enums\ClientSupportLevel;
+use App\Models\ConnectOfflineSubmissionClient;
 use App\Models\Emulator;
 use App\Models\EmulatorCoreRestriction;
 use App\Models\EmulatorUserAgent;
@@ -474,5 +475,28 @@ class UserAgentServiceClientSupportLevelTest extends TestCase
         $this->assertNull(
             $userAgentService->getCoreRestrictionForUserAgent('RetroArch/1.22.2 (Linux) dolphin_libretro/df2b1a75')
         );
+    }
+
+    public function testConnectOfflineSubmissionClientMarkerReturnsSoftcoreOnly(): void
+    {
+        $userAgentService = new UserAgentService();
+
+        $emulator = Emulator::create([
+            'name' => 'RetroArch',
+            'active' => true,
+        ]);
+        EmulatorUserAgent::create([
+            'emulator_id' => $emulator->id,
+            'client' => 'RetroArch',
+        ]);
+
+        $userAgent = 'RetroArch/1.21.0 (Android 13.0) snes9x_libretro_android/1.63_5a40cd5 RAOfflineProxy/1.0.0-alpha1';
+
+        $this->assertEquals(ClientSupportLevel::SoftcoreOnly, $userAgentService->getSupportLevel($userAgent));
+        $this->assertEquals('RetroArch', $userAgentService->decode($userAgent)['client']);
+
+        ConnectOfflineSubmissionClient::where('client', 'RAOfflineProxy')->delete();
+
+        $this->assertEquals(ClientSupportLevel::Full, $userAgentService->getSupportLevel($userAgent));
     }
 }


### PR DESCRIPTION
https://discord.com/channels/476211979464343552/1488294412600606851/1502645287003357316

```
sail artisan migrate
```

This PR adds minimal server-side handling for clients that perform deferred achievement submission.

This is achieved through a new `connected_offline_submission_clients` table that serves as an allowlist. `RAOfflineProxy` is seeded as an initial value by the migration.

When a request's User-Agent includes extras signifying a client from this table, we'll explicitly treat the request as `SoftcoreOnly`.

At the moment, the table is only modifiable through direct operations to the DB.