### PR TITLE
fix(tickets): quarantine by the reported emulator

### DIFF
--- a/app/Helpers/database/ticket.php
+++ b/app/Helpers/database/ticket.php
@@ -1,118 +1,14 @@
 <?php
 
 use App\Community\Enums\CommentableType;
-use App\Community\Enums\SubscriptionSubjectType;
 use App\Community\Enums\TicketState;
-use App\Community\Enums\TicketType;
-use App\Community\Services\SubscriptionService;
-use App\Enums\ClientSupportLevel;
 use App\Enums\UserPreference;
-use App\Models\Achievement;
 use App\Models\Comment;
-use App\Models\Game;
-use App\Models\PlayerSession;
-use App\Models\Role;
 use App\Models\Ticket;
 use App\Models\User;
-use App\Notifications\Ticket\TicketCreatedNotification;
 use App\Notifications\Ticket\TicketStatusUpdatedNotification;
-use App\Platform\Services\UserAgentService;
 use App\Platform\Services\UserTicketCountService;
 use Illuminate\Support\Facades\DB;
-
-function sendInitialTicketEmailToAssignee(Ticket $ticket, Game $game, Achievement $achievement): void
-{
-    $maintainer = $achievement->getMaintainerAt(now());
-
-    if (
-        $maintainer
-        && $maintainer->hasAnyRole([Role::DEVELOPER, Role::DEVELOPER_JUNIOR])
-        && BitSet($maintainer->preferences_bitfield, UserPreference::EmailOn_TicketActivity)
-    ) {
-        $maintainer->notify(new TicketCreatedNotification($ticket, $game, $achievement, isMaintainer: true));
-    }
-}
-
-function sendInitialTicketEmailsToSubscribers(Ticket $ticket, Game $game, Achievement $achievement): void
-{
-    $maintainer = $achievement->getMaintainerAt(now());
-
-    $subscriptionService = new SubscriptionService();
-    $subscribers = $subscriptionService->getSubscribers(SubscriptionSubjectType::GameTickets, $game->id)
-        ->filter(fn ($s) => isset($s->email) && BitSet($s->preferences_bitfield, UserPreference::EmailOn_TicketActivity));
-
-    foreach ($subscribers as $subscriber) {
-        if ($subscriber->is($maintainer)) {
-            // maintainer explicitly notified regardless of subscription state via
-            // sendInitialTicketEmailToAssignee. don't notify them again.
-        } elseif ($subscriber->is($ticket->reporter)) {
-            // reporter doesn't need to be notified of the new ticket. they just created it!
-        } else {
-            $subscriber->notify(new TicketCreatedNotification($ticket, $game, $achievement, isMaintainer: false));
-        }
-    }
-}
-
-function _createTicket(User $user, int $achievementId, int $reportType, ?int $hardcore, string $note): int
-{
-    $achievement = Achievement::find($achievementId);
-    if (!$achievement) {
-        return 0;
-    }
-
-    $hardcoreValue = $hardcore === null ? null : (bool) $hardcore;
-    $maintainer = $achievement->getMaintainerAt(now());
-
-    $newTicket = Ticket::create([
-        'ticketable_type' => 'achievement',
-        'ticketable_id' => $achievement->id,
-        'reporter_id' => $user->id,
-        'ticketable_author_id' => $maintainer?->id,
-        'type' => TicketType::fromLegacyInteger($reportType),
-        'hardcore' => $hardcoreValue,
-        'body' => $note,
-    ]);
-
-    if ($maintainer) {
-        app(UserTicketCountService::class)->clearForUserId($maintainer->id);
-    }
-
-    $newTicket->state = TicketState::Open; // normalize to a proper enum value
-
-    // Quarantine a ticket when it's filed from a restricted core or a casual-only emulator.
-    $latestSession = PlayerSession::where('user_id', $user->id)
-        ->where('game_id', $achievement->game_id)
-        ->latest()
-        ->first();
-    if ($latestSession?->user_agent) {
-        $userAgentService = new UserAgentService();
-
-        [$clientSupportLevel, $coreRestriction] = $userAgentService
-            ->getSupportLevelAndCoreRestriction($latestSession->user_agent);
-
-        if ($coreRestriction || $clientSupportLevel === ClientSupportLevel::CasualOnly) {
-            $newTicket->state = TicketState::Quarantined;
-        }
-
-        // Quarantine a ticket when it's filed from an emulator that lacks developer toolkit support.
-        if ($newTicket->state !== TicketState::Quarantined) {
-            $emulator = $userAgentService->getEmulatorUserAgent($latestSession->user_agent)?->emulator;
-            if ($emulator && !$emulator->can_debug_triggers) {
-                $newTicket->state = TicketState::Quarantined;
-            }
-        }
-    }
-
-    $newTicket->save();
-
-    // Don't notify developers about quarantined tickets.
-    if ($newTicket->state !== TicketState::Quarantined) {
-        sendInitialTicketEmailToAssignee($newTicket, $achievement->game, $achievement);
-        sendInitialTicketEmailsToSubscribers($newTicket, $achievement->game, $achievement);
-    }
-
-    return $newTicket->id;
-}
 
 function getTicket(int $ticketID): ?array
 {

--- a/app/Platform/Actions/CreateTicketAction.php
+++ b/app/Platform/Actions/CreateTicketAction.php
@@ -4,41 +4,152 @@ declare(strict_types=1);
 
 namespace App\Platform\Actions;
 
+use App\Community\Enums\SubscriptionSubjectType;
+use App\Community\Enums\TicketState;
+use App\Community\Services\SubscriptionService;
+use App\Enums\ClientSupportLevel;
+use App\Enums\UserPreference;
+use App\Models\Achievement;
 use App\Models\Emulator;
+use App\Models\EmulatorCoreRestriction;
+use App\Models\PlayerSession;
+use App\Models\Role;
 use App\Models\Ticket;
 use App\Models\User;
+use App\Notifications\Ticket\TicketCreatedNotification;
 use App\Platform\Data\StoreTicketData;
+use App\Platform\Services\UserAgentService;
+use App\Platform\Services\UserTicketCountService;
+use InvalidArgumentException;
 
 class CreateTicketAction
 {
     public function execute(StoreTicketData $data, User $user): Ticket
     {
+        // Ticketable is typed as Achievement|Leaderboard, but all the code below this block
+        // assumes an achievement. For now, we'll fail loudly here if a leaderboard is passed in.
+        if (!$data->ticketable instanceof Achievement) {
+            throw new InvalidArgumentException('Ticket creation supports achievements only.');
+        }
+
         $emulator = Emulator::where('name', $data->emulator)->first();
 
-        $note = $this->formatTicketNote($data, !$emulator);
+        $achievement = $data->ticketable;
+        $maintainer = $achievement->getMaintainerAt(now());
 
-        $newTicketId = _createTicket(
-            user: $user,
-            achievementId: $data->ticketable->id,
-            reportType: $data->issue->toLegacyInteger(),
-            hardcore: $data->mode === 'hardcore' ? 1 : 0,
-            note: $note
-        );
+        $ticket = Ticket::create([
+            'ticketable_type' => 'achievement',
+            'ticketable_id' => $achievement->id,
+            'reporter_id' => $user->id,
+            'ticketable_author_id' => $maintainer?->id,
+            'type' => $data->issue,
+            'hardcore' => $data->mode === 'hardcore',
+            'body' => $this->formatTicketNote($data, !$emulator),
+        ]);
 
-        $ticket = Ticket::find($newTicketId);
+        if ($maintainer) {
+            app(UserTicketCountService::class)->clearForUserId($maintainer->id);
+        }
+
         $ticket->game_hash_id = $data->gameHash->id;
+        $ticket->emulator_core = $data->core ?: null;
 
         if ($emulator) {
             $ticket->emulator_id = $emulator->id;
             $ticket->emulator_version = $data->emulatorVersion;
-            if (in_array($data->emulator, ['RetroArch', 'RALibRetro', 'BizHawk'], true)) {
-                $ticket->emulator_core = $data->core;
-            }
         }
+
+        $ticket->state = $this->resolveTicketState($data, $user, $achievement, $emulator);
 
         $ticket->save();
 
+        // Don't notify developers about quarantined tickets.
+        if ($ticket->state !== TicketState::Quarantined) {
+            $this->sendInitialTicketEmailToAssignee($ticket, $achievement, $maintainer);
+            $this->sendInitialTicketEmailsToSubscribers($ticket, $achievement, $maintainer);
+        }
+
         return $ticket;
+    }
+
+    private function resolveTicketState(
+        StoreTicketData $data,
+        User $user,
+        Achievement $achievement,
+        ?Emulator $emulator,
+    ): TicketState {
+        // The form's emulator list is the emulators table plus a synthetic "Other" entry, so a
+        // name that resolves to nothing means the reporter is on a client we can't reason about.
+        // Hold the ticket rather than failing open on a missing primary signal.
+        if (!$emulator) {
+            return TicketState::Quarantined;
+        }
+
+        // Quarantine a ticket when the reported emulator can't debug triggers or is casual-only.
+        if (!$emulator->can_debug_triggers || $emulator->softcore_only) {
+            return TicketState::Quarantined;
+        }
+
+        // Quarantine a ticket when the reported core is restricted.
+        if (!empty($data->core) && EmulatorCoreRestriction::forCore($data->core)->exists()) {
+            return TicketState::Quarantined;
+        }
+
+        // Fall back to the session's user agent. It carries signals the form can't:
+        // client version thresholds and offline submission clients.
+        $latestSession = PlayerSession::where('user_id', $user->id)
+            ->where('game_id', $achievement->game_id)
+            ->latest()
+            ->first();
+        if ($latestSession?->user_agent) {
+            $userAgentService = new UserAgentService();
+
+            [$clientSupportLevel, $coreRestriction] = $userAgentService
+                ->getSupportLevelAndCoreRestriction($latestSession->user_agent);
+
+            if ($coreRestriction || $clientSupportLevel === ClientSupportLevel::CasualOnly) {
+                return TicketState::Quarantined;
+            }
+
+            // Quarantine a ticket when it's opened against an emulator that lacks toolkit support.
+            $sessionEmulator = $userAgentService->getEmulatorUserAgent($latestSession->user_agent)?->emulator;
+            if ($sessionEmulator && !$sessionEmulator->can_debug_triggers) {
+                return TicketState::Quarantined;
+            }
+        }
+
+        return TicketState::Open;
+    }
+
+    private function sendInitialTicketEmailToAssignee(Ticket $ticket, Achievement $achievement, ?User $maintainer): void
+    {
+        if (
+            $maintainer
+            && $maintainer->hasAnyRole([Role::DEVELOPER, Role::DEVELOPER_JUNIOR])
+            && BitSet($maintainer->preferences_bitfield, UserPreference::EmailOn_TicketActivity)
+        ) {
+            $maintainer->notify(new TicketCreatedNotification($ticket, $achievement->game, $achievement, isMaintainer: true));
+        }
+    }
+
+    private function sendInitialTicketEmailsToSubscribers(Ticket $ticket, Achievement $achievement, ?User $maintainer): void
+    {
+        $game = $achievement->game;
+
+        $subscriptionService = new SubscriptionService();
+        $subscribers = $subscriptionService->getSubscribers(SubscriptionSubjectType::GameTickets, $game->id)
+            ->filter(fn ($s) => isset($s->email) && BitSet($s->preferences_bitfield, UserPreference::EmailOn_TicketActivity));
+
+        foreach ($subscribers as $subscriber) {
+            if ($subscriber->is($maintainer)) {
+                // maintainer explicitly notified regardless of subscription state via
+                // the assignee notification above. don't notify them again.
+            } elseif ($subscriber->is($ticket->reporter)) {
+                // reporter doesn't need to be notified of the new ticket. they just created it!
+            } else {
+                $subscriber->notify(new TicketCreatedNotification($ticket, $game, $achievement, isMaintainer: false));
+            }
+        }
     }
 
     private function formatTicketNote(StoreTicketData $data, bool $captureEmulatorData): string

--- a/tests/Feature/Platform/Actions/CreateTicketActionTest.php
+++ b/tests/Feature/Platform/Actions/CreateTicketActionTest.php
@@ -42,15 +42,18 @@ beforeEach(function () {
 
 function ticketData(array $overrides = []): StoreTicketData
 {
+    /** @var object{achievement: Achievement, gameHash: GameHash} $context */
+    $context = test();
+
     return new StoreTicketData(
-        ticketable: $overrides['ticketable'] ?? test()->achievement,
+        ticketable: $overrides['ticketable'] ?? $context->achievement,
         mode: $overrides['mode'] ?? 'hardcore',
         issue: $overrides['issue'] ?? TicketType::DidNotTrigger,
         description: $overrides['description'] ?? 'The achievement never unlocked.',
         emulator: $overrides['emulator'] ?? 'PCSX2',
         emulatorVersion: $overrides['emulatorVersion'] ?? '2.0.0',
         core: $overrides['core'] ?? null,
-        gameHash: $overrides['gameHash'] ?? test()->gameHash,
+        gameHash: $overrides['gameHash'] ?? $context->gameHash,
         extra: $overrides['extra'] ?? null,
     );
 }
@@ -87,9 +90,13 @@ it('given the reporter only has a session on the parent game and provides an emu
     expect(PlayerSession::where('game_id', $subset->id)->exists())->toEqual(false);
 });
 
-it('given the reporter provides an emulator developers cannot work with and has no session at all, it quarantines the ticket', function (array $emulatorAttributes) {
+it('given the reporter provides an emulator developers cannot work with and has no session at all, it quarantines the ticket', function (bool $canDebugTriggers, bool $softcoreOnly) {
     // Arrange
-    Emulator::factory()->create(['name' => 'ReportedEmulator', ...$emulatorAttributes]);
+    Emulator::factory()->create([
+        'name' => 'ReportedEmulator',
+        'can_debug_triggers' => $canDebugTriggers,
+        'softcore_only' => $softcoreOnly,
+    ]);
 
     // Act
     $ticket = (new CreateTicketAction())->execute(
@@ -100,18 +107,18 @@ it('given the reporter provides an emulator developers cannot work with and has 
     // Assert
     expect($ticket->state)->toEqual(TicketState::Quarantined);
 })->with([
-    'cannot debug triggers' => [['can_debug_triggers' => false, 'softcore_only' => false]],
-    'casual only' => [['can_debug_triggers' => true, 'softcore_only' => true]],
+    'cannot debug triggers' => [false, false],
+    'casual only' => [true, true],
 ]);
 
-it('given the reporter provides a restricted core on a fully supported emulator, it quarantines the ticket', function (array $restrictionAttributes) {
+it('given the reporter provides a restricted core on a fully supported emulator, it quarantines the ticket', function (?string $minimumVersion) {
     // Arrange
     Emulator::factory()->create(['name' => 'RetroArch', 'can_debug_triggers' => true]);
     EmulatorCoreRestriction::create([
         'core_name' => 'doublecherrygb_libretro',
         'support_level' => ClientSupportLevel::Warned,
+        'minimum_version' => $minimumVersion,
         'notes' => 'known issues',
-        ...$restrictionAttributes,
     ]);
 
     // Act
@@ -123,8 +130,8 @@ it('given the reporter provides a restricted core on a fully supported emulator,
     // Assert
     expect($ticket->state)->toEqual(TicketState::Quarantined);
 })->with([
-    'no minimum version' => [[]],
-    'a minimum version the form cannot satisfy' => [['minimum_version' => '9.9.9']],
+    'no minimum version' => [null],
+    'a minimum version the form cannot satisfy' => ['9.9.9'],
 ]);
 
 it('given a fully supported emulator and no session, it leaves the ticket open', function (?string $core) {

--- a/tests/Feature/Platform/Actions/CreateTicketActionTest.php
+++ b/tests/Feature/Platform/Actions/CreateTicketActionTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Community\Enums\TicketState;
+use App\Community\Enums\TicketType;
+use App\Enums\ClientSupportLevel;
+use App\Enums\UserPreference;
+use App\Models\Achievement;
+use App\Models\Emulator;
+use App\Models\EmulatorCoreRestriction;
+use App\Models\EmulatorUserAgent;
+use App\Models\Game;
+use App\Models\GameHash;
+use App\Models\Leaderboard;
+use App\Models\PlayerSession;
+use App\Models\Role;
+use App\Models\System;
+use App\Models\User;
+use App\Notifications\Ticket\TicketCreatedNotification;
+use App\Platform\Actions\CreateTicketAction;
+use App\Platform\Data\StoreTicketData;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Notification::fake();
+
+    $this->system = System::factory()->create(['name' => 'PlayStation 2', 'active' => true]);
+    $this->game = Game::factory()->create(['title' => 'Resident Evil 4', 'system_id' => $this->system->id]);
+    $this->gameHash = GameHash::factory()->create(['game_id' => $this->game->id]);
+    $this->developer = User::factory()->create();
+    $this->achievement = Achievement::factory()->promoted()->create([
+        'game_id' => $this->game->id,
+        'user_id' => $this->developer->id,
+    ]);
+    $this->reporter = User::factory()->create();
+});
+
+function ticketData(array $overrides = []): StoreTicketData
+{
+    return new StoreTicketData(
+        ticketable: $overrides['ticketable'] ?? test()->achievement,
+        mode: $overrides['mode'] ?? 'hardcore',
+        issue: $overrides['issue'] ?? TicketType::DidNotTrigger,
+        description: $overrides['description'] ?? 'The achievement never unlocked.',
+        emulator: $overrides['emulator'] ?? 'PCSX2',
+        emulatorVersion: $overrides['emulatorVersion'] ?? '2.0.0',
+        core: $overrides['core'] ?? null,
+        gameHash: $overrides['gameHash'] ?? test()->gameHash,
+        extra: $overrides['extra'] ?? null,
+    );
+}
+
+it('given the reporter only has a session on the parent game and provides an emulator that cannot debug triggers, it quarantines the subset ticket', function () {
+    // Arrange
+    $subset = Game::factory()->create([
+        'title' => 'Resident Evil 4 [Subset - Bonus]',
+        'system_id' => $this->system->id,
+    ]);
+    $subsetAchievement = Achievement::factory()->promoted()->create([
+        'game_id' => $subset->id,
+        'user_id' => $this->developer->id,
+    ]);
+
+    $emulator = Emulator::factory()->create(['name' => 'AetherSX2', 'can_debug_triggers' => false]);
+    EmulatorUserAgent::create(['emulator_id' => $emulator->id, 'client' => 'AetherSX2']);
+
+    PlayerSession::factory()->create([
+        'user_id' => $this->reporter->id,
+        'game_id' => $this->game->id, // the base game, not the subset
+        'game_hash_id' => $this->gameHash->id,
+        'user_agent' => 'AetherSX2/1.5-4248 (Android)',
+    ]);
+
+    // Act
+    $ticket = (new CreateTicketAction())->execute(
+        ticketData(['ticketable' => $subsetAchievement, 'emulator' => 'AetherSX2']),
+        $this->reporter,
+    );
+
+    // Assert
+    expect($ticket->state)->toEqual(TicketState::Quarantined);
+    expect(PlayerSession::where('game_id', $subset->id)->exists())->toEqual(false);
+});
+
+it('given the reporter provides an emulator developers cannot work with and has no session at all, it quarantines the ticket', function (array $emulatorAttributes) {
+    // Arrange
+    Emulator::factory()->create(['name' => 'ReportedEmulator', ...$emulatorAttributes]);
+
+    // Act
+    $ticket = (new CreateTicketAction())->execute(
+        ticketData(['emulator' => 'ReportedEmulator']),
+        $this->reporter,
+    );
+
+    // Assert
+    expect($ticket->state)->toEqual(TicketState::Quarantined);
+})->with([
+    'cannot debug triggers' => [['can_debug_triggers' => false, 'softcore_only' => false]],
+    'casual only' => [['can_debug_triggers' => true, 'softcore_only' => true]],
+]);
+
+it('given the reporter provides a restricted core on a fully supported emulator, it quarantines the ticket', function (array $restrictionAttributes) {
+    // Arrange
+    Emulator::factory()->create(['name' => 'RetroArch', 'can_debug_triggers' => true]);
+    EmulatorCoreRestriction::create([
+        'core_name' => 'doublecherrygb_libretro',
+        'support_level' => ClientSupportLevel::Warned,
+        'notes' => 'known issues',
+        ...$restrictionAttributes,
+    ]);
+
+    // Act
+    $ticket = (new CreateTicketAction())->execute(
+        ticketData(['emulator' => 'RetroArch', 'core' => 'doublecherrygb_libretro']),
+        $this->reporter,
+    );
+
+    // Assert
+    expect($ticket->state)->toEqual(TicketState::Quarantined);
+})->with([
+    'no minimum version' => [[]],
+    'a minimum version the form cannot satisfy' => [['minimum_version' => '9.9.9']],
+]);
+
+it('given a fully supported emulator and no session, it leaves the ticket open', function (?string $core) {
+    // Arrange
+    Emulator::factory()->create(['name' => 'PCSX2', 'can_debug_triggers' => true, 'softcore_only' => false]);
+
+    // Act
+    $ticket = (new CreateTicketAction())->execute(ticketData(['core' => $core]), $this->reporter);
+
+    // Assert
+    expect($ticket->state)->toEqual(TicketState::Open);
+})->with([
+    'an unrestricted core' => ['some_unregistered_libretro'],
+    'no core' => [null],
+]);
+
+it('given an emulator name that matches no record, it quarantines the ticket and keeps the name in the body', function () {
+    // Act
+    $ticket = (new CreateTicketAction())->execute(
+        ticketData(['emulator' => 'Other (please specify in description)']),
+        $this->reporter,
+    );
+
+    // Assert
+    expect($ticket->state)->toEqual(TicketState::Quarantined);
+    expect($ticket->emulator_id)->toEqual(null);
+    expect($ticket->emulator_version)->toEqual(null);
+    expect($ticket->body)->toContain('Emulator: Other (please specify in description)');
+});
+
+it('given an unresolvable emulator but a fully supported client in the session, it still quarantines the ticket', function () {
+    // Arrange
+    $sessionEmulator = Emulator::factory()->create(['name' => 'PCSX2', 'can_debug_triggers' => true]);
+    EmulatorUserAgent::create(['emulator_id' => $sessionEmulator->id, 'client' => 'PCSX2']);
+
+    PlayerSession::factory()->create([
+        'user_id' => $this->reporter->id,
+        'game_id' => $this->game->id,
+        'game_hash_id' => $this->gameHash->id,
+        'user_agent' => 'PCSX2 v2.0.0 (Windows)',
+    ]);
+
+    // Act
+    $ticket = (new CreateTicketAction())->execute(
+        ticketData(['emulator' => 'Other (please specify in description)']),
+        $this->reporter,
+    );
+
+    // Assert
+    expect($ticket->state)->toEqual(TicketState::Quarantined);
+});
+
+it('given ticket creation, it persists the emulator, version, core, and game hash', function () {
+    // Arrange
+    $emulator = Emulator::factory()->create(['name' => 'RetroArch', 'can_debug_triggers' => true]);
+
+    // Act
+    $ticket = (new CreateTicketAction())->execute(
+        ticketData(['emulator' => 'RetroArch', 'emulatorVersion' => '1.19.1', 'core' => 'gambatte_libretro']),
+        $this->reporter,
+    );
+
+    // Assert
+    $ticket->refresh();
+
+    expect($ticket->emulator_id)->toEqual($emulator->id);
+    expect($ticket->emulator_version)->toEqual('1.19.1');
+    expect($ticket->emulator_core)->toEqual('gambatte_libretro');
+    expect($ticket->game_hash_id)->toEqual($this->gameHash->id);
+});
+
+it('given a supported emulator on the form but a casual-only client in the session, it still quarantines the ticket', function () {
+    // Arrange
+    Emulator::factory()->create(['name' => 'PCSX2', 'can_debug_triggers' => true]);
+
+    $sessionEmulator = Emulator::factory()->create([
+        'name' => 'gopher64',
+        'softcore_only' => true,
+        'can_debug_triggers' => true,
+    ]);
+    EmulatorUserAgent::create(['emulator_id' => $sessionEmulator->id, 'client' => 'gopher64']);
+
+    PlayerSession::factory()->create([
+        'user_id' => $this->reporter->id,
+        'game_id' => $this->game->id,
+        'game_hash_id' => $this->gameHash->id,
+        'user_agent' => 'gopher64/1.15.0 (Windows)',
+    ]);
+
+    // Act
+    $ticket = (new CreateTicketAction())->execute(ticketData(), $this->reporter);
+
+    // Assert
+    expect($ticket->state)->toEqual(TicketState::Quarantined);
+});
+
+it('given a supported emulator on the form but a session client that cannot debug triggers, it still quarantines the ticket', function () {
+    // Arrange
+    Emulator::factory()->create(['name' => 'PCSX2', 'can_debug_triggers' => true]);
+
+    $sessionEmulator = Emulator::factory()->create(['name' => 'AetherSX2', 'can_debug_triggers' => false]);
+    EmulatorUserAgent::create(['emulator_id' => $sessionEmulator->id, 'client' => 'AetherSX2']);
+
+    PlayerSession::factory()->create([
+        'user_id' => $this->reporter->id,
+        'game_id' => $this->game->id,
+        'game_hash_id' => $this->gameHash->id,
+        'user_agent' => 'AetherSX2/1.5-4248 (Android)',
+    ]);
+
+    // Act
+    $ticket = (new CreateTicketAction())->execute(ticketData(), $this->reporter);
+
+    // Assert
+    expect($ticket->state)->toEqual(TicketState::Quarantined);
+});
+
+it('given no core on the form but a restricted core in the session user agent, it still quarantines the ticket', function () {
+    // Arrange
+    $sessionEmulator = Emulator::factory()->create(['name' => 'RetroArch', 'can_debug_triggers' => true]);
+    EmulatorUserAgent::create(['emulator_id' => $sessionEmulator->id, 'client' => 'RetroArch']);
+
+    EmulatorCoreRestriction::create([
+        'core_name' => 'doublecherrygb_libretro',
+        'support_level' => ClientSupportLevel::Warned,
+        'notes' => 'known issues',
+    ]);
+
+    PlayerSession::factory()->create([
+        'user_id' => $this->reporter->id,
+        'game_id' => $this->game->id,
+        'game_hash_id' => $this->gameHash->id,
+        'user_agent' => 'RetroArch/1.19.1 (Windows) doublecherrygb_libretro/5d2ac21',
+    ]);
+
+    // Act
+    $ticket = (new CreateTicketAction())->execute(
+        ticketData(['emulator' => 'RetroArch', 'core' => null]),
+        $this->reporter,
+    );
+
+    // Assert
+    expect($ticket->state)->toEqual(TicketState::Quarantined);
+});
+
+it('given a leaderboard as the ticketable, it refuses to create the ticket', function () {
+    // Arrange
+    $leaderboard = Leaderboard::factory()->create(['game_id' => $this->game->id]);
+
+    // Act
+    $execute = fn () => (new CreateTicketAction())->execute(
+        ticketData(['ticketable' => $leaderboard]),
+        $this->reporter,
+    );
+
+    // Assert
+    expect($execute)->toThrow(InvalidArgumentException::class);
+});
+
+it('given a quarantined ticket, it sends no notifications', function () {
+    // Arrange
+    $this->seed(RolesTableSeeder::class);
+    $this->developer->assignRole(Role::DEVELOPER);
+    $this->developer->update(['preferences_bitfield' => 1 << UserPreference::EmailOn_TicketActivity]);
+
+    Emulator::factory()->create(['name' => 'AetherSX2', 'can_debug_triggers' => false]);
+
+    // Act
+    (new CreateTicketAction())->execute(ticketData(['emulator' => 'AetherSX2']), $this->reporter);
+
+    // Assert
+    Notification::assertNothingSent();
+});
+
+it('given an open ticket is created, the achievement maintainer is notified', function () {
+    // Arrange
+    $this->seed(RolesTableSeeder::class);
+    $this->developer->assignRole(Role::DEVELOPER);
+    $this->developer->update(['preferences_bitfield' => 1 << UserPreference::EmailOn_TicketActivity]);
+
+    Emulator::factory()->create(['name' => 'PCSX2', 'can_debug_triggers' => true]);
+
+    // Act
+    (new CreateTicketAction())->execute(ticketData(), $this->reporter);
+
+    // Assert
+    Notification::assertSentTo($this->developer, TicketCreatedNotification::class);
+});

--- a/tests/Feature/Platform/Controllers/Api/TicketApiControllerTest.php
+++ b/tests/Feature/Platform/Controllers/Api/TicketApiControllerTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Platform\Controllers\Api;
-
 use App\Community\Enums\TicketState;
 use App\Community\Enums\TicketType;
 use App\Enums\ClientSupportLevel;
@@ -20,364 +18,450 @@ use App\Models\Ticket;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
-class TicketApiControllerTest extends TestCase
-{
-    use RefreshDatabase;
+uses(RefreshDatabase::class);
 
-    public function testStoreAbortsIfUserIsMuted(): void
-    {
-        // Arrange
-        $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
-        $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
-        $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
-        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id]);
+it('given the reporter is muted, it prevents ticket creation', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id]);
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'email_verified_at' => Carbon::parse('2013-01-01'),
-            'created_at' => Carbon::now()->subWeeks(2),
-            'muted_until' => Carbon::parse('2035-01-01'), // !!
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now()->subWeeks(2),
+        'muted_until' => Carbon::parse('2035-01-01'), // !!
+    ]);
+    $this->actingAs($user);
+
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'hardcore',
+        'issue' => TicketType::TriggeredAtWrongTime->value,
+        'description' => 'Test description',
+        'emulator' => 'RetroArch',
+        'emulatorVersion' => '1.16.0',
+        'core' => 'mupen64plus',
+        'gameHashId' => $gameHash->id,
+    ]);
+
+    // Assert
+    $response->assertForbidden();
+});
+
+it('given the reporter account is too new, it prevents ticket creation', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id]);
+
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now(), // !!
+    ]);
+    $this->actingAs($user);
+
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'hardcore',
+        'issue' => TicketType::TriggeredAtWrongTime->value,
+        'description' => 'Test description',
+        'emulator' => 'RetroArch',
+        'emulatorVersion' => '1.16.0',
+        'core' => 'mupen64plus',
+        'gameHashId' => $gameHash->id,
+    ]);
+
+    // Assert
+    $response->assertForbidden();
+});
+
+it('given a valid submission, it creates the ticket', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $developer = User::factory()->create();
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+    $emulator = Emulator::factory()->create(['name' => 'RetroArch']);
+
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now()->subWeeks(2),
+    ]);
+    $this->actingAs($user);
+
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'hardcore',
+        'issue' => TicketType::TriggeredAtWrongTime->value,
+        'description' => 'Test description',
+        'emulator' => 'RetroArch',
+        'emulatorVersion' => '1.16.0',
+        'core' => 'mupen64plus',
+        'gameHashId' => $gameHash->id,
+    ]);
+
+    // Assert
+    $response->assertOk();
+
+    $this->assertDatabaseHas('tickets', [
+        'ticketable_author_id' => $developer->id,
+        'ticketable_id' => $achievement->id,
+        'reporter_id' => $user->id,
+        'type' => TicketType::TriggeredAtWrongTime,
+        'hardcore' => 1,
+        'emulator_id' => $emulator->id,
+        'emulator_version' => '1.16.0',
+        'emulator_core' => 'mupen64plus',
+        'game_hash_id' => $gameHash->id,
+        'body' => 'Test description', // emulator data is not captured when an emulator record is found
+    ]);
+});
+
+it('given rich presence and an emulator with no record, it formats the ticket note', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $developer = User::factory()->create();
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now()->subWeeks(2),
+    ]);
+    $this->actingAs($user);
+
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'hardcore',
+        'issue' => TicketType::TriggeredAtWrongTime->value,
+        'description' => 'Test description',
+        'emulator' => 'RetroArch',
+        'emulatorVersion' => '1.16.0',
+        'core' => 'mupen64plus',
+        'gameHashId' => $gameHash->id,
+        'extra' => 'eyJ0cmlnZ2VyUmljaFByZXNlbmNlIjoi8J+Qukxpbmsg8J+Xuu+4j0RlYXRoIE1vdW50YWluIOKdpO+4jzMvMyDwn5GlMS80IPCfp78wLzQg8J+RuzAvNjAg8J+QnDAvMjQg8J+SgDUg8J+VmTEyOjAwIEFN8J+MmSJ9',
+    ]);
+
+    // Assert
+    $response->assertOk();
+
+    $this->assertDatabaseHas('tickets', [
+        'body' => "Test description\n\n" .
+            "Rich Presence at time of trigger:\n" .
+            "🐺Link 🗺️Death Mountain ❤️3/3 👥1/4 🧿0/4 👻0/60 🐜0/24 💀5 🕙12:00 AM🌙\n" .
+            "Emulator: RetroArch (mupen64plus)\n" .
+            'Emulator Version: 1.16.0',
+    ]);
+});
+
+it('given the reporter already has an open ticket, it returns a conflict instead of a duplicate', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $developer = User::factory()->create();
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now()->subWeeks(2),
+    ]);
+    $this->actingAs($user);
+
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+
+    // !!! the user already has a ticket open !!!
+    $existingTicket = Ticket::factory()->create([
+        'reporter_id' => $user->id,
+        'ticketable_id' => $achievement->id,
+        'state' => TicketState::Open,
+    ]);
+
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'hardcore',
+        'issue' => TicketType::TriggeredAtWrongTime->value,
+        'description' => 'Test description',
+        'emulator' => 'RetroArch',
+        'emulatorVersion' => '1.9.0',
+        'core' => 'genesis_plus_gx',
+        'gameHashId' => $gameHash->id,
+    ]);
+
+    // Assert
+    $response
+        ->assertStatus(409)
+        ->assertJson([
+            'message' => __('legacy.error.ticket_exists'),
+            'ticketId' => $existingTicket->id,
         ]);
