### PR TITLE
fix(GameBadgeBackfillService): don't explode when encountering a symlink

### DIFF
--- a/app/Platform/Services/GameBadgeBackfillService.php
+++ b/app/Platform/Services/GameBadgeBackfillService.php
@@ -9,6 +9,7 @@ use App\Models\GameBadge;
 use App\Models\System;
 use App\Platform\Enums\GameBadgeAttribution;
 use Carbon\CarbonInterface;
+use FilesystemIterator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 
@@ -33,7 +34,19 @@ class GameBadgeBackfillService
     {
         $entries = [];
 
-        foreach (Storage::disk('media')->allFiles('Images') as $relativePath) {
+        $imagesDirectory = Storage::disk('media')->path('Images');
+        if (!is_dir($imagesDirectory)) {
+            $this->fileIndex = [];
+
+            return;
+        }
+
+        foreach (new FilesystemIterator($imagesDirectory, FilesystemIterator::SKIP_DOTS) as $file) {
+            if ($file->isLink() || !$file->isFile()) {
+                continue;
+            }
+
+            $relativePath = 'Images/' . $file->getFilename();
             if (!preg_match('/^Images\/\d+\.png$/', $relativePath)) {
                 continue;
             }


### PR DESCRIPTION
<img width="723" height="118" alt="Screenshot 2026-06-02 at 7 37 15 PM" src="https://github.com/user-attachments/assets/044a3e29-2a0c-442e-b49b-4e5ea0f6a41d" />
