### PR TITLE
feat(settings): check username availability before showing the confirm dialog

### DIFF
--- a/app/Community/Controllers/UserSettingsController.php
+++ b/app/Community/Controllers/UserSettingsController.php
@@ -130,6 +130,13 @@ class UserSettingsController extends Controller
         return Inertia::render('settings', $props);
     }
 
+    public function checkUsernameChangeRequest(StoreUsernameChangeRequest $request): JsonResponse
+    {
+        $this->authorize('create', UserUsername::class);
+
+        return response()->json(['success' => true]);
+    }
+
     public function storeUsernameChangeRequest(StoreUsernameChangeRequest $request): JsonResponse
     {
         $this->authorize('create', UserUsername::class);

--- a/app/Community/RouteServiceProvider.php
+++ b/app/Community/RouteServiceProvider.php
@@ -406,6 +406,8 @@ class RouteServiceProvider extends ServiceProvider
 
                     Route::post('username-change-request', [UserSettingsController::class, 'storeUsernameChangeRequest'])
                         ->name('api.settings.name-change-request.store');
+                    Route::post('username-change-request/check', [UserSettingsController::class, 'checkUsernameChangeRequest'])
+                        ->name('api.settings.name-change-request.check');
 
                     Route::delete('keys/web', [UserSettingsController::class, 'resetWebApiKey'])->name('api.settings.keys.web.destroy');
                     Route::delete('keys/connect', [UserSettingsController::class, 'resetConnectApiKey'])->name('api.settings.keys.connect.destroy');

--- a/resources/js/features/settings/components/ChangeUsernameSectionCard/ChangeUsernameSectionCard.test.tsx
+++ b/resources/js/features/settings/components/ChangeUsernameSectionCard/ChangeUsernameSectionCard.test.tsx
@@ -126,9 +126,9 @@ describe('Component: ChangeUsernameSectionCard', () => {
     ).toBeVisible();
   });
 
