### PR TITLE
fix(manage/media): auth-gate screenshot force deletes

### DIFF
--- a/app/Filament/Resources/GameResource/RelationManagers/GameScreenshotsRelationManager.php
+++ b/app/Filament/Resources/GameResource/RelationManagers/GameScreenshotsRelationManager.php
@@ -152,6 +152,7 @@ class GameScreenshotsRelationManager extends RelationManager
                         ->modalHeading("Clear this game's screenshots?")
                         ->modalDescription('Published and pending screenshots will be moved to Rejected and the game will use placeholder images. You can restore them individually from the Rejected filter.')
                         ->modalSubmitActionLabel('Clear Screenshots')
+                        ->authorize(fn (): bool => $user->can('clearScreenshots', $game))
                         ->action(function () use ($game): void {
                             $clearedCount = (new ClearGameScreenshotsFromGamePageAction())->execute($game);
 
@@ -375,6 +376,7 @@ class GameScreenshotsRelationManager extends RelationManager
                         ->modalHeading('Permanently delete screenshot?')
                         ->modalDescription('This cannot be undone. The image and its history will be removed.')
                         ->visible(fn (GameScreenshot $record): bool => $record->status === GameScreenshotStatus::Rejected)
+                        ->authorize(fn (GameScreenshot $record): bool => $user->can('forceDelete', $record))
                         ->action(function (GameScreenshot $record) use ($game): void {
                             $screenshotUrl = $record->media?->getUrl();
                             $type = $record->type->label();

--- a/app/Policies/GameScreenshotPolicy.php
+++ b/app/Policies/GameScreenshotPolicy.php
@@ -80,6 +80,21 @@ class GameScreenshotPolicy
             && $screenshot->status === GameScreenshotStatus::Pending;
     }
 
+    public function forceDelete(User $user, GameScreenshot $screenshot): bool
+    {
+        // Only rejected screenshots may be permanently deleted.
+        if ($screenshot->status !== GameScreenshotStatus::Rejected) {
+            return false;
+        }
+
+        return $user->hasAnyRole([
+            Role::DEVELOPER,
+            Role::GAME_EDITOR,
+            Role::MEDIA_EDITOR,
+            Role::MODERATOR,
+        ]);
+    }
+
     public function review(User $user, GameScreenshot $screenshot): bool
     {
         if ($user->hasAnyRole(self::REVIEWER_ROLES)) {


### PR DESCRIPTION
Puts rejected screenshot hard deletes behind a policy.