### PR TITLE
feat(nav): redirect to manage if there's no dropdown on mobile

### DIFF
--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -6,6 +6,7 @@
     'dropdownClass' => '',
     'trigger' => '',
     'desktopHref' => null, // string | null
+    'forceHref' => false,
 ])
 
 <?php
@@ -13,7 +14,7 @@ use App\Actions\GetUserDeviceKindAction;
 
 $id = uniqid();
 
-$canUseDesktopHref = (new GetUserDeviceKindAction())->execute() === 'desktop';
+$canUseDesktopHref = $forceHref || (new GetUserDeviceKindAction())->execute() === 'desktop';
 ?>
 
 <div class="dropdown {{ $class ?? '' }} {{ ($active ?? false) ? 'active' : '' }}">

--- a/resources/views/components/menu/management.blade.php
+++ b/resources/views/components/menu/management.blade.php
@@ -9,6 +9,18 @@ $user = request()->user();
 $tools = $settings['tools'] ?? [];
 $visibleTools = collect($tools)->filter(fn($tool) => $user?->can($tool['abilities']));
 
+$anyDropdownItems =
+    $visibleTools->isNotEmpty() ||
+    $user?->can('develop') ||
+    $user?->can('manage', App\Models\Ticket::class) ||
+    $user?->can('manage', App\Models\AchievementSetClaim::class) ||
+    $user?->can('manage', App\Models\GameHash::class) ||
+    $user->Permissions >= Permissions::Developer ||
+    $user?->can('manage', App\Models\News::class) ||
+    $user->can('manage', User::class) ||
+    $user->Permissions === Permissions::Moderator ||
+    $user->can('tool');
+
 ?>
 
 <x-nav-dropdown
@@ -16,6 +28,7 @@ $visibleTools = collect($tools)->filter(fn($tool) => $user?->can($tool['abilitie
     dropdown-class="dropdown-menu-right"
     :title="__('Manage')"
     :desktopHref="route('filament.admin.pages.dashboard')"
+    :force-href="!$anyDropdownItems"
 >
     <x-slot name="trigger">
         <x-fas-toolbox />
@@ -38,8 +51,6 @@ $visibleTools = collect($tools)->filter(fn($tool) => $user?->can($tool['abilitie
         @endif
 
         <div class="dropdown-column">
-            <x-dropdown-header>{{ __('Manage') }}</x-dropdown-header>
-            <x-dropdown-item :href="route('filament.admin.pages.dashboard')">Dashboard</x-dropdown-item>
             @can('develop')
                 @can('manage', App\Models\Ticket::class)
                     <x-dropdown-header>{{ __('Development') }}</x-dropdown-header>

--- a/resources/views/components/menu/management.blade.php
+++ b/resources/views/components/menu/management.blade.php
@@ -38,6 +38,8 @@ $visibleTools = collect($tools)->filter(fn($tool) => $user?->can($tool['abilitie
         @endif
 
         <div class="dropdown-column">
+            <x-dropdown-header>{{ __('Manage') }}</x-dropdown-header>
+            <x-dropdown-item :href="route('filament.admin.pages.dashboard')">Dashboard</x-dropdown-item>
             @can('develop')
                 @can('manage', App\Models\Ticket::class)
                     <x-dropdown-header>{{ __('Development') }}</x-dropdown-header>

--- a/resources/views/components/nav-dropdown.blade.php
+++ b/resources/views/components/nav-dropdown.blade.php
@@ -6,6 +6,7 @@
     'title' => '',
     'trigger' => '',
     'triggerClass' => '',
+    'forceHref' => false,
 ])
 
 <x-dropdown
@@ -15,6 +16,7 @@
     :active="$active ?? false"
     :title="$title ?? ''"
     :desktopHref="$desktopHref"
+    :force-href="$forceHref"
 >
     <x-slot name="trigger">{{ $trigger }}</x-slot>
     {{ $slot }}


### PR DESCRIPTION
https://canary.discord.com/channels/310192285306454017/1498889559998595144/1498889559998595144

This PR allows mobile users who see no dropdown a way to get to the manage area.

It does (a bunch of) checks to see if there's a visible dropdown to show, and if there is not, just redirect the user.

All of this only affects mobile users. As a result, an override of the desktopHref was needed to let us effectively make it act like it does in desktop on mobile if there's no dropdown to show.