### PR TITLE
allow multiset unlocks from different subsets in same game

### DIFF
--- a/app/Connect/Actions/AwardAchievementsAction.php
+++ b/app/Connect/Actions/AwardAchievementsAction.php
@@ -79,7 +79,22 @@ class AwardAchievementsAction extends BaseAuthenticatedApiAction
                 $gameId = $achievement->game_id;
                 $this->game = $achievement->game;
             } elseif ($gameId !== $achievement->game_id) {
-                return $this->invalidParameter('All provided achievements must be from the same game.');
+                if ($this->game->parent_game_id === $achievement->game_id) {
+                    // achievement game is parent game. switch game to be the parent
+                    $gameId = $achievement->game_id;
+                    $this->game = $achievement->game;
+                } elseif ($gameId === $achievement->game->parent_game_id) {
+                    // achievement belongs to subset of currently tracked game. keep it
+                } elseif ($this->game->parent_game_id && $this->game->parent_game_id === $achievement->game->parent_game_id) {
+                    // both achievements belong to separate subsets of the same game. switch to the parent.
+                    $gameId = $this->game->parent_game_id;
+                    $this->game = Game::find($gameId);
+                } else {
+                    // achievements from two distinct games are being requested at the same time.
+                    // even if they can both be individually delegated, fail, as the process logic
+                    // can only work with one game at a time.
+                    return $this->invalidParameter('All provided achievements must be from the same game.');
+                }
             }
         }
 
@@ -92,7 +107,7 @@ class AwardAchievementsAction extends BaseAuthenticatedApiAction
 
         $this->hardcore = $request->boolean('h', false);
 
-        // Check validation hash (note use of parameters k/u - the parameter may not have the same casing as the model)
+        // Check validation hash (note use of parameters k/a - the parameter may not have the same casing as the model)
         $validationHash = strtolower($request->input('v', ''));
 
         // Delegated unlocks will be rejected if the appropriate validation hash is not provided
@@ -191,7 +206,7 @@ class AwardAchievementsAction extends BaseAuthenticatedApiAction
                 if ($this->hardcore) {
                     $this->user->points_hardcore += $achievement->points;
 
-                    if ($playerGame) {
+                    if ($playerGame && $playerGame->game_id === $achievement->game->id) {
                         $playerGame->achievements_unlocked_hardcore++;
                     }
 
@@ -201,14 +216,14 @@ class AwardAchievementsAction extends BaseAuthenticatedApiAction
                         // it must be an upgrade from softcore.
                         $this->user->points -= $achievement->points;
 
-                        if ($playerGame) {
+                        if ($playerGame && $playerGame->game_id === $achievement->game->id) {
                             $playerGame->achievements_unlocked--;
                         }
                     }
                 } else {
                     $this->user->points += $achievement->points;
 
-                    if ($playerGame) {
+                    if ($playerGame && $playerGame->game_id === $achievement->game->id) {
                         $playerGame->achievements_unlocked++;
                     }
                 }

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -103,6 +103,7 @@ class Game extends BaseModel implements HasMedia, HasPermalink, HasVersionedTrig
         'image_title_asset_path',
         'image_ingame_asset_path',
         'image_box_art_asset_path',
+        'parent_game_id',
     ];
 
     protected $casts = [
@@ -136,6 +137,7 @@ class Game extends BaseModel implements HasMedia, HasPermalink, HasVersionedTrig
         'achievements_published',
         'points_total',
         'players_total',
+        'parent_game_id',
     ];
 
     protected static function newFactory(): GameFactory

--- a/tests/Feature/Connect/AwardAchievementsTest.php
+++ b/tests/Feature/Connect/AwardAchievementsTest.php
@@ -12,6 +12,8 @@ use App\Models\PlayerGame;
 use App\Models\PlayerSession;
 use App\Models\System;
 use App\Models\User;
+use App\Platform\Actions\AssociateAchievementSetToGameAction;
+use App\Platform\Enums\AchievementSetType;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -72,6 +74,25 @@ class AwardAchievementsTestHelpers
                 $achievement4,
                 $achievement5,
                 $achievement6,
+            ],
+        ];
+    }
+
+    public static function createSubset(Game $mainGame, User $author, int $firstId = 18, string $title = 'Bonus'): array
+    {
+        $subsetGame = Game::factory()->create(['system_id' => $mainGame->system->id, 'parent_game_id' => $mainGame->id]);
+        $subsetAchievement1 = Achievement::factory()->promoted()->create(['id' => $firstId, 'game_id' => $subsetGame->id, 'user_id' => $author->id]);
+        $subsetAchievement2 = Achievement::factory()->promoted()->create(['id' => $firstId + 1, 'game_id' => $subsetGame->id, 'user_id' => $author->id]);
+
+        (new AssociateAchievementSetToGameAction())->execute(
+            $mainGame, $subsetGame, AchievementSetType::Bonus, $title,
+        );
+
+        return [
+            'game' => $subsetGame,
+            'achievements' => [
+                $subsetAchievement1,
+                $subsetAchievement2,
             ],
         ];
     }
