### PR TITLE
feat(connect): pass avatar_updated_at to client

### DIFF
--- a/app/Connect/Actions/GetFriendListAction.php
+++ b/app/Connect/Actions/GetFriendListAction.php
@@ -8,6 +8,7 @@ use App\Connect\Support\BaseAuthenticatedApiAction;
 use App\Enums\Permissions;
 use App\Models\Game;
 use App\Models\PlayerSession;
+use App\Support\Media\UserAvatarUrl;
 use Illuminate\Http\Request;
 
 class GetFriendListAction extends BaseAuthenticatedApiAction
@@ -98,7 +99,7 @@ class GetFriendListAction extends BaseAuthenticatedApiAction
         foreach ($friends as $friend) {
             $entry = [
                 'Friend' => $friend->display_name,
-                'AvatarUrl' => media_asset('UserPic/' . $friend->username . '.png'),
+                'AvatarUrl' => UserAvatarUrl::canonical($friend->username),
                 'AvatarUpdatedAt' => $friend->avatar_updated_at?->unix() ?? 0,
                 'RAPoints' => $friend->points_hardcore,
                 'LastSeen' => empty($friend->rich_presence) ? 'Unknown' : strip_tags($friend->rich_presence),

--- a/app/Connect/Actions/GetFriendListAction.php
+++ b/app/Connect/Actions/GetFriendListAction.php
@@ -39,6 +39,7 @@ class GetFriendListAction extends BaseAuthenticatedApiAction
                 'users.rich_presence_updated_at',
                 'users.last_activity_at',
                 'users.rich_presence_game_id',
+                'users.avatar_updated_at',
             ])
             ->get();
 
