### PR TITLE
fix(DeveloperSetsService): remediate issue with gameIDs union

### DIFF
--- a/app/Platform/Services/DeveloperSetsService.php
+++ b/app/Platform/Services/DeveloperSetsService.php
@@ -49,6 +49,7 @@ class DeveloperSetsService
             ->toArray();
 
         $gameAuthoredLeaderboardsList = $user->authoredLeaderboards()
+            ->promoted()
             ->select(['game_id',
                 DB::raw('COUNT(leaderboards.id) AS NumAuthoredLeaderboards'),
             ])
@@ -59,8 +60,10 @@ class DeveloperSetsService
             })
             ->toArray();
 
-        $gameIDs = array_keys($gameAuthoredAchievementsList) +
-            array_keys($gameAuthoredLeaderboardsList);
+        $gameIDs = array_unique(array_merge(
+            array_keys($gameAuthoredAchievementsList),
+            array_keys($gameAuthoredLeaderboardsList),
+        ));
 
         $gameAuthoredTicketsList = Ticket::whereIn('state', [TicketState::Open, TicketState::Request])
             ->where('ticketable_type', 'achievement')


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/RAWeb/issues/2548.

**Root Cause**
Two issues at play here:
1. The page was developed before leaderboard states were a thing. The leaderboard query now includes a `->promoted()` filter.
2. We want a value-based union on `$gameIDs`, but `array_keys($a)` + `array_keys($b)` is a positional union. Right-hand game IDs at colliding integer indices are silently discarded:
```php
[0=>X, 1=>Y, 2=>Z] + [0=>X, 1=>A] // [X,Y,Z], game A is lost
```