### PR TITLE
fix(GameListRequest): remediate server error from malformed query params

### DIFF
--- a/app/Platform/Requests/GameListRequest.php
+++ b/app/Platform/Requests/GameListRequest.php
@@ -149,7 +149,8 @@ class GameListRequest extends FormRequest
         $filters = [];
 
         // URL params take precedence over cookie preferences.
-        foreach ($this->query('filter', []) as $key => $value) {
+        $queryFilters = $this->query('filter', []);
+        foreach (is_array($queryFilters) ? $queryFilters : [] as $key => $value) {
             $filters[$key] = explode(',', $value);
         }
 

--- a/tests/Feature/Platform/Requests/GameListRequestTest.php
+++ b/tests/Feature/Platform/Requests/GameListRequestTest.php
@@ -51,6 +51,19 @@ class GameListRequestTest extends TestCase
         ], $request->getFilters());
     }
 
+    public function testItIgnoresFilterQueryParamWhenPassedAsAScalarString(): void
+    {
+        // ACT
+        $request = GameListRequest::create('/games', 'GET', [
+            'filter' => 'only-games',
+        ]);
+
+        // ASSERT
+        $this->assertSame([
+            'achievementsPublished' => ['has'],
+        ], $request->getFilters());
+    }
+
     public function testItFallsBackToDefaultsWhenUrlAndCookieValuesAreAbsent(): void
     {
         // ACT


### PR DESCRIPTION
Resolves a recurring server error, likely caused by bots:
<img width="1284" height="427" alt="Screenshot 2026-05-25 at 4 41 20 PM" src="https://github.com/user-attachments/assets/64656a9e-3278-41d1-a035-48c751060345" />
