### PR TITLE
perf: bulk write beaten games player stats

### DIFF
--- a/app/Platform/Actions/UpdatePlayerBeatenGamesStatsAction.php
+++ b/app/Platform/Actions/UpdatePlayerBeatenGamesStatsAction.php
@@ -11,11 +11,21 @@ use App\Models\User;
 use App\Platform\Enums\PlayerStatType;
 use App\Platform\Enums\UnlockMode;
 use App\Platform\Events\PlayerBeatenGamesStatsUpdated;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class UpdatePlayerBeatenGamesStatsAction
 {
+    private const BEATEN_GAMES_STAT_TYPES = [
+        PlayerStatType::GamesBeatenHardcoreDemos,
+        PlayerStatType::GamesBeatenHardcoreHacks,
+        PlayerStatType::GamesBeatenHardcoreHomebrew,
+        PlayerStatType::GamesBeatenHardcorePrototypes,
+        PlayerStatType::GamesBeatenHardcoreRetail,
+        PlayerStatType::GamesBeatenHardcoreUnlicensed,
+    ];
+
     public function execute(User $user): void
     {
         // If the user is untracked, wipe any stats they
@@ -60,7 +70,7 @@ class UpdatePlayerBeatenGamesStatsAction
         });
 
         $aggregatedPlayerStatValues = $this->calculateAggregatedGameBeatenHardcoreStatValues($playerBeatenHardcoreGames, $existingStats);
-        $this->upsertAllPlayerStats($user, $aggregatedPlayerStatValues, $existingStats);
+        $this->writeAllPlayerStats($user, $aggregatedPlayerStatValues, $existingStats);
     }
 
     /**
@@ -70,19 +80,12 @@ class UpdatePlayerBeatenGamesStatsAction
         mixed $playerBeatenHardcoreGames,
         Collection $existingStats,
     ): array {
+        // type => [value, most recent hardcore beaten game id, beaten at timestamp]
         $getInitializedStats = function () {
-            return [
-                PlayerStatType::GamesBeatenHardcoreDemos => [0, null, null],
-                PlayerStatType::GamesBeatenHardcoreHacks => [0, null, null],
-                PlayerStatType::GamesBeatenHardcoreHomebrew => [0, null, null],
-                PlayerStatType::GamesBeatenHardcorePrototypes => [0, null, null],
-                PlayerStatType::GamesBeatenHardcoreRetail => [0, null, null],
-                PlayerStatType::GamesBeatenHardcoreUnlicensed => [0, null, null],
-            ];
+            return array_fill_keys(self::BEATEN_GAMES_STAT_TYPES, [0, null, null]);
         };
 
         // We'll hold overall and per-console stat values.
-        // type => [value, most recent hardcore beaten game id, beaten at timestamp]
         $statValues = [
             'overall' => $getInitializedStats(),
         ];
@@ -159,66 +162,175 @@ class UpdatePlayerBeatenGamesStatsAction
     }
 
     /**
+     * Diff the desired stat rows against the rows the player already has, then
+     * write only the differences in a bounded number of bulk statements.
+     *
      * @param Collection<int, PlayerStat> $existingStats
      */
