### PR TITLE
fix(manage/usernames): don't crash on soft-deleted users

### DIFF
--- a/app/Models/UserUsername.php
+++ b/app/Models/UserUsername.php
@@ -51,6 +51,7 @@ class UserUsername extends BaseModel
 
         $previousApprovedChanges = static::query()
             ->with('user')
+            ->whereHas('user')
             ->where('username', $this->username)
             ->where('id', '!=', $this->id)
             ->whereNotNull('approved_at')


### PR DESCRIPTION
Resolves this burst of server errors:
<img width="1093" height="264" alt="Screenshot 2026-06-14 at 5 29 38 PM" src="https://github.com/user-attachments/assets/469ce0c5-61a4-4d8e-a439-8bf3e922b002" />
