### PR TITLE
fix(manage/logic): normalize decoded hex so equivalent logic stops showing as modified

### DIFF
--- a/app/Filament/Resources/AchievementResource/Pages/Logic.php
+++ b/app/Filament/Resources/AchievementResource/Pages/Logic.php
@@ -184,6 +184,8 @@ class Logic extends Page
             ? []
             : $decoderService->decode($triggers[$currentIndex + 1]->conditions ?? '');
 
+        $this->alignAddressWidths($decoderService, $previousGroups, $currentGroups);
+
         return ['diff' => $diffService->computeDiff($previousGroups, $currentGroups)];
     }
 
@@ -254,6 +256,7 @@ class Logic extends Page
     private function computeDiffsForTriggers(Collection $triggers, array $decodedTriggers): array
     {
         $diffService = new TriggerDiffService();
+        $decoderService = new TriggerDecoderService();
 
         $diffs = [];
 
@@ -268,9 +271,29 @@ class Logic extends Page
                 ? []
                 : $decodedTriggers[$previousKey];
 
+            $this->alignAddressWidths($decoderService, $previousGroups, $currentGroups);
+
             $diffs[$versionKey] = $diffService->computeDiff($previousGroups, $currentGroups);
         }
 
         return $diffs;
+    }
+
+    /**
+     * Pads both versions of a trigger to a shared address width so a diff
+     * never renders the same address with two different paddings.
+     *
+     * @param array<int, array<string, mixed>> $previousGroups
+     * @param array<int, array<string, mixed>> $currentGroups
+     */
+    private function alignAddressWidths(TriggerDecoderService $decoderService, array &$previousGroups, array &$currentGroups): void
+    {
+        $width = max(
+            $decoderService->getAddressWidth($previousGroups),
+            $decoderService->getAddressWidth($currentGroups),
+        );
+
+        $decoderService->applyUniformAddressWidth($previousGroups, $width);
+        $decoderService->applyUniformAddressWidth($currentGroups, $width);
     }
 }

--- a/app/Platform/Services/TriggerDecoderService.php
+++ b/app/Platform/Services/TriggerDecoderService.php
@@ -11,6 +11,13 @@ use Illuminate\Support\Str;
 
 class TriggerDecoderService
 {
+    private function formatHex(string $hex): string
+    {
+        $trimmed = ltrim(strtolower($hex), '0');
+
+        return '0x' . str_pad($trimmed, 6, '0', STR_PAD_LEFT);
+    }
+
     private function parseOperand(string $mem): array
     {
         $end = strlen($mem);
@@ -112,7 +119,7 @@ class TriggerDecoderService
                 $count++;
             }
 
-            $value = '0x' . str_pad(substr($mem, 0, $count), 6, '0', STR_PAD_LEFT);
+            $value = $this->formatHex(substr($mem, 0, $count));
             $mem = substr($mem, $count);
 
             return [$type, $size, $value, $mem];
@@ -179,7 +186,7 @@ class TriggerDecoderService
             $count++;
         }
 
-        $address = '0x' . str_pad(substr($mem, 0, $count), 6, '0', STR_PAD_LEFT);
+        $address = $this->formatHex(substr($mem, 0, $count));
         $mem = substr($mem, $count);
 
         return [$type, $size, $address, $mem];

--- a/app/Platform/Services/TriggerDecoderService.php
+++ b/app/Platform/Services/TriggerDecoderService.php
@@ -11,11 +11,17 @@ use Illuminate\Support\Str;
 
 class TriggerDecoderService
 {
+    public function formatAddress(int $address): string
+    {
+        return $this->formatHex(dechex($address));
+    }
+
     private function formatHex(string $hex): string
     {
         $trimmed = ltrim(strtolower($hex), '0');
+        $width = strlen($trimmed) > 6 ? 8 : 6;
 
-        return '0x' . str_pad($trimmed, 6, '0', STR_PAD_LEFT);
+        return '0x' . str_pad($trimmed, $width, '0', STR_PAD_LEFT);
     }
 
     private function parseOperand(string $mem): array

--- a/app/Platform/Services/TriggerDecoderService.php
+++ b/app/Platform/Services/TriggerDecoderService.php
@@ -11,15 +11,75 @@ use Illuminate\Support\Str;
 
 class TriggerDecoderService
 {
-    public function formatAddress(int $address): string
+    public function formatAddress(int $address, int $width = 6): string
     {
-        return $this->formatHex(dechex($address));
+        return $this->padHex(dechex($address), $width);
+    }
+
+    /**
+     * Determines the display width shared by every address in the trigger.
+     * The width is the digit count of the largest memory address, rounded up
+     * to an even number of digits, with a floor of 4.
+     *
+     * @param array<int, array<string, mixed>> $groups
+     */
+    public function getAddressWidth(array $groups): int
+    {
+        $maxDigits = 1;
+        foreach ($groups as $group) {
+            foreach ($group['Conditions'] ?? [] as $condition) {
+                foreach (['Source', 'Target'] as $side) {
+                    if (!$this->isMemoryReference($condition[$side . 'Type'] ?? '')) {
+                        continue;
+                    }
+
+                    $operand = $condition[$side . 'Address'] ?? '';
+                    if (str_starts_with($operand, '0x')) {
+                        $digits = strlen(ltrim(substr($operand, 2), '0'));
+                        $maxDigits = max($maxDigits, $digits);
+                    }
+                }
+            }
+        }
+
+        return max(4, $maxDigits + ($maxDigits % 2));
+    }
+
+    /**
+     * Reformats every hex operand in the trigger to a shared display width so
+     * rows in the same achievement never mix 4, 6, and 8 digit addresses.
+     * Comparison code must ignore padding, so widths only affect display.
+     *
+     * @param array<int, array<string, mixed>> $groups
+     */
+    public function applyUniformAddressWidth(array &$groups, int $width): void
+    {
+        foreach ($groups as &$group) {
+            foreach ($group['Conditions'] as &$condition) {
+                foreach (['SourceAddress', 'TargetAddress'] as $key) {
+                    $operand = $condition[$key] ?? '';
+                    if (str_starts_with($operand, '0x')) {
+                        $condition[$key] = $this->padHex(substr($operand, 2), $width);
+                    }
+                }
+            }
+        }
     }
 
     private function formatHex(string $hex): string
     {
+        return $this->padHex($hex, 6);
+    }
+
+    /**
+     * A value too large for the requested width keeps its own even-digit
+     * width instead of being truncated.
+     */
+    private function padHex(string $hex, int $width): string
+    {
         $trimmed = ltrim(strtolower($hex), '0');
-        $width = strlen($trimmed) > 6 ? 8 : 6;
+        $digits = max(strlen($trimmed), 1);
+        $width = max($width, $digits + ($digits % 2));
 
         return '0x' . str_pad($trimmed, $width, '0', STR_PAD_LEFT);
     }
@@ -349,6 +409,8 @@ class TriggerDecoderService
             $groups[] = $group;
         }
 
+        $this->applyUniformAddressWidth($groups, $this->getAddressWidth($groups));
+
         return $groups;
     }
 
