### PR TITLE
fix(issue): Prevent tabs from deleting draft comments

### DIFF
--- a/resources/js/common/components/CommentList/CommentList.test.tsx
+++ b/resources/js/common/components/CommentList/CommentList.test.tsx
@@ -8,6 +8,13 @@ import { createComment, createUser } from '@/test/factories';
 
 import { CommentList } from './CommentList';
 
+// Disable draft persistence to avoid conflicts with userEvent.type
+vi.mock('@/common/hooks/useFormDraft', () => ({
+  useFormDraft: () => ({
+    clearDraft: vi.fn(),
+  }),
+}));
+
 describe('Component: CommentList', () => {
   it('renders without crashing', () => {
     // ARRANGE

--- a/resources/js/common/components/CommentList/useSubmitCommentForm.ts
+++ b/resources/js/common/components/CommentList/useSubmitCommentForm.ts
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { route } from 'ziggy-js';
@@ -6,6 +7,8 @@ import { z } from 'zod';
 
 import { toastMessage } from '@/common/components/+vendor/BaseToaster';
 import { useSubmitCommentMutation } from '@/common/hooks/mutations/useSubmitCommentMutation';
+import { useFormDraft } from '@/common/hooks/useFormDraft';
+import { loadDraft } from '@/common/utils/loadDraft';
 
 import { useCommentListContext } from './CommentListContext';
 
@@ -35,10 +38,21 @@ export function useSubmitCommentForm({
   });
   type FormValues = z.infer<typeof addCommentFormSchema>;
 
+  const draftKey = `comment-${commentableType}-${commentableId}`;
+
+  const draft = loadDraft<FormValues>(draftKey);
+
   const form = useForm<FormValues>({
     resolver: zodResolver(addCommentFormSchema),
-    defaultValues: { body: '' },
+    defaultValues: { body: draft.body ?? '' },
   });
+
+  useEffect(() => {
+    const currentDraft = loadDraft<FormValues>(draftKey);
+    form.reset({ body: currentDraft.body ?? '' });
+  }, [draftKey, form]);
+
+  const { clearDraft } = useFormDraft(draftKey, form);
 
   const mutation = useSubmitCommentMutation();
 
@@ -55,8 +69,10 @@ export function useSubmitCommentForm({
       {
         loading: t('Submitting...'),
         success: () => {
+          clearDraft();
           onSubmitSuccess?.();
-          form.reset();
+
+          form.reset({ body: '' });
 
           return t('Submitted!');
         },

--- a/resources/js/common/hooks/useFormDraft.ts
+++ b/resources/js/common/hooks/useFormDraft.ts
@@ -10,6 +10,10 @@ import { useWatch } from 'react-hook-form';
  */
 export function useFormDraft<T extends FieldValues>(key: string | null, form: UseFormReturn<T>) {
   const values = useWatch({ control: form.control });
+
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -25,6 +29,14 @@ export function useFormDraft<T extends FieldValues>(key: string | null, form: Us
       }
     };
   }, [key, values]);
+
+  useEffect(() => {
+    return () => {
+      if (key) {
+        sessionStorage.setItem(key, JSON.stringify(valuesRef.current));
+      }
+    };
+  }, [key]);
 
   const clearDraft = () => {
     if (key) {

--- a/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.test.tsx
+++ b/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.test.tsx
@@ -10,6 +10,13 @@ import { createUser } from '@/test/factories';
 
 import { CreateMessageThreadForm } from './CreateMessageThreadForm';
 
+// Disable draft persistence to avoid conflicts with userEvent.type
+vi.mock('@/common/hooks/useFormDraft', () => ({
+  useFormDraft: () => ({
+    clearDraft: vi.fn(),
+  }),
+}));
+
 // Suppress JSDOM errors that are not relevant.
 console.error = vi.fn();
 


### PR DESCRIPTION
My bad, cleaned up some forks and deleted my RAWeb fork by mistake (please delete to avoid polluting the PR history)