-        $this->actingAs($user);
+});
 
-        PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+it('given an emulator with no record and no core, it embeds the emulator info in the note', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $developer = User::factory()->create();
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
 
-        // Act
-        $response = $this->postJson(route('api.ticket.store'), [
-            'ticketableModel' => 'achievement',
-            'ticketableId' => $achievement->id,
-            'mode' => 'hardcore',
-            'issue' => TicketType::TriggeredAtWrongTime->value,
-            'description' => 'Test description',
-            'emulator' => 'RetroArch',
-            'emulatorVersion' => '1.16.0',
-            'core' => 'mupen64plus',
-            'gameHashId' => $gameHash->id,
-        ]);
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now()->subWeeks(2),
+    ]);
+    $this->actingAs($user);
 
-        // Assert
-        $response->assertForbidden();
-    }
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
 
-    public function testStoreAbortsIfUserIsNew(): void
-    {
-        // Arrange
-        $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
-        $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
-        $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
-        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id]);
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'hardcore',
+        'issue' => TicketType::TriggeredAtWrongTime->value,
+        'description' => 'Test description',
+        'emulator' => 'RAP64',
+        'emulatorVersion' => '1.9.0',
+        // 'core' => 'genesis_plus_gx', !! commented this out on purpose, the user isn't sending it on submit
+        'gameHashId' => $gameHash->id,
+    ]);
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'email_verified_at' => Carbon::parse('2013-01-01'),
-            'created_at' => Carbon::now(), // !!
-        ]);
-        $this->actingAs($user);
+    // Assert
+    $response->assertOk();
 
