### PR TITLE
fix(event): inherit active range from event if not specified on achievement

### DIFF
--- a/app/Platform/Actions/BuildEventShowPagePropsAction.php
+++ b/app/Platform/Actions/BuildEventShowPagePropsAction.php
@@ -77,6 +77,7 @@ class BuildEventShowPagePropsAction
                 'eventAchievements.sourceAchievement.game.system',
                 'eventAchievements.sourceAchievement.game.system.nameShort',
                 'eventAchievements.sourceAchievement.game.system.iconUrl',
+                'eventAchievements.event',
                 'eventAchievements',
                 'eventAwards',
                 'eventAwards.badgeCount',

--- a/app/Platform/Actions/LoadEventWithRelationsAction.php
+++ b/app/Platform/Actions/LoadEventWithRelationsAction.php
@@ -47,6 +47,11 @@ class LoadEventWithRelationsAction
             },
         ]);
 
+        // loop reference back to event for each achievement so a fallback active range can be derived.
+        foreach ($event->achievements as &$achievement) {
+            $achievement->setRelation('event', $event);
+        }
+
         return $event;
     }
 }

--- a/app/Platform/Data/EventData.php
+++ b/app/Platform/Data/EventData.php
@@ -18,6 +18,7 @@ class EventData extends Data
         public int $id,
         public ?Carbon $activeFrom,
         public ?Carbon $activeThrough,
+        public ?Carbon $activeUntil,
         public Lazy|GameData $legacyGame,
         /** @var EventAchievementData[] */
         public Lazy|array $eventAchievements,
@@ -33,6 +34,7 @@ class EventData extends Data
             id: $event->id,
             activeFrom: $event->active_from,
             activeThrough: $event->active_through,
+            activeUntil: $event->active_until,
             legacyGame: Lazy::create(fn () => GameData::fromGame($event->legacyGame)),
 
             eventAchievements: Lazy::create(fn () => $event->achievements->map(
@@ -45,6 +47,7 @@ class EventData extends Data
                     'activeFrom',
                     'activeThrough',
                     'activeUntil',
+                    'event',
                 )
             )->all()),
 

