### PR TITLE
chore: update avatar_updated_at migration to be prod-safe

### DIFF
--- a/database/migrations/2026_07_02_233051_add_avatar_updated_at_to_users_table.php
+++ b/database/migrations/2026_07_02_233051_add_avatar_updated_at_to_users_table.php
@@ -9,6 +9,11 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
+        // This column may already exist because it was added directly on some environments to avoid a locking table rebuild.
+        if (Schema::hasColumn('users', 'avatar_updated_at')) {
+            return;
+        }
+
         Schema::table('users', function (Blueprint $table) {
             $table->timestamp('avatar_updated_at')->nullable()->after('muted_until');
         });
@@ -16,6 +21,10 @@ return new class extends Migration {
 
     public function down(): void
     {
+        if (! Schema::hasColumn('users', 'avatar_updated_at')) {
+            return;
+        }
+
         Schema::table('users', function (Blueprint $table) {
             $table->dropColumn('avatar_updated_at');
         });

--- a/database/migrations/2026_07_02_233051_add_avatar_updated_at_to_users_table.php
+++ b/database/migrations/2026_07_02_233051_add_avatar_updated_at_to_users_table.php
@@ -21,7 +21,7 @@ return new class extends Migration {
 
     public function down(): void
     {
-        if (! Schema::hasColumn('users', 'avatar_updated_at')) {
+        if (!Schema::hasColumn('users', 'avatar_updated_at')) {
             return;
         }
 


### PR DESCRIPTION
In stage, this migration caused the build to fail.

I've run/supervised this manually in prod with `ALGORITHM=INSTANT, LOCK=NONE` to mitigate the risk.