-        PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+    $this->assertDatabaseHas('tickets', [
+        'body' => "Test description\n\n" .
+            "Emulator: RAP64\n" .
+            'Emulator Version: 1.9.0',
+    ]);
+});
 
-        // Act
-        $response = $this->postJson(route('api.ticket.store'), [
-            'ticketableModel' => 'achievement',
-            'ticketableId' => $achievement->id,
-            'mode' => 'hardcore',
-            'issue' => TicketType::TriggeredAtWrongTime->value,
-            'description' => 'Test description',
-            'emulator' => 'RetroArch',
-            'emulatorVersion' => '1.16.0',
-            'core' => 'mupen64plus',
-            'gameHashId' => $gameHash->id,
-        ]);
+it('given a restricted core, it quarantines the ticket', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'Game Boy', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'Batman', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $developer = User::factory()->create();
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+    $emulator = Emulator::factory()->create(['name' => 'RetroArch']);
 
-        // Assert
-        $response->assertForbidden();
-    }
+    EmulatorUserAgent::create([
+        'emulator_id' => $emulator->id,
+        'client' => 'RetroArch',
+    ]);
 
-    public function testStoreCreatesTicketSuccessfully(): void
-    {
-        // Arrange
-        $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
-        $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
-        $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
-        $developer = User::factory()->create();
-        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
-        $emulator = Emulator::factory()->create(['name' => 'RetroArch']);
+    EmulatorCoreRestriction::create([
+        'core_name' => 'doublecherrygb_libretro',
+        'support_level' => ClientSupportLevel::Warned,
+        'notes' => 'known issues',
+    ]);
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'email_verified_at' => Carbon::parse('2013-01-01'),
-            'created_at' => Carbon::now()->subWeeks(2),
-        ]);
-        $this->actingAs($user);
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now()->subWeeks(2),
+    ]);
+    $this->actingAs($user);
 
