### PR TITLE
fix: preserve trigger authorship when promoting an achievement

### DIFF
--- a/app/Platform/Actions/UpsertTriggerVersionAction.php
+++ b/app/Platform/Actions/UpsertTriggerVersionAction.php
@@ -78,7 +78,7 @@ class UpsertTriggerVersionAction
             if ($currentTrigger->version === null) {
                 $currentTrigger->update([
                     'version' => 1,
-                    'user_id' => $user?->id,
+                    'user_id' => $currentTrigger->user_id ?? $user?->id,
                 ]);
                 $this->assignTriggerIdQuietly($triggerable, $currentTrigger->id);
             }

--- a/tests/Feature/Platform/Actions/UpsertTriggerVersionActionTest.php
+++ b/tests/Feature/Platform/Actions/UpsertTriggerVersionActionTest.php
@@ -150,13 +150,14 @@ class UpsertTriggerVersionActionTest extends TestCase
         // Arrange
         $achievement = Achievement::factory()->create();
         $user = User::factory()->create();
+        $author = User::factory()->create();
 
         $existingTrigger = Trigger::factory()->create([
             'triggerable_id' => $achievement->id,
             'triggerable_type' => TriggerableType::Achievement,
             'conditions' => '0xHaaaa=0',
             'version' => null, // !!
-            'user_id' => User::factory()->create()->id,
+            'user_id' => $author->id,
         ]);
 
         // Act
@@ -172,7 +173,7 @@ class UpsertTriggerVersionActionTest extends TestCase
         $this->assertEquals($existingTrigger->id, $trigger->id); // !! the id didn't change
         $this->assertEquals('0xHaaaa=0', $trigger->conditions);
         $this->assertEquals(1, $trigger->version); // !! versioned now
-        $this->assertEquals($user->id, $trigger->user_id);
+        $this->assertEquals($author->id, $trigger->user_id); // !! the author keeps the credit
     }
 
     public function testItUpdatesTheDenormalizedTriggerIdOnModels(): void

--- a/tests/Feature/Platform/Listeners/EnsureTriggerVersionedOnPromotionTest.php
+++ b/tests/Feature/Platform/Listeners/EnsureTriggerVersionedOnPromotionTest.php
@@ -38,6 +38,32 @@ class EnsureTriggerVersionedOnPromotionTest extends TestCase
         $this->assertEquals(1, $trigger->version);
     }
 
+    public function testItKeepsTheOriginalAuthorWhenPromotingSomeoneElsesLogic(): void
+    {
+        // Arrange
+        $author = User::factory()->create();
+        $promoter = User::factory()->create();
+        $this->actingAs($promoter);
+
+        $achievement = Achievement::factory()->create(['is_promoted' => false]);
+        $trigger = Trigger::factory()->create([
+            'triggerable_id' => $achievement->id,
+            'triggerable_type' => TriggerableType::Achievement,
+            'conditions' => '0xHaaaa=0',
+            'version' => null,
+            'user_id' => $author->id, // !!
+        ]);
+        $achievement->update(['trigger_id' => $trigger->id]);
+
+        // Act
+        $achievement->update(['is_promoted' => true]);
+
+        // Assert
+        $trigger->refresh();
+        $this->assertEquals(1, $trigger->version);
+        $this->assertEquals($author->id, $trigger->user_id);
+    }
+
     public function testItDoesNotChangeAlreadyVersionedTrigger(): void
     {
         // Arrange


### PR DESCRIPTION
Resolves https://discord.com/channels/310192285306454017/1485800695251599491/1485800695251599491.