### PR TITLE
feat(achievement): add 'Logic updated' deep links

### DIFF
--- a/app/Filament/Resources/AchievementResource/Pages/Logic.php
+++ b/app/Filament/Resources/AchievementResource/Pages/Logic.php
@@ -119,6 +119,7 @@ class Logic extends Page
      *     lazyLoad: bool,
      *     focusedVersion: int|null,
      *     shouldShowAllVersions: bool,
+     *     visibleVersionCount: int,
      *     summaries?: array<int|null, string>,
      *     diffs?: array<int|null, array>
      * }
@@ -133,6 +134,7 @@ class Logic extends Page
                 'lazyLoad' => false,
                 'focusedVersion' => null,
                 'shouldShowAllVersions' => false,
+                'visibleVersionCount' => self::VISIBLE_VERSION_COUNT,
                 'summaries' => [],
                 'diffs' => [],
             ];
@@ -148,6 +150,7 @@ class Logic extends Page
                 'lazyLoad' => true,
                 'focusedVersion' => $focusedVersion,
                 'shouldShowAllVersions' => $shouldShowAllVersions,
+                'visibleVersionCount' => self::VISIBLE_VERSION_COUNT,
             ];
         }
 
@@ -160,6 +163,7 @@ class Logic extends Page
             'lazyLoad' => false,
             'focusedVersion' => $focusedVersion,
             'shouldShowAllVersions' => $shouldShowAllVersions,
+            'visibleVersionCount' => self::VISIBLE_VERSION_COUNT,
             'summaries' => $summaries,
             'diffs' => $diffs,
         ];

--- a/app/Filament/Resources/AchievementResource/Pages/Logic.php
+++ b/app/Filament/Resources/AchievementResource/Pages/Logic.php
@@ -24,6 +24,8 @@ class Logic extends Page
     use HasAchievementSetNavigation;
     use InteractsWithRecord;
 
+    public ?int $requestedVersion = null;
+
     protected static string $resource = AchievementResource::class;
     protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-code-bracket';
     protected string $view = 'filament.resources.achievement-resource.pages.logic';
@@ -34,9 +36,18 @@ class Logic extends Page
      */
     private const LAZY_LOAD_THRESHOLD = 50000;
 
+    /**
+     * The number of versions the history shows before collapsing the rest
+     * behind a "See N more" button.
+     */
+    private const VISIBLE_VERSION_COUNT = 8;
+
     public function mount(int|string $record): void
     {
         $this->record = $this->resolveRecord($record);
+
+        $requestedVersion = request()->query('version');
+        $this->requestedVersion = is_numeric($requestedVersion) ? (int) $requestedVersion : null;
     }
 
     public function getTitle(): string|Htmlable
@@ -106,6 +117,8 @@ class Logic extends Page
      * @return array{
      *     triggers: Collection<int, Trigger>,
      *     lazyLoad: bool,
+     *     focusedVersion: int|null,
+     *     shouldShowAllVersions: bool,
      *     summaries?: array<int|null, string>,
      *     diffs?: array<int|null, array>
      * }
@@ -115,13 +128,27 @@ class Logic extends Page
         $triggers = $this->getOrderedTriggerVersions(withUser: true);
 
         if ($triggers->isEmpty()) {
-            return ['triggers' => $triggers, 'lazyLoad' => false, 'summaries' => [], 'diffs' => []];
+            return [
+                'triggers' => $triggers,
+                'lazyLoad' => false,
+                'focusedVersion' => null,
+                'shouldShowAllVersions' => false,
+                'summaries' => [],
+                'diffs' => [],
+            ];
         }
+
+        [$focusedVersion, $shouldShowAllVersions] = $this->resolveFocusedVersion($triggers);
 
         $totalConditionLength = $triggers->sum(fn ($t) => strlen($t->conditions ?? ''));
         $shouldLazyLoad = $totalConditionLength > self::LAZY_LOAD_THRESHOLD;
         if ($shouldLazyLoad) {
-            return ['triggers' => $triggers, 'lazyLoad' => true];
+            return [
+                'triggers' => $triggers,
+                'lazyLoad' => true,
+                'focusedVersion' => $focusedVersion,
+                'shouldShowAllVersions' => $shouldShowAllVersions,
+            ];
         }
 
         // For simple achievements, compute everything inline for instant display.