-  it('given the user submits valid form data, opens the confirmation dialog without submitting', async () => {
+  it('given the user submits valid form data, checks availability and opens the confirmation dialog without submitting', async () => {
     // ARRANGE
-    const postSpy = vi.spyOn(axios, 'post');
+    const postSpy = vi.spyOn(axios, 'post').mockResolvedValueOnce({ data: { success: true } });
 
     render(<ChangeUsernameSectionCard />, {
       pageProps: {
@@ -144,12 +144,19 @@ describe('Component: ChangeUsernameSectionCard', () => {
 
     // ASSERT
     expect(screen.getByRole('heading', { name: /is this right/i })).toBeVisible();
-    expect(postSpy).not.toHaveBeenCalled();
+
+    expect(postSpy).toHaveBeenCalledWith(route('api.settings.name-change-request.check'), {
+      newDisplayName: 'NewName',
+    });
+    expect(postSpy).not.toHaveBeenCalledWith(
+      route('api.settings.name-change-request.store'),
+      expect.anything(),
+    );
   });
 
   it('given the user cancels the confirmation dialog, does not submit and preserves the typed values', async () => {
     // ARRANGE
-    const postSpy = vi.spyOn(axios, 'post');
+    const postSpy = vi.spyOn(axios, 'post').mockResolvedValueOnce({ data: { success: true } });
 
     render(<ChangeUsernameSectionCard />, {
       pageProps: {
@@ -165,7 +172,10 @@ describe('Component: ChangeUsernameSectionCard', () => {
     await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
 
     // ASSERT
-    expect(postSpy).not.toHaveBeenCalled();
+    expect(postSpy).not.toHaveBeenCalledWith(
+      route('api.settings.name-change-request.store'),
+      expect.anything(),
+    );
 
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -177,6 +187,8 @@ describe('Component: ChangeUsernameSectionCard', () => {
 
   it('given the user cancels and resubmits, reopens the dialog with the acknowledgement value reset', async () => {
     // ARRANGE
+    vi.spyOn(axios, 'post').mockResolvedValue({ data: { success: true } });
+
     render(<ChangeUsernameSectionCard />, {
       pageProps: {
         auth: { user: createAuthenticatedUser({ displayName: 'test-user' }) },
@@ -204,7 +216,7 @@ describe('Component: ChangeUsernameSectionCard', () => {
 
   it('given the user acknowledges and confirms, sends the request and closes the dialog', async () => {
     // ARRANGE
-    const postSpy = vi.spyOn(axios, 'post').mockResolvedValueOnce({
+    const postSpy = vi.spyOn(axios, 'post').mockResolvedValue({
       data: {
         success: true,
       },
@@ -236,7 +248,7 @@ describe('Component: ChangeUsernameSectionCard', () => {
 
   it('given the user cancels and retypes a different username, confirms and submits the new one', async () => {
     // ARRANGE
-    const postSpy = vi.spyOn(axios, 'post').mockResolvedValueOnce({
+    const postSpy = vi.spyOn(axios, 'post').mockResolvedValue({
       data: {
         success: true,
       },
@@ -279,6 +291,8 @@ describe('Component: ChangeUsernameSectionCard', () => {
 
   it('given the dialog is open, shows the requested username so the user can check it', async () => {
     // ARRANGE
+    vi.spyOn(axios, 'post').mockResolvedValueOnce({ data: { success: true } });
+
     render(<ChangeUsernameSectionCard />, {
       pageProps: {
         auth: { user: createAuthenticatedUser({ displayName: 'TestUser' }) },
@@ -296,9 +310,9 @@ describe('Component: ChangeUsernameSectionCard', () => {
     expect(screen.getByText(/can't ask again for 30 days/i)).toBeVisible();
   });
 
-  it('given the API returns a username taken error, shows the appropriate error message', async () => {
+  it('given the availability check returns a username taken error, shows the error without opening the dialog', async () => {
     // ARRANGE
-    vi.spyOn(axios, 'post').mockRejectedValueOnce({
+    const postSpy = vi.spyOn(axios, 'post').mockRejectedValueOnce({
       response: {
         data: {
           message: 'has already been taken',
@@ -317,16 +331,20 @@ describe('Component: ChangeUsernameSectionCard', () => {
     await userEvent.type(screen.getAllByLabelText(/new username/i)[0], 'NewName');
     await userEvent.type(screen.getByLabelText(/confirm new username/i), 'NewName');
     await userEvent.click(screen.getByRole('button', { name: /update/i }));
-    await userEvent.click(screen.getByRole('checkbox'));
-    await userEvent.click(screen.getByRole('button', { name: /change name/i }));
 
     // ASSERT
     await waitFor(() => {
       expect(screen.getByText(/this username is already taken/i)).toBeVisible();
     });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(postSpy).not.toHaveBeenCalledWith(
+      route('api.settings.name-change-request.store'),
+      expect.anything(),
+    );
   });
 
-  it('given the API returns a username not available error, shows the appropriate error message', async () => {
+  it('given the availability check returns a username not available error, shows the error without opening the dialog', async () => {
     // ARRANGE
     vi.spyOn(axios, 'post').mockRejectedValueOnce({
       response: {
@@ -347,24 +365,26 @@ describe('Component: ChangeUsernameSectionCard', () => {
     await userEvent.type(screen.getAllByLabelText(/new username/i)[0], 'NewName');
     await userEvent.type(screen.getByLabelText(/confirm new username/i), 'NewName');
     await userEvent.click(screen.getByRole('button', { name: /update/i }));
-    await userEvent.click(screen.getByRole('checkbox'));
-    await userEvent.click(screen.getByRole('button', { name: /change name/i }));
 
     // ASSERT
     await waitFor(() => {
       expect(screen.getByText(/this username is not available/i)).toBeVisible();
     });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('given the API returns an unexpected error, shows a generic error message', async () => {
+  it('given the submission fails after confirmation, shows an error and closes the dialog', async () => {
     // ARRANGE
-    vi.spyOn(axios, 'post').mockRejectedValueOnce({
-      response: {
-        data: {
-          message: 'some other error',
+    vi.spyOn(axios, 'post')
+      .mockResolvedValueOnce({ data: { success: true } })
+      .mockRejectedValueOnce({
+        response: {
+          data: {
+            message: 'some other error',
+          },
         },
-      },
-    });
+      });
 
     render(<ChangeUsernameSectionCard />, {
       pageProps: {
@@ -385,11 +405,8 @@ describe('Component: ChangeUsernameSectionCard', () => {
       expect(screen.getByText(/something went wrong/i)).toBeVisible();
     });
 
-    expect(screen.getByRole('dialog')).toBeVisible();
-    expect(screen.getByRole('checkbox')).toBeChecked();
-
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /change name/i })).toBeEnabled();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
 

--- a/resources/js/features/settings/components/ChangeUsernameSectionCard/ChangeUsernameSectionCard.tsx
+++ b/resources/js/features/settings/components/ChangeUsernameSectionCard/ChangeUsernameSectionCard.tsx
@@ -28,9 +28,10 @@ export const ChangeUsernameSectionCard: FC = () => {
   const { t } = useTranslation();
 
   const {
+    checkMutation,
     form,
     isConfirmDialogOpen,
-    mutation,
+    createMutation,
     onConfirmUsernameChange,
     onSubmit,
     pendingUsername,
@@ -49,7 +50,7 @@ export const ChangeUsernameSectionCard: FC = () => {
       t_headingLabel={t('Change Username')}
       formMethods={form}
       onSubmit={onSubmit}
-      isSubmitting={mutation.isPending}
+      isSubmitting={checkMutation.isPending || createMutation.isPending}
       shouldShowFooter={canShowForm}
     >
       <div className="@container">
@@ -146,7 +147,7 @@ export const ChangeUsernameSectionCard: FC = () => {
 
       <ChangeUsernameConfirmDialog
         isOpen={isConfirmDialogOpen}
-        isSubmitting={mutation.isPending}
+        isSubmitting={createMutation.isPending}
         requestedUsername={pendingUsername}
         onConfirm={onConfirmUsernameChange}
         onOpenChange={setIsConfirmDialogOpen}

--- a/resources/js/features/settings/components/ChangeUsernameSectionCard/useChangeUsernameForm.ts
+++ b/resources/js/features/settings/components/ChangeUsernameSectionCard/useChangeUsernameForm.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { toastMessage } from '@/common/components/+vendor/BaseToaster';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import type { LaravelValidationError } from '@/common/models';
+import { useCheckNameChangeRequestMutation } from '@/features/settings/hooks/mutations/useCheckNameChangeRequestMutation';
 import { useCreateNameChangeRequestMutation } from '@/features/settings/hooks/mutations/useCreateNameChangeRequestMutation';
 
 import { requestedUsernameAtom } from '../../state/settings.atoms';
@@ -51,7 +52,8 @@ export function useChangeUsernameForm() {
     },
   });
 
-  const mutation = useCreateNameChangeRequestMutation();
+  const checkMutation = useCheckNameChangeRequestMutation();
+  const createMutation = useCreateNameChangeRequestMutation();
 
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
   const [pendingUsername, setPendingUsername] = useState('');
@@ -59,10 +61,22 @@ export function useChangeUsernameForm() {
   const isOnlyCapitalizationChange = (newUsername: string) =>
     auth!.user.displayName.toLowerCase() === newUsername.toLowerCase();
 
+  const getErrorMessage = ({ response }: LaravelValidationError) => {
+    if (response.data.message.includes('already been taken')) {
+      return t('This username is already taken.');
+    }
+
+    if (response.data.message.includes('not available')) {
+      return t('This username is not available.');
+    }
+
+    return t('Something went wrong.');
+  };
+
   const submitUsernameChange = async (newUsername: string) => {
     const payload = { newDisplayName: newUsername };
 
-    await toastMessage.promise(mutation.mutateAsync({ payload }), {
+    await toastMessage.promise(createMutation.mutateAsync({ payload }), {
       loading: t('Submitting username change request...'),
       success: () => {
         setIsConfirmDialogOpen(false);
@@ -77,16 +91,10 @@ export function useChangeUsernameForm() {
 
         return t('Submitted username change request!');
       },
-      error: ({ response }: LaravelValidationError) => {
-        if (response.data.message.includes('already been taken')) {
-          return t('This username is already taken.');
-        }
+      error: (error: LaravelValidationError) => {
+        setIsConfirmDialogOpen(false);
 
-        if (response.data.message.includes('not available')) {
-          return t('This username is not available.');
-        }
-
-        return t('Something went wrong.');
+        return getErrorMessage(error);
       },
     });
   };
@@ -95,6 +103,15 @@ export function useChangeUsernameForm() {
     // Bypass the confirm dialog on capitalization-only changes.
     if (isOnlyCapitalizationChange(formValues.newUsername)) {
       await submitUsernameChange(formValues.newUsername);
+
+      return;
+    }
+
+    // Don't ask the user to confirm a name the server is guaranteed to reject.
+    try {
+      await checkMutation.mutateAsync({ payload: { newDisplayName: formValues.newUsername } });
+    } catch (error) {
+      toastMessage.error(getErrorMessage(error as LaravelValidationError));
 
       return;
     }
@@ -108,9 +125,10 @@ export function useChangeUsernameForm() {
   };
 
   return {
+    checkMutation,
     form,
     isConfirmDialogOpen,
-    mutation,
+    createMutation,
     onConfirmUsernameChange,
     onSubmit,
     pendingUsername,

--- a/resources/js/features/settings/hooks/mutations/useCheckNameChangeRequestMutation.ts
+++ b/resources/js/features/settings/hooks/mutations/useCheckNameChangeRequestMutation.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { route } from 'ziggy-js';
+
+interface Variables {
+  payload: {
+    newDisplayName: string;
+  };
+}
+
+export function useCheckNameChangeRequestMutation() {
+  return useMutation({
+    mutationFn: ({ payload }: Variables) => {
+      return axios.post(route('api.settings.name-change-request.check'), payload);
+    },
+  });
+}

--- a/tests/Feature/Community/Controllers/UserSettingsControllerTest.php
+++ b/tests/Feature/Community/Controllers/UserSettingsControllerTest.php
@@ -163,6 +163,50 @@ class UserSettingsControllerTest extends TestCase
         $this->assertNull($user->email_verified_at);
     }
 
+    public function testCheckUsernameChangeRequestWithValidUsername(): void
+    {
+        // Arrange
+        $this->withoutMiddleware();
+
+        /** @var User $user */
+        $user = User::factory()->create([
+            'username' => 'Scott',
+            'display_name' => 'Scott',
+        ]);
+
+        // Act
+        $response = $this->actingAs($user)
+            ->postJson(route('api.settings.name-change-request.check'), [
+                'newDisplayName' => 'Scott123456712',
+            ]);
+
+        // Assert
+        $response->assertStatus(200);
+    }
+
+    public function testCheckUsernameChangeRequestWithTakenUsername(): void
+    {
+        // Arrange
+        $this->withoutMiddleware();
+
+        User::factory()->create(['username' => 'TakenName', 'display_name' => 'TakenName']);
+
+        /** @var User $user */
+        $user = User::factory()->create([
+            'username' => 'Scott',
+            'display_name' => 'Scott',
+        ]);
+
+        // Act
+        $response = $this->actingAs($user)
+            ->postJson(route('api.settings.name-change-request.check'), [
+                'newDisplayName' => 'TakenName',
+            ]);
+
+        // Assert
+        $response->assertStatus(422);
+    }
+
     public function testUpdateUsername(): void
     {
         // Arrange


### PR DESCRIPTION
Follow-up to https://github.com/RetroAchievements/RAWeb/pull/5117.

Now, before popping the dialog, we check if the username is even available.

<img width="1180" height="752" alt="Screenshot 2026-07-29 at 5 31 16 PM" src="https://github.com/user-attachments/assets/5aba86e8-4837-4218-aa9b-fd0308edc278" />