-        PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+    PlayerSession::factory()->create([
+        'user_id' => $user->id,
+        'game_id' => $game->id,
+        'game_hash_id' => $gameHash->id,
+        'user_agent' => 'RetroArch/1.19.1 (Windows) doublecherrygb_libretro/5d2ac21',
+    ]);
 
-        // Act
-        $response = $this->postJson(route('api.ticket.store'), [
-            'ticketableModel' => 'achievement',
-            'ticketableId' => $achievement->id,
-            'mode' => 'hardcore',
-            'issue' => TicketType::TriggeredAtWrongTime->value,
-            'description' => 'Test description',
-            'emulator' => 'RetroArch',
-            'emulatorVersion' => '1.16.0',
-            'core' => 'mupen64plus',
-            'gameHashId' => $gameHash->id,
-        ]);
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'hardcore',
+        'issue' => TicketType::TriggeredAtWrongTime->value,
+        'description' => 'Test description',
+        'emulator' => 'RetroArch',
+        'emulatorVersion' => '1.19.1',
+        'core' => 'doublecherrygb_libretro',
+        'gameHashId' => $gameHash->id,
+    ]);
 
-        // Assert
-        $response->assertOk();
+    // Assert
+    $response->assertOk();
 
-        $this->assertDatabaseHas('tickets', [
-            'ticketable_author_id' => $developer->id,
-            'ticketable_id' => $achievement->id,
-            'reporter_id' => $user->id,
-            'type' => TicketType::TriggeredAtWrongTime,
-            'hardcore' => 1,
-            'emulator_id' => $emulator->id,
-            'emulator_version' => '1.16.0',
-            'emulator_core' => 'mupen64plus',
-            'game_hash_id' => $gameHash->id,
-            "body" => "Test description", // emulator data is not captured when an emulator record is found
-        ]);
-    }
+    $this->assertDatabaseHas('tickets', [
+        'ticketable_id' => $achievement->id,
+        'reporter_id' => $user->id,
+        'state' => TicketState::Quarantined,
+    ]);
+});
 
