### PR TITLE
fix(ui): move displayed badge dialog back to center

### DIFF
--- a/resources/js/tall-stack/dynamic/reorderSiteAwards/badgePicker.ts
+++ b/resources/js/tall-stack/dynamic/reorderSiteAwards/badgePicker.ts
@@ -54,7 +54,7 @@ export function renderBadgePickerDialog(
   const dialog = document.createElement('dialog');
   dialog.id = DIALOG_ID;
   dialog.className =
-    'bg-embed text-text border border-embed-highlight rounded p-0 backdrop:bg-black/70';
+    'bg-embed text-text border border-embed-highlight rounded p-0 backdrop:bg-black/70 fixed inset-0 m-auto';
   dialog.setAttribute('aria-labelledby', 'badge-picker-title');
 
   dialog.addEventListener('click', (event) => {


### PR DESCRIPTION
Small regression from the Tailwind 4 update. Adds some classes to force it to the center of the screen like before.

Before:
<img width="3682" height="2482" alt="CleanShot 2026-07-30 at 19 45 38@2x" src="https://github.com/user-attachments/assets/919d7b0c-5bfd-4c40-8665-508198e4f8ce" />

After:
<img width="3682" height="2482" alt="CleanShot 2026-07-30 at 19 45 13@2x" src="https://github.com/user-attachments/assets/8afabf29-5d13-4f2f-8e92-feeec140eb1d" />