--- a/resources/js/common/utils/getEventAchievementTimeStatus.test.ts
+++ b/resources/js/common/utils/getEventAchievementTimeStatus.test.ts
@@ -206,9 +206,9 @@ describe('Util: getStatus', () => {
     // ARRANGE
     const achievement = createAchievement({ id: 1 });
     const evnt = createRaEvent({
-        activeFrom: dayjs().subtract(1, 'second').toISOString(),
-        activeThrough: dayjs().add(1, 'second').toISOString(),
-        activeUntil: dayjs().add(2, 'second').add(1, 'day').toISOString(),
+      activeFrom: dayjs().subtract(1, 'second').toISOString(),
+      activeThrough: dayjs().add(1, 'second').toISOString(),
+      activeUntil: dayjs().add(2, 'second').add(1, 'day').toISOString(),
     });
 
     const eventAchievements = [
@@ -229,9 +229,9 @@ describe('Util: getStatus', () => {
     // ARRANGE
     const achievement = createAchievement({ id: 1 });
     const evnt = createRaEvent({
-        activeFrom: dayjs().subtract(8, 'days').toISOString(),
-        activeThrough: dayjs().subtract(3, 'days').toISOString(),
-        activeUntil: dayjs().subtract(2, 'days').toISOString(),
+      activeFrom: dayjs().subtract(8, 'days').toISOString(),
+      activeThrough: dayjs().subtract(3, 'days').toISOString(),
+      activeUntil: dayjs().subtract(2, 'days').toISOString(),
     });
 
     const eventAchievements = [
@@ -247,5 +247,4 @@ describe('Util: getStatus', () => {
     // ASSERT
     expect(result).toEqual(1);
   });
-
 });

--- a/resources/js/common/utils/getEventAchievementTimeStatus.test.ts
+++ b/resources/js/common/utils/getEventAchievementTimeStatus.test.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 
-import { createAchievement, createEventAchievement } from '@/test/factories';
+import { createAchievement, createEventAchievement, createRaEvent } from '@/test/factories';
 
 import { getEventAchievementTimeStatus } from './getEventAchievementTimeStatus';
 
@@ -22,9 +22,11 @@ describe('Util: getStatus', () => {
   it('given an achievement that is currently active, returns active status', () => {
     // ARRANGE
     const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({ activeFrom: null, activeThrough: null, activeUntil: null });
     const eventAchievements = [
       createEventAchievement({
         achievement,
+        event: evnt,
         activeFrom: dayjs().subtract(1, 'second').toISOString(),
         activeThrough: dayjs().add(1, 'second').toISOString(),
         activeUntil: dayjs().add(1, 'second').toISOString(),
@@ -44,9 +46,11 @@ describe('Util: getStatus', () => {
     const expiryDate = dayjs().subtract(1, 'second').toISOString();
 
     const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({ activeFrom: null, activeThrough: null, activeUntil: null });
     const eventAchievements: App.Platform.Data.EventAchievement[] = [
       createEventAchievement({
         achievement,
+        event: evnt,
         activeFrom,
         activeThrough: expiryDate,
         activeUntil: expiryDate,
@@ -63,9 +67,11 @@ describe('Util: getStatus', () => {
   it('given an achievement that is upcoming within 30 days, returns upcoming status', () => {
     // ARRANGE
     const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({ activeFrom: null, activeThrough: null, activeUntil: null });
     const eventAchievements = [
       createEventAchievement({
         achievement,
+        event: evnt,
         activeFrom: dayjs().add(15, 'day').toISOString(),
         activeThrough: dayjs().add(20, 'day').toISOString(),
       }),
@@ -81,9 +87,11 @@ describe('Util: getStatus', () => {
   it('given an achievement that is upcoming but more than 30 days away, returns future status', () => {
     // ARRANGE
     const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({ activeFrom: null, activeThrough: null, activeUntil: null });
     const eventAchievements = [
       createEventAchievement({
         achievement,
+        event: evnt,
         activeFrom: dayjs().add(40, 'day').toISOString(),
         activeThrough: dayjs().add(45, 'day').toISOString(),
       }),
@@ -99,9 +107,11 @@ describe('Util: getStatus', () => {
   it('given an achievement with activeUntil different from activeThrough, uses activeUntil for active check', () => {
     // ARRANGE
     const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({ activeFrom: null, activeThrough: null, activeUntil: null });
     const eventAchievements = [
       createEventAchievement({
         achievement,
+        event: evnt,
         activeFrom: dayjs().subtract(1, 'second').toISOString(),
         activeThrough: dayjs().add(1, 'second').toISOString(),
         activeUntil: dayjs().add(2, 'second').add(1, 'day').toISOString(),
@@ -118,9 +128,11 @@ describe('Util: getStatus', () => {
   it('given an achievement where now is after activeThrough but before activeUntil, returns active status', () => {
     // ARRANGE
     const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({ activeFrom: null, activeThrough: null, activeUntil: null });
     const eventAchievements = [
       createEventAchievement({
         achievement,
+        event: evnt,
         activeFrom: dayjs().subtract(2, 'second').toISOString(),
         activeThrough: dayjs().subtract(0.5, 'second').toISOString(), // already passed
         activeUntil: dayjs().add(1, 'second').add(1, 'day').toISOString(), // still active
@@ -133,4 +145,107 @@ describe('Util: getStatus', () => {
     // ASSERT
     expect(result).toEqual(0);
   });
+
+  it('given an achievement with no start or end date, returns evergreen status', () => {
+    // ARRANGE
+    const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({ activeFrom: null, activeThrough: null, activeUntil: null });
+    const eventAchievements = [
+      createEventAchievement({
+        achievement,
+        event: evnt,
+      }),
+    ];
+
+    // ACT
+    const result = getEventAchievementTimeStatus(achievement, eventAchievements);
+
+    // ASSERT
+    expect(result).toEqual(4);
+  });
+
+  it('given an achievement with no end date and past the start date, returns evergreen status', () => {
+    // ARRANGE
+    const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({ activeFrom: null, activeThrough: null, activeUntil: null });
+    const eventAchievements = [
+      createEventAchievement({
+        achievement,
+        event: evnt,
+        activeFrom: dayjs().subtract(2, 'second').toISOString(),
+      }),
+    ];
+
+    // ACT
+    const result = getEventAchievementTimeStatus(achievement, eventAchievements);
+
+    // ASSERT
+    expect(result).toEqual(4);
+  });
+
+  it('given an achievement with no end date but not past the start date, returns upcoming status', () => {
+    // ARRANGE
+    const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({ activeFrom: null, activeThrough: null, activeUntil: null });
+    const eventAchievements = [
+      createEventAchievement({
+        achievement,
+        event: evnt,
+        activeFrom: dayjs().add(2, 'days').toISOString(),
+      }),
+    ];
+
+    // ACT
+    const result = getEventAchievementTimeStatus(achievement, eventAchievements);
+
+    // ASSERT
+    expect(result).toEqual(2);
+  });
+
+  it('given an achievement with no start or end dates, but event has active start and end dates, returns active status', () => {
+    // ARRANGE
+    const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({
+        activeFrom: dayjs().subtract(1, 'second').toISOString(),
+        activeThrough: dayjs().add(1, 'second').toISOString(),
+        activeUntil: dayjs().add(2, 'second').add(1, 'day').toISOString(),
+    });
+
+    const eventAchievements = [
+      createEventAchievement({
+        achievement,
+        event: evnt,
+      }),
+    ];
+
+    // ACT
+    const result = getEventAchievementTimeStatus(achievement, eventAchievements);
+
+    // ASSERT
+    expect(result).toEqual(0);
+  });
+
+  it('given an achievement with no start or end dates, but event has end date in the past, returns expired status', () => {
+    // ARRANGE
+    const achievement = createAchievement({ id: 1 });
+    const evnt = createRaEvent({
+        activeFrom: dayjs().subtract(8, 'days').toISOString(),
+        activeThrough: dayjs().subtract(3, 'days').toISOString(),
+        activeUntil: dayjs().subtract(2, 'days').toISOString(),
+    });
+
+    const eventAchievements = [
+      createEventAchievement({
+        achievement,
+        event: evnt,
+      }),
+    ];
+
+    // ACT
+    const result = getEventAchievementTimeStatus(achievement, eventAchievements);
+
+    // ASSERT
+    expect(result).toEqual(1);
+  });
+
 });

--- a/resources/js/common/utils/getEventAchievementTimeStatus.ts
+++ b/resources/js/common/utils/getEventAchievementTimeStatus.ts
@@ -23,29 +23,41 @@ export function getEventAchievementTimeStatus(
   eventAchievements?: App.Platform.Data.EventAchievement[],
 ): EventAchievementTimeStatus {
   const eventAchievement = eventAchievements?.find((ea) => ea.achievement?.id === achievement.id);
-  if (!eventAchievement?.activeFrom || !eventAchievement?.activeThrough) {
+  if (!eventAchievement) {
+    // Not found. Assume it's not restricted.
     return eventAchievementTimeStatus.evergreen;
   }
 
   const now = dayjs.utc();
-  const activeFrom = dayjs.utc(eventAchievement.activeFrom);
-  const activeThrough = dayjs.utc(eventAchievement.activeThrough);
-  const activeUntil = dayjs.utc(eventAchievement.activeUntil);
+  const activeFrom = eventAchievement.activeFrom ?? eventAchievement.event?.activeFrom;
+  if (activeFrom) {
+    const activeFromDate = dayjs.utc(activeFrom);
 
-  if (activeFrom.isSameOrBefore(now) && now.isBefore(activeUntil)) {
-    return eventAchievementTimeStatus.active;
+    if (activeFromDate.isAfter(now)) {
+      // Not active yet.
+      const thirtyDaysFromNow = now.add(30, 'day');
+      if (activeFromDate.isSameOrBefore(thirtyDaysFromNow)) {
+        // 30 days or less until before it becomes active.
+        return eventAchievementTimeStatus.upcoming;
+      }
+
+      // More than 30 days before it becomes active.
+      return eventAchievementTimeStatus.future;
+    }
   }
 
-  // Check if upcoming is within the next 30 days.
-  const thirtyDaysFromNow = now.add(30, 'day');
-  if (activeFrom.isAfter(now) && activeFrom.isSameOrBefore(thirtyDaysFromNow)) {
-    return eventAchievementTimeStatus.upcoming;
+  const activeUntil = eventAchievement.activeUntil ?? eventAchievement.event?.activeUntil;
+  if (!activeUntil) {
+    // Active with no end date.
+    return eventAchievementTimeStatus.evergreen;
   }
 
-  if (activeThrough.isBefore(now)) {
+  const activeUntilDate = dayjs.utc(activeUntil);
+  if (activeUntilDate.isBefore(now)) {
+    // No longer active.
     return eventAchievementTimeStatus.expired;
   }
 
-  // More than 30 days away.
-  return eventAchievementTimeStatus.future;
+  // Active.
+  return eventAchievementTimeStatus.active;
 }

--- a/resources/js/test/factories/createRaEvent.ts
+++ b/resources/js/test/factories/createRaEvent.ts
@@ -13,7 +13,7 @@ export const createRaEvent = createFactory<App.Platform.Data.Event>((faker) => {
     legacyGame: createGame(),
     activeFrom: faker.date.past().toISOString(),
     activeThrough: activeThrough.toISOString(),
-    activeUntil: new Date(activeThrough.getDate() + 1).toISOString(),
+    activeUntil: new Date(activeThrough.getTime() + 24 * 60 * 60 * 1000).toISOString(),
     state: faker.helpers.arrayElement(['active', 'evergreen', 'concluded']),
   };
 });

--- a/resources/js/test/factories/createRaEvent.ts
+++ b/resources/js/test/factories/createRaEvent.ts
@@ -7,11 +7,13 @@ import { createGame } from './createGame';
  * share the same name, IDEs get very confused.
  */
 export const createRaEvent = createFactory<App.Platform.Data.Event>((faker) => {
+  const activeThrough = faker.date.future();
   return {
     id: faker.number.int({ min: 1, max: 10000 }),
     legacyGame: createGame(),
     activeFrom: faker.date.past().toISOString(),
-    activeThrough: faker.date.future().toISOString(),
+    activeThrough: activeThrough.toISOString(),
+    activeUntil: new Date(activeThrough.getDate() + 1).toISOString(),
     state: faker.helpers.arrayElement(['active', 'evergreen', 'concluded']),
   };
 });

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -676,6 +676,7 @@ export type Event = {
 id: number;
 activeFrom: string | null;
 activeThrough: string | null;
+activeUntil: string | null;
 legacyGame?: App.Platform.Data.Game;
 eventAchievements?: Array<App.Platform.Data.EventAchievement>;
 eventAwards?: Array<App.Platform.Data.EventAward>;


### PR DESCRIPTION
Given an event with an end date, but an event acheivement without an end date, the achievement should still be classified as active instead of evergreen.

https://discord.com/channels/310192285306454017/1513336624690233414/1524930667560042640