-    private function upsertAllPlayerStats(
+    private function writeAllPlayerStats(
         User $user,
         array $aggregatedPlayerStatValues,
         Collection $existingStats,
-    ): int {
-        $updatedCount = 0;
+    ): void {
+        [$existingStatsMap, $duplicateIdsToDelete] = $this->buildExistingStatsMap($existingStats);
+        [$rowsToInsert, $rowsToUpdate] = $this->buildWriteBuckets($user, $aggregatedPlayerStatValues, $existingStatsMap);
 
-        // Create a map for quick lookups using system_id and type as the key.
-        $existingStatsMap = [];
-        foreach ($existingStats as $stat) {
-            $key = ($stat->system_id ?? 'overall') . '|' . $stat->type;
-            $existingStatsMap[$key] = true;
+        if (!$duplicateIdsToDelete && !$rowsToInsert && !$rowsToUpdate) {
+            return;
         }
+
+        // Sort every payload ascending so concurrent writers acquire locks in the
+        // same order, which is what keeps them from deadlocking each other.
+        sort($duplicateIdsToDelete);
+        usort($rowsToInsert, fn ($a, $b) => [$a['system_id'] ?? 0, $a['type']] <=> [$b['system_id'] ?? 0, $b['type']]);
+        usort($rowsToUpdate, fn ($a, $b) => $a['id'] <=> $b['id']);
+
+        // Retry on a deadlock, as several queue workers can write this table at once.
+        DB::transaction(function () use ($duplicateIdsToDelete, $rowsToInsert, $rowsToUpdate) {
+            // Discard duplicates first.
+            if ($duplicateIdsToDelete) {
+                PlayerStat::whereIn('id', $duplicateIdsToDelete)->delete();
+            }
+
+            if ($rowsToInsert) {
+                PlayerStat::insert($rowsToInsert);
+            }
+
+            if ($rowsToUpdate) {
+                PlayerStat::upsert(
+                    $rowsToUpdate,
+                    ['id'],
+                    ['last_game_id', 'value', 'stat_updated_at', 'updated_at']
+                );
+            }
+        }, attempts: 3);
+
+        PlayerBeatenGamesStatsUpdated::dispatch($user);
+    }
+
+    /**
+     * Route every desired stat row to the insert bucket, the update bucket, or
+     * neither. A row whose stored values already match is not written at all.
+     *
+     * @param array<string, PlayerStat> $existingStatsMap
+     * @return array{0: array<int, array<string, mixed>>, 1: array<int, array<string, mixed>>}
+     */
+    private function buildWriteBuckets(
+        User $user,
+        array $aggregatedPlayerStatValues,
+        array $existingStatsMap,
+    ): array {
+        $now = now();
+        $rowsToInsert = [];
+        $rowsToUpdate = [];
 
         // Loop through each console ID in the aggregated values (including 'overall').
         foreach ($aggregatedPlayerStatValues as $aggregateSystemId => $systemStats) {
             // Check if it's the 'overall' key or a specific console ID.
-            $systemId = $aggregateSystemId === 'overall' ? null : $aggregateSystemId;
+            $systemId = $aggregateSystemId === 'overall' ? null : (int) $aggregateSystemId;
 
             // Now, loop through each stat type for this system.
             foreach ($systemStats as $statType => $values) {
                 // Extract the value and most recent game ID.
                 [$value, $lastGameId, $statUpdatedAt] = $values;
 
-                // Check if this stat combination exists in our map.
-                $key = ($systemId ?? 'overall') . '|' . $statType;
+                $existingStat = $existingStatsMap[$this->buildStatKey($systemId, $statType)] ?? null;
 
-                if ($value > 0 || isset($existingStatsMap[$key])) {
-                    $this->upsertPlayerStat($user, $statType, $value, $systemId, $lastGameId, $statUpdatedAt);
-                    $updatedCount++;
+                if ($value === 0 && $existingStat === null) {
+                    continue;
+                }
+
+                if ($existingStat !== null && $this->isStatUnchanged($existingStat, $value, $lastGameId, $statUpdatedAt)) {
+                    continue;
+                }
+
+                $row = [
+                    'user_id' => $user->id,
+                    'system_id' => $systemId,
+                    'type' => $statType,
+                    'last_game_id' => $lastGameId,
+                    'value' => $value,
+                    'stat_updated_at' => $statUpdatedAt,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+
+                if ($existingStat === null) {
+                    $rowsToInsert[] = $row;
+                } else {
+                    $rowsToUpdate[] = ['id' => $existingStat->id] + $row;
                 }
             }
         }
 
-        return $updatedCount;
+        return [$rowsToInsert, $rowsToUpdate];
     }
 
-    private function upsertPlayerStat(
-        User $user,
-        string $statType,
+    /**
+     * Key the player's existing rows by system and type for lookup during the diff.
+     *
+     * @param Collection<int, PlayerStat> $existingStats
+     * @return array{0: array<string, PlayerStat>, 1: array<int, int>}
+     */
+    private function buildExistingStatsMap(Collection $existingStats): array
+    {
+        $existingStatsMap = [];
+        $duplicateIdsToDelete = [];
+
+        foreach ($existingStats as $stat) {
+            $key = $this->buildStatKey($stat->system_id, $stat->type);
+            $incumbent = $existingStatsMap[$key] ?? null;
+
+            if ($incumbent === null) {
+                $existingStatsMap[$key] = $stat;
+
+                continue;
+            }
+
+            if (!in_array($stat->type, self::BEATEN_GAMES_STAT_TYPES, true)) {
+                continue;
+            }
+
+            if ($stat->id < $incumbent->id) {
+                $existingStatsMap[$key] = $stat;
+                $duplicateIdsToDelete[] = $incumbent->id;
+            } else {
+                $duplicateIdsToDelete[] = $stat->id;
+            }
+        }
+
+        return [$existingStatsMap, $duplicateIdsToDelete];
+    }
+
+    private function buildStatKey(?int $systemId, string $statType): string
+    {
+        return ($systemId ?? 'overall') . '|' . $statType;
+    }
+
+    private function isStatUnchanged(
+        PlayerStat $existingStat,
         int $value,
-        ?int $systemId,
         ?int $lastGameId,
         ?string $statUpdatedAt,
-    ): void {
-        PlayerStat::updateOrCreate(
-            [
-                'user_id' => $user->id,
-                'system_id' => $systemId,
-                'type' => $statType,
-            ],
-            [
-                'last_game_id' => $lastGameId,
-                'value' => $value,
-                'stat_updated_at' => $statUpdatedAt,
-            ]
-        );
+    ): bool {
+        $existingLastGameId = $existingStat->last_game_id === null ? null : (int) $existingStat->last_game_id;
 
-        PlayerBeatenGamesStatsUpdated::dispatch($user);
+        return
+            (int) $existingStat->value === $value
+            && $existingLastGameId === ($lastGameId === null ? null : (int) $lastGameId)
+            && $this->normalizeTimestamp($existingStat->stat_updated_at) === $this->normalizeTimestamp($statUpdatedAt);
+    }
+
+    /**
+     * The model casts stat_updated_at to Carbon while the aggregation carries the
+     * raw string it read. Both sides need the same shape or every row looks changed.
+     */
+    private function normalizeTimestamp(mixed $timestamp): ?string
+    {
+        if ($timestamp === null || $timestamp === '') {
+            return null;
+        }
+
+        return Carbon::parse($timestamp)->toDateTimeString();
     }
 }

--- a/app/Platform/Commands/UpdatePlayerBeatenGamesStats.php
+++ b/app/Platform/Commands/UpdatePlayerBeatenGamesStats.php
@@ -57,7 +57,8 @@ class UpdatePlayerBeatenGamesStats extends Command
                 })->all();
 
                 // Dispatch jobs for the current chunk.
-                Bus::batch($jobs)->onQueue('player-beaten-games-stats')->dispatch();
+                // We use allowFailures() so one player's failure doesn't cancel the whole batch.
+                Bus::batch($jobs)->allowFailures()->onQueue('player-beaten-games-stats')->dispatch();
 
                 $progressBar->advance(count($users));
             });