@@ -131,9 +158,33 @@ class Logic extends Page
         return [
             'triggers' => $triggers,
             'lazyLoad' => false,
+            'focusedVersion' => $focusedVersion,
+            'shouldShowAllVersions' => $shouldShowAllVersions,
             'summaries' => $summaries,
             'diffs' => $diffs,
         ];
+    }
+
+    /**
+     * Resolve the requested deep-link version against real trigger rows.
+     *
+     * @param Collection<int, Trigger> $triggers ordered descending by version
+     * @return array{0: int|null, 1: bool} the version to expand, and whether the older
+     *                                     versions hidden behind "See N more" must be
+     *                                     shown for that version to be reachable
+     */
+    private function resolveFocusedVersion(Collection $triggers): array
+    {
+        if ($this->requestedVersion === null) {
+            return [null, false];
+        }
+
+        $index = $triggers->search(fn (Trigger $trigger) => $trigger->version === $this->requestedVersion);
+        if ($index === false) {
+            return [null, false];
+        }
+
+        return [$this->requestedVersion, $index >= self::VISIBLE_VERSION_COUNT];
     }
 
     /**

--- a/app/Platform/Actions/BuildAchievementChangelogAction.php
+++ b/app/Platform/Actions/BuildAchievementChangelogAction.php
@@ -349,6 +349,7 @@ class BuildAchievementChangelogAction
                 type: AchievementChangelogEntryType::LogicUpdated,
                 createdAt: Carbon::parse($trigger->created_at),
                 user: $user,
+                triggerVersion: $trigger->version,
             );
         }
 

--- a/app/Platform/Data/AchievementChangelogEntryData.php
+++ b/app/Platform/Data/AchievementChangelogEntryData.php
@@ -22,6 +22,7 @@ class AchievementChangelogEntryData extends Data
         public ?UserData $user = null,
         public array $fieldChanges = [],
         public int $count = 1,
+        public ?int $triggerVersion = null,
     ) {
     }
 }

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -1342,6 +1342,7 @@
     "Badge updated": "Badge updated",
     "Embed URL updated": "Embed URL updated",
     "Logic updated": "Logic updated",
+    "View logic": "View logic",
     "Transferred from {{fromGame}} to {{toGame}}": "Transferred from {{fromGame}} to {{toGame}}",
     "Transferred to a different achievement set": "Transferred to a different achievement set",
     "Type set": "Type set",

--- a/resources/js/features/achievements/components/AchievementChangelog/AchievementChangelogEntry.test.tsx
+++ b/resources/js/features/achievements/components/AchievementChangelog/AchievementChangelogEntry.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from '@/test';
-import { createAchievementChangelogEntry, createUser } from '@/test/factories';
+import { createAchievement, createAchievementChangelogEntry, createUser } from '@/test/factories';
 
 import { AchievementChangelogEntry } from './AchievementChangelogEntry';
 
@@ -359,5 +359,90 @@ describe('Component: AchievementChangelogEntry', () => {
 
     // ASSERT
     expect(screen.getByText('DevAuthor')).toBeVisible();
+  });
+
+  it('given the user can view logic and the entry has a trigger version, links to that version on the Logic page', () => {
+    // ARRANGE
+    render(
+      <ul>
+        <AchievementChangelogEntry
+          entry={createAchievementChangelogEntry({ type: 'logic-updated', triggerVersion: 4 })}
+        />
+      </ul>,
+      {
+        pageProps: {
+          achievement: createAchievement({ id: 9 }),
+          can: { viewAchievementLogic: true },
+        },
+      },
+    );
+
+    // ASSERT
+    expect(screen.getByRole('link', { name: 'Logic updated' })).toHaveAttribute(
+      'href',
+      '/manage/achievements/9/logic?version=4',
+    );
+  });
+
+  it('given the user cannot view logic, renders the logic entry as plain text', () => {
+    // ARRANGE
+    render(
+      <ul>
+        <AchievementChangelogEntry
+          entry={createAchievementChangelogEntry({ type: 'logic-updated', triggerVersion: 4 })}
+        />
+      </ul>,
+      {
+        pageProps: {
+          achievement: createAchievement({ id: 9 }),
+          can: { viewAchievementLogic: false },
+        },
+      },
+    );
+
+    // ASSERT
+    expect(screen.getByText('Logic updated')).toBeVisible();
+    expect(screen.queryByRole('link', { name: 'Logic updated' })).not.toBeInTheDocument();
+  });
+
+  it('given the entry has no trigger version, renders it as plain text', () => {
+    // ARRANGE
+    render(
+      <ul>
+        <AchievementChangelogEntry
+          entry={createAchievementChangelogEntry({ type: 'logic-updated', triggerVersion: null })}
+        />
+      </ul>,
+      {
+        pageProps: {
+          achievement: createAchievement({ id: 9 }),
+          can: { viewAchievementLogic: true },
+        },
+      },
+    );
+
+    // ASSERT
+    expect(screen.getByText('Logic updated')).toBeVisible();
+    expect(screen.queryByRole('link', { name: 'Logic updated' })).not.toBeInTheDocument();
+  });
+
+  it('given the entry is not a logic entry, does not render a link', () => {
+    // ARRANGE
+    render(
+      <ul>
+        <AchievementChangelogEntry
+          entry={createAchievementChangelogEntry({ type: 'description-updated' })}
+        />
+      </ul>,
+      {
+        pageProps: {
+          achievement: createAchievement({ id: 9 }),
+          can: { viewAchievementLogic: true },
+        },
+      },
+    );
+
+    // ASSERT
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/resources/js/features/achievements/components/AchievementChangelog/AchievementChangelogEntry.test.tsx
+++ b/resources/js/features/achievements/components/AchievementChangelog/AchievementChangelogEntry.test.tsx
@@ -361,7 +361,7 @@ describe('Component: AchievementChangelogEntry', () => {
     expect(screen.getByText('DevAuthor')).toBeVisible();
   });
 
-  it('given the user can view logic and the entry has a trigger version, links to that version on the Logic page', () => {
+  it('given the user can view logic and the entry has a trigger version, renders an icon link to that version on the Logic page', () => {
     // ARRANGE
     render(
       <ul>
@@ -378,7 +378,8 @@ describe('Component: AchievementChangelogEntry', () => {
     );
 
     // ASSERT
-    expect(screen.getByRole('link', { name: 'Logic updated' })).toHaveAttribute(
+    expect(screen.getByText('Logic updated')).toBeVisible();
+    expect(screen.getByRole('link', { name: 'View logic' })).toHaveAttribute(
       'href',
       '/manage/achievements/9/logic?version=4',
     );
@@ -402,7 +403,7 @@ describe('Component: AchievementChangelogEntry', () => {
 
     // ASSERT
     expect(screen.getByText('Logic updated')).toBeVisible();
-    expect(screen.queryByRole('link', { name: 'Logic updated' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('given the entry has no trigger version, renders it as plain text', () => {
@@ -423,7 +424,7 @@ describe('Component: AchievementChangelogEntry', () => {
 
     // ASSERT
     expect(screen.getByText('Logic updated')).toBeVisible();
-    expect(screen.queryByRole('link', { name: 'Logic updated' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('given the entry is not a logic entry, does not render a link', () => {

--- a/resources/js/features/achievements/components/AchievementChangelog/AchievementChangelogEntry.tsx
+++ b/resources/js/features/achievements/components/AchievementChangelog/AchievementChangelogEntry.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/common/components/+vendor/BaseTooltip';
 import { UserAvatar } from '@/common/components/UserAvatar';
 import { useFormatDate } from '@/common/hooks/useFormatDate';
+import { usePageProps } from '@/common/hooks/usePageProps';
 import { cn } from '@/common/utils/cn';
 
 import { FIELD_LEVEL_TRACKING_CUTOFF } from '../../utils/fieldLevelTrackingCutoff';
@@ -23,10 +24,12 @@ export const AchievementChangelogEntry: FC<AchievementChangelogEntryProps> = ({
   entry,
   isCreatedAsPromoted,
 }) => {
+  const { achievement, can } = usePageProps<App.Platform.Data.AchievementShowPageProps>();
   const { t } = useTranslation();
   const { formatDate } = useFormatDate();
 
   const header = buildHeader(entry, t);
+  const logicHref = buildLogicHref(entry, achievement?.id, can?.viewAchievementLogic);
 
   return (
     <li className="group relative flex gap-3 pb-6 last:pb-0" data-testid="changelog-entry">
@@ -43,7 +46,13 @@ export const AchievementChangelogEntry: FC<AchievementChangelogEntryProps> = ({
 
       <div className="flex min-w-0 flex-col gap-0.5">
         <p className="flex items-center gap-1 text-xs">
-          {header}
+          {logicHref ? (
+            <a href={logicHref} target="_blank" rel="noopener noreferrer">
+              {header}
+            </a>
+          ) : (
+            header
+          )}
 
           {entry.count > 1 && entry.type === 'edited' ? (
             <span className="text-neutral-400">
@@ -120,6 +129,23 @@ const FieldChangeDiff: FC<FieldChangeDiffProps> = ({ change, type }) => {
     </div>
   );
 };
+
+function buildLogicHref(
+  entry: App.Platform.Data.AchievementChangelogEntry,
+  achievementId: number | undefined,
+  canViewAchievementLogic: boolean | undefined,
+): string | null {
+  if (
+    entry.type !== 'logic-updated' ||
+    !entry.triggerVersion ||
+    !canViewAchievementLogic ||
+    !achievementId
+  ) {
+    return null;
+  }
+
+  return `/manage/achievements/${achievementId}/logic?version=${entry.triggerVersion}`;
+}
 
 function getDotColor(type: EntryType, isCreatedAsPromoted?: boolean): string {
   switch (type) {

--- a/resources/js/features/achievements/components/AchievementChangelog/AchievementChangelogEntry.tsx
+++ b/resources/js/features/achievements/components/AchievementChangelog/AchievementChangelogEntry.tsx
@@ -1,7 +1,7 @@
 import type { TFunction } from 'i18next';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { LuArrowRight, LuInfo } from 'react-icons/lu';
+import { LuArrowRight, LuCode, LuInfo } from 'react-icons/lu';
 
 import {
   BaseTooltip,
@@ -46,13 +46,26 @@ export const AchievementChangelogEntry: FC<AchievementChangelogEntryProps> = ({
 
       <div className="flex min-w-0 flex-col gap-0.5">
         <p className="flex items-center gap-1 text-xs">
+          {header}
+
           {logicHref ? (
-            <a href={logicHref} target="_blank" rel="noopener noreferrer">
-              {header}
-            </a>
-          ) : (
-            header
-          )}
+            <BaseTooltip>
+              <BaseTooltipTrigger asChild>
+                <a
+                  href={logicHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={t('View logic')}
+                >
+                  <LuCode className="size-3.5 text-link transition hover:text-link-hover" />
+                </a>
+              </BaseTooltipTrigger>
+
+              <BaseTooltipContent>
+                <span className="text-xs">{t('View logic')}</span>
+              </BaseTooltipContent>
+            </BaseTooltip>
+          ) : null}
 
           {entry.count > 1 && entry.type === 'edited' ? (
             <span className="text-neutral-400">

--- a/resources/js/test/factories/createAchievementChangelogEntry.ts
+++ b/resources/js/test/factories/createAchievementChangelogEntry.ts
@@ -17,5 +17,6 @@ export const createAchievementChangelogEntry =
       user: null,
       fieldChanges: [],
       count: 1,
+      triggerVersion: null,
     };
   });

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -529,6 +529,7 @@ createdAt: string;
 user: App.Data.User | null;
 fieldChanges: Array<App.Platform.Data.ChangelogFieldChange>;
 count: number;
+triggerVersion: number | null;
 };
 export type Achievement = {
 badgeLockedUrl: string;

--- a/resources/views/filament/resources/achievement-resource/pages/logic.blade.php
+++ b/resources/views/filament/resources/achievement-resource/pages/logic.blade.php
@@ -47,6 +47,8 @@
                 $versionData = $this->getVersionHistoryData();
                 $triggers = $versionData['triggers'];
                 $lazyLoad = $versionData['lazyLoad'];
+                $focusedVersion = $versionData['focusedVersion'];
+                $shouldShowAllVersions = $versionData['shouldShowAllVersions'];
                 $summaries = $versionData['summaries'] ?? [];
                 $diffs = $versionData['diffs'] ?? [];
             @endphp

--- a/resources/views/filament/resources/achievement-resource/pages/logic.blade.php
+++ b/resources/views/filament/resources/achievement-resource/pages/logic.blade.php
@@ -49,6 +49,7 @@
                 $lazyLoad = $versionData['lazyLoad'];
                 $focusedVersion = $versionData['focusedVersion'];
                 $shouldShowAllVersions = $versionData['shouldShowAllVersions'];
+                $visibleVersionCount = $versionData['visibleVersionCount'];
                 $summaries = $versionData['summaries'] ?? [];
                 $diffs = $versionData['diffs'] ?? [];
             @endphp

--- a/resources/views/filament/resources/achievement-resource/partials/version-history.blade.php
+++ b/resources/views/filament/resources/achievement-resource/partials/version-history.blade.php
@@ -4,6 +4,8 @@
     Expected variables from the parent view:
     - $triggers: Collection of Trigger models with version history.
     - $lazyLoad: bool - Whether to load data asynchronously (true for complex achievements).
+    - $focusedVersion: int|null - Version to expand on load, from a changelog deep link.
+    - $shouldShowAllVersions: bool - Whether the older versions hidden behind "See N more" must be shown for $focusedVersion to be reachable.
     - $summaries: array<int, string> - Pre-computed summaries (only when $lazyLoad is false).
     - $diffs: array<int, array> - Pre-computed diffs (only when $lazyLoad is false).
 
@@ -26,7 +28,8 @@
         x-data="{
             expanded: {},
             viewMode: {},
-            showAll: false,
+            showAll: {{ ($shouldShowAllVersions ?? false) ? 'true' : 'false' }},
+            focusedVersion: @js($focusedVersion ?? null),
             lazyLoad: {{ ($lazyLoad ?? false) ? 'true' : 'false' }},
             summaries: @js($summaries ?? []),
             diffs: @js($diffs ?? []),
@@ -36,6 +39,12 @@
                 if (this.lazyLoad) {
                     this.summaries = await $wire.loadAllSummaries();
                     this.loadingSummaries = false;
+                }
+
+                // Expand through toggleVersion rather than seeding `expanded` directly,
+                // so a lazy-loaded version still fetches its diff.
+                if (this.focusedVersion !== null) {
+                    await this.toggleVersion(this.focusedVersion);
                 }
             },
             async toggleVersion(version) {

--- a/resources/views/filament/resources/achievement-resource/partials/version-history.blade.php
+++ b/resources/views/filament/resources/achievement-resource/partials/version-history.blade.php
@@ -6,6 +6,7 @@
     - $lazyLoad: bool - Whether to load data asynchronously (true for complex achievements).
     - $focusedVersion: int|null - Version to expand on load, from a changelog deep link.
     - $shouldShowAllVersions: bool - Whether the older versions hidden behind "See N more" must be shown for $focusedVersion to be reachable.
+    - $visibleVersionCount: int - How many versions render before the rest collapse behind "See N more". Owned by the page so this partial and the page cannot drift apart.
     - $summaries: array<int, string> - Pre-computed summaries (only when $lazyLoad is false).
     - $diffs: array<int, array> - Pre-computed diffs (only when $lazyLoad is false).
 
@@ -78,7 +79,7 @@
         @foreach ($triggers as $trigger)
             <div
                 class="border-b border-neutral-200 dark:border-neutral-700 py-3 last:border-0"
-                x-show="showAll || {{ $loop->index }} < 8"
+                x-show="showAll || {{ $loop->index }} < {{ $visibleVersionCount }}"
             >
                 {{-- Version header --}}
                 <button
@@ -314,13 +315,17 @@
             </div>
         @endforeach
 
-        @if ($triggers->count() > 8)
+        @if ($triggers->count() > $visibleVersionCount)
+            @php
+                $hiddenVersionCount = $triggers->count() - $visibleVersionCount;
+            @endphp
+
             <button
                 x-show="!showAll"
                 @click="showAll = true"
                 class="w-full py-3 text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
             >
-                See {{ $triggers->count() - 8 }} more {{ Str::plural('version', $triggers->count() - 8) }}...
+                See {{ $hiddenVersionCount }} more {{ Str::plural('version', $hiddenVersionCount) }}...
             </button>
         @endif
     </div>

--- a/tests/Feature/Filament/Pages/AchievementLogicPageTest.php
+++ b/tests/Feature/Filament/Pages/AchievementLogicPageTest.php
@@ -7,7 +7,6 @@ namespace Tests\Feature\Filament\Pages;
 use App\Filament\Resources\AchievementResource\Pages\Logic as LogicPage;
 use App\Models\Achievement;
 use App\Models\Game;
-use App\Models\Role;
 use App\Models\System;
 use App\Models\Trigger;
 use App\Models\User;

--- a/tests/Feature/Filament/Pages/AchievementLogicPageTest.php
+++ b/tests/Feature/Filament/Pages/AchievementLogicPageTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Filament\Pages;
 use App\Filament\Resources\AchievementResource\Pages\Logic as LogicPage;
 use App\Models\Achievement;
 use App\Models\Game;
+use App\Models\Role;
 use App\Models\System;
 use App\Models\Trigger;
 use App\Models\User;
@@ -30,6 +31,30 @@ class AchievementLogicPageTest extends TestCase
         }
 
         return implode('_', $conditions);
+    }
+
+    private function createAchievementWithVersions(int $versionCount): Achievement
+    {
+        $user = User::factory()->create();
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['system_id' => $system->id]);
+        $achievement = Achievement::factory()->create(['game_id' => $game->id]);
+
+        $parentId = null;
+        for ($version = 1; $version <= $versionCount; $version++) {
+            $trigger = Trigger::factory()->create([
+                'triggerable_type' => TriggerableType::Achievement,
+                'triggerable_id' => $achievement->id,
+                'conditions' => '0xH001234=' . $version,
+                'version' => $version,
+                'parent_id' => $parentId,
+                'user_id' => $user->id,
+            ]);
+
+            $parentId = $trigger->id;
+        }
+
+        return $achievement;
     }
 
     public function testGetVersionHistoryDataReturnsLazyLoadFalseForEmptyTriggers(): void
@@ -210,5 +235,39 @@ class AchievementLogicPageTest extends TestCase
         $this->assertNotEmpty($result['diff']);
         $this->assertArrayHasKey('Label', $result['diff'][0]);
         $this->assertArrayHasKey('Conditions', $result['diff'][0]);
+    }
+
+    public function testGetVersionHistoryDataFocusesARequestedVersionThatExists(): void
+    {
+        // Arrange
+        $achievement = $this->createAchievementWithVersions(3);
+
+        $page = new LogicPage();
+        $page->record = $achievement;
+        $page->requestedVersion = 2;
+
+        // Act
+        $result = $page->getVersionHistoryData();
+
+        // Assert
+        $this->assertEquals(2, $result['focusedVersion']);
+        $this->assertFalse($result['shouldShowAllVersions']);
+    }
+
+    public function testGetVersionHistoryDataShowsAllVersionsToReachAHiddenOlderVersion(): void
+    {
+        // Arrange
+        $achievement = $this->createAchievementWithVersions(15);
+
+        $page = new LogicPage();
+        $page->record = $achievement;
+        $page->requestedVersion = 3;
+
+        // Act
+        $result = $page->getVersionHistoryData();
+
+        // Assert
+        $this->assertEquals(3, $result['focusedVersion']);
+        $this->assertTrue($result['shouldShowAllVersions']);
     }
 }

--- a/tests/Feature/Platform/Actions/BuildAchievementChangelogActionTest.php
+++ b/tests/Feature/Platform/Actions/BuildAchievementChangelogActionTest.php
@@ -426,6 +426,82 @@ describe('Trigger Entries', function () {
         $entries = entriesOfType($result, AchievementChangelogEntryType::LogicUpdated);
         expect($entries)->toHaveCount(1);
         expect($entries[0]->user->displayName)->toEqual($user->display_name);
+        expect($entries[0]->triggerVersion)->toEqual(2);
+    });
+
+    it('given a trigger has no version, it creates an entry with a null triggerVersion', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $game = Game::factory()->create();
+        $achievement = createAchievementWithoutLog(['game_id' => $game->id, 'user_id' => $user->id]);
+
+        $parentTrigger = Trigger::factory()->create([
+            'triggerable_type' => 'achievement',
+            'triggerable_id' => $achievement->id,
+            'user_id' => $user->id,
+            'parent_id' => null,
+            'version' => 1,
+            'created_at' => '2025-03-15 12:00:00',
+        ]);
+
+        Trigger::factory()->create([
+            'triggerable_type' => 'achievement',
+            'triggerable_id' => $achievement->id,
+            'user_id' => $user->id,
+            'parent_id' => $parentTrigger->id,
+            'version' => null,
+            'created_at' => '2025-03-15 12:00:00',
+        ]);
+
+        // Act
+        $result = (new BuildAchievementChangelogAction())->execute($achievement);
+
+        // Assert
+        $entries = entriesOfType($result, AchievementChangelogEntryType::LogicUpdated);
+        expect($entries)->toHaveCount(1);
+        expect($entries[0]->triggerVersion)->toBeNull();
+    });
+
+    it('given consecutive trigger versions by the same user, each entry keeps its own version', function () {
+        // Arrange
+        $user = User::factory()->create();
+        $game = Game::factory()->create();
+        $achievement = createAchievementWithoutLog(['game_id' => $game->id, 'user_id' => $user->id]);
+
+        $firstTrigger = Trigger::factory()->create([
+            'triggerable_type' => 'achievement',
+            'triggerable_id' => $achievement->id,
+            'user_id' => $user->id,
+            'parent_id' => null,
+            'version' => 1,
+            'created_at' => '2025-03-15 12:00:00',
+        ]);
+
+        $secondTrigger = Trigger::factory()->create([
+            'triggerable_type' => 'achievement',
+            'triggerable_id' => $achievement->id,
+            'user_id' => $user->id,
+            'parent_id' => $firstTrigger->id,
+            'version' => 2,
+            'created_at' => '2025-03-15 12:00:00',
+        ]);
+
+        Trigger::factory()->create([
+            'triggerable_type' => 'achievement',
+            'triggerable_id' => $achievement->id,
+            'user_id' => $user->id,
+            'parent_id' => $secondTrigger->id,
+            'version' => 3,
+            'created_at' => '2025-03-16 12:00:00',
+        ]);
+
+        // Act
+        $result = (new BuildAchievementChangelogAction())->execute($achievement);
+
+        // Assert
+        $entries = entriesOfType($result, AchievementChangelogEntryType::LogicUpdated);
+        expect($entries)->toHaveCount(2);
+        expect(collect($entries)->pluck('triggerVersion')->sort()->values()->all())->toEqual([2, 3]);
     });
 
     it('ignores triggers with a null parent_id', function () {
@@ -447,6 +523,24 @@ describe('Trigger Entries', function () {
 
         // Assert
         expect(entriesOfType($result, AchievementChangelogEntryType::LogicUpdated))->toHaveCount(0);
+    });
+
+    it('given a legacy comment describes a logic edit, it creates an entry with a null triggerVersion', function () {
+        // Arrange
+        createSystemUser();
+        $user = User::factory()->create(['display_name' => 'Scott']);
+        $game = Game::factory()->create();
+        $achievement = createAchievementWithoutLog(['game_id' => $game->id, 'user_id' => $user->id]);
+
+        createLegacyComment($achievement, "Scott edited this achievement's logic.", '2019-05-01 12:00:00');
+
+        // Act
+        $result = (new BuildAchievementChangelogAction())->execute($achievement);
+
+        // Assert
+        $entries = entriesOfType($result, AchievementChangelogEntryType::LogicUpdated);
+        expect($entries)->toHaveCount(1);
+        expect($entries[0]->triggerVersion)->toBeNull();
     });
 });
 


### PR DESCRIPTION
Resolves #5100.

<img width="487" height="517" alt="Screenshot 2026-08-01 at 2 16 12 PM" src="https://github.com/user-attachments/assets/f491f68b-c486-424c-9f4d-f29b70eb94ad" />

If we have a diff associated with a logic update changelog entry, we now deep link to the Logic page for permissioned users.