### PR TITLE
fix(user): hide all media contribution tiers when user hides the badge

### DIFF
--- a/public/request/user/update-site-awards.php
+++ b/public/request/user/update-site-awards.php
@@ -63,7 +63,7 @@ foreach ($awards as $award) {
     // Change display order for all entries if it's a "stacking" award type.
     $awardTypeEnum = AwardType::fromLegacyInteger($awardType);
     $awardTypeValue = $awardTypeEnum->value;
-    if (in_array($awardTypeEnum, [AwardType::AchievementUnlocksYield, AwardType::AchievementPointsYield])) {
+    if (in_array($awardTypeEnum, [AwardType::AchievementUnlocksYield, AwardType::AchievementPointsYield, AwardType::MediaContribution])) {
         $query = "UPDATE user_awards SET order_column = $value WHERE user_id = $userId " .
             "AND award_type = '$awardTypeValue' " .
             "AND award_tier = $awardDataExtra";


### PR DESCRIPTION
`AwardType::MediaContribution` is missing from the _update-site-awards.php_ list of "stacking" award types.