-    public function testStoreFormatsTicketNotesCorrectly(): void
-    {
-        // Arrange
-        $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
-        $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
-        $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
-        $developer = User::factory()->create();
-        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+it('given a casual-only emulator, it quarantines the ticket', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $developer = User::factory()->create();
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+    $emulator = Emulator::factory()->create(['name' => 'gopher64', 'softcore_only' => true]);
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'email_verified_at' => Carbon::parse('2013-01-01'),
-            'created_at' => Carbon::now()->subWeeks(2),
-        ]);
-        $this->actingAs($user);
+    EmulatorUserAgent::create([
+        'emulator_id' => $emulator->id,
+        'client' => 'gopher64',
+    ]);
 
-        PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now()->subWeeks(2),
+    ]);
+    $this->actingAs($user);
 
-        // Act
-        $response = $this->postJson(route('api.ticket.store'), [
-            'ticketableModel' => 'achievement',
-            'ticketableId' => $achievement->id,
-            'mode' => 'hardcore',
-            'issue' => TicketType::TriggeredAtWrongTime->value,
-            'description' => 'Test description',
-            'emulator' => 'RetroArch',
-            'emulatorVersion' => '1.16.0',
-            'core' => 'mupen64plus',
-            'gameHashId' => $gameHash->id,
-            'extra' => 'eyJ0cmlnZ2VyUmljaFByZXNlbmNlIjoi8J+Qukxpbmsg8J+Xuu+4j0RlYXRoIE1vdW50YWluIOKdpO+4jzMvMyDwn5GlMS80IPCfp78wLzQg8J+RuzAvNjAg8J+QnDAvMjQg8J+SgDUg8J+VmTEyOjAwIEFN8J+MmSJ9',
-        ]);
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+    PlayerSession::factory()->create([
+        'user_id' => $user->id,
+        'game_id' => $game->id,
+        'game_hash_id' => $gameHash->id,
+        'user_agent' => 'gopher64/1.15.0 (Windows)',
+    ]);
 
