### PR TITLE
fix undefined array key error if user has changed their display name but still logs in with their username

### DIFF
--- a/app/Connect/Actions/BuildConnectSniffsAction.php
+++ b/app/Connect/Actions/BuildConnectSniffsAction.php
@@ -105,6 +105,7 @@ class BuildConnectSniffsAction
         $userInfos = [];
         $users = User::query()
             ->whereIn('display_name', $usernames)
+            ->orWhereIn('username', $usernames)
             ->withTrashed()
             ->select('id', 'username', 'display_name', 'Permissions', 'deleted_at', 'unranked_at')
             ->get()

--- a/resources/views/pages-legacy/sentry.blade.php
+++ b/resources/views/pages-legacy/sentry.blade.php
@@ -243,7 +243,7 @@ foreach ($clients as $client) {
                         <?php
                             if ($sniff['user']) {
                                 echo "&middot; <a href='" . $sniff['link'] . "'>" . $sniff['user'] . '</a>';
-                                if (!$sniff['userinfo']) {
+                                if (!array_key_exists('userinfo', $sniff)) {
                                     echo ' (non-existant)';
                                 } elseif ($sniff['userinfo']['deleted_at'] ?? false) {
                                     echo ' (deleted)';

--- a/tests/Feature/Connect/BuildConnectSniffsTest.php
+++ b/tests/Feature/Connect/BuildConnectSniffsTest.php
@@ -191,15 +191,32 @@ describe('returns entries', function () {
         $this->assertStringContainsString('Player1', $sniffs[0]['link']);
     });
 
-    test('user data', function () {
+    test('user data by display_name', function () {
         $leaderboard1 = Leaderboard::factory()->create();
-        $user1 = User::factory()->create();
+        $user1 = User::factory()->create(['username' => 'UserName', 'display_name' => 'DisplayName']);
         $entry1 = BuildConnectSniffsTestHelpers::createLeaderboardWarning($user1->display_name, $leaderboard1, 1234);
 
         $clients = [];
         $sniffs = (new BuildConnectSniffsAction())->execute(Carbon::now(), $clients);
         $this->assertEquals(1, count($sniffs));
         $this->assertEquals($user1->display_name, $sniffs[0]['user']);
+        $this->assertEquals($user1->id, $sniffs[0]['userinfo']['id']);
+        $this->assertEquals($user1->username, $sniffs[0]['userinfo']['username']);
+        $this->assertEquals($user1->display_name, $sniffs[0]['userinfo']['display_name']);
+        $this->assertEquals($user1->Permissions, $sniffs[0]['userinfo']['Permissions']);
+        $this->assertNull($sniffs[0]['userinfo']['deleted_at']);
+        $this->assertNull($sniffs[0]['userinfo']['unranked_at']);
+    });
+
+    test('user data by username', function () {
+        $leaderboard1 = Leaderboard::factory()->create();
+        $user1 = User::factory()->create(['username' => 'UserName', 'display_name' => 'DisplayName']);
+        $entry1 = BuildConnectSniffsTestHelpers::createLeaderboardWarning($user1->username, $leaderboard1, 1234);
+
+        $clients = [];
+        $sniffs = (new BuildConnectSniffsAction())->execute(Carbon::now(), $clients);
+        $this->assertEquals(1, count($sniffs));
+        $this->assertEquals($user1->username, $sniffs[0]['user']);
         $this->assertEquals($user1->id, $sniffs[0]['userinfo']['id']);
         $this->assertEquals($user1->username, $sniffs[0]['userinfo']['username']);
         $this->assertEquals($user1->display_name, $sniffs[0]['userinfo']['display_name']);


### PR DESCRIPTION

fixes:
> Undefined array key "userinfo" (View: /home/forge/retroachievements.org/releases/2026-05-09T115251-2026.05.09-d832f1a/resources/views/pages-legacy/sentry.blade.php)