### PR TITLE
fix(connect): remediate potential DoS

### DIFF
--- a/app/Connect/Actions/SubmitCodeNotesAction.php
+++ b/app/Connect/Actions/SubmitCodeNotesAction.php
@@ -13,6 +13,8 @@ use Illuminate\Http\Request;
 
 class SubmitCodeNotesAction extends BaseAuthenticatedApiAction
 {
+    private const MAX_NOTES_PER_REQUEST = 35000;
+
     protected int $gameId;
     protected array $notes;
 
@@ -31,12 +33,23 @@ class SubmitCodeNotesAction extends BaseAuthenticatedApiAction
             return $this->missingParameters();
         }
 
+        // Reject callers without proper perms before parsing.
+        // Without this, an unauthenticated user could still force the server
+        // to parse a multi-MB payload and build a wide `IN()`.
+        if (!$this->user->can('create', MemoryNote::class)) {
+            return $this->mustBeDeveloper();
+        }
+
         $this->notes = [];
         $this->gameId = request()->integer('g', 0);
         $notes = request()->input('n') ?? '';
         foreach (explode("\n", $notes) as $line) {
             if (empty($line)) {
                 continue;
+            }
+
+            if (count($this->notes) >= self::MAX_NOTES_PER_REQUEST) {
+                return $this->invalidParameter('Too many notes in a single request.');
             }
 
             $index = strpos($line, ':');

--- a/app/Connect/Actions/SubmitCodeNotesAction.php
+++ b/app/Connect/Actions/SubmitCodeNotesAction.php
@@ -13,7 +13,7 @@ use Illuminate\Http\Request;
 
 class SubmitCodeNotesAction extends BaseAuthenticatedApiAction
 {
-    private const MAX_NOTES_PER_REQUEST = 35000;
+    private const MAX_NOTES_PER_REQUEST = 500;
 
     protected int $gameId;
     protected array $notes;
@@ -80,6 +80,8 @@ class SubmitCodeNotesAction extends BaseAuthenticatedApiAction
             ->whereIn('address', array_keys($this->notes))
             ->get();
 
+        $canCreate = $this->user->can('create', MemoryNote::class);
+
         $accessDenied = [];
         $successful = [];
         foreach ($this->notes as $address => $note) {
@@ -96,7 +98,7 @@ class SubmitCodeNotesAction extends BaseAuthenticatedApiAction
                 }
             } else {
                 if (!$memoryNote) {
-                    if (!$this->user->can('create', MemoryNote::class)) {
+                    if (!$canCreate) {
                         $accessDenied[] = $address;
                         continue;
                     }
@@ -106,7 +108,7 @@ class SubmitCodeNotesAction extends BaseAuthenticatedApiAction
                         'address' => $address,
                     ]);
                 } elseif ($memoryNote->trashed()) {
-                    if (!$this->user->can('create', MemoryNote::class)) {
+                    if (!$canCreate) {
                         $accessDenied[] = $address;
                         continue;
                     }

--- a/tests/Feature/Connect/SubmitCodeNotesTest.php
+++ b/tests/Feature/Connect/SubmitCodeNotesTest.php
@@ -313,7 +313,7 @@ describe('developer', function () {
         $game = Game::factory()->create();
 
         $lines = [];
-        for ($i = 1; $i <= 35001; $i++) {
+        for ($i = 1; $i <= 501; $i++) {
             $lines[] = $i . ':Note ' . $i;
         }
 
@@ -569,7 +569,7 @@ describe('non-developer', function () {
         $game = Game::factory()->create();
 
         $lines = [];
-        for ($i = 1; $i <= 35001; $i++) {
+        for ($i = 1; $i <= 501; $i++) {
             $lines[] = $i . ':Note ' . $i;
         }
 

--- a/tests/Feature/Connect/SubmitCodeNotesTest.php
+++ b/tests/Feature/Connect/SubmitCodeNotesTest.php
@@ -531,7 +531,6 @@ describe('non-developer', function () {
          * pre-existing live not and a soft-deleted note to confirm neither
          * is touched by the request.
          */
-
         $game = Game::factory()->create();
         $otherUser = User::factory()->create();
         $live = MemoryNote::create(['game_id' => $game->id, 'user_id' => $otherUser->id, 'address' => 0x1234, 'body' => 'Live']);

--- a/tests/Feature/Connect/SubmitCodeNotesTest.php
+++ b/tests/Feature/Connect/SubmitCodeNotesTest.php
@@ -307,6 +307,30 @@ describe('developer', function () {
 
         $this->assertEquals(0, MemoryNote::count());
     });
+
+    test('cannot submit more notes than the per-request limit', function () {
+        $this->user->assignRole(Role::DEVELOPER);
+        $game = Game::factory()->create();
+
+        $lines = [];
+        for ($i = 1; $i <= 35001; $i++) {
+            $lines[] = $i . ':Note ' . $i;
+        }
+
+        $this->post('dorequest.php', $this->apiParams('submitcodenotes', [
+            'g' => $game->id,
+            'n' => implode("\n", $lines),
+        ]))
+            ->assertStatus(422)
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 422,
+                'Code' => 'invalid_parameter',
+                'Error' => 'Too many notes in a single request.',
+            ]);
+
+        $this->assertEquals(0, MemoryNote::count());
+    });
 });
 
 describe('junior developer', function () {
@@ -500,104 +524,68 @@ describe('junior developer', function () {
 });
 
 describe('non-developer', function () {
-    test('cannot create new memory note', function () {
-        $game = Game::factory()->create();
+    test('is rejected by the developer gate without touching any notes', function () {
+        /**
+         * Non-developers have no MemoryNote capability, so the endpoint must
+         * short-circuit before parsing or querying. The fixture mixes a
+         * pre-existing live not and a soft-deleted note to confirm neither
+         * is touched by the request.
+         */
 
-        $this->post('dorequest.php', $this->apiParams('submitcodenotes', [
-            'g' => $game->id,
-            'n' => "4660:This is a note\n",
-        ]))
-            ->assertStatus(403)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 403,
-                'Code' => 'access_denied',
-                'Error' => 'Access denied.',
-                'SuccessfulAddresses' => [],
-                'AccessDeniedAddresses' => [0x1234],
-            ]);
-
-        $game->refresh();
-        $note = $game->memoryNotes->where('address', 0x1234)->first();
-        $this->assertNull($note);
-    });
-
-    test('cannot update other\'s memory note', function () {
         $game = Game::factory()->create();
         $otherUser = User::factory()->create();
-        $note = MemoryNote::create(['game_id' => $game->id, 'user_id' => $otherUser->id, 'address' => 0x1234, 'body' => 'Test']);
+        $live = MemoryNote::create(['game_id' => $game->id, 'user_id' => $otherUser->id, 'address' => 0x1234, 'body' => 'Live']);
+        $trashed = MemoryNote::create(['game_id' => $game->id, 'user_id' => $otherUser->id, 'address' => 0x1235, 'body' => 'Trashed']);
+        $trashed->delete();
 
         $this->post('dorequest.php', $this->apiParams('submitcodenotes', [
             'g' => $game->id,
-            'n' => "4660:This is a note\n",
+            'n' => "4660:Try to update\n4661:Try to replace\n4662:Try to create\n",
         ]))
             ->assertStatus(403)
             ->assertExactJson([
                 'Success' => false,
                 'Status' => 403,
                 'Code' => 'access_denied',
-                'Error' => 'Access denied.',
-                'SuccessfulAddresses' => [],
-                'AccessDeniedAddresses' => [0x1234],
+                'Error' => 'You must be a developer to perform this action! Please drop a message in the forums to apply.',
             ]);
 
-        $note->refresh();
-        $this->assertNotNull($note);
-        $this->assertEquals('Test', $note->body);
-        $this->assertEquals($otherUser->id, $note->user_id);
+        $live->refresh();
+        $this->assertEquals('Live', $live->body);
+        $this->assertEquals($otherUser->id, $live->user_id);
+        $this->assertFalse($live->trashed());
+
+        $trashed->refresh();
+        $this->assertEquals('Trashed', $trashed->body);
+        $this->assertTrue($trashed->trashed());
+
+        $this->assertNull($game->memoryNotes()->where('address', 0x1236)->first());
     });
 
-    test('cannot delete other\'s memory note', function () {
-        $this->user->assignRole(Role::DEVELOPER_JUNIOR);
+    test('is rejected before parsing an oversized payload', function () {
+        /**
+         * Non-developers must be rejected up front so a potential attacker can't
+         * force unbounded parsing/IN() queries by submitting massive note payloads.
+         */
         $game = Game::factory()->create();
-        $otherUser = User::factory()->create();
-        $note = MemoryNote::create(['game_id' => $game->id, 'user_id' => $otherUser->id, 'address' => 0x1234, 'body' => 'Test']);
+
+        $lines = [];
+        for ($i = 1; $i <= 35001; $i++) {
+            $lines[] = $i . ':Note ' . $i;
+        }
 
         $this->post('dorequest.php', $this->apiParams('submitcodenotes', [
             'g' => $game->id,
-            'n' => "4660:\n",
+            'n' => implode("\n", $lines),
         ]))
             ->assertStatus(403)
             ->assertExactJson([
                 'Success' => false,
                 'Status' => 403,
                 'Code' => 'access_denied',
-                'Error' => 'Access denied.',
-                'SuccessfulAddresses' => [],
-                'AccessDeniedAddresses' => [0x1234],
+                'Error' => 'You must be a developer to perform this action! Please drop a message in the forums to apply.',
             ]);
 
-        $note->refresh();
-        $this->assertNotNull($note);
-        $this->assertEquals('Test', $note->body);
-        $this->assertEquals($otherUser->id, $note->user_id);
-        $this->assertFalse($note->trashed());
-    });
-
-    test('cannot replace other\'s deleted memory note', function () {
-        $game = Game::factory()->create();
-        $otherUser = User::factory()->create();
-        $note = MemoryNote::create(['game_id' => $game->id, 'user_id' => $otherUser->id, 'address' => 0x1234, 'body' => 'Test']);
-        $note->delete();
-
-        $this->post('dorequest.php', $this->apiParams('submitcodenotes', [
-            'g' => $game->id,
-            'n' => "4660:This is a note\n",
-        ]))
-            ->assertStatus(403)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 403,
-                'Code' => 'access_denied',
-                'Error' => 'Access denied.',
-                'SuccessfulAddresses' => [],
-                'AccessDeniedAddresses' => [0x1234],
-            ]);
-
-        $note->refresh();
-        $this->assertNotNull($note);
-        $this->assertEquals('Test', $note->body);
-        $this->assertEquals($otherUser->id, $note->user_id);
-        $this->assertTrue($note->trashed());
+        $this->assertEquals(0, MemoryNote::count());
     });
 });


### PR DESCRIPTION
Cap the max notes in the payload to 35,000 and immediately bail if the user doesn't have the correct perms. cc @Jamiras

Discovered by Codex:

> SubmitCodeNotesAction parses the entire attacker-controlled n parameter into an array without any maximum note count or size validation. It then calls whereIn('address', array_keys($this->notes)) for the full set before determining whether the caller is allowed to create, update, or delete any of those notes. Because BaseAuthenticatedApiAction only requires a valid registered Connect user before initialize/process runs, even a non-developer user can submit a very large list for a valid game and force large in-memory parsing plus a large SQL query/binding set. With typical post_max_size limits, a single request can still contain many thousands of entries and may trigger database placeholder limits, slow queries, high memory use, or repeated 500s. The action should cap the number and total size of submitted notes, validate input before building the query, and preferably reject callers without any memory-note capability before expensive work.