-        // Assert
-        $response->assertOk();
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'casual',
+        'issue' => TicketType::TriggeredAtWrongTime->value,
+        'description' => 'Test description',
+        'emulator' => 'gopher64',
+        'emulatorVersion' => '1.15.0',
+        'gameHashId' => $gameHash->id,
+    ]);
 
-        $this->assertDatabaseHas('tickets', [
-            "body" => "Test description\n\n" .
-                "Rich Presence at time of trigger:\n" .
-                "🐺Link 🗺️Death Mountain ❤️3/3 👥1/4 🧿0/4 👻0/60 🐜0/24 💀5 🕙12:00 AM🌙\n" .
-                "Emulator: RetroArch (mupen64plus)\n" .
-                "Emulator Version: 1.16.0",
-        ]);
-    }
+    // Assert
+    $response->assertOk();
 
-    public function testStoreDoesNotCreateDuplicateTickets(): void
-    {
-        // Arrange
-        $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
-        $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
-        $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
-        $developer = User::factory()->create();
-        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+    $this->assertDatabaseHas('tickets', [
+        'ticketable_id' => $achievement->id,
+        'reporter_id' => $user->id,
+        'state' => TicketState::Quarantined,
+    ]);
+});
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'email_verified_at' => Carbon::parse('2013-01-01'),
-            'created_at' => Carbon::now()->subWeeks(2),
-        ]);
-        $this->actingAs($user);
+it('given an emulator that cannot debug triggers and no player session, it quarantines the ticket', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'PlayStation 2', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'Resident Evil 4', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $developer = User::factory()->create();
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
 
-        PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+    Emulator::factory()->create(['name' => 'AetherSX2', 'can_debug_triggers' => false]);
 
-        // !!! the user already has a ticket open !!!
-        $existingTicket = Ticket::factory()->create([
-            'reporter_id' => $user->id,
-            'ticketable_id' => $achievement->id,
-            'state' => TicketState::Open,
-        ]);
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now()->subWeeks(2),
+    ]);
+    $this->actingAs($user);
 
