### PR TITLE
feat(GameScreenshotValidationService): adjust duplicate images validation rule

### DIFF
--- a/app/Platform/Enums/GameScreenshotRejectionReason.php
+++ b/app/Platform/Enums/GameScreenshotRejectionReason.php
@@ -13,7 +13,7 @@ enum GameScreenshotRejectionReason: string
     case PoorQuality = 'poor_quality';
     case Duplicate = 'duplicate'; // too similar to another image in the game's gallery
     case IncorrectType = 'incorrect_type';
-    case MissingMatchingCompanion = 'missing_matching_companion'; // image itself is fine, but a paired companion screenshot is missing
+    case MissingMatchingCompanion = 'missing_matching_companion';
     case InappropriateContent = 'inappropriate_content';
     case Other = 'other';
 

--- a/app/Platform/Enums/GameScreenshotRejectionReason.php
+++ b/app/Platform/Enums/GameScreenshotRejectionReason.php
@@ -13,6 +13,7 @@ enum GameScreenshotRejectionReason: string
     case PoorQuality = 'poor_quality';
     case Duplicate = 'duplicate'; // too similar to another image in the game's gallery
     case IncorrectType = 'incorrect_type';
+    case MissingMatchingCompanion = 'missing_matching_companion'; // image itself is fine, but a paired companion screenshot is missing
     case InappropriateContent = 'inappropriate_content';
     case Other = 'other';
 
@@ -23,6 +24,7 @@ enum GameScreenshotRejectionReason: string
             self::PoorQuality => 'Poor Quality',
             self::Duplicate => 'Duplicate',
             self::IncorrectType => 'Incorrect Type',
+            self::MissingMatchingCompanion => 'Missing Matching Companion',
             self::InappropriateContent => 'Inappropriate Content',
             self::Other => 'Other',
         };

--- a/app/Platform/Services/GameScreenshotValidationService.php
+++ b/app/Platform/Services/GameScreenshotValidationService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Platform\Services;
 
 use App\Models\Game;
+use App\Platform\Enums\GameScreenshotRejectionReason;
+use App\Platform\Enums\GameScreenshotStatus;
 use App\Rules\DisallowAnimatedImageRule;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Validator;
@@ -73,12 +75,20 @@ class GameScreenshotValidationService
     {
         $hash = sha1_file($file->getRealPath());
 
-        // Reject duplicates based on SHA1 across all of this game's screenshots,
-        // including those previously rejected. A rejection is a review decision,
-        // so re-uploading the same image should not bypass the decision.
+        // Reject duplicates based on SHA1 across this game's screenshots so a
+        // rejection cannot be bypassed by re-uploading the same image. The one
+        // exception is MissingMatchingCompanion: the image itself was fine and
+        // was only rejected pending a paired companion, so resubmission with
+        // the missing companion is the intended way to clear that decision.
         $isDuplicate = $game->gameScreenshots()
             ->whereHas('media', function ($query) use ($hash) {
                 $query->where('custom_properties->sha1', $hash);
+            })
+            ->where(function ($query) {
+                $query
+                    ->where('status', '!=', GameScreenshotStatus::Rejected)
+                    ->orWhere('rejection_reason', '!=', GameScreenshotRejectionReason::MissingMatchingCompanion)
+                    ->orWhereNull('rejection_reason');
             })
             ->exists();
 

--- a/tests/Feature/Platform/Actions/SubmitPendingGameScreenshotActionTest.php
+++ b/tests/Feature/Platform/Actions/SubmitPendingGameScreenshotActionTest.php
@@ -7,6 +7,8 @@ use App\Models\GameScreenshot;
 use App\Models\System;
 use App\Models\User;
 use App\Platform\Actions\SubmitPendingGameScreenshotAction;
+use App\Platform\Enums\GameScreenshotRejectionReason;
+use App\Platform\Enums\GameScreenshotStatus;
 use App\Platform\Enums\ScreenshotType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
@@ -41,4 +43,64 @@ it('enforces the configurable pending submission cap', function () {
 
     // ASSERT
     expect($attempt)->toThrow(ValidationException::class);
+});
+
+it('blocks resubmission of the same file when a prior submission was rejected for a non-companion reason', function () {
+    // ARRANGE
+    $game = Game::factory()->create(['system_id' => System::factory()]);
+    $user = User::factory()->create();
+    $file = UploadedFile::fake()->image('shot.png', 256, 224);
+
+    $submitted = (new SubmitPendingGameScreenshotAction())->execute(
+        $game,
+        $file,
+        ScreenshotType::Ingame,
+        $user,
+    );
+    $submitted->update([
+        'status' => GameScreenshotStatus::Rejected,
+        'rejection_reason' => GameScreenshotRejectionReason::PoorQuality,
+    ]);
+
+    // ACT
+    $attempt = fn () => (new SubmitPendingGameScreenshotAction())->execute(
+        $game,
+        $file,
+        ScreenshotType::Ingame,
+        $user,
+    );
+
+    // ASSERT
+    expect($attempt)->toThrow(ValidationException::class);
+});
+
+it('allows resubmission of the same file when the only prior match was rejected as missing a matching companion', function () {
+    // ARRANGE
+    $game = Game::factory()->create(['system_id' => System::factory()]);
+    $user = User::factory()->create();
+    $file = UploadedFile::fake()->image('shot.png', 256, 224);
+
+    $submitted = (new SubmitPendingGameScreenshotAction())->execute(
+        $game,
+        $file,
+        ScreenshotType::Ingame,
+        $user,
+    );
+    $submitted->update([
+        'status' => GameScreenshotStatus::Rejected,
+        'rejection_reason' => GameScreenshotRejectionReason::MissingMatchingCompanion,
+    ]);
+
+    // ACT
+    $resubmitted = (new SubmitPendingGameScreenshotAction())->execute(
+        $game,
+        $file,
+        ScreenshotType::Ingame,
+        $user,
+    );
+
+    // ASSERT
+    expect($resubmitted->id)->not->toEqual($submitted->id);
+    expect($resubmitted->status)->toEqual(GameScreenshotStatus::Pending);
+    expect(GameScreenshot::where('game_id', $game->id)->count())->toEqual(2);
 });


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/1512802214152900648/1513330251797889184

Accompanies #4963.

Given an image is rejected for missing a companion image, allows that rejected image to be submitted again, bypassing duplicate image validation.