@@ -98,6 +99,7 @@ class GetFriendListAction extends BaseAuthenticatedApiAction
             $entry = [
                 'Friend' => $friend->display_name,
                 'AvatarUrl' => media_asset('UserPic/' . $friend->username . '.png'),
+                'AvatarUpdatedAt' => $friend->avatar_updated_at?->unix() ?? 0,
                 'RAPoints' => $friend->points_hardcore,
                 'LastSeen' => empty($friend->rich_presence) ? 'Unknown' : strip_tags($friend->rich_presence),
                 'LastSeenTime' => ($friend->rich_presence_updated_at ?? $friend->last_activity_at)?->unix(),

--- a/app/Connect/Actions/LoginAction.php
+++ b/app/Connect/Actions/LoginAction.php
@@ -146,6 +146,7 @@ class LoginAction extends BaseApiAction
             'Success' => true,
             'User' => $user->display_name,
             'AvatarUrl' => UserAvatarUrl::canonical($user->username),
+            'AvatarUpdatedAt' => $user->avatar_updated_at?->unix() ?? 0,
             'Token' => $user->connect_token,
             'Score' => $user->points_hardcore,
             'SoftcoreScore' => $user->points,

--- a/tests/Feature/Connect/GetFriendListTest.php
+++ b/tests/Feature/Connect/GetFriendListTest.php
@@ -9,55 +9,87 @@ use App\Enums\Permissions;
 use App\Models\Game;
 use App\Models\PlayerSession;
 use App\Models\User;
+use App\Models\UserRelation;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
-use Tests\TestCase;
 
-class GetFriendListTest extends TestCase
+uses(LazilyRefreshDatabase::class);
+uses(TestsConnect::class);
+
+class GetFriendListTestHelpers
 {
-    use BootstrapsConnect;
-    use RefreshDatabase;
-
-    public function testGetFriendList(): void
+    public static function createUser(Game $game, string $richPresence, Carbon $richPresenceUpdatedAt): User
     {
-        $date1 = Carbon::parse('2020-10-02 06:18:11');
-        $date2 = Carbon::parse('2024-03-05 17:53:03');
-        $date3 = Carbon::parse('2024-05-27 13:36:42');
+        return User::factory()->create([
+            'rich_presence_game_id' => $game->id,
+            'rich_presence' => $richPresence,
+            'rich_presence_updated_at' => $richPresenceUpdatedAt,
+        ]);
+    }
 
-        /** @var Game $game1 */
-        $game1 = $this->seedGame();
-        /** @var Game $game2 */
-        $game2 = $this->seedGame();
+    public static function createSession(User $user, Game $game, string $richPresence, Carbon $richPresenceUpdatedAt): void
+    {
+        PlayerSession::factory()->create([
+            'user_id' => $user->id,
+            'game_id' => $game->id,
+            'rich_presence' => $richPresence,
+            'rich_presence_updated_at' => $richPresenceUpdatedAt,
+        ]);
+    }
 
-        /** @var User $user2 */
-        $user2 = User::factory()->create();
-        /** @var User $user3 */
-        $user3 = User::factory()->create();
-        /** @var User $user4 */
-        $user4 = User::factory()->create();
-        /** @var User $user5 */
-        $user5 = User::factory()->create();
-        /** @var User $user6 */
-        $user6 = User::factory()->create();
+    public static function followUser(User $user, User $userToFollow): void
+    {
+        UserRelation::create([
+            'user_id' => $user->id,
+            'related_user_id' => $userToFollow->id,
+            'status' => UserRelationStatus::Following,
+        ]);
+    }
 
-        // no followed users
+    public static function unfollowUser(User $user, User $userToFollow): void
+    {
+        UserRelation::create([
+            'user_id' => $user->id,
+            'related_user_id' => $userToFollow->id,
+            'status' => UserRelationStatus::NotFollowing,
+        ]);
+    }
+
+    public static function blockUser(User $user, User $userToFollow): void
+    {
+        UserRelation::create([
+            'user_id' => $user->id,
+            'related_user_id' => $userToFollow->id,
+            'status' => UserRelationStatus::Blocked,
+        ]);
+    }
+}
+
+beforeEach(function () {
+    Carbon::setTestNow(Carbon::now()->startOfSecond());
+
+    $this->createConnectUser();
+});
+
+describe('get followed user activity', function () {
+    test('no followed users', function () {
         $this->get($this->apiUrl('getfriendlist'))
             ->assertStatus(200)
             ->assertExactJson([
                 'Success' => true,
                 'Friends' => [],
             ]);
+    });
 
-        // user2 is playing game1
-        $user2->rich_presence_game_id = $game1->id;
-        $user2->rich_presence = "Running through a forest";
-        $user2->rich_presence_updated_at = $date1;
-        $user2->save();
-
-        // user is following user2 (legacy RP - no session)
-        changeFriendStatus($this->user, $user2, UserRelationStatus::Following);
+    test('rich presence from session', function () {
+        $game1 = Game::factory()->create();
+        $date1 = Carbon::parse('2020-10-02 06:18:11');
+        $date2 = Carbon::parse('2024-03-05 17:53:03');
+        $user2 = GetFriendListTestHelpers::createUser($game1, 'Running through a forest', $date1);
+        GetFriendListTestHelpers::createSession($user2, $game1, 'Titles', $date2);
+        GetFriendListTestHelpers::followUser($this->user, $user2);
 
         $this->get($this->apiUrl('getfriendlist'))
             ->assertStatus(200)
@@ -67,60 +99,34 @@ class GetFriendListTest extends TestCase
                     [
                         'Friend' => $user2->display_name,
                         'AvatarUrl' => $user2->avatar_url,
+                        'AvatarUpdatedAt' => 0,
                         'RAPoints' => $user2->points_hardcore,
-                        'LastSeen' => $user2->rich_presence,
-                        'LastSeenTime' => $date1->unix(),
-                        'LastGameId' => $game1->id,
-                        'LastGameTitle' => $game1->title,
-                        'LastGameIconUrl' => $game1->badge_url,
-                    ],
-                ],
-            ]);
-
-        // user3 is playing game2
-        $user3->rich_presence_game_id = $game2->id;
-        $user3->rich_presence = "Killing everything";
-        $user3->rich_presence_updated_at = $date2->clone()->subMinutes(45);
-        $user3->save();
-
-        PlayerSession::factory()->create([
-            'user_id' => $user3->id,
-            'game_id' => $game2->id,
-            'rich_presence' => "Titles",
-            'rich_presence_updated_at' => $date2,
-        ]);
-
-        // user4 is playing game2
-        $user4->rich_presence_game_id = $game2->id;
-        $user4->rich_presence = "Killing everything";
-        $user4->rich_presence_updated_at = $date3;
-        $user4->setAttribute('Permissions', Permissions::Banned);
-        $user4->save();
-
-        // user is following user3 (RP from session)
-        changeFriendStatus($this->user, $user3, UserRelationStatus::Following);
-
-        // user is following user4 (banned - should not be returned)
-        changeFriendStatus($this->user, $user4, UserRelationStatus::Following);
-
-        $this->get($this->apiUrl('getfriendlist'))
-            ->assertStatus(200)
-            ->assertExactJson([
-                'Success' => true,
-                'Friends' => [
-                    [
-                        'Friend' => $user3->display_name,
-                        'AvatarUrl' => $user3->avatar_url,
-                        'RAPoints' => $user3->points_hardcore,
-                        'LastSeen' => "Titles",
+                        'LastSeen' => 'Titles', // session rp is given preference
                         'LastSeenTime' => $date2->unix(),
-                        'LastGameId' => $game2->id,
-                        'LastGameTitle' => $game2->title,
-                        'LastGameIconUrl' => $game2->badge_url,
+                        'LastGameId' => $game1->id,
+                        'LastGameTitle' => $game1->title,
+                        'LastGameIconUrl' => $game1->badge_url,
                     ],
+                ],
+            ]);
+    });
+
+    test('rich presence without session', function () {
+        $game1 = Game::factory()->create();
+        $date1 = Carbon::parse('2020-10-02 06:18:11');
+        $user2 = GetFriendListTestHelpers::createUser($game1, 'Running through a forest', $date1);
+        GetFriendListTestHelpers::followUser($this->user, $user2);
+
+        // some users may not have played since we started tracking sessions
+        $this->get($this->apiUrl('getfriendlist'))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'Friends' => [
                     [
                         'Friend' => $user2->display_name,
                         'AvatarUrl' => $user2->avatar_url,
+                        'AvatarUpdatedAt' => 0,
                         'RAPoints' => $user2->points_hardcore,
                         'LastSeen' => $user2->rich_presence,
                         'LastSeenTime' => $date1->unix(),
@@ -130,22 +136,12 @@ class GetFriendListTest extends TestCase
                     ],
                 ],
             ]);
+    });
 