-        // Act
-        $response = $this->postJson(route('api.ticket.store'), [
-            'ticketableModel' => 'achievement',
-            'ticketableId' => $achievement->id,
-            'mode' => 'hardcore',
-            'issue' => TicketType::TriggeredAtWrongTime->value,
-            'description' => 'Test description',
-            'emulator' => 'RetroArch',
-            'emulatorVersion' => '1.9.0',
-            'core' => 'genesis_plus_gx',
-            'gameHashId' => $gameHash->id,
-        ]);
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
 
-        // Assert
-        $response
-            ->assertStatus(409)
-            ->assertJson([
-                'message' => __('legacy.error.ticket_exists'),
-                'ticketId' => $existingTicket->id,
-            ]);
-    }
+    // ... no player session ...
 
-    public function testStoreProperlyHandlesEmulatorsWithoutCore(): void
-    {
-        // Arrange
-        $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
-        $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
-        $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
-        $developer = User::factory()->create();
-        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'hardcore',
+        'issue' => TicketType::DidNotTrigger->value,
+        'description' => 'Test description',
+        'emulator' => 'AetherSX2',
+        'emulatorVersion' => '1.5-4248',
+        'gameHashId' => $gameHash->id,
+    ]);
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'email_verified_at' => Carbon::parse('2013-01-01'),
-            'created_at' => Carbon::now()->subWeeks(2),
-        ]);
-        $this->actingAs($user);
+    // Assert
+    $response->assertOk();
 
-        PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+    $this->assertDatabaseHas('tickets', [
+        'ticketable_id' => $achievement->id,
+        'reporter_id' => $user->id,
+        'state' => TicketState::Quarantined,
+    ]);
+});
 
-        // Act
-        $response = $this->postJson(route('api.ticket.store'), [
-            'ticketableModel' => 'achievement',
-            'ticketableId' => $achievement->id,
-            'mode' => 'hardcore',
-            'issue' => TicketType::TriggeredAtWrongTime->value,
-            'description' => 'Test description',
-            'emulator' => 'RAP64',
-            'emulatorVersion' => '1.9.0',
-            // 'core' => 'genesis_plus_gx', !! commented this out on purpose, the user isn't sending it on submit
-            'gameHashId' => $gameHash->id,
-        ]);
+it('given a subset achievement, a session only on the parent game, and an emulator that cannot debug triggers, it quarantines the ticket', function () {
+    // Arrange
+    $system = System::factory()->create(['name' => 'PlayStation 2', 'active' => true]);
+    $game = Game::factory()->create(['title' => 'Resident Evil 4', 'system_id' => $system->id]);
+    $subset = Game::factory()->create(['title' => 'Resident Evil 4 [Subset - Bonus]', 'system_id' => $system->id]);
+    $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
+    $developer = User::factory()->create();
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $subset->id, 'user_id' => $developer->id]);
 