@@ -419,13 +481,15 @@ class TriggerDecoderService
     {
         ksort($codeNotes);
 
+        $addressWidth = $this->getAddressWidth($groups);
+
         foreach ($groups as &$group) {
             $groupNotes = [];
             $indirectNote = '';
             $indirectChain = '';
             foreach ($group['Conditions'] as &$condition) {
-                $this->setTooltipFromNotes($condition, 'Source', $codeNotes, $indirectChain, $indirectNote, $groupNotes);
-                $this->setTooltipFromNotes($condition, 'Target', $codeNotes, $indirectChain, $indirectNote, $groupNotes);
+                $this->setTooltipFromNotes($condition, 'Source', $codeNotes, $indirectChain, $indirectNote, $groupNotes, $addressWidth);
+                $this->setTooltipFromNotes($condition, 'Target', $codeNotes, $indirectChain, $indirectNote, $groupNotes, $addressWidth);
 
                 if ($condition['Flag'] === 'Add Address' && ($condition['Operator'] === '' || $condition['Operator'] === '&')) {
                     $indirectNote = $condition['SourceTooltip'] ?? '';
@@ -450,7 +514,7 @@ class TriggerDecoderService
     }
 
     private function setTooltipFromNotes(array &$condition, string $type, array $codeNotes,
-        string $indirectChain, string $indirectNote, array &$groupNotes): void
+        string $indirectChain, string $indirectNote, array &$groupNotes, int $addressWidth): void
     {
         if ($this->isMemoryReference($condition[$type . 'Type'])) {
             $formattedAddress = $condition[$type . 'Address'];
@@ -478,7 +542,7 @@ class TriggerDecoderService
                     $note = $codeNotes[$noteAddress] ?? '';
                     $note = $this->resolveNoteRedirects($note, $codeNotes);
                     if (!empty($note)) {
-                        $formattedNoteAddress = '0x' . str_pad(dechex($noteAddress), 6, '0', STR_PAD_LEFT);
+                        $formattedNoteAddress = $this->padHex(dechex($noteAddress), $addressWidth);
                         $offset = $address - $noteAddress;
                         $condition[$type . 'Tooltip'] = "[$formattedNoteAddress + $offset]\n" . $note;
                     }

--- a/app/Platform/Services/TriggerDiffService.php
+++ b/app/Platform/Services/TriggerDiffService.php
@@ -187,10 +187,24 @@ class TriggerDiffService
     {
         $parts = [];
         foreach (self::COMPARABLE_KEYS as $key) {
-            $parts[] = $condition[$key] ?? '';
+            $parts[] = $this->comparableValue($condition[$key] ?? '');
         }
 
         return implode('|', $parts);
+    }
+
+    /**
+     * Normalizes a condition field for comparison. Hex operands drop their
+     * zero padding because display width is chosen per trigger version, so
+     * padding differences never represent a real logic change.
+     */
+    private function comparableValue(mixed $value): mixed
+    {
+        if (is_string($value) && str_starts_with($value, '0x')) {
+            return '0x' . (ltrim(substr($value, 2), '0') ?: '0');
+        }
+
+        return $value;
     }
 
     /**

--- a/app/Platform/Services/TriggerViewerService.php
+++ b/app/Platform/Services/TriggerViewerService.php
@@ -383,30 +383,6 @@ class TriggerViewerService
     }
 
     /**
-     * Determines the appropriate address format string based on address sizes.
-     * Returns '0x%08x' for 32-bit addresses, '0x%06x' otherwise.
-     *
-     * @param array<int, array<string, mixed>> $groups The decoded groups
-     */
-    public function getAddressFormat(array $groups): string
-    {
-        foreach ($groups as $group) {
-            foreach ($group['Conditions'] ?? [] as $condition) {
-                $sourceAddr = $condition['SourceAddress'] ?? '';
-                $targetAddr = $condition['TargetAddress'] ?? '';
-
-                // 32-bit addresses are "0x" + 8 hex digits = 10 characters.
-                if ((str_starts_with($sourceAddr, '0x') && strlen($sourceAddr) === 10)
-                    || (str_starts_with($targetAddr, '0x') && strlen($targetAddr) === 10)) {
-                    return '0x%08x';
-                }
-            }
-        }
-
-        return '0x%06x';
-    }
-
-    /**
      * Strips brackets from an alias string, but preserves [Pointer] markers.
      */
     private function stripBrackets(string $alias): string

--- a/resources/views/components/trigger/viewer.blade.php
+++ b/resources/views/components/trigger/viewer.blade.php
@@ -4,7 +4,10 @@
 ])
 
 <div class="flex flex-col gap-y-8">
-@php $j = 1; $addrFormat = '0x%06x'; @endphp
+@php
+    $j = 1;
+    $triggerDecoderService = new App\Platform\Services\TriggerDecoderService();
+@endphp
 @foreach ($groups as $group)
     <table class="table-highlight border-t border-embed-highlight">
         <tr class="do-not-highlight text-center">
@@ -32,9 +35,6 @@
                 <td>{{ $condition['SourceSize'] }}</td>
                 @if (($condition['SourceTooltip'] ?? '') !== '')
                     <td class="cursor-help" title="{{ $condition['SourceTooltip'] }}">{{ $condition['SourceAddress'] }}</td>
-                    @if (str_starts_with($condition['SourceAddress'], '0x') && strlen($condition['SourceAddress']) === 10)
-                        @php $addrFormat = '0x%08x'; @endphp
-                    @endif
                 @else
                     <td>{{ $condition['SourceAddress'] }}</td>
                 @endif
@@ -71,7 +71,7 @@
                         <table id="notes{{ $prefix }}{{ $j }}" class="hidden">
                             @foreach ($group['Notes'] as $addr => $note)
                                 <tr>
-                                    <td class="whitespace-nowrap align-top font-mono"><b>{{ sprintf($addrFormat, $addr) }}</b></td>
+                                    <td class="whitespace-nowrap align-top font-mono"><b>{{ $triggerDecoderService->formatAddress($addr) }}</b></td>
                                     <td class="text-xs"><code>{{ $note }}<code></td>
                                 </tr>
                             @endforeach

--- a/resources/views/components/trigger/viewer.blade.php
+++ b/resources/views/components/trigger/viewer.blade.php
@@ -7,6 +7,7 @@
 @php
     $j = 1;
     $triggerDecoderService = new App\Platform\Services\TriggerDecoderService();
+    $addressWidth = $triggerDecoderService->getAddressWidth($groups);
 @endphp
 @foreach ($groups as $group)
     <table class="table-highlight border-t border-embed-highlight">
@@ -71,7 +72,7 @@
                         <table id="notes{{ $prefix }}{{ $j }}" class="hidden">
                             @foreach ($group['Notes'] as $addr => $note)
                                 <tr>
-                                    <td class="whitespace-nowrap align-top font-mono"><b>{{ $triggerDecoderService->formatAddress($addr) }}</b></td>
+                                    <td class="whitespace-nowrap align-top font-mono"><b>{{ $triggerDecoderService->formatAddress($addr, $addressWidth) }}</b></td>
                                     <td class="text-xs"><code>{{ $note }}<code></td>
                                 </tr>
                             @endforeach

--- a/resources/views/filament/resources/achievement-resource/pages/logic.blade.php
+++ b/resources/views/filament/resources/achievement-resource/pages/logic.blade.php
@@ -21,7 +21,6 @@
             $triggerDecoderService->addCodeNotes($groups, $record->game_id);
 
             $hasAddAddress = $triggerViewerService->hasAddAddressFlag($groups);
-            $addrFormat = $triggerViewerService->getAddressFormat($groups);
             $markdownOutput = $triggerViewerService->generateMarkdown($groups);
 
             $tooltipStyle = 'white-space: pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: 11px; max-height: 300px; overflow-y: auto; display: block';
@@ -331,7 +330,7 @@
                                 <div class="divide-y divide-gray-950/5 dark:divide-white/5">
                                     @foreach ($group['Notes'] as $addr => $note)
                                         <div class="flex gap-3 text-xs py-2 first:pt-0 last:pb-0">
-                                            <code class="shrink-0 font-medium text-blue-600 dark:text-blue-400">{{ sprintf($addrFormat, $addr) }}</code>
+                                            <code class="shrink-0 font-medium text-blue-600 dark:text-blue-400">{{ $triggerDecoderService->formatAddress($addr) }}</code>
                                             <span class="font-mono text-neutral-600 dark:text-neutral-400 wrap-break-word whitespace-pre-wrap">{{ $note }}</span>
                                         </div>
                                     @endforeach

--- a/resources/views/filament/resources/achievement-resource/pages/logic.blade.php
+++ b/resources/views/filament/resources/achievement-resource/pages/logic.blade.php
@@ -19,6 +19,7 @@
 
             $groups = $triggerDecoderService->decode($conditions);
             $triggerDecoderService->addCodeNotes($groups, $record->game_id);
+            $addressWidth = $triggerDecoderService->getAddressWidth($groups);
 
             $hasAddAddress = $triggerViewerService->hasAddAddressFlag($groups);
             $markdownOutput = $triggerViewerService->generateMarkdown($groups);
@@ -330,7 +331,7 @@
                                 <div class="divide-y divide-gray-950/5 dark:divide-white/5">
                                     @foreach ($group['Notes'] as $addr => $note)
                                         <div class="flex gap-3 text-xs py-2 first:pt-0 last:pb-0">
-                                            <code class="shrink-0 font-medium text-blue-600 dark:text-blue-400">{{ $triggerDecoderService->formatAddress($addr) }}</code>
+                                            <code class="shrink-0 font-medium text-blue-600 dark:text-blue-400">{{ $triggerDecoderService->formatAddress($addr, $addressWidth) }}</code>
                                             <span class="font-mono text-neutral-600 dark:text-neutral-400 wrap-break-word whitespace-pre-wrap">{{ $note }}</span>
                                         </div>
                                     @endforeach

--- a/tests/Feature/Platform/Services/TriggerDecoderServiceTest.php
+++ b/tests/Feature/Platform/Services/TriggerDecoderServiceTest.php
@@ -65,45 +65,45 @@ class TriggerDecoderServiceTest extends TestCase
 
     public function testParseOperand(): void
     {
-        $this->assertParseOperand('0xH1234', 'Mem', '8-bit', '0x001234');
-        $this->assertParseOperand('0xh1234', 'Mem', '8-bit', '0x001234');
-        $this->assertParseOperand('0x 1234', 'Mem', '16-bit', '0x001234');
-        $this->assertParseOperand('0x1234', 'Mem', '16-bit', '0x001234');
-        $this->assertParseOperand('0xW1234', 'Mem', '24-bit', '0x001234');
-        $this->assertParseOperand('0xX1234', 'Mem', '32-bit', '0x001234');
+        $this->assertParseOperand('0xH1234', 'Mem', '8-bit', '0x1234');
+        $this->assertParseOperand('0xh1234', 'Mem', '8-bit', '0x1234');
+        $this->assertParseOperand('0x 1234', 'Mem', '16-bit', '0x1234');
+        $this->assertParseOperand('0x1234', 'Mem', '16-bit', '0x1234');
+        $this->assertParseOperand('0xW1234', 'Mem', '24-bit', '0x1234');
+        $this->assertParseOperand('0xX1234', 'Mem', '32-bit', '0x1234');
 
-        $this->assertParseOperand('0xL1234', 'Mem', 'Lower4', '0x001234');
-        $this->assertParseOperand('0xU1234', 'Mem', 'Upper4', '0x001234');
-        $this->assertParseOperand('0xM1234', 'Mem', 'Bit0', '0x001234');
-        $this->assertParseOperand('0xN1234', 'Mem', 'Bit1', '0x001234');
-        $this->assertParseOperand('0xO1234', 'Mem', 'Bit2', '0x001234');
-        $this->assertParseOperand('0xP1234', 'Mem', 'Bit3', '0x001234');
-        $this->assertParseOperand('0xQ1234', 'Mem', 'Bit4', '0x001234');
-        $this->assertParseOperand('0xR1234', 'Mem', 'Bit5', '0x001234');
-        $this->assertParseOperand('0xS1234', 'Mem', 'Bit6', '0x001234');
-        $this->assertParseOperand('0xT1234', 'Mem', 'Bit7', '0x001234');
+        $this->assertParseOperand('0xL1234', 'Mem', 'Lower4', '0x1234');
+        $this->assertParseOperand('0xU1234', 'Mem', 'Upper4', '0x1234');
+        $this->assertParseOperand('0xM1234', 'Mem', 'Bit0', '0x1234');
+        $this->assertParseOperand('0xN1234', 'Mem', 'Bit1', '0x1234');
+        $this->assertParseOperand('0xO1234', 'Mem', 'Bit2', '0x1234');
+        $this->assertParseOperand('0xP1234', 'Mem', 'Bit3', '0x1234');
+        $this->assertParseOperand('0xQ1234', 'Mem', 'Bit4', '0x1234');
+        $this->assertParseOperand('0xR1234', 'Mem', 'Bit5', '0x1234');
+        $this->assertParseOperand('0xS1234', 'Mem', 'Bit6', '0x1234');
+        $this->assertParseOperand('0xT1234', 'Mem', 'Bit7', '0x1234');
 
-        $this->assertParseOperand('0xK1234', 'Mem', 'BitCount', '0x001234');
+        $this->assertParseOperand('0xK1234', 'Mem', 'BitCount', '0x1234');
 
-        $this->assertParseOperand('0xI1234', 'Mem', '16-bit BE', '0x001234');
-        $this->assertParseOperand('0xJ1234', 'Mem', '24-bit BE', '0x001234');
-        $this->assertParseOperand('0xG1234', 'Mem', '32-bit BE', '0x001234');
+        $this->assertParseOperand('0xI1234', 'Mem', '16-bit BE', '0x1234');
+        $this->assertParseOperand('0xJ1234', 'Mem', '24-bit BE', '0x1234');
+        $this->assertParseOperand('0xG1234', 'Mem', '32-bit BE', '0x1234');
 
-        $this->assertParseOperand('d0xH1234', 'Delta', '8-bit', '0x001234');
-        $this->assertParseOperand('p0xH1234', 'Prior', '8-bit', '0x001234');
-        $this->assertParseOperand('b0xH1234', 'BCD', '8-bit', '0x001234');
-        $this->assertParseOperand('~0xH1234', 'Inverted', '8-bit', '0x001234');
+        $this->assertParseOperand('d0xH1234', 'Delta', '8-bit', '0x1234');
+        $this->assertParseOperand('p0xH1234', 'Prior', '8-bit', '0x1234');
+        $this->assertParseOperand('b0xH1234', 'BCD', '8-bit', '0x1234');
+        $this->assertParseOperand('~0xH1234', 'Inverted', '8-bit', '0x1234');
 
-        $this->assertParseOperand('fF1234', 'Mem', 'Float', '0x001234');
-        $this->assertParseOperand('fB1234', 'Mem', 'Float BE', '0x001234');
-        $this->assertParseOperand('fH1234', 'Mem', 'Double32', '0x001234');
-        $this->assertParseOperand('fI1234', 'Mem', 'Double32 BE', '0x001234');
-        $this->assertParseOperand('fM1234', 'Mem', 'MBF32', '0x001234');
-        $this->assertParseOperand('fL1234', 'Mem', 'MBF32 LE', '0x001234');
+        $this->assertParseOperand('fF1234', 'Mem', 'Float', '0x1234');
+        $this->assertParseOperand('fB1234', 'Mem', 'Float BE', '0x1234');
+        $this->assertParseOperand('fH1234', 'Mem', 'Double32', '0x1234');
+        $this->assertParseOperand('fI1234', 'Mem', 'Double32 BE', '0x1234');
+        $this->assertParseOperand('fM1234', 'Mem', 'MBF32', '0x1234');
+        $this->assertParseOperand('fL1234', 'Mem', 'MBF32 LE', '0x1234');
 
-        $this->assertParseOperand('1234', 'Value', '', '0x0004d2'); // raw value
-        $this->assertParseOperand('h1234', 'Value', '', '0x001234'); // hex value
-        $this->assertParseOperand('v1234', 'Value', '', '0x0004d2'); // legacy raw value
+        $this->assertParseOperand('1234', 'Value', '', '0x04d2'); // raw value
+        $this->assertParseOperand('h1234', 'Value', '', '0x1234'); // hex value
+        $this->assertParseOperand('v1234', 'Value', '', '0x04d2'); // legacy raw value
         $this->assertParseOperand('v-1234', 'Value', '', '0xfffffb2e'); // signed legacy raw value
 
         $this->assertParseOperand('f123.4', 'Float', '', '123.4');
@@ -115,27 +115,56 @@ class TriggerDecoderServiceTest extends TestCase
 
     public function testParseOperandNormalizesHexSpelling(): void
     {
-        // addresses shorter than the canonical width are padded out
-        $this->assertParseOperand('0xH1234', 'Mem', '8-bit', '0x001234');
+        // the trigger's largest address picks the display width, with a floor of 4 digits
+        $this->assertParseOperand('0xH1234', 'Mem', '8-bit', '0x1234');
 
-        // addresses too wide for the narrow form settle on the wide form
+        // addresses too wide for 6 digits settle on 8 digits
         $this->assertParseOperand('0xH01bac044', 'Mem', '8-bit', '0x01bac044');
         $this->assertParseOperand('0xH1bac044', 'Mem', '8-bit', '0x01bac044');
 
-        // surplus leading zeros drop away when the narrow form still fits
+        // surplus leading zeros drop away when a narrower even width still fits
         $this->assertParseOperand('0xG00966c5c', 'Mem', '32-bit BE', '0x966c5c');
         $this->assertParseOperand('0xG966c5c', 'Mem', '32-bit BE', '0x966c5c');
 
         // uppercase and lowercase hex digits describe the same address
-        $this->assertParseOperand('0xHabcd', 'Mem', '8-bit', '0x00abcd');
-        $this->assertParseOperand('0xHABCD', 'Mem', '8-bit', '0x00abcd');
+        $this->assertParseOperand('0xHabcd', 'Mem', '8-bit', '0xabcd');
+        $this->assertParseOperand('0xHABCD', 'Mem', '8-bit', '0xabcd');
 
-        // hex values follow the same rules as addresses
-        $this->assertParseOperand('h0000000a', 'Value', '', '0x00000a');
-        $this->assertParseOperand('hA', 'Value', '', '0x00000a');
+        // hex values pad to the trigger width too
+        $this->assertParseOperand('h0000000a', 'Value', '', '0x000a');
+        $this->assertParseOperand('hA', 'Value', '', '0x000a');
 
-        // an address of zero still renders at the canonical width
-        $this->assertParseOperand('0xH0000000', 'Mem', '8-bit', '0x000000');
+        // an address of zero still renders at the minimum width
+        $this->assertParseOperand('0xH0000000', 'Mem', '8-bit', '0x0000');
+    }
+
+    public function testDecodeUsesOneAddressWidthPerTrigger(): void
+    {
+        $service = new TriggerDecoderService();
+
+        // ... the 7-digit address forces every address in the trigger to 8 digits ...
+        $groups = $service->decode('0xG00966c5c=1_0xH01bac044=2');
+        $conditions = $groups[0]['Conditions'];
+
+        $this->assertEquals(8, $service->getAddressWidth($groups));
+        $this->assertEquals('0x00966c5c', $conditions[0]['SourceAddress']);
+        $this->assertEquals('0x01bac044', $conditions[1]['SourceAddress']);
+
+        // ... a trigger of small addresses settles on the 4-digit floor ...
+        $groups = $service->decode('0xH12=1_0xH1234=2');
+        $conditions = $groups[0]['Conditions'];
+
+        $this->assertEquals(4, $service->getAddressWidth($groups));
+        $this->assertEquals('0x0012', $conditions[0]['SourceAddress']);
+        $this->assertEquals('0x1234', $conditions[1]['SourceAddress']);
+
+        // ... a large hex value widens itself but never the addresses ...
+        $groups = $service->decode('0xH1234=h554c4a4d');
+        $conditions = $groups[0]['Conditions'];
+
+        $this->assertEquals(4, $service->getAddressWidth($groups));
+        $this->assertEquals('0x1234', $conditions[0]['SourceAddress']);
+        $this->assertEquals('0x554c4a4d', $conditions[0]['TargetAddress']);
     }
 
     public function testFormatAddressMatchesTheAddressesOnDecodedConditions(): void
@@ -144,18 +173,20 @@ class TriggerDecoderServiceTest extends TestCase
 
         $groups = $service->decode('0xG00966c5c=1_0xH01bac044=2');
         $conditions = $groups[0]['Conditions'];
+        $width = $service->getAddressWidth($groups);
 
         $this->assertEquals(
             $conditions[0]['SourceAddress'],
-            $service->formatAddress(hexdec($conditions[0]['SourceAddress']))
+            $service->formatAddress(hexdec($conditions[0]['SourceAddress']), $width)
         );
         $this->assertEquals(
             $conditions[1]['SourceAddress'],
-            $service->formatAddress(hexdec($conditions[1]['SourceAddress']))
+            $service->formatAddress(hexdec($conditions[1]['SourceAddress']), $width)
         );
 
         $this->assertEquals('0x966c5c', $service->formatAddress(0x966C5C));
         $this->assertEquals('0x01bac044', $service->formatAddress(0x1BAC044));
+        $this->assertEquals('0x0034', $service->formatAddress(0x34, 4));
         $this->assertEquals('0x000000', $service->formatAddress(0));
     }
 
@@ -163,30 +194,30 @@ class TriggerDecoderServiceTest extends TestCase
     {
         $condition = $this->parseSingleCondition("0xH1234=6");
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1234');
         $this->assertConditionOperator($condition, '=');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000006');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0006');
         $this->assertConditionHitTarget($condition, '0');
 
         $condition = $this->parseSingleCondition("R:0xH1234>d0xH1234.5.");
         $this->assertConditionFlag($condition, 'Reset If');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1234');
         $this->assertConditionOperator($condition, '>');
-        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x001234');
+        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x1234');
         $this->assertConditionHitTarget($condition, '5');
 
         $condition = $this->parseSingleCondition("A:0xH1234*2");
         $this->assertConditionFlag($condition, 'Add Source');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1234');
         $this->assertConditionOperator($condition, '*');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000002');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0002');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $this->parseSingleCondition("K:{recall}+2");
         $this->assertConditionFlag($condition, 'Remember');
         $this->assertConditionSourceOperand($condition, 'Recall', '', '');
         $this->assertConditionOperator($condition, '+');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000002');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0002');
         $this->assertConditionHitTarget($condition, '');
     }
 
