### PR TITLE
feat(sentry): remove UI data before dumping record

### DIFF
--- a/resources/views/pages-legacy/sentry.blade.php
+++ b/resources/views/pages-legacy/sentry.blade.php
@@ -265,6 +265,13 @@ foreach ($clients as $client) {
                                 (hardcore)
                             <?php endif ?>
                         <?php endif ?>
+                        <?php // remove the additional data we added for the UI before dumping the record
+                        unset($sniff['achievement']);
+                        unset($sniff['game']);
+                        unset($sniff['leaderboard']);
+                        unset($sniff['link']);
+                        unset($sniff['userinfo']);
+                        ?>
                         <?php if ($sniff['leaderboard'] ?? null): ?>
                             &middot; <a href="/leaderboardinfo.php?i=<?= $sniff['leaderboard']->id ?>"><?= $sniff['leaderboard']->title ?></a>
                             &middot; <code><?= $sniff['score'] ?></code>


### PR DESCRIPTION
I removed this code as part of #4925 thinking it wasn't needed. While it doesn't break anything, it was filtering out extra data used to initialize the UI that's not actually part of the captured information.