-        // Assert
-        $response->assertOk();
+    $emulator = Emulator::factory()->create(['name' => 'AetherSX2', 'can_debug_triggers' => false]);
+    EmulatorUserAgent::create(['emulator_id' => $emulator->id, 'client' => 'AetherSX2']);
 
-        $this->assertDatabaseHas('tickets', [
-            'body' => "Test description\n\n" .
-                "Emulator: RAP64\n" .
-                "Emulator Version: 1.9.0",
-        ]);
-    }
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email_verified_at' => Carbon::parse('2013-01-01'),
+        'created_at' => Carbon::now()->subWeeks(2),
+    ]);
+    $this->actingAs($user);
 
-    public function testStoreQuarantinesTicketsFromRestrictedCores(): void
-    {
-        $system = System::factory()->create(['name' => 'Game Boy', 'active' => true]);
-        $game = Game::factory()->create(['title' => 'Batman', 'system_id' => $system->id]);
-        $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
-        $developer = User::factory()->create();
-        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
-        $emulator = Emulator::factory()->create(['name' => 'RetroArch']);
+    PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
+    PlayerSession::factory()->create([
+        'user_id' => $user->id,
+        'game_id' => $game->id,
+        'game_hash_id' => $gameHash->id,
+        'user_agent' => 'AetherSX2/1.5-4248 (Android)',
+    ]);
 
-        EmulatorUserAgent::create([
-            'emulator_id' => $emulator->id,
-            'client' => 'RetroArch',
-        ]);
+    // Act
+    $response = $this->postJson(route('api.ticket.store'), [
+        'ticketableModel' => 'achievement',
+        'ticketableId' => $achievement->id,
+        'mode' => 'hardcore',
+        'issue' => TicketType::DidNotTrigger->value,
+        'description' => 'Test description',
+        'emulator' => 'AetherSX2',
+        'emulatorVersion' => '1.5-4248',
+        'gameHashId' => $gameHash->id,
+    ]);
 
-        EmulatorCoreRestriction::create([
-            'core_name' => 'doublecherrygb_libretro',
-            'support_level' => ClientSupportLevel::Warned,
-            'notes' => 'known issues',
-        ]);
+    // Assert
+    $response->assertOk();
 
-        /** @var User $user */
-        $user = User::factory()->create([
-            'email_verified_at' => Carbon::parse('2013-01-01'),
-            'created_at' => Carbon::now()->subWeeks(2),
-        ]);
-        $this->actingAs($user);
-
-        PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
-        PlayerSession::factory()->create([
-            'user_id' => $user->id,
-            'game_id' => $game->id,
-            'game_hash_id' => $gameHash->id,
-            'user_agent' => 'RetroArch/1.19.1 (Windows) doublecherrygb_libretro/5d2ac21',
-        ]);
-
-        $response = $this->postJson(route('api.ticket.store'), [
-            'ticketableModel' => 'achievement',
-            'ticketableId' => $achievement->id,
-            'mode' => 'hardcore',
-            'issue' => TicketType::TriggeredAtWrongTime->value,
-            'description' => 'Test description',
-            'emulator' => 'RetroArch',
-            'emulatorVersion' => '1.19.1',
-            'core' => 'doublecherrygb_libretro',
-            'gameHashId' => $gameHash->id,
-        ]);
-
-        $response->assertOk();
-
-        $this->assertDatabaseHas('tickets', [
-            'ticketable_id' => $achievement->id,
-            'reporter_id' => $user->id,
-            'state' => TicketState::Quarantined,
-        ]);
-    }
-
-    public function testStoreQuarantinesTicketsFromSoftcoreOnlyEmulators(): void
-    {
-        $system = System::factory()->create(['name' => 'Nintendo 64', 'active' => true]);
-        $game = Game::factory()->create(['title' => 'StarCraft 64', 'system_id' => $system->id]);
-        $gameHash = GameHash::factory()->create(['game_id' => $game->id]);
-        $developer = User::factory()->create();
-        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
-        $emulator = Emulator::factory()->create(['name' => 'gopher64', 'softcore_only' => true]);
-
-        EmulatorUserAgent::create([
-            'emulator_id' => $emulator->id,
-            'client' => 'gopher64',
-        ]);
-
-        /** @var User $user */
-        $user = User::factory()->create([
-            'email_verified_at' => Carbon::parse('2013-01-01'),
-            'created_at' => Carbon::now()->subWeeks(2),
-        ]);
-        $this->actingAs($user);
-
-        PlayerGame::factory()->create(['user_id' => $user->id, 'game_id' => $game->id]);
-        PlayerSession::factory()->create([
-            'user_id' => $user->id,
-            'game_id' => $game->id,
-            'game_hash_id' => $gameHash->id,
-            'user_agent' => 'gopher64/1.15.0 (Windows)',
-        ]);
-
-        $response = $this->postJson(route('api.ticket.store'), [
-            'ticketableModel' => 'achievement',
-            'ticketableId' => $achievement->id,
-            'mode' => 'casual',
-            'issue' => TicketType::TriggeredAtWrongTime->value,
-            'description' => 'Test description',
-            'emulator' => 'gopher64',
-            'emulatorVersion' => '1.15.0',
-            'gameHashId' => $gameHash->id,
-        ]);
-
-        $response->assertOk();
-
-        $this->assertDatabaseHas('tickets', [
-            'ticketable_id' => $achievement->id,
-            'reporter_id' => $user->id,
-            'state' => TicketState::Quarantined,
-        ]);
-    }
-}
+    $this->assertDatabaseHas('tickets', [
+        'ticketable_id' => $achievement->id,
+        'reporter_id' => $user->id,
+        'state' => TicketState::Quarantined,
+    ]);
+});


### PR DESCRIPTION
https://discord.com/channels/310192285306454017/645777658319208448/1533876623043199047

The quarantine check on tickets searches for a session on the achievement's exact game ID. Subsets still have their own game IDs, so a reporter who plays the base game has no session to match. The quarantine check is skipped and tickets stay Open, with notifications still going out for stuff like AetherSX2.

This PR makes an adjustment so that the emulator the reporter names on the ticket is the primary signal for the quarantine check. We quarantine when that emulator cannot debug triggers, is casual only, or when the given core matches a core restriction.

We keep session lookup as a fallback, as it carries signals the form itself cannot, such as client version thresholds and offline submission clients.

This PR also deletes `_createTicket` and its accompanying helpers from the legacy helper file and moves them into `CreateTicketAction`. One place now owns the ticket creation lifecycle. Additionally, `TicketApiControllerTest` has been migrated from PHPUnit syntax to Pest syntax.