--- a/app/Platform/Jobs/UpdatePlayerBeatenGamesStatsJob.php
+++ b/app/Platform/Jobs/UpdatePlayerBeatenGamesStatsJob.php
@@ -28,6 +28,8 @@ class UpdatePlayerBeatenGamesStatsJob implements ShouldQueue, ShouldBeUniqueUnti
     }
 
     public int $uniqueFor = 3600;
+    public int $tries = 3;
+    public int $backoff = 10;
 
     public function uniqueId(): string
     {

--- a/tests/Feature/Platform/Actions/UpdatePlayerBeatenGamesStatsActionTest.php
+++ b/tests/Feature/Platform/Actions/UpdatePlayerBeatenGamesStatsActionTest.php
@@ -11,8 +11,10 @@ use App\Models\User;
 use App\Platform\Actions\UpdatePlayerBeatenGamesStatsAction;
 use App\Platform\Enums\PlayerStatType;
 use App\Platform\Enums\UnlockMode;
+use App\Platform\Events\PlayerBeatenGamesStatsUpdated;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
 use Tests\Feature\Platform\Concerns\TestsPlayerBadges;
 use Tests\TestCase;
 
@@ -242,6 +244,151 @@ class UpdatePlayerBeatenGamesStatsActionTest extends TestCase
         $this->assertEquals(PlayerStatType::GamesBeatenHardcoreRetail, $systemStats->type);
         $this->assertNull($systemStats->last_game_id);
         $this->assertNull($systemStats->stat_updated_at);
+    }
+
+    public function testItOnlyWritesAffectedRowsWhenANewAwardArrives(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $systems = System::factory()->count(2)->create();
+        $gameOne = Game::factory()->create(['system_id' => $systems->get(0)->id, 'title' => 'Super Mario Bros.']);
+        $gameTwo = Game::factory()->create(['system_id' => $systems->get(1)->id, 'title' => 'Sonic the Hedgehog']);
+
+        $this->addGameBeatenAward($user, $gameOne, UnlockMode::Hardcore, Carbon::create(2023, 1, 1));
+
+        Carbon::setTestNow(Carbon::create(2023, 6, 1));
+        (new UpdatePlayerBeatenGamesStatsAction())->execute($user);
+
+        $systemOneStat = PlayerStat::where('user_id', $user->id)->where('system_id', $systems->get(0)->id)->sole();
+        $overallStat = PlayerStat::where('user_id', $user->id)->whereNull('system_id')->sole();
+
+        // Act
+        Event::fake();
+
+        Carbon::setTestNow(Carbon::create(2023, 6, 2));
+        $this->addGameBeatenAward($user, $gameTwo, UnlockMode::Hardcore, Carbon::create(2023, 2, 1));
+        (new UpdatePlayerBeatenGamesStatsAction())->execute($user);
+
+        // Assert
+        Event::assertDispatchedTimes(PlayerBeatenGamesStatsUpdated::class, 1);
+
+        // ... the untouched system's row was not rewritten ...
+        $this->assertEquals(
+            $systemOneStat->updated_at->toDateTimeString(),
+            $systemOneStat->fresh()->updated_at->toDateTimeString()
+        );
+
+        // ... but the overall row was, in place ...
+        $freshOverallStat = $overallStat->fresh();
+        $this->assertEquals(2, $freshOverallStat->value);
+        $this->assertEquals('2023-06-02 00:00:00', $freshOverallStat->updated_at->toDateTimeString());
+
+        // ... and the new system got its own row ...
+        $systemTwoStat = PlayerStat::where('user_id', $user->id)->where('system_id', $systems->get(1)->id)->sole();
+        $this->assertEquals(1, $systemTwoStat->value);
+        $this->assertEquals($gameTwo->id, $systemTwoStat->last_game_id);
+    }
+
+    public function testItDoesntDispatchAnEventWhenWipingUntrackedUserStats(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['system_id' => $system->id, 'title' => 'Super Mario Bros.']);
+
+        $this->addGameBeatenAward($user, $game, UnlockMode::Hardcore, Carbon::create(2023, 1, 1));
+        (new UpdatePlayerBeatenGamesStatsAction())->execute($user);
+
+        $user->unranked_at = now();
+        $user->save();
+
+        // Act
+        Event::fake();
+        (new UpdatePlayerBeatenGamesStatsAction())->execute($user);
+
+        // Assert
+        Event::assertNotDispatched(PlayerBeatenGamesStatsUpdated::class);
+        $this->assertCount(0, PlayerStat::where('user_id', $user->id)->get());
+    }
+
+    public function testItHealsDuplicateOverallRowsForBeatenGamesStatTypes(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['system_id' => $system->id, 'title' => 'Super Mario Bros.']);
+
+        $this->addGameBeatenAward($user, $game, UnlockMode::Hardcore, Carbon::create(2023, 1, 1));
+        (new UpdatePlayerBeatenGamesStatsAction())->execute($user);
+
+        $originalOverallStat = PlayerStat::where('user_id', $user->id)->whereNull('system_id')->sole();
+
+        PlayerStat::insert([
+            'user_id' => $user->id,
+            'system_id' => null,
+            'type' => PlayerStatType::GamesBeatenHardcoreRetail,
+            'last_game_id' => $game->id,
+            'value' => 999,
+            'stat_updated_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // Act
+        (new UpdatePlayerBeatenGamesStatsAction())->execute($user);
+
+        // Assert
+        $overallStats = PlayerStat::where('user_id', $user->id)->whereNull('system_id')->get();
+        $this->assertCount(1, $overallStats);
+        $this->assertEquals($originalOverallStat->id, $overallStats->first()->id);
+        $this->assertEquals(1, $overallStats->first()->value);
+    }
+
+    public function testItLeavesDuplicateRowsOfOtherStatTypesAlone(): void
+    {
+        // Arrange
+        $user = User::factory()->create();
+        $system = System::factory()->create();
+        $game = Game::factory()->create(['system_id' => $system->id, 'title' => 'Super Mario Bros.']);
+
+        $this->addGameBeatenAward($user, $game, UnlockMode::Hardcore, Carbon::create(2023, 1, 1));
+        (new UpdatePlayerBeatenGamesStatsAction())->execute($user);
+
+        PlayerStat::insert([
+            [
+                'user_id' => $user->id,
+                'system_id' => null,
+                'type' => PlayerStatType::PointsHardcoreDay,
+                'last_game_id' => null,
+                'value' => 10,
+                'stat_updated_at' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'user_id' => $user->id,
+                'system_id' => null,
+                'type' => PlayerStatType::PointsHardcoreDay,
+                'last_game_id' => null,
+                'value' => 20,
+                'stat_updated_at' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        // Act
+        (new UpdatePlayerBeatenGamesStatsAction())->execute($user);
+
+        // Assert
+        $pointsStats = PlayerStat::where('user_id', $user->id)
+            ->where('type', PlayerStatType::PointsHardcoreDay)
+            ->orderBy('id')
+            ->get();
+
+        $this->assertCount(2, $pointsStats);
+        $this->assertEquals(10, $pointsStats->first()->value);
+        $this->assertEquals(20, $pointsStats->last()->value);
     }
 
     protected function assertPlayerStatDetails(


### PR DESCRIPTION
Resolves [RAWEB-CC](https://retroachievementsorg.sentry.io/issues/44904822/?environment=production&project=4508694685417552&referrer=issue-list&statsPeriod=30d) and [RAWEB-CH](https://retroachievementsorg.sentry.io/issues/44905101/?environment=production&project=4508694685417552&referrer=issue-list&statsPeriod=30d).

The job for updating beaten games player stats runs about 67,000 times per month. In prod, this is kicking off ~3,218,000 DB queries and ~1,609,000 event dispatches. Most of this work is a no-op at best. At worst, it's tying up our resources with 1.5 million pointless `UPDATE` statements per month.

Nothing listens to those 1,609,000 event dispatches, so we're also doing work with no purpose at all.

This PR should drastically reduce some of these numbers, ideally to ~201,000 DB statements per month from this code path. We achieve this by replacing the per-row `updateOrCreate` with a diff-then-bulk-write approach. We load the player's rows once, compare them against potential diffs, and write only diffs.

