### PR TITLE
feat(event): allow game hash to specify system returned in patch data

### DIFF
--- a/app/Connect/Actions/GetAchievementSetsAction.php
+++ b/app/Connect/Actions/GetAchievementSetsAction.php
@@ -94,6 +94,12 @@ class GetAchievementSetsAction extends BaseAuthenticatedApiAction
             return $this->gameNotFound();
         }
 
+        // if the game hash specifies a system id, use it instead of whatever is in the game record.
+        // this primarily allows for "event game" records where the game record is associated to System::Events.
+        if ($gameHash?->system_id) {
+            $response['ConsoleId'] = $gameHash->system_id;
+        }
+
         if ($this->clientSupportLevel !== ClientSupportLevel::Full && $game->achievements_published > 0) {
             if ($this->clientSupportLevel === ClientSupportLevel::Blocked) {
                 $this->replaceWithBlockedCoreWarning($response);

--- a/app/Connect/Support/GeneratesConnectWarnings.php
+++ b/app/Connect/Support/GeneratesConnectWarnings.php
@@ -7,6 +7,7 @@ namespace App\Connect\Support;
 use App\Enums\ClientSupportLevel;
 use App\Models\ConnectWarning;
 use App\Models\Game;
+use App\Models\System;
 use App\Platform\Services\UserAgentService;
 use App\Support\Alerts\SuspiciousConnectWarningAlert;
 use Carbon\Carbon;
@@ -48,7 +49,7 @@ trait GeneratesConnectWarnings
 
             default:
                 $emulatorUserAgent = $userAgentService->getEmulatorUserAgent($this->userAgent);
-                if ($emulatorUserAgent) {
+                if ($emulatorUserAgent && $game->system_id !== System::Events) {
                     $supportedSystemCount = $emulatorUserAgent->emulator->systems()->count();
                     if ($supportedSystemCount > 0 && $supportedSystemCount < 5) {
                         // if the emulator only supports a handful of systems, and the game is not

--- a/tests/Feature/Connect/AchievementSetsTest.php
+++ b/tests/Feature/Connect/AchievementSetsTest.php
@@ -481,7 +481,7 @@ describe('Non multi-set', function () {
         $game = $data['game'];
         $achievementSet = $game->achievementSets()->first();
         $gameHash = AchievementSetsTestHelpers::createGameHash($game);
-        $gameHash->system_id = $game->system_id;
+        $this->assertEquals($game->system_id, $gameHash->system_id);
         $game->system_id = System::Events;
         $game->save();
 

--- a/tests/Feature/Connect/AchievementSetsTest.php
+++ b/tests/Feature/Connect/AchievementSetsTest.php
@@ -475,6 +475,59 @@ describe('Non multi-set', function () {
             ]);
     });
 
+    test('returns console id from hash for non-game system', function () {
+        $data = AchievementSetsTestHelpers::createGameWithUnpromotedAchievements();
+        System::factory()->create(['id' => System::Events]);
+        $game = $data['game'];
+        $achievementSet = $game->achievementSets()->first();
+        $gameHash = AchievementSetsTestHelpers::createGameHash($game);
+        $gameHash->system_id = $game->system_id;
+        $game->system_id = System::Events;
+        $game->save();
+
+        $this->withHeaders(['User-Agent' => $this->userAgentValid])
+            ->get($this->apiUrl('achievementsets', ['m' => $gameHash->md5]))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'GameId' => $game->id,
+                'Title' => $game->title,
+                'ImageIconUrl' => media_asset($game->image_icon_asset_path),
+                'ConsoleId' => $gameHash->system_id,
+                'RichPresenceGameId' => $game->id,
+                'RichPresencePatch' => $game->trigger_definition,
+                'Sets' => [
+                    [
+                        'AchievementSetId' => $achievementSet->id,
+                        'Title' => null, // request by hash engages multiset code, which returns null for the core set title
+                        'Type' => 'core',
+                        'GameId' => $game->id,
+                        'ImageIconUrl' => media_asset($game->image_icon_asset_path),
+                        'Achievements' => [
+                            AchievementSetsTestHelpers::getAchievementPatchData($data['achievements'][0]), // DisplayOrder: 1
+                            AchievementSetsTestHelpers::getAchievementPatchData($data['achievements'][2]), // DisplayOrder: 2
+                            AchievementSetsTestHelpers::getAchievementPatchData($data['achievements'][1]), // DisplayOrder: 3
+                            AchievementSetsTestHelpers::getAchievementPatchData($data['achievements'][6]), // DisplayOrder: 4
+                            AchievementSetsTestHelpers::getAchievementPatchData($data['achievements'][3]), // DisplayOrder: 5
+                            AchievementSetsTestHelpers::getAchievementPatchData($data['achievements'][4]), // DisplayOrder: 6 (unpromoted)
+                            AchievementSetsTestHelpers::getAchievementPatchData($data['achievements'][5]), // DisplayOrder: 7
+                            AchievementSetsTestHelpers::getAchievementPatchData($data['achievements'][7]), // DisplayOrder: 8 (unpromoted)
+                            AchievementSetsTestHelpers::getAchievementPatchData($data['achievements'][8]), // DisplayOrder: 9
+                        ],
+                        'Leaderboards' => [
+                            AchievementSetsTestHelpers::getLeaderboardPatchData($data['leaderboards'][2]), // DisplayOrder: -1
+                            AchievementSetsTestHelpers::getLeaderboardPatchData($data['leaderboards'][1]), // DisplayOrder: 1
+                            AchievementSetsTestHelpers::getLeaderboardPatchData($data['leaderboards'][0]), // DisplayOrder: 2
+                            // leaderboards[3] is unpromoted - have to specifically ask for those as older clients don't check state
+                            // leaderboards[4] is disabled - it should never be returned to any client
+                        ],
+                    ],
+                ],
+            ]);
+
+        $this->assertNotEquals($gameHash->system_id, System::Events);
+    });
+
     test('only returns published data for a given id', function () {
         $data = AchievementSetsTestHelpers::createGameWithUnpromotedAchievements();
         $game = $data['game'];

--- a/tests/Feature/Connect/AwardAchievementTest.php
+++ b/tests/Feature/Connect/AwardAchievementTest.php
@@ -2724,6 +2724,60 @@ describe('validation', function () {
         });
     });
 
+    test('user agent for incorrect system for event game does not generate warning', function () {
+        $data = AwardAchievementTestHelpers::createGame();
+        System::factory()->create(['id' => System::Events]);
+        $game = $data['game'];
+        $game->system_id = System::Events;
+        $game->save();
+        $achievement1 = $data['achievements'][0];
+        $achievement3 = $data['achievements'][2];
+        $gameHash = $data['gameHash'];
+        $now = Carbon::now();
+
+        $unlock1Date = $now->clone()->subMinutes(65);
+        $this->addHardcoreUnlock($this->user, $achievement1, $unlock1Date, $gameHash);
+
+        // $userAgentValid is associated to the "Test Client". Attach a differing system to that.
+        $otherSystem = System::factory()->create();
+        Emulator::where('name', 'Test Client')->first()->systems()->attach($otherSystem->id);
+
+        // do the hardcore unlock
+        $validationHash = AwardAchievementTestHelpers::buildValidationHash($achievement3, $this->user, 1);
+        $scoreBefore = $this->user->points_hardcore;
+        $casualScoreBefore = $this->user->points;
+        $truePointsBefore = $this->user->points_weighted;
+
+        $this->withHeaders(['User-Agent' => $this->userAgentValid])
+            ->get($this->apiUrl('awardachievement', [
+                'a' => $achievement3->id,
+                'h' => 1,
+                'm' => $gameHash->md5,
+                'v' => $validationHash,
+            ]))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'AchievementID' => $achievement3->id,
+                'AchievementsRemaining' => 4,
+                'Score' => $scoreBefore, // event achievement does not award points
+                'SoftcoreScore' => $casualScoreBefore,
+            ]);
+        $this->user->refresh();
+
+        // achievement unlock should go through as hardcore
+        $this->assertHasCasualUnlock($this->user, $achievement3);
+        $this->assertHasHardcoreUnlock($this->user, $achievement3);
+
+        // player score should not have increased
+        $user1 = User::whereName($this->user->username)->first();
+        $this->assertEquals($scoreBefore, $user1->points_hardcore);
+        $this->assertEquals($casualScoreBefore, $user1->points);
+
+        // smell should not be captured
+        $this->assertEquals(0, ConnectWarning::count());
+    });
+
     test('user agent for incorrect system on multi-system client does not generate warning', function () {
         $data = AwardAchievementTestHelpers::createGame();
         $game = $data['game'];


### PR DESCRIPTION
There's currently an issue with the [Find the Pixel: Pokemon Emerald](https://retroachievements.org/event/221-find-the-pixel-pokemon-emerald) event wherein the achievements don't unlock in RetroArch. This is because RetroArch relies on the system_id in the patch response to tell it which memory map to apply, and there is no memory map for the Events system_id. As a result, it maps a chunk of system memory followed by a chunk of sram. That works for the SNES, but not for GBA, where there's two system memory chunks that need to be mapped.

This PR attempts to address the issue by returning the game hash's system_id when it is set. For now, just the three event games will have system ids added to the game hash as follows:
```
update game_hashes set system_id=3 where game_id in (23117,33104);
update game_hashes set system_id=5 where game_id=38687;
```

This PR also suppresses the warnings being logged when emulators unlock these achievements as emulators cannot be associated  to the Events console.