### PR TITLE
fix(RecordGameBadgeChangeAction): pull badges from S3 when unavailable from local disk

### DIFF
--- a/app/Platform/Actions/RecordGameBadgeChangeAction.php
+++ b/app/Platform/Actions/RecordGameBadgeChangeAction.php
@@ -10,6 +10,7 @@ use App\Models\System;
 use App\Models\User;
 use App\Platform\Enums\GameBadgeAttribution;
 use Carbon\CarbonInterface;
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use RuntimeException;
@@ -45,12 +46,13 @@ class RecordGameBadgeChangeAction
             }
 
             $storagePath = ltrim($imageAssetPath, '/');
+            $fileContents = $this->getBadgeFileContents($storagePath);
 
-            if (!Storage::disk('media')->exists($storagePath)) {
+            if ($fileContents === null) {
                 throw new RuntimeException("Badge file missing at {$imageAssetPath}");
             }
 
-            $sha1 = sha1(Storage::disk('media')->get($storagePath));
+            $sha1 = sha1($fileContents);
 
             // a placeholder re-uploaded under a unique filename means the badge was removed,
             // so retire the current row without recording the placeholder as a real badge.
@@ -100,5 +102,19 @@ class RecordGameBadgeChangeAction
                 'replaced_at' => null,
             ]);
         });
+    }
+
+    private function getBadgeFileContents(string $storagePath): ?string
+    {
+        foreach (['media', 's3'] as $diskName) {
+            /** @var Filesystem $disk */
+            $disk = Storage::disk($diskName);
+
+            if ($disk->exists($storagePath)) {
+                return $disk->get($storagePath);
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Feature/Platform/Actions/RecordGameBadgeChangeActionTest.php
+++ b/tests/Feature/Platform/Actions/RecordGameBadgeChangeActionTest.php
@@ -13,6 +13,7 @@ uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Storage::fake('media');
+    Storage::fake('s3');
 });
 
 function recordBadgePath(string $numericName): string
@@ -36,6 +37,24 @@ it('writes a badge row when the game is playable', function () {
     // ASSERT
     expect($badge)->not->toBeNull();
     expect(GameBadge::where('game_id', $game->id)->count())->toEqual(1);
+    expect($game->badges()->first()->image_asset_path)->toEqual($path);
+});
+
+it('writes a badge row from s3 when the media disk is missing the badge file', function () {
+    // ARRANGE
+    $game = Game::factory()->create([
+        'system_id' => System::factory(),
+        'achievements_published' => 5,
+    ]);
+    $path = '/Images/200099.png';
+    Storage::disk('s3')->put('Images/200099.png', 'badge-content-200099');
+
+    // ACT
+    $badge = (new RecordGameBadgeChangeAction())->execute($game, $path);
+
+    // ASSERT
+    expect($badge)->not->toBeNull();
+    expect($badge->sha1)->toEqual(sha1('badge-content-200099'));
     expect($game->badges()->first()->image_asset_path)->toEqual($path);
 });
 


### PR DESCRIPTION
No local disk to grab stuff from in the context this action is running (worker server). Need to grab from R2/S3 instead:
<img width="1446" height="519" alt="Screenshot 2026-06-06 at 6 45 55 PM" src="https://github.com/user-attachments/assets/f9eeacd6-85d2-4708-9cca-21b01f2a6529" />