-        // user5 is playing game2
-        $user5->rich_presence_game_id = $game2->id;
-        $user5->rich_presence = "Killing everything";
-        $user5->rich_presence_updated_at = $date3;
-        $user5->save();
-
-        // user5 is following user (inverse relationship)
-        changeFriendStatus($user5, $this->user, UserRelationStatus::Following);
-
-        // user6 has no activity
-        $user6->last_activity_at = $date3;
-        $user6->save();
-
-        // user is following user6 (legacy RP - no session)
-        changeFriendStatus($this->user, $user6, UserRelationStatus::Following);
+    test('no rich presence', function () {
+        $date1 = Carbon::parse('2020-10-02 06:18:11');
+        $user2 = User::factory()->create(['last_activity_at' => $date1]);
+        GetFriendListTestHelpers::followUser($this->user, $user2);
 
         $this->get($this->apiUrl('getfriendlist'))
             ->assertStatus(200)
@@ -153,21 +149,50 @@ class GetFriendListTest extends TestCase
                 'Success' => true,
                 'Friends' => [
                     [
-                        'Friend' => $user6->display_name,
-                        'AvatarUrl' => $user6->avatar_url,
-                        'RAPoints' => $user6->points_hardcore,
+                        'Friend' => $user2->display_name,
+                        'AvatarUrl' => $user2->avatar_url,
+                        'AvatarUpdatedAt' => 0,
+                        'RAPoints' => $user2->points_hardcore,
                         'LastSeen' => 'Unknown',
-                        'LastSeenTime' => $date3->unix(),
+                        'LastSeenTime' => $date1->unix(),
                         'LastGameId' => null,
                         'LastGameTitle' => null,
                         'LastGameIconUrl' => null,
                     ],
+                ],
+            ]);
+    });
+
+    test('multiple friends', function () {
+        $game1 = Game::factory()->create();
+        $game2 = Game::factory()->create();
+        $date1 = Carbon::parse('2020-10-02 06:18:11');
+        $date2 = Carbon::parse('2024-03-05 17:53:03');
+        $date3 = Carbon::parse('2024-05-27 13:36:42');
+        $user2 = GetFriendListTestHelpers::createUser($game1, 'Running through a forest', $date1);
+        GetFriendListTestHelpers::createSession($user2, $game1, 'Titles', $date2);
+        GetFriendListTestHelpers::followUser($this->user, $user2);
+        $user3 = GetFriendListTestHelpers::createUser($game2, 'Killing everything', $date3);
+        GetFriendListTestHelpers::createSession($user3, $game2, 'Killing everything', $date3);
+        GetFriendListTestHelpers::followUser($this->user, $user3);
+        $user4 = GetFriendListTestHelpers::createUser($game2, 'Killing everything', $date1);
+        GetFriendListTestHelpers::createSession($user3, $game2, 'Killing everything', $date1);
+        GetFriendListTestHelpers::followUser($this->user, $user4);
+        $user3->avatar_updated_at = $date2;
+        $user3->save();
+
+        $this->get($this->apiUrl('getfriendlist'))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'Friends' => [ // newest activity first
                     [
                         'Friend' => $user3->display_name,
-                        'AvatarUrl' => $user3->avatar_url,
+                        'AvatarUrl' => media_asset("UserPic/{$user3->username}.png"), // version not included in avatar url
+                        'AvatarUpdatedAt' => $date2->unix(),
                         'RAPoints' => $user3->points_hardcore,
-                        'LastSeen' => "Titles",
-                        'LastSeenTime' => $date2->unix(),
+                        'LastSeen' => $user3->rich_presence,
+                        'LastSeenTime' => $date3->unix(),
                         'LastGameId' => $game2->id,
                         'LastGameTitle' => $game2->title,
                         'LastGameIconUrl' => $game2->badge_url,
@@ -175,49 +200,96 @@ class GetFriendListTest extends TestCase
                     [
                         'Friend' => $user2->display_name,
                         'AvatarUrl' => $user2->avatar_url,
+                        'AvatarUpdatedAt' => 0,
                         'RAPoints' => $user2->points_hardcore,
-                        'LastSeen' => $user2->rich_presence,
-                        'LastSeenTime' => $date1->unix(),
+                        'LastSeen' => 'Titles', // session rp is given preference
+                        'LastSeenTime' => $date2->unix(),
                         'LastGameId' => $game1->id,
                         'LastGameTitle' => $game1->title,
                         'LastGameIconUrl' => $game1->badge_url,
                     ],
-                ],
-            ]);
-
-        // user6 is playing game 2
-        $user6->rich_presence_game_id = $game2->id;
-        $user6->rich_presence = "Killing everything";
-        $user6->rich_presence_updated_at = $date3;
-        $user6->save();
-
-        // user has stopped following user2
-        changeFriendStatus($this->user, $user2, UserRelationStatus::NotFollowing);
-
-        // user has blocked user3
-        changeFriendStatus($this->user, $user3, UserRelationStatus::NotFollowing);
-
-        $this->get($this->apiUrl('getfriendlist'))
-            ->assertStatus(200)
-            ->assertExactJson([
-                'Success' => true,
-                'Friends' => [
                     [
-                        'Friend' => $user6->display_name,
-                        'AvatarUrl' => $user6->avatar_url,
-                        'RAPoints' => $user6->points_hardcore,
-                        'LastSeen' => $user6->rich_presence,
-                        'LastSeenTime' => $date3->unix(),
+                        'Friend' => $user4->display_name,
+                        'AvatarUrl' => $user4->avatar_url,
+                        'AvatarUpdatedAt' => 0,
+                        'RAPoints' => $user4->points_hardcore,
+                        'LastSeen' => $user4->rich_presence,
+                        'LastSeenTime' => $date1->unix(),
                         'LastGameId' => $game2->id,
                         'LastGameTitle' => $game2->title,
                         'LastGameIconUrl' => $game2->badge_url,
                     ],
                 ],
             ]);
-    }
+    });
 
-    public function testSqlLeak(): void
-    {
+    test('banned user is not returned', function () {
+        $game1 = Game::factory()->create();
+        $date1 = Carbon::parse('2020-10-02 06:18:11');
+        $user2 = GetFriendListTestHelpers::createUser($game1, 'Running through a forest', $date1);
+        GetFriendListTestHelpers::followUser($this->user, $user2);
+
+        $user2->Permissions = Permissions::Banned;
+        $user2->banned_at = Carbon::now()->subDays(8);
+        $user2->save();
+
+        // some users may not have played since we started tracking sessions
+        $this->get($this->apiUrl('getfriendlist'))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'Friends' => [],
+            ]);
+    });
+
+    test('unfollowed user is not returned', function () {
+        $game1 = Game::factory()->create();
+        $date1 = Carbon::parse('2020-10-02 06:18:11');
+        $user2 = GetFriendListTestHelpers::createUser($game1, 'Running through a forest', $date1);
+        GetFriendListTestHelpers::unfollowUser($user2, $this->user);
+
+        // some users may not have played since we started tracking sessions
+        $this->get($this->apiUrl('getfriendlist'))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'Friends' => [],
+            ]);
+    });
+
+    test('blocked user is not returned', function () {
+        $game1 = Game::factory()->create();
+        $date1 = Carbon::parse('2020-10-02 06:18:11');
+        $user2 = GetFriendListTestHelpers::createUser($game1, 'Running through a forest', $date1);
+        GetFriendListTestHelpers::blockUser($user2, $this->user);
+
+        // some users may not have played since we started tracking sessions
+        $this->get($this->apiUrl('getfriendlist'))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'Friends' => [],
+            ]);
+    });
+
+    test('user following caller is not returned', function () {
+        $game1 = Game::factory()->create();
+        $date1 = Carbon::parse('2020-10-02 06:18:11');
+        $user2 = GetFriendListTestHelpers::createUser($game1, 'Running through a forest', $date1);
+        GetFriendListTestHelpers::followUser($user2, $this->user);
+
+        // some users may not have played since we started tracking sessions
+        $this->get($this->apiUrl('getfriendlist'))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'Friends' => [],
+            ]);
+    });
+});
+
+describe('validation', function () {
+    test('sql error does not leak sql', function () {
         // change the column name to force a query failure
         Schema::table('users', function (Blueprint $table) {
             $table->renameColumn('rich_presence', 'broken');
@@ -243,5 +315,5 @@ class GetFriendListTest extends TestCase
         $this->assertStringNotContainsStringIgnoringCase('INSERT', $errorMessage);
         $this->assertStringNotContainsStringIgnoringCase('FROM', $errorMessage);
         $this->assertStringNotContainsStringIgnoringCase('WHERE', $errorMessage);
-    }
-}
+    });
+});