@@ -238,30 +269,30 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, 'Add Address');
-        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x1234');
         $this->assertConditionOperator($condition, '');
         $this->assertConditionTargetOperand($condition, '', '', '');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, 'Add Source');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000000');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0000');
         $this->assertConditionOperator($condition, '&');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x00003f');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x003f');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $groups[0]['Conditions'][2];
         $this->assertConditionFlag($condition, 'Add Address');
-        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x1234');
         $this->assertConditionOperator($condition, '');
         $this->assertConditionTargetOperand($condition, '', '', '');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $groups[0]['Conditions'][3];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000001');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0001');
         $this->assertConditionOperator($condition, '<');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000007');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0007');
         $this->assertConditionHitTarget($condition, '0');
     }
 
@@ -278,25 +309,25 @@ class TriggerDecoderServiceTest extends TestCase
         $this->assertEquals('Core Group', $groups[0]['Label']);
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1234');
         $this->assertConditionOperator($condition, '=');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000001');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0001');
         $this->assertConditionHitTarget($condition, '0');
 
         $this->assertEquals('Alt Group 1', $groups[1]['Label']);
         $condition = $groups[1]['Conditions'][0];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x002345');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x2345');
         $this->assertConditionOperator($condition, '<');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000006');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0006');
         $this->assertConditionHitTarget($condition, '0');
 
         $this->assertEquals('Alt Group 2', $groups[2]['Label']);
         $condition = $groups[2]['Conditions'][0];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x003456');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x3456');
         $this->assertConditionOperator($condition, '>=');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000009');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0009');
         $this->assertConditionHitTarget($condition, '0');
     }
 
