### PR TITLE
fix(users): update Patreon badge tiers in place

### DIFF
--- a/app/Helpers/database/site-award.php
+++ b/app/Helpers/database/site-award.php
@@ -167,13 +167,19 @@ function SetPatreonSupporter(User $user, int $tier): void
     $existing = $user->playerBadges()
         ->where('award_type', AwardType::PatreonSupporter)
         ->first();
-    $awardedAt = $existing?->awarded_at;
 
     if ($existing) {
-        $user->playerBadges()->where('award_type', AwardType::PatreonSupporter)->delete();
+        if ((int) $existing->award_tier !== $tier) {
+            $existing->award_tier = $tier;
+            $existing->save();
+        }
+
+        SiteBadgeAwarded::dispatch($existing);
+
+        return;
     }
 
-    $badge = AddSiteAward($user, AwardType::PatreonSupporter, 0, $tier, $awardedAt);
+    $badge = AddSiteAward($user, AwardType::PatreonSupporter, 0, $tier);
     SiteBadgeAwarded::dispatch($badge);
 }
 


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/453242743292952578/1532713839773093918

Don't delete and reaward the badge when moving from the $1 to $2 tier.