--- a/tests/Feature/Connect/LoginTest.php
+++ b/tests/Feature/Connect/LoginTest.php
@@ -6,41 +6,36 @@ namespace Tests\Feature\Connect;
 
 use App\Enums\Permissions;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
-use Tests\TestCase;
 
-class LoginTest extends TestCase
-{
-    use BootstrapsConnect;
-    use RefreshDatabase;
+uses(LazilyRefreshDatabase::class);
+uses(TestsConnect::class);
 
-    public function testLogin(): void
-    {
-        Carbon::setTestNow(Carbon::now());
+beforeEach(function () {
+    Carbon::setTestNow(Carbon::now()->startOfSecond());
+
+    $this->createConnectUser();
+});
+
+describe('login', function () {
+    test('with password', function () {
         $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->Permissions = Permissions::JuniorDeveloper;
+        $this->user->points_hardcore = 12345;
+        $this->user->points = 4321;
+        $this->user->save();
 
-        // === with password ===
-
-        /** @var User $user */
-        $user = User::factory()->create([
-            'display_name' => 'MyDisplayName',
-            'connect_token' => Str::random(16),
-            'password' => Hash::make($password),
-            'Permissions' => Permissions::JuniorDeveloper,
-            'points_hardcore' => 12345,
-            'points' => 4321,
-        ]);
-
-        $this->get($this->apiUrl('login', ['u' => $user->username, 'p' => $password], credentials: false))
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 'p' => $password])
             ->assertStatus(200)
             ->assertExactJson([
                 'Success' => true,
-                'User' => $user->display_name,
-                'AvatarUrl' => $user->avatar_url,
-                'Token' => $user->connect_token,
+                'User' => $this->user->display_name,
+                'AvatarUrl' => $this->user->avatar_url,
+                'AvatarUpdatedAt' => 0,
+                'Token' => $this->user->connect_token,
                 'Score' => 12345,
                 'SoftcoreScore' => 4321,
                 'Messages' => 0,
@@ -48,19 +43,25 @@ class LoginTest extends TestCase
                 'AccountType' => 'Junior Developer',
             ]);
 
-        /** @var User $user1 */
-        $user1 = User::whereName($user->username)->first();
-        $this->assertEquals(Carbon::now()->clone()->addDays(14)->startOfSecond(), $user1->connect_token_expires_at);
+        // connect expiration should have been updated
+        $this->user->refresh();
+        $this->assertEquals(Carbon::now()->clone()->addDays(14)->startOfSecond(), $this->user->connect_token_expires_at);
+    });
 
-        // === with token ===
+    test('with token', function () {
+        $this->user->Permissions = Permissions::JuniorDeveloper;
+        $this->user->points_hardcore = 12345;
+        $this->user->points = 4321;
+        $this->user->save();
 
-        $this->get($this->apiUrl('login', ['u' => $user->username, 't' => $user->connect_token], credentials: false))
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 't' => $this->user->connect_token])
             ->assertStatus(200)
             ->assertExactJson([
                 'Success' => true,
-                'User' => $user->display_name,
-                'AvatarUrl' => $user->avatar_url,
-                'Token' => $user->connect_token,
+                'User' => $this->user->display_name,
+                'AvatarUrl' => $this->user->avatar_url,
+                'AvatarUpdatedAt' => 0,
+                'Token' => $this->user->connect_token,
                 'Score' => 12345,
                 'SoftcoreScore' => 4321,
                 'Messages' => 0,
@@ -68,69 +69,181 @@ class LoginTest extends TestCase
                 'AccountType' => 'Junior Developer',
             ]);
 
-        // === with legacy password (and no previous connect_token) ===
+        // connect expiration should have been updated
+        $this->user->refresh();
+        $this->assertEquals(Carbon::now()->clone()->addDays(14)->startOfSecond(), $this->user->connect_token_expires_at);
+    });
 
-        /** @var User $user2 */
-        $user2 = User::factory()->create([
-            'connect_token' => '',
-            'legacy_salted_password' => md5($password . config('app.legacy_password_salt')),
-            'Permissions' => Permissions::Developer,
-            'points_hardcore' => 99999,
-            'points' => 99,
-        ]);
-
-        $response = $this->get($this->apiUrl('login', ['u' => $user2->username, 'p' => $password], credentials: false));
-
-        $data = User::withTrashed()->where('username', $user2->username)->first()->getAttributes();
-        $this->assertNotEquals('', $data['connect_token']);
-        $this->assertEquals('', $data['legacy_salted_password']);
-        $this->assertTrue(Hash::check($password, $data['password']));
-
-        $response->assertStatus(200)->assertExactJson([
-            'Success' => true,
-            'User' => $user2->display_name,
-            'AvatarUrl' => $user2->avatar_url,
-            'Token' => $data['connect_token'],
-            'Score' => 99999,
-            'SoftcoreScore' => 99,
-            'Messages' => 0,
-            'Permissions' => Permissions::Developer,
-            'AccountType' => 'Developer',
-        ]);
-
-    }
-
-    public function testLoginKeepsAvatarUrlCanonicalWhenAvatarVersionExists(): void
-    {
-        Carbon::setTestNow(Carbon::now());
+    test('with legacy password', function () {
         $password = 'Pa$$w0rd';
+        $this->user->legacy_salted_password = md5($password . config('app.legacy_password_salt'));
+        $this->user->Permissions = Permissions::JuniorDeveloper;
+        $this->user->points_hardcore = 12345;
+        $this->user->points = 4321;
+        $this->user->save();
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'avatar_updated_at' => Carbon::parse('2026-07-02 10:00:00 UTC'),
-            'connect_token' => Str::random(16),
-            'password' => Hash::make($password),
-            'Permissions' => Permissions::Registered,
-        ]);
-
-        $this->get($this->apiUrl('login', ['u' => $user->username, 'p' => $password], credentials: false))
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 'p' => $password])
             ->assertStatus(200)