@@ -524,6 +545,270 @@ describe('normal unlock', function () {
         $this->assertEquals($now, $unlocks[$achievement2->id]['DateEarnedHardcore']);
         $this->assertEquals($now, $unlocks[$achievement2->id]['DateEarned']);
     });
+
+    test('multiple subset achievements hardcore', function () {
+        $data = AwardAchievementsTestHelpers::createStandaloneGame();
+        $game = $data['game'];
+        $delegatedUser = $data['delegatedUser'];
+        $integrationUser = $data['integrationUser'];
+
+        $subsetData = AwardAchievementsTestHelpers::createSubset($game, $integrationUser);
+        $subsetGame = $subsetData['game'];
+        $subsetAchievement1 = $subsetData['achievements'][0];
+        $subsetAchievement2 = $subsetData['achievements'][1];
+
+        // do the delegated unlocks sync
+        $scoreBefore = $delegatedUser->points_hardcore;
+        $softcoreScoreBefore = $delegatedUser->points;
+
+        $params = [
+            'u' => $integrationUser->username,
+            't' => $integrationUser->connect_token,
+            'r' => 'awardachievements',
+            'k' => $delegatedUser->username,
+        ];
+        $payload = [
+            'a' => '18,19',
+            'h' => 1,
+            'v' => AwardAchievementsTestHelpers::buildValidationHash('18,19', $delegatedUser, 1),
+        ];
+
+        $requestUrl = sprintf('dorequest.php?%s', http_build_query($params));
+        $this->post($requestUrl, $payload)
+            ->assertStatus(200)
+            ->assertExactJson([
+                "Success" => true,
+                "Score" => $scoreBefore + $subsetAchievement1->points + $subsetAchievement2->points,
+                "SoftcoreScore" => $softcoreScoreBefore,
+                "ExistingIDs" => [],
+                "SuccessfulIDs" => [
+                    $subsetAchievement1->id,
+                    $subsetAchievement2->id,
+                ],
+                "AchievementsRemaining" => 0, // subset count
+            ]);
+        $delegatedUser->refresh();
+
+        // two achievements unlocked
+        $playerAchievement1 = PlayerAchievement::where([
+            'user_id' => $delegatedUser->id,
+            'achievement_id' => $subsetAchievement1->id,
+        ])->first();
+        $this->assertModelExists($playerAchievement1);
+        $this->assertNotNull($playerAchievement1->unlocked_at);
+        $this->assertNotNull($playerAchievement1->unlocked_hardcore_at);
+
+        // one subset achievement unlocked
+        $playerAchievement2 = PlayerAchievement::where([
+            'user_id' => $delegatedUser->id,
+            'achievement_id' => $subsetAchievement2->id,
+        ])->first();
+        $this->assertModelExists($playerAchievement2);
+        $this->assertNotNull($playerAchievement2->unlocked_at);
+        $this->assertNotNull($playerAchievement2->unlocked_hardcore_at);
+
+        // player score should have increased
+        $user1 = User::whereName($delegatedUser->username)->first();
+        $this->assertEquals(
+            $scoreBefore + $subsetAchievement1->points + $subsetAchievement2->points,
+            $user1->points_hardcore
+        );
+        $this->assertEquals($softcoreScoreBefore, $user1->points);
+    });
+
+    test('base and subset achievements hardcore', function () {
+        $data = AwardAchievementsTestHelpers::createStandaloneGame();
+        $game = $data['game'];
+        $achievement1 = $data['achievements'][0];
+        $achievement2 = $data['achievements'][1];
+        $delegatedUser = $data['delegatedUser'];
+        $integrationUser = $data['integrationUser'];
+
+        $subsetData = AwardAchievementsTestHelpers::createSubset($game, $integrationUser);
+        $subsetGame = $subsetData['game'];
+        $subsetAchievement1 = $subsetData['achievements'][0];
+
+        $now = Carbon::now();
+        $unlock1Date = $now->clone()->subMinutes(65);
+        $this->addHardcoreUnlock($delegatedUser, $achievement1, $unlock1Date);
+
+        $playerSession1 = PlayerSession::where([
+            'user_id' => $delegatedUser->id,
+            'game_id' => $achievement1->game_id,
+        ])->orderByDesc('id')->first();
+        $this->assertModelExists($playerSession1);
+
+        // do the delegated unlocks sync
+        $scoreBefore = $delegatedUser->points_hardcore;
+        $softcoreScoreBefore = $delegatedUser->points;
+
+        $params = [
+            'u' => $integrationUser->username,
+            't' => $integrationUser->connect_token,
+            'r' => 'awardachievements',
+            'k' => $delegatedUser->username,
+        ];
+        $payload = [
+            // Note that 1 is already unlocked, thus it will not be in the "SuccessfulIDs" list.
+            'a' => '1,2,18',
+            'h' => 1,
+            'v' => AwardAchievementsTestHelpers::buildValidationHash('1,2,18', $delegatedUser, 1),
+        ];
+
+        $requestUrl = sprintf('dorequest.php?%s', http_build_query($params));
+        $this->post($requestUrl, $payload)
+            ->assertStatus(200)
+            ->assertExactJson([
+                "Success" => true,
+                "Score" => $scoreBefore + $achievement2->points + $subsetAchievement1->points,
+                "SoftcoreScore" => $softcoreScoreBefore,
+                "ExistingIDs" => [
+                    $achievement1->id,
+                ],
+                "SuccessfulIDs" => [
+                    $achievement2->id,
+                    $subsetAchievement1->id,
+                ],
+                "AchievementsRemaining" => 4, // from base set only
+            ]);
+        $delegatedUser->refresh();
+
+        // player session resumed
+        $playerSession2 = PlayerSession::where([
+            'user_id' => $delegatedUser->id,
+            'game_id' => $achievement2->game_id,
+        ])->orderByDesc('id')->first();
+        $this->assertModelExists($playerSession2);
+
+        // player session resumed
+        $playerSession3 = PlayerSession::where([
+            'user_id' => $delegatedUser->id,
+            'game_id' => $subsetAchievement1->game_id,
+        ])->orderByDesc('id')->first();
+        $this->assertModelExists($playerSession3);
+
+        // game attached
+        $playerGame = PlayerGame::where([
+            'user_id' => $delegatedUser->id,
+            'game_id' => $achievement2->game_id,
+        ])->first();
+        $this->assertModelExists($playerGame);
+        $this->assertNotNull($playerGame->last_played_at);
+
+        // one base set achievements unlocked
+        $playerAchievement1 = PlayerAchievement::where([
+            'user_id' => $delegatedUser->id,
+            'achievement_id' => $achievement2->id,
+        ])->first();
+        $this->assertModelExists($playerAchievement1);
+        $this->assertNotNull($playerAchievement1->unlocked_at);
+        $this->assertNotNull($playerAchievement1->unlocked_hardcore_at);
+        $this->assertEquals($playerAchievement1->player_session_id, $playerSession2->id);
+
+        // one subset achievement unlocked
+        $playerAchievement2 = PlayerAchievement::where([
+            'user_id' => $delegatedUser->id,
+            'achievement_id' => $subsetAchievement1->id,
+        ])->first();
+        $this->assertModelExists($playerAchievement2);
+        $this->assertNotNull($playerAchievement2->unlocked_at);
+        $this->assertNotNull($playerAchievement2->unlocked_hardcore_at);
+        $this->assertEquals($playerAchievement2->player_session_id, $playerSession3->id);
+
+        // player score should have increased
+        $user1 = User::whereName($delegatedUser->username)->first();
+        $this->assertEquals(
+            $scoreBefore + $achievement2->points + $subsetAchievement1->points,
+            $user1->points_hardcore
+        );
+        $this->assertEquals($softcoreScoreBefore, $user1->points);
+    });
+
+    test('achievements from two subsets of same game hardcore', function () {
+        $data = AwardAchievementsTestHelpers::createStandaloneGame();
+        $game = $data['game'];
+        $achievement1 = $data['achievements'][0];
+        $achievement2 = $data['achievements'][1];
+        $delegatedUser = $data['delegatedUser'];
+        $integrationUser = $data['integrationUser'];
+
+        $subset1Data = AwardAchievementsTestHelpers::createSubset($game, $integrationUser);
+        $subset1Game = $subset1Data['game'];
+        $subset1Achievement1 = $subset1Data['achievements'][0];
+
+        $subset2Data = AwardAchievementsTestHelpers::createSubset($game, $integrationUser, firstId: 24, title: 'Bonus2');
+        $subset2Game = $subset2Data['game'];
+        $subset2Achievement1 = $subset2Data['achievements'][0];
+
+        $now = Carbon::now();
+        $unlock1Date = $now->clone()->subMinutes(65);
+        $this->addHardcoreUnlock($delegatedUser, $achievement1, $unlock1Date);
+
+        $playerSession1 = PlayerSession::where([
+            'user_id' => $delegatedUser->id,
+            'game_id' => $achievement1->game_id,
+        ])->orderByDesc('id')->first();
+        $this->assertModelExists($playerSession1);
+
+        // do the delegated unlocks sync
+        $scoreBefore = $delegatedUser->points_hardcore;
+        $softcoreScoreBefore = $delegatedUser->points;
+
+        $params = [
+            'u' => $integrationUser->username,
+            't' => $integrationUser->connect_token,
+            'r' => 'awardachievements',
+            'k' => $delegatedUser->username,
+        ];
+        $payload = [
+            // Note that 1 is already unlocked, thus it will not be in the "SuccessfulIDs" list.
+            'a' => '18,24',
+            'h' => 1,
+            'v' => AwardAchievementsTestHelpers::buildValidationHash('18,24', $delegatedUser, 1),
+        ];
+
+        $requestUrl = sprintf('dorequest.php?%s', http_build_query($params));
+        $this->post($requestUrl, $payload)
+            ->assertStatus(200)
+            ->assertExactJson([
+                "Success" => true,
+                "Score" => $scoreBefore + $subset1Achievement1->points + $subset2Achievement1->points,
+                "SoftcoreScore" => $softcoreScoreBefore,
+                "ExistingIDs" => [],
+                "SuccessfulIDs" => [
+                    $subset1Achievement1->id,
+                    $subset2Achievement1->id,
+                ],
+                "AchievementsRemaining" => 5, // from base set only
+            ]);
+        $delegatedUser->refresh();
+
+        // first subset achievement unlocked
+        $playerAchievement1 = PlayerAchievement::where([
+            'user_id' => $delegatedUser->id,
+            'achievement_id' => $subset1Achievement1->id,
+        ])->first();
+        $this->assertModelExists($playerAchievement1);
+        $this->assertNotNull($playerAchievement1->unlocked_at);
+        $this->assertNotNull($playerAchievement1->unlocked_hardcore_at);
+
+        // second subset achievement unlocked
+        $playerAchievement2 = PlayerAchievement::where([
+            'user_id' => $delegatedUser->id,
+            'achievement_id' => $subset2Achievement1->id,
+        ])->first();
+        $this->assertModelExists($playerAchievement2);
+        $this->assertNotNull($playerAchievement2->unlocked_at);
+        $this->assertNotNull($playerAchievement2->unlocked_hardcore_at);
+
+        // player score should have increased
+        $user1 = User::whereName($delegatedUser->username)->first();
+        $this->assertEquals(
+            $scoreBefore + $subset1Achievement1->points + $subset2Achievement1->points,
+            $user1->points_hardcore
+        );
+        $this->assertEquals($softcoreScoreBefore, $user1->points);
+    });
 });
 
 describe('validation', function () {
@@ -875,54 +1160,6 @@ describe('validation', function () {
         // A session shouldn't have been created.
         $this->assertDatabaseMissing((new PlayerSession())->getTable(), [
             'user_id' => $delegatedUser->id,
-            'game_id' => $game->id,
-        ]);
-    });
-
-    test('empty delegate target is rejected', function () {
-        $system = System::factory()->create(['id' => 1]);
-        $game = Game::factory()->create(['system_id' => $system->id]);
-        $achievement1 = Achievement::factory()->promoted()->create(['game_id' => $game->id]);
-
-        $scoreBefore = $this->user->points_hardcore;
-        $softcoreScoreBefore = $this->user->points;
-
-        $params = [
-            'u' => $this->user->username,
-            't' => $this->user->connect_token,
-            'r' => 'awardachievements',
-            'k' => '',
-        ];
-        $payload = [
-            'a' => $achievement1->id,
-            'h' => 1,
-            'v' => md5($achievement1->id . '1'),
-        ];
-
-        $requestUrl = sprintf('dorequest.php?%s', http_build_query($params));
-        $this->post($requestUrl, $payload)
-            ->assertStatus(404)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 404,
-                'Code' => 'not_found',
-                'Error' => 'Unknown target user.',
-            ]);
-        $this->user->refresh();
-
-        // points shouldn't change
-        $this->assertEquals($scoreBefore, $this->user->points_hardcore);
-        $this->assertEquals($softcoreScoreBefore, $this->user->points);
-
-        // no achievement unlock should have been recorded
-        $this->assertDatabaseMissing((new PlayerAchievement())->getTable(), [
-            'user_id' => $this->user->id,
-            'achievement_id' => $achievement1->id,
-        ]);
-
-        // no session should have been created
-        $this->assertDatabaseMissing((new PlayerSession())->getTable(), [
-            'user_id' => $this->user->id,
             'game_id' => $game->id,
         ]);
     });

