### PR TITLE
feat(forums): add quote/citation support to forum posts

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -729,6 +729,7 @@
     "<1>last</1> edited": "<1>last</1> edited",
     "Joined {{joinDate}}": "Joined {{joinDate}}",
     "Edit": "Edit",
+    "Quote post": "Quote post",
     "Copy post link": "Copy post link",
     "Copied!": "Copied!",
     "Authorize": "Authorize",

--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeQuote/ShortcodeQuote.test.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeQuote/ShortcodeQuote.test.tsx
@@ -1,3 +1,5 @@
+import userEvent from '@testing-library/user-event';
+
 import { render, screen } from '@/test';
 
 import { ShortcodeQuote } from './ShortcodeQuote';
@@ -51,5 +53,71 @@ describe('Component: ShortcodeQuote', () => {
     const spanEl = screen.getByText(/test/i);
     expect(spanEl).toBeVisible();
     expect(spanEl.innerHTML).toEqual('test<br>content');
+  });
+
+  it('given a top-level quote, does not show a collapse toggle', () => {
+    // ARRANGE
+    render(<ShortcodeQuote>Top-level quoted content</ShortcodeQuote>);
+
+    // ASSERT
+    expect(screen.getByText(/top-level quoted content/i)).toBeVisible();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('given a quote nested inside another quote, collapses the nested quote behind a toggle', () => {
+    // ARRANGE
+    render(
+      <ShortcodeQuote>
+        Outer quoted content
+        <ShortcodeQuote>Inner quoted content</ShortcodeQuote>
+      </ShortcodeQuote>,
+    );
+
+    // ASSERT
+    expect(screen.getByText(/outer quoted content/i)).toBeVisible();
+
+    const toggleButton = screen.getByRole('button', { name: /quote/i });
+    expect(toggleButton).toBeVisible();
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('given the user clicks the toggle on a nested quote, reveals its content', async () => {
+    // ARRANGE
+    render(
+      <ShortcodeQuote>
+        Outer quoted content
+        <ShortcodeQuote>Inner quoted content</ShortcodeQuote>
+      </ShortcodeQuote>,
+    );
+
+    // ACT
+    const toggleButton = screen.getByRole('button', { name: /quote/i });
+    await userEvent.click(toggleButton);
+
+    // ASSERT
+    expect(screen.getByText(/inner quoted content/i)).toBeVisible();
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('given a quote nested three levels deep, collapses every level past the outermost', () => {
+    // ARRANGE
+    render(
+      <ShortcodeQuote>
+        Level 1
+        <ShortcodeQuote>
+          Level 2
+          <ShortcodeQuote>Level 3</ShortcodeQuote>
+        </ShortcodeQuote>
+      </ShortcodeQuote>,
+    );
+
+    // ASSERT
+    expect(screen.getByText(/level 1/i)).toBeVisible();
+
+    // !! two nested levels (2 and 3), so two collapsed toggles, both closed by default
+    const toggleButtons = screen.getAllByRole('button', { name: /quote/i });
+    expect(toggleButtons).toHaveLength(2);
+    expect(toggleButtons[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(toggleButtons[1]).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeQuote/ShortcodeQuote.test.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeQuote/ShortcodeQuote.test.tsx
@@ -13,15 +13,16 @@ describe('Component: ShortcodeQuote', () => {
     expect(container).toBeTruthy();
   });
 
-  it('given a simple string child, renders it inside a span with the quotedtext class', () => {
+  it('given a simple string child, renders it inside a div with the quotedtext class', () => {
     // ARRANGE
     render(<ShortcodeQuote>test content</ShortcodeQuote>);
 
     // ASSERT
-    const spanEl = screen.getByText(/test content/i);
+    const quoteEl = screen.getByText(/test content/i);
 
-    expect(spanEl).toBeVisible();
-    expect(spanEl).toHaveClass('quotedtext');
+    expect(quoteEl).toBeVisible();
+    expect(quoteEl).toHaveClass('quotedtext');
+    expect(quoteEl.nodeName).toEqual('DIV');
   });
 
   it('removes leading line breaks in the output', () => {
@@ -34,9 +35,9 @@ describe('Component: ShortcodeQuote', () => {
     );
 
     // ASSERT
-    const spanEl = screen.getByText(/test/i);
-    expect(spanEl).toBeVisible();
-    expect(spanEl.innerHTML).toEqual('test content');
+    const quoteEl = screen.getByText(/test/i);
+    expect(quoteEl).toBeVisible();
+    expect(quoteEl.innerHTML).toEqual('test content');
   });
 
   it('retains inner line breaks in the output', () => {
@@ -50,9 +51,9 @@ describe('Component: ShortcodeQuote', () => {
     );
 
     // ASSERT
-    const spanEl = screen.getByText(/test/i);
-    expect(spanEl).toBeVisible();
-    expect(spanEl.innerHTML).toEqual('test<br>content');
+    const quoteEl = screen.getByText(/test/i);
+    expect(quoteEl).toBeVisible();
+    expect(quoteEl.innerHTML).toEqual('test<br>content');
   });
 
   it('given a top-level quote, does not show a collapse toggle', () => {

--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeQuote/ShortcodeQuote.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeQuote/ShortcodeQuote.tsx
@@ -1,11 +1,76 @@
-import type { FC, ReactNode } from 'react';
+import { createContext, type FC, type ReactNode, useContext, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LuChevronDown } from 'react-icons/lu';
+
+import { cn } from '@/common/utils/cn';
 
 import { stripLeadingWhitespaceFromChildren } from '../../../utils/shortcodes/stripLeadingWhitespaceFromChildren';
+import { BaseButton } from '../../+vendor/BaseButton';
+import {
+  BaseCollapsible,
+  BaseCollapsibleContent,
+  BaseCollapsibleTrigger,
+} from '../../+vendor/BaseCollapsible';
+
+/**
+ * Tracks how many [quote] tags deep we are. A quote chain from repeated
+ * replies nests [quote] blocks inside [quote] blocks, so we collapse
+ * anything past the outermost (most recent) quote by default.
+ */
+const QuoteDepthContext = createContext(0);
 
 interface ShortcodeQuoteProps {
   children: ReactNode;
 }
 
 export const ShortcodeQuote: FC<ShortcodeQuoteProps> = ({ children }) => {
-  return <span className="quotedtext mb-3">{stripLeadingWhitespaceFromChildren(children)}</span>;
+  const { t } = useTranslation();
+
+  const depth = useContext(QuoteDepthContext);
+  const isNested = depth > 0;
+
+  const [isOpen, setIsOpen] = useState(!isNested);
+
+  const content = (
+    <QuoteDepthContext.Provider value={depth + 1}>
+      {stripLeadingWhitespaceFromChildren(children)}
+    </QuoteDepthContext.Provider>
+  );
+
+  if (!isNested) {
+    return <span className="quotedtext mb-3">{content}</span>;
+  }
+
+  return (
+    <BaseCollapsible open={isOpen} onOpenChange={setIsOpen}>
+      <BaseCollapsibleTrigger asChild>
+        <BaseButton
+          size="sm"
+          className={cn('mb-1', isOpen ? 'rounded-b-none border-transparent bg-embed' : null)}
+        >
+          {t('Quote')}
+
+          <LuChevronDown
+            className={cn(
+              'ml-1 size-4 transition-transform duration-300',
+              isOpen ? 'rotate-180' : 'rotate-0',
+            )}
+          />
+        </BaseButton>
+      </BaseCollapsibleTrigger>
+
+      <BaseCollapsibleContent forceMount>
+        <div
+          className={cn(
+            'grid transition-[grid-template-rows] duration-300 ease-in-out',
+            isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+          )}
+        >
+          <div className="overflow-hidden">
+            <span className="quotedtext mb-3">{content}</span>
+          </div>
+        </div>
+      </BaseCollapsibleContent>
+    </BaseCollapsible>
+  );
 };

--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeQuote/ShortcodeQuote.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeQuote/ShortcodeQuote.tsx
@@ -38,7 +38,8 @@ export const ShortcodeQuote: FC<ShortcodeQuoteProps> = ({ children }) => {
   );
 
   if (!isNested) {
-    return <span className="quotedtext mb-3">{content}</span>;
+    // div, not span: a nested quote can render block-level content.
+    return <div className="quotedtext mb-3">{content}</div>;
   }
 
   return (
@@ -67,7 +68,7 @@ export const ShortcodeQuote: FC<ShortcodeQuoteProps> = ({ children }) => {
           )}
         >
           <div className="overflow-hidden">
-            <span className="quotedtext mb-3">{content}</span>
+            <div className="quotedtext mb-3">{content}</div>
           </div>
         </div>
       </BaseCollapsibleContent>

--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeRenderer.test.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeRenderer.test.tsx
@@ -72,7 +72,7 @@ describe('Component: ShortcodeRenderer', () => {
     const textEl = screen.getByText(/this is some stuff/i);
 
     expect(textEl).toBeVisible();
-    expect(textEl.nodeName).toEqual('SPAN');
+    expect(textEl.nodeName).toEqual('DIV');
     expect(textEl).toHaveClass('quotedtext');
   });
 

--- a/resources/js/common/components/ShortcodeRenderer/ShortcodeRenderer.test.tsx
+++ b/resources/js/common/components/ShortcodeRenderer/ShortcodeRenderer.test.tsx
@@ -76,6 +76,20 @@ describe('Component: ShortcodeRenderer', () => {
     expect(textEl).toHaveClass('quotedtext');
   });
 
+  it('given a body with a nested quote tag, collapses the nested quote behind a toggle', () => {
+    // ARRANGE
+    const body = '[quote]Outer reply[quote]Original post[/quote][/quote]';
+
+    render(<ShortcodeRenderer body={body} />);
+
+    // ASSERT
+    expect(screen.getByText(/outer reply/i)).toBeVisible();
+    expect(screen.getByRole('button', { name: /quote/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
   it('given a body with a spoiler tag, renders the spoiler shortcode component', () => {
     // ARRANGE
     const body = '[spoiler]this is a spoiler![/spoiler]';

--- a/resources/js/features/forums/components/ForumPostCard/ForumPostCard.test.tsx
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostCard.test.tsx
@@ -168,4 +168,58 @@ describe('Component: ForumPostCard', () => {
     // ASSERT
     expect(screen.queryByRole('link', { name: /report/i })).not.toBeInTheDocument();
   });
+
+  it('given canQuote is true and onQuote is provided, shows the quote button', () => {
+    // ARRANGE
+    const comment = createForumTopicComment();
+    const topic = createForumTopic();
+
+    render(
+      <ForumPostCard
+        body="Test content"
+        comment={comment}
+        topic={topic}
+        canQuote={true}
+        onQuote={vi.fn()}
+      />,
+      { pageProps: { can: { authorizeForumTopicComments: false } } },
+    );
+
+    // ASSERT
+    expect(screen.getByRole('button', { name: /quote post/i })).toBeVisible();
+  });
+
+  it('given canQuote is false, does not show the quote button', () => {
+    // ARRANGE
+    const comment = createForumTopicComment();
+    const topic = createForumTopic();
+
+    render(
+      <ForumPostCard
+        body="Test content"
+        comment={comment}
+        topic={topic}
+        canQuote={false}
+        onQuote={vi.fn()}
+      />,
+      { pageProps: { can: { authorizeForumTopicComments: false } } },
+    );
+
+    // ASSERT
+    expect(screen.queryByRole('button', { name: /quote post/i })).not.toBeInTheDocument();
+  });
+
+  it('given canQuote is true but no onQuote handler is provided, does not show the quote button', () => {
+    // ARRANGE
+    const comment = createForumTopicComment();
+    const topic = createForumTopic();
+
+    render(
+      <ForumPostCard body="Test content" comment={comment} topic={topic} canQuote={true} />,
+      { pageProps: { can: { authorizeForumTopicComments: false } } },
+    );
+
+    // ASSERT
+    expect(screen.queryByRole('button', { name: /quote post/i })).not.toBeInTheDocument();
+  });
 });

--- a/resources/js/features/forums/components/ForumPostCard/ForumPostCard.tsx
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostCard.tsx
@@ -13,14 +13,17 @@ import { ForumPostAuthorBox } from './ForumPostAuthorBox';
 import { ForumPostCardMeta } from './ForumPostCardMeta';
 import { ForumPostCopyLinkButton } from './ForumPostCopyLinkButton';
 import { ForumPostManage } from './ForumPostManage';
+import { ForumPostQuoteButton } from './ForumPostQuoteButton';
 
 interface ForumPostCardProps {
   body: string;
 
   canManage?: boolean;
+  canQuote?: boolean;
   canUpdate?: boolean;
   comment?: App.Data.ForumTopicComment;
   isHighlighted?: boolean;
+  onQuote?: (quoteText: string) => void;
   topic?: App.Data.ForumTopic;
 }
 
@@ -29,8 +32,10 @@ export const ForumPostCard: FC<ForumPostCardProps> = ({
   comment,
   topic,
   canManage = false,
+  canQuote = false,
   canUpdate = false,
   isHighlighted = false,
+  onQuote,
 }) => {
   const { auth, can } = usePageProps<App.Community.Data.MessageThreadShowPageProps>();
   const { t } = useTranslation();
@@ -95,6 +100,10 @@ export const ForumPostCard: FC<ForumPostCardProps> = ({
                       <LuFlag className="size-3" />
                       {t('Report')}
                     </InertiaLink>
+                  ) : null}
+
+                  {canQuote && onQuote ? (
+                    <ForumPostQuoteButton comment={comment} topic={topic} onQuote={onQuote} />
                   ) : null}
 
                   <ForumPostCopyLinkButton comment={comment} topic={topic} />

--- a/resources/js/features/forums/components/ForumPostCard/ForumPostQuoteButton/ForumPostQuoteButton.test.tsx
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostQuoteButton/ForumPostQuoteButton.test.tsx
@@ -1,0 +1,63 @@
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '@/test';
+import { createForumTopic, createForumTopicComment, createUser } from '@/test/factories';
+
+import { ForumPostQuoteButton } from './ForumPostQuoteButton';
+
+describe('Component: ForumPostQuoteButton', () => {
+  it('renders without crashing', () => {
+    // ARRANGE
+    const topic = createForumTopic();
+    const comment = createForumTopicComment();
+
+    const { container } = render(
+      <ForumPostQuoteButton comment={comment} topic={topic} onQuote={vi.fn()} />,
+    );
+
+    // ASSERT
+    expect(container).toBeTruthy();
+  });
+
+  it('given the user clicks the button, calls onQuote with the composed citation', async () => {
+    // ARRANGE
+    const onQuote = vi.fn();
+
+    const topic = createForumTopic({ id: 123 });
+    const comment = createForumTopicComment({
+      id: 456,
+      body: 'This is the original post body.',
+      user: createUser({ displayName: 'Scott' }),
+    });
+
+    render(<ForumPostQuoteButton comment={comment} topic={topic} onQuote={onQuote} />);
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: /quote post/i }));
+
+    // ASSERT
+    expect(onQuote).toHaveBeenCalledWith(
+      expect.stringContaining('This is the original post body.'),
+    );
+    expect(onQuote).toHaveBeenCalledWith(expect.stringContaining('Scott wrote:'));
+    expect(onQuote).toHaveBeenCalledWith(expect.stringContaining('forum-topic.show'));
+    expect(onQuote).toHaveBeenCalledWith(expect.stringContaining('[quote]'));
+    expect(onQuote).toHaveBeenCalledWith(expect.stringContaining('[/quote]'));
+  });
+
+  it('given a comment with a different display name, includes that name in the composed citation', async () => {
+    // ARRANGE
+    const onQuote = vi.fn();
+
+    const topic = createForumTopic();
+    const comment = createForumTopicComment({ user: createUser({ displayName: 'MaxMilyin' }) });
+
+    render(<ForumPostQuoteButton comment={comment} topic={topic} onQuote={onQuote} />);
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: /quote post/i }));
+
+    // ASSERT
+    expect(onQuote).toHaveBeenCalledWith(expect.stringContaining('MaxMilyin wrote:'));
+  });
+});

--- a/resources/js/features/forums/components/ForumPostCard/ForumPostQuoteButton/ForumPostQuoteButton.test.tsx
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostQuoteButton/ForumPostQuoteButton.test.tsx
@@ -60,4 +60,20 @@ describe('Component: ForumPostQuoteButton', () => {
     // ASSERT
     expect(onQuote).toHaveBeenCalledWith(expect.stringContaining('MaxMilyin wrote:'));
   });
+
+  it('given a comment with no user, falls back to a generic display name', async () => {
+    // ARRANGE
+    const onQuote = vi.fn();
+
+    const topic = createForumTopic();
+    const comment = createForumTopicComment({ user: null });
+
+    render(<ForumPostQuoteButton comment={comment} topic={topic} onQuote={onQuote} />);
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: /quote post/i }));
+
+    // ASSERT
+    expect(onQuote).toHaveBeenCalledWith(expect.stringContaining('Deleted User wrote:'));
+  });
 });

--- a/resources/js/features/forums/components/ForumPostCard/ForumPostQuoteButton/ForumPostQuoteButton.tsx
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostQuoteButton/ForumPostQuoteButton.tsx
@@ -1,0 +1,55 @@
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LuQuote } from 'react-icons/lu';
+import { route } from 'ziggy-js';
+
+import { BaseButton } from '@/common/components/+vendor/BaseButton';
+import {
+  BaseTooltip,
+  BaseTooltipContent,
+  BaseTooltipTrigger,
+} from '@/common/components/+vendor/BaseTooltip';
+
+interface ForumPostQuoteButtonProps {
+  comment: App.Data.ForumTopicComment;
+  onQuote: (quoteText: string) => void;
+  topic: App.Data.ForumTopic;
+}
+
+export const ForumPostQuoteButton: FC<ForumPostQuoteButtonProps> = ({
+  comment,
+  onQuote,
+  topic,
+}) => {
+  const { t } = useTranslation();
+
+  const handleClick = () => {
+    const permalink =
+      route('forum-topic.show', { topic: topic.id, _query: { comment: comment.id } }) +
+      '#' +
+      comment.id;
+
+    const displayName = comment.user?.displayName ?? 'Deleted User';
+
+    const quoteText = `[url=${permalink}][b]${displayName} wrote:[/b][/url]\n[quote]\n${comment.body}\n[/quote]\n\n`;
+
+    onQuote(quoteText);
+  };
+
+  return (
+    <BaseTooltip>
+      <BaseTooltipTrigger asChild>
+        <BaseButton
+          aria-label={t('Quote post')}
+          size="sm"
+          className="max-h-5.5 p-1! text-2xs! lg:text-xs!"
+          onClick={handleClick}
+        >
+          <LuQuote className="size-3!" />
+        </BaseButton>
+      </BaseTooltipTrigger>
+
+      <BaseTooltipContent className="text-xs">{t('Quote post')}</BaseTooltipContent>
+    </BaseTooltip>
+  );
+};

--- a/resources/js/features/forums/components/ForumPostCard/ForumPostQuoteButton/index.ts
+++ b/resources/js/features/forums/components/ForumPostCard/ForumPostQuoteButton/index.ts
@@ -1,0 +1,1 @@
+export * from './ForumPostQuoteButton';

--- a/resources/js/features/forums/components/QuickReplyForm/QuickReplyForm.test.tsx
+++ b/resources/js/features/forums/components/QuickReplyForm/QuickReplyForm.test.tsx
@@ -14,6 +14,9 @@ console.error = vi.fn();
 // Prevent the autosize textarea from flooding the console with errors.
 window.scrollTo = vi.fn();
 
+// happy-dom doesn't implement scrollIntoView.
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
 describe('Component: QuickReplyForm', () => {
   it('renders without crashing', () => {
     // ARRANGE
@@ -368,5 +371,83 @@ describe('Component: QuickReplyForm', () => {
     expect(options[1]).toHaveTextContent('AlphaTeam');
     expect(options[2]).toHaveTextContent('BetaTeam');
     expect(options[3]).toHaveTextContent('ZetaTeam');
+  });
+
+  it('given a quotedPost is provided, injects the quoted text into the body field', () => {
+    // ARRANGE
+    render(
+      <QuickReplyForm
+        onPreview={() => {}}
+        quotedPost={{ text: '[quote]\nSome quoted text\n[/quote]\n\n', insertedAt: 1 }}
+      />,
+      {
+        pageProps: {
+          auth: { user: createAuthenticatedUser() },
+          forumTopic: createForumTopic(),
+        },
+      },
+    );
+
+    // ASSERT
+    const textArea = screen.getByPlaceholderText(/don't ask for links/i);
+    expect(textArea).toHaveValue('[quote]\nSome quoted text\n[/quote]\n\n');
+  });
+
+  it('given the body already has content, appends the quoted text rather than replacing it', async () => {
+    // ARRANGE
+    const { rerender } = render(<QuickReplyForm onPreview={() => {}} quotedPost={null} />, {
+      pageProps: {
+        auth: { user: createAuthenticatedUser() },
+        forumTopic: createForumTopic(),
+      },
+    });
+
+    const textArea = screen.getByPlaceholderText(/don't ask for links/i);
+    await userEvent.type(textArea, 'My in-progress draft');
+
+    // ACT
+    rerender(
+      <QuickReplyForm
+        onPreview={() => {}}
+        quotedPost={{ text: '[quote]\nQuoted text\n[/quote]\n\n', insertedAt: 1 }}
+      />,
+    );
+
+    // ASSERT
+    expect(textArea).toHaveValue(
+      'My in-progress draft\n\n[quote]\nQuoted text\n[/quote]\n\n',
+    );
+  });
+
+  it('given quotedPost changes to a new insertedAt, re-injects the quoted text', () => {
+    // ARRANGE
+    const { rerender } = render(
+      <QuickReplyForm
+        onPreview={() => {}}
+        quotedPost={{ text: '[quote]\nFirst quote\n[/quote]\n\n', insertedAt: 1 }}
+      />,
+      {
+        pageProps: {
+          auth: { user: createAuthenticatedUser() },
+          forumTopic: createForumTopic(),
+        },
+      },
+    );
+
+    const textArea = screen.getByPlaceholderText(/don't ask for links/i);
+    expect(textArea).toHaveValue('[quote]\nFirst quote\n[/quote]\n\n');
+
+    // ACT
+    rerender(
+      <QuickReplyForm
+        onPreview={() => {}}
+        quotedPost={{ text: '[quote]\nFirst quote\n[/quote]\n\n', insertedAt: 2 }} // !! same text, new insertedAt
+      />,
+    );
+
+    // ASSERT
+    expect(textArea).toHaveValue(
+      '[quote]\nFirst quote\n[/quote]\n\n\n\n[quote]\nFirst quote\n[/quote]\n\n',
+    );
   });
 });

--- a/resources/js/features/forums/components/QuickReplyForm/QuickReplyForm.tsx
+++ b/resources/js/features/forums/components/QuickReplyForm/QuickReplyForm.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -24,9 +24,10 @@ import { useUpsertPostForm } from '../../hooks/useUpsertPostForm';
 
 interface QuickReplyFormProps {
   onPreview: (content: string) => void;
+  quotedPost?: { text: string; insertedAt: number } | null;
 }
 
-export const QuickReplyForm: FC<QuickReplyFormProps> = ({ onPreview }) => {
+export const QuickReplyForm: FC<QuickReplyFormProps> = ({ onPreview, quotedPost }) => {
   const { auth, forumTopic, replyableTeamAccounts } =
     usePageProps<App.Data.ShowForumTopicPageProps>();
 
@@ -38,6 +39,32 @@ export const QuickReplyForm: FC<QuickReplyFormProps> = ({ onPreview }) => {
   );
   const watchedBody = useWatch({ name: 'body', control: form.control });
   const watchedPostAsUserId = useWatch({ name: 'postAsUserId', control: form.control });
+
+  useEffect(() => {
+    if (!quotedPost) {
+      return;
+    }
+
+    const currentBody = form.getValues('body');
+    const newBody = currentBody.trim().length
+      ? `${currentBody}\n\n${quotedPost.text}`
+      : quotedPost.text;
+
+    form.setValue('body', newBody, { shouldDirty: true });
+
+    setTimeout(() => {
+      const textareaEl = document.querySelector('textarea[name="body"]') as HTMLTextAreaElement;
+      if (!textareaEl) {
+        return;
+      }
+
+      textareaEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      textareaEl.focus();
+      textareaEl.setSelectionRange(newBody.length, newBody.length);
+    }, 0);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-inject when a new quote arrives, not on every body change
+  }, [quotedPost?.insertedAt]);
 
   const watchedPostAsUser =
     watchedPostAsUserId !== 'self'

--- a/resources/js/features/forums/components/ShowForumTopicMainRoot/ShowForumTopicMainRoot.test.tsx
+++ b/resources/js/features/forums/components/ShowForumTopicMainRoot/ShowForumTopicMainRoot.test.tsx
@@ -20,6 +20,9 @@ import { ShowForumTopicMainRoot } from './ShowForumTopicMainRoot';
 // Prevent the autosize textarea from flooding the console with errors.
 window.scrollTo = vi.fn();
 
+// happy-dom doesn't implement scrollIntoView.
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
 describe('Component: ShowForumTopicMainRoot', () => {
   it('renders without crashing', () => {
     // ARRANGE
@@ -649,5 +652,97 @@ describe('Component: ShowForumTopicMainRoot', () => {
 
     // ASSERT
     expect(screen.queryByRole('link', { name: 'Edit' })).not.toBeInTheDocument();
+  });
+
+  it('given the user clicks quote on a post, fills the reply composer with the quoted content and author name', async () => {
+    // ARRANGE
+    const user = createAuthenticatedUser({ displayName: 'CurrentUser' });
+
+    const category = createForumCategory();
+    const forum = createForum({ category });
+    const forumTopic = createForumTopic({ forum });
+
+    const comment = createForumTopicComment({
+      body: 'This is the quoted post.',
+      user: createUser({ displayName: 'OriginalPoster' }),
+    });
+    const paginatedForumTopicComments = createPaginatedData([comment]);
+
+    render(<ShowForumTopicMainRoot />, {
+      pageProps: {
+        auth: { user },
+        forumTopic,
+        paginatedForumTopicComments,
+        can: { createForumTopicComments: true }, // !!
+        ziggy: createZiggyProps(),
+      },
+    });
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: /quote post/i }));
+
+    // ASSERT
+    const textArea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textArea.value).toContain('This is the quoted post.');
+    expect(textArea.value).toContain('OriginalPoster wrote:');
+  });
+
+  it('given the user already has text in the reply composer, appends the quote rather than replacing it', async () => {
+    // ARRANGE
+    const user = createAuthenticatedUser({ displayName: 'CurrentUser' });
+
+    const category = createForumCategory();
+    const forum = createForum({ category });
+    const forumTopic = createForumTopic({ forum });
+
+    const comment = createForumTopicComment({
+      body: 'This is the quoted post.',
+      user: createUser({ displayName: 'OriginalPoster' }),
+    });
+    const paginatedForumTopicComments = createPaginatedData([comment]);
+
+    render(<ShowForumTopicMainRoot />, {
+      pageProps: {
+        auth: { user },
+        forumTopic,
+        paginatedForumTopicComments,
+        can: { createForumTopicComments: true }, // !!
+        ziggy: createZiggyProps(),
+      },
+    });
+
+    // ACT
+    const textArea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    await userEvent.type(textArea, 'My in-progress reply');
+    await userEvent.click(screen.getByRole('button', { name: /quote post/i }));
+
+    // ASSERT
+    expect(textArea.value).toContain('My in-progress reply');
+    expect(textArea.value).toContain('This is the quoted post.');
+  });
+
+  it('given the user cannot create forum topic comments, does not show the quote button', () => {
+    // ARRANGE
+    const user = createAuthenticatedUser({ displayName: 'CurrentUser' });
+
+    const category = createForumCategory();
+    const forum = createForum({ category });
+    const forumTopic = createForumTopic({ forum });
+
+    const comment = createForumTopicComment({ user: createUser({ displayName: 'OriginalPoster' }) });
+    const paginatedForumTopicComments = createPaginatedData([comment]);
+
+    render(<ShowForumTopicMainRoot />, {
+      pageProps: {
+        auth: { user },
+        forumTopic,
+        paginatedForumTopicComments,
+        can: { createForumTopicComments: false }, // !!
+        ziggy: createZiggyProps(),
+      },
+    });
+
+    // ASSERT
+    expect(screen.queryByRole('button', { name: /quote post/i })).not.toBeInTheDocument();
   });
 });

--- a/resources/js/features/forums/components/ShowForumTopicMainRoot/ShowForumTopicMainRoot.tsx
+++ b/resources/js/features/forums/components/ShowForumTopicMainRoot/ShowForumTopicMainRoot.tsx
@@ -1,5 +1,6 @@
 import { router } from '@inertiajs/react';
 import type { FC } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LuLock } from 'react-icons/lu';
 import { route } from 'ziggy-js';
@@ -32,6 +33,11 @@ export const ShowForumTopicMainRoot: FC = () => {
   const { t } = useTranslation();
 
   const { initiatePreview, previewContent } = useShortcodeBodyPreview();
+
+  const [pendingQuote, setPendingQuote] = useState<{ text: string; insertedAt: number } | null>(
+    null,
+  );
+  const handleQuote = (text: string) => setPendingQuote({ text, insertedAt: Date.now() });
 
   const handlePageSelectValueChange = (newPageValue: number) => {
     router.visit(
@@ -78,12 +84,14 @@ export const ShowForumTopicMainRoot: FC = () => {
             key={`comment-${comment.id}`}
             body={comment.body}
             canManage={can.manageForumTopicComments}
+            canQuote={can.createForumTopicComments}
             canUpdate={
               can.manageForumTopicComments ||
               getCanUpdatePost(forumTopic, comment, auth?.user, accessibleTeamAccounts)
             }
             comment={comment}
             isHighlighted={ziggy.query.comment === String(comment.id)}
+            onQuote={handleQuote}
             topic={forumTopic}
           />
         ))}
@@ -121,7 +129,7 @@ export const ShowForumTopicMainRoot: FC = () => {
 
         {can.createForumTopicComments ? (
           <div className="mt-4">
-            <QuickReplyForm onPreview={initiatePreview} />
+            <QuickReplyForm onPreview={initiatePreview} quotedPost={pendingQuote} />
           </div>
         ) : null}
 


### PR DESCRIPTION
Adds a "Quote" button to each forum post. Clicking it drops a citation into the reply:
- a link back to the original post
- the author's name
- the quoted body
 
Built entirely from the existing `[url]`/`[b]`/`[quote]` shortcodes.

Quotes chains can balloon fast, so nested [quote] blocks collapse behind a toggle by default, leaving only the most recent quote expanded.

Quote :
<img width="923" height="429" alt="Capture d&#39;écran 2026-08-11 173600" src="https://github.com/user-attachments/assets/37c2161e-1ef3-4216-bc33-bb6f2fe5cdcc" />

Quote collapsed :

<img width="918" height="327" alt="Capture d&#39;écran 2026-08-11 173729" src="https://github.com/user-attachments/assets/048ec98c-1e9f-40e5-adfb-380e2f930827" />

Quote expanded : 

<img width="901" height="543" alt="Capture d&#39;écran 2026-08-11 173753" src="https://github.com/user-attachments/assets/6779bcdc-2021-4037-bbf4-1248f3a4b1ef" />


If you click on the username from the quote it links to the quoted post.


## AI disclosure
Claude Code was used for this change: it wrote the component, hook wiring, and tests. 
I reviewed every line, tested the flow manually in the browser (quoting a post, quoting a reply that itself contains a quote to check the collapse behavior, and quoting with an in-progress draft to confirm it appends instead of replacing), and ran the full test suite before pushing.