-            ->assertJsonPath('AvatarUrl', media_asset("UserPic/{$user->username}.png"));
-    }
+            ->assertExactJson([
+                'Success' => true,
+                'User' => $this->user->display_name,
+                'AvatarUrl' => $this->user->avatar_url,
+                'AvatarUpdatedAt' => 0,
+                'Token' => $this->user->connect_token,
+                'Score' => 12345,
+                'SoftcoreScore' => 4321,
+                'Messages' => 0,
+                'Permissions' => Permissions::JuniorDeveloper,
+                'AccountType' => 'Junior Developer',
+            ]);
 
-    public function testInvalidCredentials(): void
-    {
-        Carbon::setTestNow(Carbon::now());
+        // connect expiration should have been updated
+        $this->user->refresh();
+        $this->assertEquals(Carbon::now()->clone()->addDays(14)->startOfSecond(), $this->user->connect_token_expires_at);
+
+        // password should be initialized and legacy salted password should have been discarded
+        $this->assertTrue(Hash::check($password, $this->user->password));
+        $this->assertEquals('', $this->user->legacy_salted_password);
+    });
+
+    test('avatar updated', function () {
+        $this->user->avatar_updated_at = Carbon::parse('2026-07-02 10:00:00 UTC');
+        $this->user->save();
+
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 't' => $this->user->connect_token])
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'User' => $this->user->display_name,
+                'AvatarUrl' => media_asset("UserPic/{$this->user->username}.png"), // version not included in avatar url
+                'AvatarUpdatedAt' => 1782986400,
+                'Token' => $this->user->connect_token,
+                'Score' => $this->user->points_hardcore,
+                'SoftcoreScore' => $this->user->points,
+                'Messages' => 0,
+                'Permissions' => Permissions::Registered,
+                'AccountType' => 'Registered',
+            ]);
+    });
+});
+
+describe('legacy login', function () {
+    test('with password', function () {
         $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->Permissions = Permissions::JuniorDeveloper;
+        $this->user->points_hardcore = 12345;
+        $this->user->points = 4321;
+        $this->user->save();
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'connect_token' => Str::random(16),
-            'password' => Hash::make($password),
-        ]);
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 'p' => $password], credentials: false))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'User' => $this->user->display_name,
+                'AvatarUrl' => $this->user->avatar_url,
+                'AvatarUpdatedAt' => 0,
+                'Token' => $this->user->connect_token,
+                'Score' => 12345,
+                'SoftcoreScore' => 4321,
+                'Messages' => 0,
+                'Permissions' => Permissions::JuniorDeveloper,
+                'AccountType' => 'Junior Developer',
+            ]);
 
-        // invalid password
-        $this->post('dorequest.php', ['r' => 'login2', 'u' => $user->username, 'p' => $password . '1'])
+        // connect expiration should have been updated
+        $this->user->refresh();
+        $this->assertEquals(Carbon::now()->clone()->addDays(14)->startOfSecond(), $this->user->connect_token_expires_at);
+    });
+
+    test('with token', function () {
+        $this->user->Permissions = Permissions::JuniorDeveloper;
+        $this->user->points_hardcore = 12345;
+        $this->user->points = 4321;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 't' => $this->user->connect_token], credentials: false))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'User' => $this->user->display_name,
+                'AvatarUrl' => $this->user->avatar_url,
+                'AvatarUpdatedAt' => 0,
+                'Token' => $this->user->connect_token,
+                'Score' => 12345,
+                'SoftcoreScore' => 4321,
+                'Messages' => 0,
+                'Permissions' => Permissions::JuniorDeveloper,
+                'AccountType' => 'Junior Developer',
+            ]);
+
+        // connect expiration should have been updated
+        $this->user->refresh();
+        $this->assertEquals(Carbon::now()->clone()->addDays(14)->startOfSecond(), $this->user->connect_token_expires_at);
+    });
+
+    test('with legacy password', function () {
+        $password = 'Pa$$w0rd';
+        $this->user->legacy_salted_password = md5($password . config('app.legacy_password_salt'));
+        $this->user->Permissions = Permissions::JuniorDeveloper;
+        $this->user->points_hardcore = 12345;
+        $this->user->points = 4321;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 'p' => $password], credentials: false))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'User' => $this->user->display_name,
+                'AvatarUrl' => $this->user->avatar_url,
+                'AvatarUpdatedAt' => 0,
+                'Token' => $this->user->connect_token,
+                'Score' => 12345,
+                'SoftcoreScore' => 4321,
+                'Messages' => 0,
+                'Permissions' => Permissions::JuniorDeveloper,
+                'AccountType' => 'Junior Developer',
+            ]);
+
+        // connect expiration should have been updated
+        $this->user->refresh();
+        $this->assertEquals(Carbon::now()->clone()->addDays(14)->startOfSecond(), $this->user->connect_token_expires_at);
+
+        // password should be initialized and legacy salted password should have been discarded
+        $this->assertTrue(Hash::check($password, $this->user->password));
+        $this->assertEquals('', $this->user->legacy_salted_password);
+    });
+
+    test('avatar updated', function () {
+        $this->user->avatar_updated_at = Carbon::parse('2026-07-02 10:00:00 UTC');
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 't' => $this->user->connect_token], credentials: false))
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'User' => $this->user->display_name,
+                'AvatarUrl' => media_asset("UserPic/{$this->user->username}.png"), // version not included in avatar url
+                'AvatarUpdatedAt' => 1782986400,
+                'Token' => $this->user->connect_token,
+                'Score' => $this->user->points_hardcore,
+                'SoftcoreScore' => $this->user->points,
+                'Messages' => 0,
+                'Permissions' => Permissions::Registered,
+                'AccountType' => 'Registered',
+            ]);
+    });
+});
+
+describe('validation', function () {
+    test('invalid password', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 'p' => $password . '1'])
             ->assertStatus(401)
             ->assertHeader('WWW-Authenticate', 'Bearer')
             ->assertExactJson([
@@ -140,8 +253,17 @@ class LoginTest extends TestCase
                 'Error' => 'Invalid user/password combination. Please try again.',
             ]);
 
-        // invalid token
-        $this->post('dorequest.php', ['r' => 'login2', 'u' => $user->username, 't' => $user->connect_token . '1'])
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('invalid token', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 't' => $this->user->connect_token . '1'])
             ->assertStatus(401)
             ->assertHeader('WWW-Authenticate', 'Bearer')
             ->assertExactJson([
@@ -151,98 +273,20 @@ class LoginTest extends TestCase
                 'Error' => 'Invalid user/token combination.',
             ]);
 