@@ -311,16 +342,16 @@ class TriggerDecoderServiceTest extends TestCase
         $this->assertEquals('Value', $groups[0]['Label']);
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, 'Add Source');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000001');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0001');
         $this->assertConditionOperator($condition, '*');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000064');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0064');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, 'Measured');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000002');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0002');
         $this->assertConditionOperator($condition, '*');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x00000a');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000a');
         $this->assertConditionHitTarget($condition, '');
     }
 
@@ -334,16 +365,16 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, 'Add Source');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000001');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0001');
         $this->assertConditionOperator($condition, '*');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000064');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0064');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, 'Measured');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000002');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0002');
         $this->assertConditionOperator($condition, '*');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x00000a');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000a');
         $this->assertConditionHitTarget($condition, '');
     }
 
@@ -357,21 +388,21 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, 'Add Source');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000001');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0001');
         $this->assertConditionOperator($condition, '*');
         $this->assertConditionTargetOperand($condition, 'Float', '', '0.5');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, 'Sub Source');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000002');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0002');
         $this->assertConditionOperator($condition, '*');
         $this->assertConditionTargetOperand($condition, 'Float', '', '2.4');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $groups[0]['Conditions'][2];
         $this->assertConditionFlag($condition, 'Measured');
-        $this->assertConditionSourceOperand($condition, 'Value', '', '0x000000');
+        $this->assertConditionSourceOperand($condition, 'Value', '', '0x0000');
         $this->assertConditionOperator($condition, '');
         $this->assertConditionTargetOperand($condition, '', '', '');
         $this->assertConditionHitTarget($condition, '');
