### PR TITLE
set hash.user_id when creating new hash from management page

### DIFF
--- a/app/Filament/Resources/GameResource/Pages/Hashes.php
+++ b/app/Filament/Resources/GameResource/Pages/Hashes.php
@@ -90,6 +90,8 @@ class Hashes extends ManageRelatedRecords
                             Forms\Components\TextInput::make('labels'),
 
                             Forms\Components\Select::make('compatibility')
+                                ->required()
+                                ->default(GameHashCompatibility::Untested->value)
                                 ->options([
                                     GameHashCompatibility::Compatible->value => GameHashCompatibility::Compatible->label(),
                                     GameHashCompatibility::Incompatible->value => GameHashCompatibility::Incompatible->label(),
@@ -190,6 +192,11 @@ class Hashes extends ManageRelatedRecords
                     ->modalHeading('Add hash to game')
                     ->modalAutofocus(false)
                     ->schema(Hashes::getFormSchema())
+                    ->mutateFormDataUsing(function (array $data): array {
+                        $data['user_id'] = Auth::user()?->id;
+
+                        return $data;
+                    })
                     ->visible(function (): bool {
                         /** @var User $user */
                         $user = Auth::user();


### PR DESCRIPTION
Fixes #5142

The user who created the record is captured in the audit log, but I'm not sure how to automatically extract that. After this is deployed, I'll look at manually updating the affected records.

Also makes Compatibility a required field with a default of Untested