-        // unknown user
-        $this->post('dorequest.php', ['r' => 'login2', 'u' => $user->username . '1', 'p' => $password])
-            ->assertStatus(401)
-            ->assertHeader('WWW-Authenticate', 'Bearer')
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 401,
-                'Code' => 'invalid_credentials',
-                'Error' => 'Invalid user/password combination. Please try again.',
-            ]);
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
 
-        // no user
-        $this->post('dorequest.php', ['r' => 'login2', 'p' => $password])
-            ->assertStatus(422)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 422,
-                'Code' => 'missing_parameter',
-                'Error' => 'One or more required parameters is missing.',
-            ]);
+    test('unregistered user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->Permissions = Permissions::Unregistered;
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
 
-        // blank user
-        $this->post('dorequest.php', ['r' => 'login2', 'u' => '', 'p' => $password])
-            ->assertStatus(401)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 401,
-                'Code' => 'invalid_credentials',
-                'Error' => 'Invalid user/password combination. Please try again.',
-            ]);
-
-        // no password or token
-        $this->post('dorequest.php', ['r' => 'login2', 'u' => $user->username])
-            ->assertStatus(422)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 422,
-                'Code' => 'missing_parameter',
-                'Error' => 'One or more required parameters is missing.',
-            ]);
-
-        // no user or password
-        $this->post('dorequest.php', ['r' => 'login2'])
-            ->assertStatus(422)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 422,
-                'Code' => 'missing_parameter',
-                'Error' => 'One or more required parameters is missing.',
-            ]);
-
-        // blank password
-        $this->post('dorequest.php', ['r' => 'login2', 'u' => $user->username, 'p' => ''])
-            ->assertStatus(401)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 401,
-                'Code' => 'invalid_credentials',
-                'Error' => 'Invalid user/password combination. Please try again.',
-            ]);
-
-        // expired token
-        $user->connect_token_expires_at = Carbon::now()->clone()->subDays(15);
-        $user->timestamps = false;
-        $user->save();
-        $this->post('dorequest.php', ['r' => 'login2', 'u' => $user->username, 't' => $user->connect_token])
-            ->assertStatus(401)
-            ->assertHeader('WWW-Authenticate', 'Bearer')
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 401,
-                'Code' => 'expired_token',
-                'Error' => 'The access token has expired. Please log in again.',
-            ]);
-
-        // try with banned user - response should be the same as a non-existent user
-        /** @var User $user2 */
-        $user2 = User::factory()->create(['Permissions' => Permissions::Banned, 'banned_at' => Carbon::now()->clone()->subMonths(2), 'password' => Hash::make($password)]);
-        $this->post('dorequest.php', ['r' => 'login2', 'u' => $user2->username, 'p' => $password])
-            ->assertStatus(401)
-            ->assertHeader('WWW-Authenticate', 'Bearer')
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 401,
-                'Code' => 'invalid_credentials',
-                'Error' => 'Invalid user/password combination. Please try again.',
-            ]);
-
-        // try with unregistered user - expect permissions error
-        /** @var User $user3 */
-        $user3 = User::factory()->create(['Permissions' => Permissions::Unregistered, 'password' => Hash::make($password)]);
-        $this->post('dorequest.php', ['r' => 'login2', 'u' => $user3->username, 'p' => $password])
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 'p' => $password])
             ->assertStatus(403)
             ->assertExactJson([
                 'Success' => false,
@@ -250,27 +294,22 @@ class LoginTest extends TestCase
                 'Code' => 'access_denied',
                 'Error' => 'Access denied. Please verify your email address.',
             ]);
-    }
 
-    public function testInvalidCredentialsLegacy(): void
-    {
-        // This is the exact same set of tests as testInvalidCredentials, but it goes through
-        // the login API instead of the login2 API. The login API always returns a 200 status
-        // code so legacy clients will still look at the response body instead of just failing
-        // when they see the non-200 status code.
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
 
-        Carbon::setTestNow(Carbon::now());
+    test('unknown user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
         $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'connect_token' => Str::random(16),
-            'password' => Hash::make($password),
-        ]);
-
-        // invalid password
-        $this->get($this->apiUrl('login', ['u' => $user->username, 'p' => $password . '1'], credentials: false))
-            ->assertStatus(200)
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username . '1', 'p' => $password])
+            ->assertStatus(401)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
             ->assertExactJson([
                 'Success' => false,
                 'Status' => 401,
@@ -278,9 +317,171 @@ class LoginTest extends TestCase
                 'Error' => 'Invalid user/password combination. Please try again.',
             ]);
 