@@ -388,24 +419,24 @@ class TriggerDecoderServiceTest extends TestCase
         $this->assertEquals('Value 1', $groups[0]['Label']);
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, 'Add Source');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000001');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0001');
         $this->assertConditionOperator($condition, '*');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000064');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0064');
         $this->assertConditionHitTarget($condition, '');
 
         $this->assertEquals('Value 2', $groups[1]['Label']);
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, 'Measured');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000002');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0002');
         $this->assertConditionOperator($condition, '*');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x00000a');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000a');
         $this->assertConditionHitTarget($condition, '');
 
         $this->assertEquals(1, count($groups[1]['Conditions']));
 
         $condition = $groups[1]['Conditions'][0];
         $this->assertConditionFlag($condition, 'Measured');
-        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x1234');
         $this->assertConditionOperator($condition, '');
         $this->assertConditionTargetOperand($condition, '', '', '');
         $this->assertConditionHitTarget($condition, '');
@@ -421,14 +452,14 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, 'Add Source');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000001');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0001');
         $this->assertConditionOperator($condition, '');
         $this->assertConditionTargetOperand($condition, '', '', '');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, 'Measured');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x000002');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x0002');
         $this->assertConditionOperator($condition, '');
         $this->assertConditionTargetOperand($condition, '', '', '');
         $this->assertConditionHitTarget($condition, '');