--- a/tests/Feature/Connect/AwardAchievementsTest.php
+++ b/tests/Feature/Connect/AwardAchievementsTest.php
@@ -1163,4 +1163,52 @@ describe('validation', function () {
             'game_id' => $game->id,
         ]);
     });
+
+    test('empty delegate target is rejected', function () {
+        $system = System::factory()->create(['id' => 1]);
+        $game = Game::factory()->create(['system_id' => $system->id]);
+        $achievement1 = Achievement::factory()->promoted()->create(['game_id' => $game->id]);
+
+        $scoreBefore = $this->user->points_hardcore;
+        $softcoreScoreBefore = $this->user->points;
+
+        $params = [
+            'u' => $this->user->username,
+            't' => $this->user->connect_token,
+            'r' => 'awardachievements',
+            'k' => '',
+        ];
+        $payload = [
+            'a' => $achievement1->id,
+            'h' => 1,
+            'v' => md5($achievement1->id . '1'),
+        ];
+
+        $requestUrl = sprintf('dorequest.php?%s', http_build_query($params));
+        $this->post($requestUrl, $payload)
+            ->assertStatus(404)
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 404,
+                'Code' => 'not_found',
+                'Error' => 'Unknown target user.',
+            ]);
+        $this->user->refresh();
+
+        // points shouldn't change
+        $this->assertEquals($scoreBefore, $this->user->points_hardcore);
+        $this->assertEquals($softcoreScoreBefore, $this->user->points);
+
+        // no achievement unlock should have been recorded
+        $this->assertDatabaseMissing((new PlayerAchievement())->getTable(), [
+            'user_id' => $this->user->id,
+            'achievement_id' => $achievement1->id,
+        ]);
+
+        // no session should have been created
+        $this->assertDatabaseMissing((new PlayerSession())->getTable(), [
+            'user_id' => $this->user->id,
+            'game_id' => $game->id,
+        ]);
+    });
 });


### PR DESCRIPTION
The refactoring in #4926 restricted the `r=awardachievements` request to a single game at a time. This is interfering with multiset behavior for standalones. Additional changes to support this functionality have been implemented.