-        // invalid token
-        $this->get($this->apiUrl('login', ['u' => $user->username, 't' => $user->connect_token . '1'], credentials: false))
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('no user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->post('dorequest.php', ['r' => 'login2', 't' => $this->user->connect_token])
+            ->assertStatus(422)
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 422,
+                'Code' => 'missing_parameter',
+                'Error' => 'One or more required parameters is missing.',
+            ]);
+
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('blank user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => '', 'p' => $password])
+            ->assertStatus(401)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 401,
+                'Code' => 'invalid_credentials',
+                'Error' => 'Invalid user/password combination. Please try again.',
+            ]);
+
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('banned user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->Permissions = Permissions::Banned;
+        $this->user->banned_at = Carbon::now()->clone()->subDays(3);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        // response should be the same as unknown user
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 'p' => $password])
+            ->assertStatus(401)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 401,
+                'Code' => 'invalid_credentials',
+                'Error' => 'Invalid user/password combination. Please try again.',
+            ]);
+
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('no password or token', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username])
+            ->assertStatus(422)
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 422,
+                'Code' => 'missing_parameter',
+                'Error' => 'One or more required parameters is missing.',
+            ]);
+
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('blank password', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = '';
+        $this->user->password = Hash::make($password);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 'p' => $password])
+            ->assertStatus(401)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 401,
+                'Code' => 'invalid_credentials',
+                'Error' => 'Invalid user/password combination. Please try again.',
+            ]);
+
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('expired token', function () {
+        $recently = Carbon::now()->clone()->subHours(3);
+        $token = $this->user->connect_token;
+        $this->user->connect_token_expires_at = $recently;
+        $this->user->save();
+
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->username, 't' => $token])
+            ->assertStatus(401)
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 401,
+                'Code' => 'expired_token',
+                'Error' => 'The access token has expired. Please log in again.',
+            ]);
+
+        // a new connect token will have been generated with a future expiration
+        $this->user->refresh();
+        $this->assertNotEquals($token, $this->user->connect_token);
+        $this->assertEquals(Carbon::now()->clone()->addDays(14)->startOfSecond(), $this->user->connect_token_expires_at);
+    });
+});
+
+describe('legacy validation', function () {
+    test('invalid password', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 'p' => $password . '1'], credentials: false))
             ->assertStatus(200)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 401,
+                'Code' => 'invalid_credentials',
+                'Error' => 'Invalid user/password combination. Please try again.',
+            ]);
+
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('invalid token', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 't' => $this->user->connect_token . '1'], credentials: false))
+            ->assertStatus(200)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
             ->assertExactJson([
                 'Success' => false,
                 'Status' => 401,
@@ -288,9 +489,43 @@ class LoginTest extends TestCase
                 'Error' => 'Invalid user/token combination.',
             ]);
 
-        // unknown user
-        $this->get($this->apiUrl('login', ['u' => $user->username . '1', 'p' => $password], credentials: false))
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('unregistered user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->Permissions = Permissions::Unregistered;
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 'p' => $password], credentials: false))
             ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 403,
+                'Code' => 'access_denied',
+                'Error' => 'Access denied. Please verify your email address.',
+            ]);
+
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('unknown user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username . '1', 'p' => $password], credentials: false))
+            ->assertStatus(200)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
             ->assertExactJson([
                 'Success' => false,
                 'Status' => 401,
@@ -298,8 +533,17 @@ class LoginTest extends TestCase
                 'Error' => 'Invalid user/password combination. Please try again.',
             ]);
 
-        // no user
-        $this->get($this->apiUrl('login', ['p' => $password], credentials: false))
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('no user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['t' => $this->user->connect_token], credentials: false))
             ->assertStatus(200)
             ->assertExactJson([
                 'Success' => false,
@@ -308,9 +552,21 @@ class LoginTest extends TestCase
                 'Error' => 'One or more required parameters is missing.',
             ]);
 
-        // blank user
-        $this->post($this->apiUrl('login', ['u' => '', 'p' => $password], credentials: false))
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('blank user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => '', 'p' => $password], credentials: false))
             ->assertStatus(200)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
             ->assertExactJson([
                 'Success' => false,
                 'Status' => 401,
@@ -318,8 +574,42 @@ class LoginTest extends TestCase
                 'Error' => 'Invalid user/password combination. Please try again.',
             ]);
 
-        // no password or token
-        $this->get($this->apiUrl('login', ['u' => $user->username], credentials: false))
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('banned user', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = 'Pa$$w0rd';
+        $this->user->password = Hash::make($password);
+        $this->user->Permissions = Permissions::Banned;
+        $this->user->banned_at = Carbon::now()->clone()->subDays(3);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        // response should be the same as unknown user
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 'p' => $password], credentials: false))
+            ->assertStatus(200)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson([
+                'Success' => false,
+                'Status' => 401,
+                'Code' => 'invalid_credentials',
+                'Error' => 'Invalid user/password combination. Please try again.',
+            ]);
+
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('no password or token', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username], credentials: false))
             ->assertStatus(200)
             ->assertExactJson([
                 'Success' => false,
@@ -328,9 +618,21 @@ class LoginTest extends TestCase
                 'Error' => 'One or more required parameters is missing.',
             ]);
 
-        // blank password
-        $this->get($this->apiUrl('login', ['u' => $user->username, 'p' => ''], credentials: false))
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
+
+    test('blank password', function () {
+        $soon = Carbon::now()->clone()->addHours(3);
+        $password = '';
+        $this->user->password = Hash::make($password);
+        $this->user->connect_token_expires_at = $soon;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 'p' => $password], credentials: false))
             ->assertStatus(200)
+            ->assertHeader('WWW-Authenticate', 'Bearer')
             ->assertExactJson([
                 'Success' => false,
                 'Status' => 401,
@@ -338,21 +640,18 @@ class LoginTest extends TestCase
                 'Error' => 'Invalid user/password combination. Please try again.',
             ]);
 