@@ -444,46 +475,46 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1234');
         $this->assertConditionSourceTooltip($condition, '');
         $this->assertConditionOperator($condition, '>');
-        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x001234');
+        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x1234');
         $this->assertConditionTargetTooltip($condition, '');
         $this->assertConditionHitTarget($condition, '0');
 
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001235');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1235');
         $this->assertConditionSourceTooltip($condition, '');
         $this->assertConditionOperator($condition, '=');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000024');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0024');
         $this->assertConditionTargetTooltip($condition, '36');
         $this->assertConditionHitTarget($condition, '0');
 
         $service->mergeCodeNotes($groups, [
-            0x001234 => 'Lives',
+            0x1234 => 'Lives',
             0x001236 => 'Unused',
         ]);
 
         $this->assertEquals($groups[0]['Notes'], [
-            0x001234 => 'Lives',
+            0x1234 => 'Lives',
         ]);
 
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1234');
         $this->assertConditionSourceTooltip($condition, 'Lives');
         $this->assertConditionOperator($condition, '>');
-        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x001234');
+        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x1234');
         $this->assertConditionTargetTooltip($condition, 'Lives');
         $this->assertConditionHitTarget($condition, '0');
 
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001235');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1235');
         $this->assertConditionSourceTooltip($condition, '');
         $this->assertConditionOperator($condition, '=');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000024');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0024');
         $this->assertConditionTargetTooltip($condition, '36');
         $this->assertConditionHitTarget($condition, '0');
     }
@@ -493,7 +524,7 @@ class TriggerDecoderServiceTest extends TestCase
         $service = new TriggerDecoderService();
         $groups = $service->decode("I:0xX1234_I:0xX0004_0x 0002!=0x 0000");
         $service->mergeCodeNotes($groups, [
-            0x001234 => "[32-bit] pointer\n" .
+            0x1234 => "[32-bit] pointer\n" .
                         "+0 | [32-bit] index\n" .
                         "+4 | [32-bit] nested pointer\n" .
                         "++0 | [16-bit] value1\n" .
@@ -507,7 +538,7 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, 'Add Address');
-        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x1234');
         $this->assertConditionSourceTooltip($condition, '[32-bit] pointer');
         $this->assertConditionOperator($condition, '');
         $this->assertConditionTargetOperand($condition, '', '', '');
@@ -516,8 +547,8 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, 'Add Address');
-        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x000004');
-        $this->assertConditionSourceTooltip($condition, "[Indirect 0x001234 + 0x000004]\n[32-bit] nested pointer");
+        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x0004');
+        $this->assertConditionSourceTooltip($condition, "[Indirect 0x1234 + 0x0004]\n[32-bit] nested pointer");
         $this->assertConditionOperator($condition, '');
         $this->assertConditionTargetOperand($condition, '', '', '');
         $this->assertConditionTargetTooltip($condition, '');
@@ -525,11 +556,11 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][2];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '16-bit', '0x000002');
-        $this->assertConditionSourceTooltip($condition, "[Indirect 0x001234 + 0x000004 + 0x000002]\n[16-bit] value2");
+        $this->assertConditionSourceOperand($condition, 'Mem', '16-bit', '0x0002');
+        $this->assertConditionSourceTooltip($condition, "[Indirect 0x1234 + 0x0004 + 0x0002]\n[16-bit] value2");
         $this->assertConditionOperator($condition, '!=');
-        $this->assertConditionTargetOperand($condition, 'Mem', '16-bit', '0x000000');
-        $this->assertConditionTargetTooltip($condition, "[Indirect 0x001234 + 0x000004 + 0x000000]\n[16-bit] value1");
+        $this->assertConditionTargetOperand($condition, 'Mem', '16-bit', '0x0000');
+        $this->assertConditionTargetTooltip($condition, "[Indirect 0x1234 + 0x0004 + 0x0000]\n[16-bit] value1");
         $this->assertConditionHitTarget($condition, '0');
     }
 
@@ -574,8 +605,8 @@ class TriggerDecoderServiceTest extends TestCase
         $service = new TriggerDecoderService();
         $groups = $service->decode("I:0xH1200*2_0xX1234!=16");
         $service->mergeCodeNotes($groups, [
-            0x001200 => "[8-bit] selected item index",
-            0x001234 => "[100x16-bit] array of items",
+            0x1200 => "[8-bit] selected item index",
+            0x1234 => "[100x16-bit] array of items",
         ]);
 
         $this->assertEquals(1, count($groups));
@@ -583,19 +614,19 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, 'Add Address');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001200');
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1200');
         $this->assertConditionSourceTooltip($condition, '[8-bit] selected item index');
         $this->assertConditionOperator($condition, '*');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000002');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0002');
         $this->assertConditionTargetTooltip($condition, '2');
         $this->assertConditionHitTarget($condition, '');
 
         $condition = $groups[0]['Conditions'][1];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x001234');
+        $this->assertConditionSourceOperand($condition, 'Mem', '32-bit', '0x1234');
         $this->assertConditionSourceTooltip($condition, "[With indirection]\n[100x16-bit] array of items");
         $this->assertConditionOperator($condition, '!=');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000010');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0010');
         $this->assertConditionTargetTooltip($condition, '16');
         $this->assertConditionHitTarget($condition, '0');
     }
