### PR TITLE
fix: prevent achievement page tabs from deleting draft comments

### DIFF
--- a/resources/js/common/components/CommentList/CommentList.test.tsx
+++ b/resources/js/common/components/CommentList/CommentList.test.tsx
@@ -8,14 +8,11 @@ import { createComment, createUser } from '@/test/factories';
 
 import { CommentList } from './CommentList';
 
-// Disable draft persistence to avoid conflicts with userEvent.type
-vi.mock('@/common/hooks/useFormDraft', () => ({
-  useFormDraft: () => ({
-    clearDraft: vi.fn(),
-  }),
-}));
-
 describe('Component: CommentList', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
   it('renders without crashing', () => {
     // ARRANGE
     const { container } = render(

--- a/resources/js/common/components/CommentList/CommentList.test.tsx
+++ b/resources/js/common/components/CommentList/CommentList.test.tsx
@@ -8,6 +8,13 @@ import { createComment, createUser } from '@/test/factories';
 
 import { CommentList } from './CommentList';
 
+// Disable draft persistence to avoid conflicts with userEvent.type
+vi.mock('@/common/hooks/useFormDraft', () => ({
+  useFormDraft: () => ({
+    clearDraft: vi.fn(),
+  }),
+}));
+
 describe('Component: CommentList', () => {
   it('renders without crashing', () => {
     // ARRANGE

--- a/resources/js/common/components/CommentList/useSubmitCommentForm.ts
+++ b/resources/js/common/components/CommentList/useSubmitCommentForm.ts
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { route } from 'ziggy-js';
@@ -39,20 +38,16 @@ export function useSubmitCommentForm({
   type FormValues = z.infer<typeof addCommentFormSchema>;
 
   const draftKey = `comment-${commentableType}-${commentableId}`;
+  const baseDefaults = { body: '' };
 
   const draft = loadDraft<FormValues>(draftKey);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(addCommentFormSchema),
-    defaultValues: { body: draft.body ?? '' },
+    defaultValues: { ...baseDefaults, ...draft },
   });
 
-  useEffect(() => {
-    const currentDraft = loadDraft<FormValues>(draftKey);
-    form.reset({ body: currentDraft.body ?? '' });
-  }, [draftKey, form]);
-
-  const { clearDraft } = useFormDraft(draftKey, form);
+  const { clearDraft } = useFormDraft(draftKey, form, baseDefaults);
 
   const mutation = useSubmitCommentMutation();
 
@@ -72,7 +67,7 @@ export function useSubmitCommentForm({
           clearDraft();
           onSubmitSuccess?.();
 
-          form.reset({ body: '' });
+          form.reset(baseDefaults);
 
           return t('Submitted!');
         },

--- a/resources/js/common/components/CommentList/useSubmitCommentForm.ts
+++ b/resources/js/common/components/CommentList/useSubmitCommentForm.ts
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { route } from 'ziggy-js';
@@ -6,6 +7,8 @@ import { z } from 'zod';
 
 import { toastMessage } from '@/common/components/+vendor/BaseToaster';
 import { useSubmitCommentMutation } from '@/common/hooks/mutations/useSubmitCommentMutation';
+import { useFormDraft } from '@/common/hooks/useFormDraft';
+import { loadDraft } from '@/common/utils/loadDraft';
 
 import { useCommentListContext } from './CommentListContext';
 
@@ -35,10 +38,21 @@ export function useSubmitCommentForm({
   });
   type FormValues = z.infer<typeof addCommentFormSchema>;
 
+  const draftKey = `comment-${commentableType}-${commentableId}`;
+
+  const draft = loadDraft<FormValues>(draftKey);
+
   const form = useForm<FormValues>({
     resolver: zodResolver(addCommentFormSchema),
-    defaultValues: { body: '' },
+    defaultValues: { body: draft.body ?? '' },
   });
+
+  useEffect(() => {
+    const currentDraft = loadDraft<FormValues>(draftKey);
+    form.reset({ body: currentDraft.body ?? '' });
+  }, [draftKey, form]);
+
+  const { clearDraft } = useFormDraft(draftKey, form);
 
   const mutation = useSubmitCommentMutation();
 
@@ -55,8 +69,10 @@ export function useSubmitCommentForm({
       {
         loading: t('Submitting...'),
         success: () => {
+          clearDraft();
           onSubmitSuccess?.();
-          form.reset();
+
+          form.reset({ body: '' });
 
           return t('Submitted!');
         },

--- a/resources/js/common/hooks/useFormDraft.test.ts
+++ b/resources/js/common/hooks/useFormDraft.test.ts
@@ -1,0 +1,154 @@
+import { useForm } from 'react-hook-form';
+
+import { loadDraft } from '@/common/utils/loadDraft';
+import { act, renderHook } from '@/test';
+
+import { useFormDraft } from './useFormDraft';
+
+vi.mock('@/common/utils/loadDraft', () => ({
+  loadDraft: vi.fn(),
+}));
+
+describe('Hook: useFormDraft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('given the key changes after initial mount, rehydrates the form if draft is different', () => {
+    // ARRANGE
+    const baseDefaults = { body: '' };
+    vi.mocked(loadDraft).mockReturnValue({ body: 'new draft content' });
+
+    const { result, rerender } = renderHook(
+      ({ key }) => {
+        const form = useForm({ defaultValues: baseDefaults });
+        useFormDraft(key, form, baseDefaults);
+        return form;
+      },
+      { initialProps: { key: 'initial-key' } },
+    );
+
+    // ACT
+    rerender({ key: 'new-key' });
+
+    // ASSERT
+    expect(result.current.getValues('body')).toBe('new draft content');
+  });
+
+  it('given clearDraft is called, prevents a pending debounce timer from saving base defaults', () => {
+    // ARRANGE
+    const baseDefaults = { body: '' };
+    vi.mocked(loadDraft).mockReturnValue(baseDefaults);
+
+    let clearDraftFn: () => void;
+
+    const { result } = renderHook(() => {
+      const form = useForm({ defaultValues: { body: 'typed text' } });
+      const { clearDraft } = useFormDraft('test-key', form, baseDefaults);
+      clearDraftFn = clearDraft;
+      return form;
+    });
+
+    // ACT
+    act(() => {
+      result.current.reset(baseDefaults);
+      clearDraftFn();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // ASSERT
+    expect(sessionStorage.getItem('test-key')).toBeNull();
+  });
+
+  it('given the key changes after initial mount but draft is identical to current values, does not rehydrate', () => {
+    // ARRANGE
+    const baseDefaults = { body: '' };
+    vi.mocked(loadDraft).mockReturnValue(baseDefaults);
+
+    const { result, rerender } = renderHook(
+      ({ key }) => {
+        const form = useForm({ defaultValues: baseDefaults });
+        useFormDraft(key, form, baseDefaults);
+        return form;
+      },
+      { initialProps: { key: 'initial-key' } },
+    );
+
+    const resetSpy = vi.spyOn(result.current, 'reset');
+
+    // ACT
+    rerender({ key: 'new-key' });
+
+    // ASSERT
+    expect(resetSpy).not.toHaveBeenCalled();
+  });
+
+  it('given clearDraft is called when there is no pending timer, removes draft from storage safely', () => {
+    // ARRANGE
+    const baseDefaults = { body: '' };
+    vi.mocked(loadDraft).mockReturnValue(baseDefaults);
+
+    const { result } = renderHook(() => {
+      const form = useForm({ defaultValues: baseDefaults });
+      return useFormDraft('test-key', form, baseDefaults);
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    // ACT
+    act(() => {
+      result.current.clearDraft();
+    });
+
+    // ASSERT
+    expect(sessionStorage.getItem('test-key')).toBeNull();
+  });
+
+  it('given the key changes to null after initial mount, does not rehydrate', () => {
+    // ARRANGE
+    const { rerender } = renderHook(
+      ({ key }) => {
+        const form = useForm({ defaultValues: { body: '' } });
+        useFormDraft(key, form);
+        return form;
+      },
+      { initialProps: { key: 'initial-key' as string | null } },
+    );
+
+    // ACT
+    rerender({ key: null });
+
+    // ASSERT
+    expect(true).toBe(true);
+  });
+
+  it('given clearDraft is called before effects run, safely handles null timerRef', () => {
+    // ARRANGE
+    const baseDefaults = { body: '' };
+    vi.mocked(loadDraft).mockReturnValue(baseDefaults);
+
+    // ACT
+    renderHook(() => {
+      const form = useForm({ defaultValues: baseDefaults });
+      const { clearDraft } = useFormDraft('test-key', form, baseDefaults);
+
+      clearDraft();
+
+      return form;
+    });
+
+    // ASSERT
+    expect(sessionStorage.getItem('test-key')).toBeNull();
+  });
+});

--- a/resources/js/common/hooks/useFormDraft.ts
+++ b/resources/js/common/hooks/useFormDraft.ts
@@ -10,6 +10,10 @@ import { useWatch } from 'react-hook-form';
  */
 export function useFormDraft<T extends FieldValues>(key: string | null, form: UseFormReturn<T>) {
   const values = useWatch({ control: form.control });
+
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -25,6 +29,14 @@ export function useFormDraft<T extends FieldValues>(key: string | null, form: Us
       }
     };
   }, [key, values]);
+
+  useEffect(() => {
+    return () => {
+      if (key) {
+        sessionStorage.setItem(key, JSON.stringify(valuesRef.current));
+      }
+    };
+  }, [key]);
 
   const clearDraft = () => {
     if (key) {

--- a/resources/js/common/hooks/useFormDraft.ts
+++ b/resources/js/common/hooks/useFormDraft.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { DefaultValues, FieldValues, UseFormReturn } from 'react-hook-form';
 import { useWatch } from 'react-hook-form';
+
 import { loadDraft } from '@/common/utils/loadDraft';
 
 /**

--- a/resources/js/common/hooks/useFormDraft.ts
+++ b/resources/js/common/hooks/useFormDraft.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
-import type { FieldValues, UseFormReturn } from 'react-hook-form';
+import type { DefaultValues, FieldValues, UseFormReturn } from 'react-hook-form';
 import { useWatch } from 'react-hook-form';
+import { loadDraft } from '@/common/utils/loadDraft';
 
 /**
  * Persists form values to sessionStorage so drafts survive back-button
@@ -8,18 +9,48 @@ import { useWatch } from 'react-hook-form';
  * to avoid blocking the main thread on every keystroke in large text fields.
  * Pass null as a key to disable persistence (eg: when editing, not creating).
  */
-export function useFormDraft<T extends FieldValues>(key: string | null, form: UseFormReturn<T>) {
+export function useFormDraft<T extends FieldValues>(
+  key: string | null,
+  form: UseFormReturn<T>,
+  baseDefaults: DefaultValues<T> = {} as DefaultValues<T>,
+) {
   const values = useWatch({ control: form.control });
 
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isClearedRef = useRef(false);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    if (key) {
+      isClearedRef.current = false;
+      const draft = loadDraft<T>(key);
+      
+      if (JSON.stringify(form.getValues()) !== JSON.stringify({ ...baseDefaults, ...draft })) {
+        form.reset({ ...baseDefaults, ...draft } as DefaultValues<T>);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
 
   useEffect(() => {
     if (key) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+
       timerRef.current = setTimeout(() => {
+        if (isClearedRef.current && JSON.stringify(values) === JSON.stringify(baseDefaults)) {
+          return;
+        }
+
         sessionStorage.setItem(key, JSON.stringify(values));
+        isClearedRef.current = false;
       }, 500);
     }
 
@@ -28,11 +59,11 @@ export function useFormDraft<T extends FieldValues>(key: string | null, form: Us
         clearTimeout(timerRef.current);
       }
     };
-  }, [key, values]);
+  }, [key, values, baseDefaults]);
 
   useEffect(() => {
     return () => {
-      if (key) {
+      if (key && !isClearedRef.current) {
         sessionStorage.setItem(key, JSON.stringify(valuesRef.current));
       }
     };
@@ -40,7 +71,11 @@ export function useFormDraft<T extends FieldValues>(key: string | null, form: Us
 
   const clearDraft = () => {
     if (key) {
+      isClearedRef.current = true;
       sessionStorage.removeItem(key);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
     }
   };
 

--- a/resources/js/common/hooks/useFormDraft.ts
+++ b/resources/js/common/hooks/useFormDraft.ts
@@ -32,7 +32,7 @@ export function useFormDraft<T extends FieldValues>(
     if (key) {
       isClearedRef.current = false;
       const draft = loadDraft<T>(key);
-      
+
       if (JSON.stringify(form.getValues()) !== JSON.stringify({ ...baseDefaults, ...draft })) {
         form.reset({ ...baseDefaults, ...draft } as DefaultValues<T>);
       }

--- a/resources/js/features/forums/components/CreateForumTopicMainRoot/CreateTopicForm/CreateTopicForm.test.tsx
+++ b/resources/js/features/forums/components/CreateForumTopicMainRoot/CreateTopicForm/CreateTopicForm.test.tsx
@@ -16,6 +16,10 @@ window.scrollTo = vi.fn();
 console.error = vi.fn();
 
 describe('Component: CreateTopicForm', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
   it('renders without crashing', () => {
     // ARRANGE
     const { container } = render(<CreateTopicForm onPreview={vi.fn()} />, {

--- a/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.test.tsx
+++ b/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.test.tsx
@@ -10,19 +10,13 @@ import { createUser } from '@/test/factories';
 
 import { CreateMessageThreadForm } from './CreateMessageThreadForm';
 
-// Disable draft persistence to avoid conflicts with userEvent.type
-vi.mock('@/common/hooks/useFormDraft', () => ({
-  useFormDraft: () => ({
-    clearDraft: vi.fn(),
-  }),
-}));
-
 // Suppress JSDOM errors that are not relevant.
 console.error = vi.fn();
 
 describe('Component: CreateMessageThreadForm', () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
+    sessionStorage.clear();
   });
 
   it('renders without crashing', () => {

--- a/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.test.tsx
+++ b/resources/js/features/messages/components/CreateMessageThreadForm/CreateMessageThreadForm.test.tsx
@@ -10,6 +10,13 @@ import { createUser } from '@/test/factories';
 
 import { CreateMessageThreadForm } from './CreateMessageThreadForm';
 
+// Disable draft persistence to avoid conflicts with userEvent.type
+vi.mock('@/common/hooks/useFormDraft', () => ({
+  useFormDraft: () => ({
+    clearDraft: vi.fn(),
+  }),
+}));
+
 // Suppress JSDOM errors that are not relevant.
 console.error = vi.fn();
 


### PR DESCRIPTION
Resolves #4737 

The problem was that useFormDraft's debounce is cancelled when the form unmounts. Also, Inertia navigation doesn't reload drafts because React Hook Form caches defaultValues on initial mount.

Forced a synchronous save to sessionStorage during unmount cleanup, and explicitly reset the form whenever the draftKey changes. As mentioned in the Issue's discussion, it also solves the problems in the "View all comments" page. (https://retroachievements.org/achievement/243928/comments)