-        // no user or password
-        $this->get($this->apiUrl('login', [], credentials: false))
-            ->assertStatus(200)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 422,
-                'Code' => 'missing_parameter',
-                'Error' => 'One or more required parameters is missing.',
-            ]);
+        // connect expiration should have not been updated
+        $this->user->refresh();
+        $this->assertEquals($soon, $this->user->connect_token_expires_at);
+    });
 
-        // expired token
-        $user->connect_token_expires_at = Carbon::now()->clone()->subDays(15);
-        $user->timestamps = false;
-        $user->save();
-        $this->get($this->apiUrl('login', ['u' => $user->username, 't' => $user->connect_token], credentials: false))
+    test('expired token', function () {
+        $recently = Carbon::now()->clone()->subHours(3);
+        $token = $this->user->connect_token;
+        $this->user->connect_token_expires_at = $recently;
+        $this->user->save();
+
+        $this->get($this->apiUrl('login', ['u' => $this->user->username, 't' => $this->user->connect_token], credentials: false))
             ->assertStatus(200)
             ->assertExactJson([
                 'Success' => false,
@@ -361,28 +660,10 @@ class LoginTest extends TestCase
                 'Error' => 'The access token has expired. Please log in again.',
             ]);
 
-        // try with banned user - response should be the same as a non-existent user
-        /** @var User $user2 */
-        $user2 = User::factory()->create(['Permissions' => Permissions::Banned, 'banned_at' => Carbon::now()->clone()->subMonths(2), 'password' => Hash::make($password)]);
-        $this->get($this->apiUrl('login', ['u' => $user2->username, 'p' => $password], credentials: false))
-            ->assertStatus(200)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 401,
-                'Code' => 'invalid_credentials',
-                'Error' => 'Invalid user/password combination. Please try again.',
-            ]);
+        // a new connect token will have been generated with a future expiration
+        $this->user->refresh();
+        $this->assertNotEquals($token, $this->user->connect_token);
+        $this->assertEquals(Carbon::now()->clone()->addDays(14)->startOfSecond(), $this->user->connect_token_expires_at);
+    });
 
-        // try with unregistered user - expect permissions error
-        /** @var User $user3 */
-        $user3 = User::factory()->create(['Permissions' => Permissions::Unregistered, 'password' => Hash::make($password)]);
-        $this->get($this->apiUrl('login', ['u' => $user3->username, 'p' => $password], credentials: false))
-            ->assertStatus(200)
-            ->assertExactJson([
-                'Success' => false,
-                'Status' => 403,
-                'Code' => 'access_denied',
-                'Error' => 'Access denied. Please verify your email address.',
-            ]);
-    }
-}
+});

--- a/tests/Feature/Connect/LoginTest.php
+++ b/tests/Feature/Connect/LoginTest.php
@@ -22,6 +22,7 @@ beforeEach(function () {
 describe('login', function () {
     test('with password', function () {
         $password = 'Pa$$w0rd';
+        $this->user->display_name = 'DisplayName'; // unique display name
         $this->user->password = Hash::make($password);
         $this->user->Permissions = Permissions::JuniorDeveloper;
         $this->user->points_hardcore = 12345;
@@ -105,6 +106,66 @@ describe('login', function () {
         $this->assertTrue(Hash::check($password, $this->user->password));
         $this->assertEquals('', $this->user->legacy_salted_password);
     });
+
+    test('using display name', function () {
+        $password = 'Pa$$w0rd';
+        $this->user->display_name = 'DisplayName';
+        $this->user->password = Hash::make($password);
+        $this->user->Permissions = Permissions::JuniorDeveloper;
+        $this->user->points_hardcore = 12345;
+        $this->user->points = 4321;
+        $this->user->save();
+
+        $this->post('dorequest.php', ['r' => 'login2', 'u' => $this->user->display_name, 'p' => $password])
+            ->assertStatus(200)
+            ->assertExactJson([
+                'Success' => true,
+                'User' => $this->user->display_name,
+                'AvatarUrl' => $this->user->avatar_url,
+                'AvatarUpdatedAt' => 0,
+                'Token' => $this->user->connect_token,
+                'Score' => 12345,
+                'SoftcoreScore' => 4321,
+                'Messages' => 0,
+                'Permissions' => Permissions::JuniorDeveloper,
+                'AccountType' => 'Junior Developer',
+            ]);
+
+        // connect expiration should have been updated
+        $this->user->refresh();
+        $this->assertEquals(Carbon::now()->clone()->addDays(365)->startOfSecond(), $this->user->connect_token_expires_at);
+    });
+
+    // SQLite doesn't match case insensitively
+    // test('case insensitive', function () {
+    //     $password = 'Pa$$w0rd';
+    //     $this->user->display_name = 'DisplayName';
+    //     $this->user->username = 'UserName123';
+    //     $this->user->password = Hash::make($password);
+    //     $this->user->Permissions = Permissions::JuniorDeveloper;
+    //     $this->user->points_hardcore = 12345;
+    //     $this->user->points = 4321;
+    //     $this->user->save();
+
+    //     $this->post('dorequest.php', ['r' => 'login2', 'u' => 'username123', 'p' => $password])
+    //         ->assertStatus(200)
+    //         ->assertExactJson([
+    //             'Success' => true,
+    //             'User' => $this->user->display_name,
+    //             'AvatarUrl' => $this->user->avatar_url,
+    //             'AvatarUpdatedAt' => 0,
+    //             'Token' => $this->user->connect_token,
+    //             'Score' => 12345,
+    //             'SoftcoreScore' => 4321,
+    //             'Messages' => 0,
+    //             'Permissions' => Permissions::JuniorDeveloper,
+    //             'AccountType' => 'Junior Developer',
+    //         ]);
+
+    //     // connect expiration should have been updated
+    //     $this->user->refresh();
+    //     $this->assertEquals(Carbon::now()->clone()->addDays(365)->startOfSecond(), $this->user->connect_token_expires_at);
+    // });
 
     test('avatar updated', function () {
         $this->user->avatar_updated_at = Carbon::parse('2026-07-02 10:00:00 UTC');


### PR DESCRIPTION
For `login` and `getfriendlist` APIs. Also updates the associated tests to pest.