@@ -605,7 +636,7 @@ class TriggerDecoderServiceTest extends TestCase
         $service = new TriggerDecoderService();
         $groups = $service->decode("0xH1240=6");
         $service->mergeCodeNotes($groups, [
-            0x001234 => "[128 bytes] Inventory",
+            0x1234 => "[128 bytes] Inventory",
         ]);
 
         $this->assertEquals(1, count($groups));
@@ -613,10 +644,10 @@ class TriggerDecoderServiceTest extends TestCase
 
         $condition = $groups[0]['Conditions'][0];
         $this->assertConditionFlag($condition, '');
-        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001240');
-        $this->assertConditionSourceTooltip($condition, "[0x001234 + 12]\n[128 bytes] Inventory");
+        $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x1240');
+        $this->assertConditionSourceTooltip($condition, "[0x1234 + 12]\n[128 bytes] Inventory");
         $this->assertConditionOperator($condition, '=');
-        $this->assertConditionTargetOperand($condition, 'Value', '', '0x000006');
+        $this->assertConditionTargetOperand($condition, 'Value', '', '0x0006');
         $this->assertConditionTargetTooltip($condition, '6');
         $this->assertConditionHitTarget($condition, '0');
     }
@@ -642,8 +673,8 @@ class TriggerDecoderServiceTest extends TestCase
         $service = new TriggerDecoderService();
         $groups = $service->decode("0xH1234=6_0xH5678=7");
         $service->mergeCodeNotes($groups, [
-            0x001234 => 'Player Health',
-            0x005678 => 'refer to $0x001234',
+            0x1234 => 'Player Health',
+            0x005678 => 'refer to $0x1234',
         ]);
 
         $this->assertEquals(1, count($groups));
@@ -663,9 +694,9 @@ class TriggerDecoderServiceTest extends TestCase
         $service = new TriggerDecoderService();
         $groups = $service->decode("0xH1234=6_0xH5678=7_0xH9ABC=8");
         $service->mergeCodeNotes($groups, [
-            0x001234 => 'Player Health', // A
+            0x1234 => 'Player Health', // A
             0x005678 => 'refer to $0x009ABC', // B, resolves to C, resolves to A
-            0x009ABC => 'refer to $0x001234', // C, resolves to A
+            0x009ABC => 'refer to $0x1234', // C, resolves to A
         ]);
 
         // ... all notes should resolve to "Player Health" through the chain ...

--- a/tests/Feature/Platform/Services/TriggerDecoderServiceTest.php
+++ b/tests/Feature/Platform/Services/TriggerDecoderServiceTest.php
@@ -118,9 +118,11 @@ class TriggerDecoderServiceTest extends TestCase
         // addresses shorter than the canonical width are padded out
         $this->assertParseOperand('0xH1234', 'Mem', '8-bit', '0x001234');
 
-        // addresses wider than the canonical width drop their surplus leading zeros
-        $this->assertParseOperand('0xH01bac044', 'Mem', '8-bit', '0x1bac044');
-        $this->assertParseOperand('0xH1bac044', 'Mem', '8-bit', '0x1bac044');
+        // addresses too wide for the narrow form settle on the wide form
+        $this->assertParseOperand('0xH01bac044', 'Mem', '8-bit', '0x01bac044');
+        $this->assertParseOperand('0xH1bac044', 'Mem', '8-bit', '0x01bac044');
+
+        // surplus leading zeros drop away when the narrow form still fits
         $this->assertParseOperand('0xG00966c5c', 'Mem', '32-bit BE', '0x966c5c');
         $this->assertParseOperand('0xG966c5c', 'Mem', '32-bit BE', '0x966c5c');
 
@@ -134,6 +136,27 @@ class TriggerDecoderServiceTest extends TestCase
 
         // an address of zero still renders at the canonical width
         $this->assertParseOperand('0xH0000000', 'Mem', '8-bit', '0x000000');
+    }
+
+    public function testFormatAddressMatchesTheAddressesOnDecodedConditions(): void
+    {
+        $service = new TriggerDecoderService();
+
+        $groups = $service->decode('0xG00966c5c=1_0xH01bac044=2');
+        $conditions = $groups[0]['Conditions'];
+
+        $this->assertEquals(
+            $conditions[0]['SourceAddress'],
+            $service->formatAddress(hexdec($conditions[0]['SourceAddress']))
+        );
+        $this->assertEquals(
+            $conditions[1]['SourceAddress'],
+            $service->formatAddress(hexdec($conditions[1]['SourceAddress']))
+        );
+
+        $this->assertEquals('0x966c5c', $service->formatAddress(0x966C5C));
+        $this->assertEquals('0x01bac044', $service->formatAddress(0x1BAC044));
+        $this->assertEquals('0x000000', $service->formatAddress(0));
     }
 
     public function testParseCondition(): void

--- a/tests/Feature/Platform/Services/TriggerDecoderServiceTest.php
+++ b/tests/Feature/Platform/Services/TriggerDecoderServiceTest.php
@@ -113,6 +113,29 @@ class TriggerDecoderServiceTest extends TestCase
         $this->assertParseOperand('{recall}', 'Recall', '', '');
     }
 
+    public function testParseOperandNormalizesHexSpelling(): void
+    {
+        // addresses shorter than the canonical width are padded out
+        $this->assertParseOperand('0xH1234', 'Mem', '8-bit', '0x001234');
+
+        // addresses wider than the canonical width drop their surplus leading zeros
+        $this->assertParseOperand('0xH01bac044', 'Mem', '8-bit', '0x1bac044');
+        $this->assertParseOperand('0xH1bac044', 'Mem', '8-bit', '0x1bac044');
+        $this->assertParseOperand('0xG00966c5c', 'Mem', '32-bit BE', '0x966c5c');
+        $this->assertParseOperand('0xG966c5c', 'Mem', '32-bit BE', '0x966c5c');
+
+        // uppercase and lowercase hex digits describe the same address
+        $this->assertParseOperand('0xHabcd', 'Mem', '8-bit', '0x00abcd');
+        $this->assertParseOperand('0xHABCD', 'Mem', '8-bit', '0x00abcd');
+
+        // hex values follow the same rules as addresses
+        $this->assertParseOperand('h0000000a', 'Value', '', '0x00000a');
+        $this->assertParseOperand('hA', 'Value', '', '0x00000a');
+
+        // an address of zero still renders at the canonical width
+        $this->assertParseOperand('0xH0000000', 'Mem', '8-bit', '0x000000');
+    }
+
     public function testParseCondition(): void
     {
         $condition = $this->parseSingleCondition("0xH1234=6");
@@ -401,7 +424,7 @@ class TriggerDecoderServiceTest extends TestCase
         $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001234');
         $this->assertConditionSourceTooltip($condition, '');
         $this->assertConditionOperator($condition, '>');
-        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x00001234');
+        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x001234');
         $this->assertConditionTargetTooltip($condition, '');
         $this->assertConditionHitTarget($condition, '0');
 
@@ -428,7 +451,7 @@ class TriggerDecoderServiceTest extends TestCase
         $this->assertConditionSourceOperand($condition, 'Mem', '8-bit', '0x001234');
         $this->assertConditionSourceTooltip($condition, 'Lives');
         $this->assertConditionOperator($condition, '>');
-        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x00001234');
+        $this->assertConditionTargetOperand($condition, 'Delta', '8-bit', '0x001234');
         $this->assertConditionTargetTooltip($condition, 'Lives');
         $this->assertConditionHitTarget($condition, '0');
 

--- a/tests/Feature/Platform/Services/TriggerDiffServiceTest.php
+++ b/tests/Feature/Platform/Services/TriggerDiffServiceTest.php
@@ -500,6 +500,26 @@ class TriggerDiffServiceTest extends TestCase
         $this->assertEquals('No changes', $this->service->formatSummary($summary));
     }
 
