### PR TITLE
fix(seo): format meta description numbers with an explicit locale

### DIFF
--- a/resources/js/features/game-list/hooks/useHubPageMetaDescription.ts
+++ b/resources/js/features/game-list/hooks/useHubPageMetaDescription.ts
@@ -2,6 +2,7 @@ import { usePage } from '@inertiajs/react';
 
 import { usePageProps } from '@/common/hooks/usePageProps';
 import { cleanHubTitle } from '@/common/utils/cleanHubTitle';
+import { formatNumber } from '@/common/utils/l10n/formatNumber';
 
 export function useHubPageMetaDescription() {
   const page = usePage();
@@ -21,7 +22,7 @@ export function useHubPageMetaDescription() {
   }
 
   if (paginatedGameListEntries.total) {
-    return `Explore a collection of ${paginatedGameListEntries.total.toLocaleString()} ${paginatedGameListEntries.total === 1 ? 'classic game' : 'classic games'} in the ${cleanedTitle} hub.`;
+    return `Explore a collection of ${formatNumber(paginatedGameListEntries.total)} ${paginatedGameListEntries.total === 1 ? 'classic game' : 'classic games'} in the ${cleanedTitle} hub.`;
   }
 
   // This only happens with orphaned hubs, which probably generate no SEO juice anyway.

--- a/resources/js/features/game-list/utils/buildSystemGamesMetaDescription.ts
+++ b/resources/js/features/game-list/utils/buildSystemGamesMetaDescription.ts
@@ -1,3 +1,5 @@
+import { formatNumber } from '@/common/utils/l10n/formatNumber';
+
 export function buildSystemGamesMetaDescription(totalGames: number, systemName: string): string {
   let firstPhrase;
 
@@ -11,7 +13,7 @@ export function buildSystemGamesMetaDescription(totalGames: number, systemName: 
   } else {
     // For a games count of 100+, round down to nearest hundred and add a plus sign.
     const roundedGames = Math.floor(totalGames / 100) * 100;
-    firstPhrase = `Explore ${roundedGames.toLocaleString()}+ ${systemName} games on RetroAchievements.`;
+    firstPhrase = `Explore ${formatNumber(roundedGames)}+ ${systemName} games on RetroAchievements.`;
   }
 
   const secondPhrase = 'Track your progress as you beat and master each title.';

--- a/resources/js/features/games/hooks/useGameMetaDescription.ts
+++ b/resources/js/features/games/hooks/useGameMetaDescription.ts
@@ -1,4 +1,5 @@
 import { usePageProps } from '@/common/hooks/usePageProps';
+import { formatNumber } from '@/common/utils/l10n/formatNumber';
 
 import { getAchievementSetPointsStats } from '../utils/getAchievementSetPointsStats';
 
@@ -24,7 +25,7 @@ export function useGameMetaDescription(): { description: string; noindex: boolea
     const { pointsTotal } = getAchievementSetPointsStats(allAchievements);
 
     return {
-      description: `There are ${allAchievements.length} unpublished achievements worth ${pointsTotal.toLocaleString()} points. ${backingGame.title} for ${game.system!.name} - explore and compete on this classic game at RetroAchievements.`,
+      description: `There are ${allAchievements.length} unpublished achievements worth ${formatNumber(pointsTotal)} points. ${backingGame.title} for ${game.system!.name} - explore and compete on this classic game at RetroAchievements.`,
       noindex: true,
     };
   }
@@ -38,7 +39,7 @@ export function useGameMetaDescription(): { description: string; noindex: boolea
   }
 
   return {
-    description: `There are ${backingGame.achievementsPublished} achievements worth ${backingGame.pointsTotal!.toLocaleString()} points. ${backingGame.title} for ${game.system!.name} - explore and compete on this classic game at RetroAchievements.`,
+    description: `There are ${backingGame.achievementsPublished} achievements worth ${formatNumber(backingGame.pointsTotal!)} points. ${backingGame.title} for ${game.system!.name} - explore and compete on this classic game at RetroAchievements.`,
     noindex: false,
   };
 }

--- a/resources/js/pages/games.tsx
+++ b/resources/js/pages/games.tsx
@@ -4,6 +4,7 @@ import { SEO } from '@/common/components/SEO';
 import { usePageProps } from '@/common/hooks/usePageProps';
 import { AppLayout } from '@/common/layouts/AppLayout';
 import type { AppPage } from '@/common/models';
+import { formatNumber } from '@/common/utils/l10n/formatNumber';
 import { AllGamesMainRoot } from '@/features/game-list/components/AllGamesMainRoot';
 
 const AllGames: AppPage = () => {
@@ -15,7 +16,7 @@ const AllGames: AppPage = () => {
     <>
       <SEO
         title={t('All Games')}
-        description={`Browse our catalog of ${(Math.floor(paginatedGameListEntries.total / 100) * 100).toLocaleString()}+ retro games with achievements. View detailed listings with achievement counts, points, rarity scores, and release dates.`}
+        description={`Browse our catalog of ${formatNumber(Math.floor(paginatedGameListEntries.total / 100) * 100)}+ retro games with achievements. View detailed listings with achievement counts, points, rarity scores, and release dates.`}
       />
 
       <AppLayout.Main>


### PR DESCRIPTION
Follow-on to #5140, which pinned the locale for test runs and closed #5133. This fixes the call sites those tests were pointing at, so it's complementary rather than an alternative. Rebased on top of #5140; no overlap with it.

## Summary
Five meta descriptions format their numbers with a bare `.toLocaleString()`, which resolves against whatever locale the runtime happens to have. `formatNumber()` is what the rest of the codebase already uses for this (29 files call it directly and 27 more go through `useFormatNumber()`) and it defaults to `en-US`. These five were the only bare calls left.

Output is unchanged for anyone already running in an en-US-style locale, including CI.

<details>
<summary><b>Why it's worth doing on top of the test pin</b></summary>

These strings are built inside components that render through Inertia SSR, where `.toLocaleString()` reads the **SSR process's** locale, so the formatting depends on how the server happens to be provisioned rather than on anything deterministic. `useFormatNumber()`'s docblock names this exact hazard: it exists to prevent "SSR hydration mismatches from locale leaking between concurrent requests".

To be clear about the severity: this is latent rather than visibly broken. A server running with `LANG` unset or `C` resolves to `en-US`, so production output is almost certainly correct today; it just isn't guaranteed by anything except the deployment environment. The change makes it explicit, and brings the last five stragglers in line with the convention the other 56 call sites already follow.

</details>

<details>
<summary><b>Testing</b></summary>

The suite passes under every locale that reproduced the original #5133 failures, with nothing pinned:

| `LANG` | Result |
| --- | --- |
| `hr_HR.UTF-8` | 4720 passed |
| `de_DE.UTF-8` | 4720 passed |
| `sl_SI.UTF-8` | 4720 passed |
| `it_IT.UTF-8` | 4720 passed |

`hr_HR`, `de_DE` and `nl_NL` group thousands with a `.`; `sl_SI` and `it_IT` don't group 4-digit numbers at all (CLDR `minimumGroupingDigits`), so they failed with an ungrouped `2300`. Both classes are fixed at the source.

Note that since #5140 the npm scripts set `LC_ALL` themselves, so reproducing the matrix means invoking vitest directly:

```shell
env -u LC_ALL LANG=hr_HR.UTF-8 TZ=UTC ./node_modules/.bin/vitest --run
```

`pnpm lint`, `pnpm tsc`, `pnpm format` and the coverage thresholds all pass.

</details>

## AI disclosure
Claude Code was used for this change: it traced the root cause, made the edits, and ran the locale matrix above. I reviewed every line and can explain the implementation.