+    public function testComputeSummaryIgnoresAddressWidthChangesBetweenVersions(): void
+    {
+        // Arrange
+        $decoder = new TriggerDecoderService();
+
+        $oldGroups = $decoder->decode('0xH1234=1');
+        $newGroups = $decoder->decode('0xH1234=1_0xH1bac044=2');
+
+        $this->assertEquals('0x1234', $oldGroups[0]['Conditions'][0]['SourceAddress']);
+        $this->assertEquals('0x00001234', $newGroups[0]['Conditions'][0]['SourceAddress']);
+
+        // Act
+        $summary = $this->service->computeSummary($oldGroups, $newGroups);
+
+        // Assert
+        $this->assertEquals(1, $summary['added']);
+        $this->assertEquals(0, $summary['removed']);
+        $this->assertEquals(0, $summary['modified']);
+    }
+
     public function testComputeSummaryStillDetectsRealChangesToPaddedAddresses(): void
     {
         // Arrange

--- a/tests/Feature/Platform/Services/TriggerDiffServiceTest.php
+++ b/tests/Feature/Platform/Services/TriggerDiffServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Platform\Services;
 
+use App\Platform\Services\TriggerDecoderService;
 use App\Platform\Services\TriggerDiffService;
 use Tests\TestCase;
 
@@ -478,5 +479,39 @@ class TriggerDiffServiceTest extends TestCase
         $this->assertEquals(2, $summary['added']);
         $this->assertEquals(2, $summary['removed']);
         $this->assertEquals(0, $summary['modified']);
+    }
+
+    public function testComputeSummaryIgnoresHexSpellingDifferences(): void
+    {
+        // Arrange
+        $decoder = new TriggerDecoderService();
+
+        // ... both strings describe the same logic, but the newer one pads its addresses ...
+        $oldGroups = $decoder->decode('0xG966c5c=h554c4a4d_O:0xH1bac044=4_0xHABCD=ha');
+        $newGroups = $decoder->decode('0xG00966c5c=h554c4a4d_O:0xH01bac044=4_0xHabcd=h0000000a');
+
+        // Act
+        $summary = $this->service->computeSummary($oldGroups, $newGroups);
+
+        // Assert
+        $this->assertEquals(0, $summary['added']);
+        $this->assertEquals(0, $summary['removed']);
+        $this->assertEquals(0, $summary['modified']);
+        $this->assertEquals('No changes', $this->service->formatSummary($summary));
+    }
+
+    public function testComputeSummaryStillDetectsRealChangesToPaddedAddresses(): void
+    {
+        // Arrange
+        $decoder = new TriggerDecoderService();
+
+        $oldGroups = $decoder->decode('0xH1bac044=4');
+        $newGroups = $decoder->decode('0xH01bac045=4');
+
+        // Act
+        $summary = $this->service->computeSummary($oldGroups, $newGroups);
+
+        // Assert
+        $this->assertEquals(1, $summary['modified']);
     }
 }

--- a/tests/Feature/Platform/Services/TriggerViewerServiceTest.php
+++ b/tests/Feature/Platform/Services/TriggerViewerServiceTest.php
@@ -661,63 +661,6 @@ class TriggerViewerServiceTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    public function testGetAddressFormatReturns24BitFormatByDefault(): void
-    {
-        $groups = [
-            [
-                'Label' => 'Core',
-                'Conditions' => [
-                    ['SourceAddress' => '0x001234', 'TargetAddress' => '0x000001'],
-                ],
-            ],
-        ];
-
-        $result = $this->service->getAddressFormat($groups);
-
-        $this->assertEquals('0x%06x', $result);
-    }
-
-    public function testGetAddressFormatReturns32BitFormatWhenSourceIs32Bit(): void
-    {
-        $groups = [
-            [
-                'Label' => 'Core',
-                'Conditions' => [
-                    ['SourceAddress' => '0x00123456', 'TargetAddress' => '0x000001'],
-                ],
-            ],
-        ];
-
-        $result = $this->service->getAddressFormat($groups);
-
-        $this->assertEquals('0x%08x', $result);
-    }
-
-    public function testGetAddressFormatReturns32BitFormatWhenTargetIs32Bit(): void
-    {
-        $groups = [
-            [
-                'Label' => 'Core',
-                'Conditions' => [
-                    ['SourceAddress' => '0x001234', 'TargetAddress' => '0x00123456'],
-                ],
-            ],
-        ];
-
-        $result = $this->service->getAddressFormat($groups);
-
-        $this->assertEquals('0x%08x', $result);
-    }
-
-    public function testGetAddressFormatHandlesEmptyGroups(): void
-    {
-        $groups = [];
-
-        $result = $this->service->getAddressFormat($groups);
-
-        $this->assertEquals('0x%06x', $result);
-    }
-
     public function testResolveValueAliasWithPipeDelimiterFormat(): void
     {
         /**


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1505528547559866428/1505528547559866428.

http://localhost:64000/manage/achievements/340159/logic

**Before**
<img width="1325" height="1118" alt="Screenshot 2026-08-02 at 4 34 55 PM" src="https://github.com/user-attachments/assets/76cfc264-bef5-4fef-8b14-0c75f9c849b4" />


**After**
<img width="1330" height="1113" alt="Screenshot 2026-08-02 at 4 34 47 PM" src="https://github.com/user-attachments/assets/dba7c91e-f000-4a28-ae35-d67dda82296e" />
