### PR TITLE
fix(api/v2): set attribute nullability in the schema

### DIFF
--- a/app/Api/V2/AchievementSetClaims/AchievementSetClaimSchema.php
+++ b/app/Api/V2/AchievementSetClaims/AchievementSetClaimSchema.php
@@ -98,6 +98,33 @@ class AchievementSetClaimSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'claimedAt' => false,
+            'finishedAt' => false,
+            'updatedAt' => false,
+            'status' => false,
+            'claimType' => false,
+            'setType' => false,
+            'specialType' => false,
+            'extensionsCount' => false,
+            'minutesLeft' => false,
+            'userId' => false,
+            'userDisplayName' => false,
+            'gameId' => false,
+            'gameTitle' => false,
+            'gameIconUrl' => false,
+            'systemId' => false,
+            'systemName' => false,
+        ];
+    }
+
+    /**
      * Get the sortable fields for this resource.
      */
     public function sortables(): iterable

--- a/app/Api/V2/AchievementSetVersions/AchievementSetVersionSchema.php
+++ b/app/Api/V2/AchievementSetVersions/AchievementSetVersionSchema.php
@@ -76,6 +76,26 @@ class AchievementSetVersionSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'version' => false,
+            'createdAt' => false,
+            'updatedAt' => false,
+            'playersTotal' => false,
+            'playersHardcore' => false,
+            'achievementsPublished' => false,
+            'achievementsUnpublished' => false,
+            'pointsTotal' => false,
+            'achievementSetId' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/AchievementSets/AchievementSetSchema.php
+++ b/app/Api/V2/AchievementSets/AchievementSetSchema.php
@@ -79,6 +79,31 @@ class AchievementSetSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'title' => true,
+            'pointsTotal' => false,
+            'pointsWeighted' => false,
+            'achievementsPublished' => false,
+            'achievementsUnpublished' => false,
+            'timesCompleted' => false,
+            'timesMastered' => false,
+            'medianTimeToCompleteSeconds' => true,
+            'medianTimeToMasterSeconds' => true,
+            'badgeUrl' => false,
+            'achievementsFirstPublishedAt' => true,
+            'types' => false,
+            'createdAt' => true,
+            'updatedAt' => true,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/Achievements/AchievementSchema.php
+++ b/app/Api/V2/Achievements/AchievementSchema.php
@@ -113,6 +113,36 @@ class AchievementSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'title' => false,
+            'description' => false,
+            'points' => false,
+            'pointsWeighted' => false,
+            'badgeUrl' => false,
+            'badgeLockedUrl' => false,
+            'type' => true,
+            'state' => false,
+            'orderColumn' => true,
+            'unlocksTotal' => true,
+            'unlocksHardcore' => true,
+            'unlockPercentage' => true,
+            'unlockHardcorePercentage' => true,
+            'medianTimeToUnlockSeconds' => true,
+            'medianTimeToUnlockHardcoreSeconds' => true,
+            'medianTimeToUnlockSamples' => true,
+            'medianTimeToUnlockHardcoreSamples' => true,
+            'createdAt' => false,
+            'modifiedAt' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/Comments/CommentSchema.php
+++ b/app/Api/V2/Comments/CommentSchema.php
@@ -63,6 +63,23 @@ class CommentSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'body' => false,
+            'authorAvatarUrl' => false,
+            'authorDisplayName' => false,
+            'authorId' => false,
+            'permalink' => false,
+            'submittedAt' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/EventAchievements/EventAchievementSchema.php
+++ b/app/Api/V2/EventAchievements/EventAchievementSchema.php
@@ -80,6 +80,20 @@ class EventAchievementSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'activeFrom' => true,
+            'activeUntil' => true,
+            'decorator' => true,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/EventAwards/EventAwardSchema.php
+++ b/app/Api/V2/EventAwards/EventAwardSchema.php
@@ -53,6 +53,21 @@ class EventAwardSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'tierIndex' => false,
+            'label' => false,
+            'pointsRequired' => false,
+            'badgeUrl' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/Events/EventSchema.php
+++ b/app/Api/V2/Events/EventSchema.php
@@ -78,6 +78,25 @@ class EventSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'title' => false,
+            'sortTitle' => false,
+            'badgeUrl' => false,
+            'state' => false,
+            'playersTotal' => false,
+            'achievementsPublished' => false,
+            'activeFrom' => true,
+            'activeThrough' => true,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/GameHashes/GameHashSchema.php
+++ b/app/Api/V2/GameHashes/GameHashSchema.php
@@ -57,6 +57,23 @@ class GameHashSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'raMd5' => false,
+            'name' => true,
+            'compatibility' => false,
+            'patchUrl' => true,
+            'createdAt' => true,
+            'updatedAt' => true,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/Games/GameSchema.php
+++ b/app/Api/V2/Games/GameSchema.php
@@ -103,6 +103,35 @@ class GameSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'title' => false,
+            'sortTitle' => false,
+            'badgeUrl' => false,
+            'imageBoxArtUrl' => false,
+            'imageTitleUrl' => false,
+            'imageIngameUrl' => false,
+            'releasedAt' => true,
+            'releasedAtGranularity' => true,
+            'playersTotal' => false,
+            'playersHardcore' => false,
+            'achievementsPublished' => false,
+            'achievementsUnpublished' => false,
+            'pointsTotal' => false,
+            'pointsWeighted' => false,
+            'timesBeaten' => false,
+            'timesBeatenHardcore' => false,
+            'medianTimeToBeatSeconds' => true,
+            'medianTimeToBeatHardcoreSeconds' => true,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/Hubs/HubSchema.php
+++ b/app/Api/V2/Hubs/HubSchema.php
@@ -72,6 +72,26 @@ class HubSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'title' => false,
+            'sortTitle' => false,
+            'badgeUrl' => false,
+            'hasMatureContent' => false,
+            'gamesCount' => false,
+            'linkedHubsCount' => false,
+            'isEventHub' => false,
+            'createdAt' => false,
+            'updatedAt' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/LeaderboardEntries/LeaderboardEntrySchema.php
+++ b/app/Api/V2/LeaderboardEntries/LeaderboardEntrySchema.php
@@ -68,6 +68,21 @@ class LeaderboardEntrySchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'score' => false,
+            'rank' => true,
+            'createdAt' => true,
+            'updatedAt' => false,
+        ];
+    }
+
+    /**
      * Get the allowed include paths.
      */
     public function includePaths(): iterable

--- a/app/Api/V2/Leaderboards/LeaderboardSchema.php
+++ b/app/Api/V2/Leaderboards/LeaderboardSchema.php
@@ -73,6 +73,25 @@ class LeaderboardSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'title' => false,
+            'description' => false,
+            'format' => false,
+            'rankAsc' => false,
+            'state' => false,
+            'orderColumn' => false,
+            'createdAt' => true,
+            'updatedAt' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/PlayerAchievementSets/PlayerAchievementSetSchema.php
+++ b/app/Api/V2/PlayerAchievementSets/PlayerAchievementSetSchema.php
@@ -84,6 +84,31 @@ class PlayerAchievementSetSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'achievementsUnlocked' => false,
+            'achievementsUnlockedHardcore' => false,
+            'points' => false,
+            'pointsHardcore' => false,
+            'pointsWeighted' => false,
+            'completionPercentage' => false,
+            'completionPercentageHardcore' => false,
+            'lastUnlockAt' => true,
+            'lastUnlockHardcoreAt' => true,
+            'completedAt' => true,
+            'completedHardcoreAt' => true,
+            'timeTakenSeconds' => false,
+            'timeTakenHardcoreSeconds' => false,
+            'setContext' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/PlayerAchievements/PlayerAchievementSchema.php
+++ b/app/Api/V2/PlayerAchievements/PlayerAchievementSchema.php
@@ -70,6 +70,19 @@ class PlayerAchievementSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'unlockedAt' => false,
+            'unlockedHardcoreAt' => true,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/PlayerGames/PlayerGameSchema.php
+++ b/app/Api/V2/PlayerGames/PlayerGameSchema.php
@@ -85,6 +85,26 @@ class PlayerGameSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'lastPlayedAt' => true,
+            'firstUnlockAt' => true,
+            'lastUnlockAt' => true,
+            'lastUnlockHardcoreAt' => true,
+            'beatenAt' => true,
+            'beatenHardcoreAt' => true,
+            'playtimeTotalSeconds' => true,
+            'timeToBeatSeconds' => true,
+            'timeToBeatHardcoreSeconds' => true,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/Systems/SystemSchema.php
+++ b/app/Api/V2/Systems/SystemSchema.php
@@ -61,6 +61,23 @@ class SystemSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'name' => false,
+            'nameFull' => false,
+            'nameShort' => false,
+            'manufacturer' => true,
+            'iconUrl' => false,
+            'active' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/Tickets/TicketSchema.php
+++ b/app/Api/V2/Tickets/TicketSchema.php
@@ -101,6 +101,27 @@ class TicketSchema extends Schema
         ];
     }
 
+    /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'state' => false,
+            'type' => false,
+            'body' => false,
+            'hardcore' => true,
+            'reportedAt' => false,
+            'resolvedAt' => true,
+            'ticketableType' => false,
+            'ticketableId' => false,
+            'gameIconUrl' => true,
+            'systemName' => true,
+        ];
+    }
+
     public function filters(): array
     {
         return [

--- a/app/Api/V2/UserAwards/UserAwardSchema.php
+++ b/app/Api/V2/UserAwards/UserAwardSchema.php
@@ -98,6 +98,25 @@ class UserAwardSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'awardedAt' => false,
+            'kind' => false,
+            'title' => false,
+            'badgeUrl' => false,
+            'displayOrder' => false,
+            'context' => false,
+            'userDisplayName' => true,
+            'userId' => true,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/UserFollows/UserFollowSchema.php
+++ b/app/Api/V2/UserFollows/UserFollowSchema.php
@@ -78,6 +78,24 @@ class UserFollowSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'followedAt' => true,
+            'userId' => true,
+            'displayName' => true,
+            'avatarUrl' => true,
+            'points' => false,
+            'pointsHardcore' => false,
+            'isMutual' => false,
+        ];
+    }
+
+    /**
      * Get the resource paginator.
      */
     public function pagination(): ?Paginator

--- a/app/Api/V2/UserGameListEntries/UserGameListEntrySchema.php
+++ b/app/Api/V2/UserGameListEntries/UserGameListEntrySchema.php
@@ -78,6 +78,25 @@ class UserGameListEntrySchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'createdAt' => false,
+            'gameId' => false,
+            'gameTitle' => false,
+            'gameIconUrl' => false,
+            'systemId' => false,
+            'systemName' => false,
+            'pointsTotal' => false,
+            'achievementsPublished' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/app/Api/V2/Users/UserSchema.php
+++ b/app/Api/V2/Users/UserSchema.php
@@ -158,6 +158,36 @@ class UserSchema extends Schema
     }
 
     /**
+     * Which attributes can be null in a response.
+     *
+     * @return array<string, bool>
+     */
+    public function attributeNullability(): array
+    {
+        return [
+            'displayName' => false,
+            'avatarUrl' => false,
+            'motto' => false,
+            'points' => false,
+            'pointsHardcore' => false,
+            'pointsWeighted' => false,
+            'rankHardcore' => true,
+            'rankCasual' => true,
+            'yieldUnlocks' => false,
+            'yieldPoints' => false,
+            'joinedAt' => false,
+            'lastActivityAt' => true,
+            'deletedAt' => false,
+            'isUnranked' => false,
+            'isUserWallActive' => false,
+            'richPresence' => true,
+            'richPresenceUpdatedAt' => true,
+            'visibleRole' => true,
+            'displayableRoles' => false,
+        ];
+    }
+
+    /**
      * Get the resource filters.
      */
     public function filters(): array

--- a/public/openapi/v2.json
+++ b/public/openapi/v2.json
@@ -740,11 +740,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -765,6 +767,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -785,16 +788,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -1087,6 +1093,7 @@
                                                                     "title": {
                                                                         "title": "title",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "pointsTotal": {
@@ -1122,11 +1129,13 @@
                                                                     "medianTimeToCompleteSeconds": {
                                                                         "title": "medianTimeToCompleteSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToMasterSeconds": {
                                                                         "title": "medianTimeToMasterSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "badgeUrl": {
@@ -1137,6 +1146,7 @@
                                                                     "achievementsFirstPublishedAt": {
                                                                         "title": "achievementsFirstPublishedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "types": {
@@ -1147,11 +1157,13 @@
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
                                                                         "title": "updatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -1337,11 +1349,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -1377,11 +1391,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -1547,6 +1563,7 @@
                                                                     "unlockedHardcoreAt": {
                                                                         "title": "unlockedHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -1660,6 +1677,7 @@
                                                                     "hardcore": {
                                                                         "title": "hardcore",
                                                                         "type": "boolean",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "reportedAt": {
@@ -1670,6 +1688,7 @@
                                                                     "resolvedAt": {
                                                                         "title": "resolvedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "ticketableType": {
@@ -1685,11 +1704,13 @@
                                                                     "gameIconUrl": {
                                                                         "title": "gameIconUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "systemName": {
                                                                         "title": "systemName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -2119,11 +2140,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -2144,6 +2167,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -2164,16 +2188,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -2466,6 +2493,7 @@
                                                                     "title": {
                                                                         "title": "title",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "pointsTotal": {
@@ -2501,11 +2529,13 @@
                                                                     "medianTimeToCompleteSeconds": {
                                                                         "title": "medianTimeToCompleteSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToMasterSeconds": {
                                                                         "title": "medianTimeToMasterSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "badgeUrl": {
@@ -2516,6 +2546,7 @@
                                                                     "achievementsFirstPublishedAt": {
                                                                         "title": "achievementsFirstPublishedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "types": {
@@ -2526,11 +2557,13 @@
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
                                                                         "title": "updatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -2716,11 +2749,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -2756,11 +2791,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -2926,6 +2963,7 @@
                                                                     "unlockedHardcoreAt": {
                                                                         "title": "unlockedHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -3039,6 +3077,7 @@
                                                                     "hardcore": {
                                                                         "title": "hardcore",
                                                                         "type": "boolean",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "reportedAt": {
@@ -3049,6 +3088,7 @@
                                                                     "resolvedAt": {
                                                                         "title": "resolvedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "ticketableType": {
@@ -3064,11 +3104,13 @@
                                                                     "gameIconUrl": {
                                                                         "title": "gameIconUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "systemName": {
                                                                         "title": "systemName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -4397,11 +4439,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -4437,11 +4481,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -5347,11 +5393,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -5372,6 +5420,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -5392,16 +5441,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -5721,11 +5773,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -5761,11 +5815,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -6154,6 +6210,7 @@
                                                                     "title": {
                                                                         "title": "title",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "pointsTotal": {
@@ -6189,11 +6246,13 @@
                                                                     "medianTimeToCompleteSeconds": {
                                                                         "title": "medianTimeToCompleteSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToMasterSeconds": {
                                                                         "title": "medianTimeToMasterSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "badgeUrl": {
@@ -6204,6 +6263,7 @@
                                                                     "achievementsFirstPublishedAt": {
                                                                         "title": "achievementsFirstPublishedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "types": {
@@ -6214,11 +6274,13 @@
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
                                                                         "title": "updatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -6605,11 +6667,13 @@
                                                                     "activeFrom": {
                                                                         "title": "activeFrom",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "activeThrough": {
                                                                         "title": "activeThrough",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -6717,6 +6781,7 @@
                                                                     "type": {
                                                                         "title": "type",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "state": {
@@ -6727,46 +6792,55 @@
                                                                     "orderColumn": {
                                                                         "title": "orderColumn",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksTotal": {
                                                                         "title": "unlocksTotal",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksHardcore": {
                                                                         "title": "unlocksHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockPercentage": {
                                                                         "title": "unlockPercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockHardcorePercentage": {
                                                                         "title": "unlockHardcorePercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSeconds": {
                                                                         "title": "medianTimeToUnlockSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSeconds": {
                                                                         "title": "medianTimeToUnlockHardcoreSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSamples": {
                                                                         "title": "medianTimeToUnlockSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSamples": {
                                                                         "title": "medianTimeToUnlockHardcoreSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
@@ -6968,6 +7042,7 @@
                                                                     "type": {
                                                                         "title": "type",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "state": {
@@ -6978,46 +7053,55 @@
                                                                     "orderColumn": {
                                                                         "title": "orderColumn",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksTotal": {
                                                                         "title": "unlocksTotal",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksHardcore": {
                                                                         "title": "unlocksHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockPercentage": {
                                                                         "title": "unlockPercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockHardcorePercentage": {
                                                                         "title": "unlockHardcorePercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSeconds": {
                                                                         "title": "medianTimeToUnlockSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSeconds": {
                                                                         "title": "medianTimeToUnlockHardcoreSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSamples": {
                                                                         "title": "medianTimeToUnlockSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSamples": {
                                                                         "title": "medianTimeToUnlockHardcoreSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
@@ -7407,11 +7491,13 @@
                                                                     "activeFrom": {
                                                                         "title": "activeFrom",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "activeThrough": {
                                                                         "title": "activeThrough",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -7519,6 +7605,7 @@
                                                                     "type": {
                                                                         "title": "type",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "state": {
@@ -7529,46 +7616,55 @@
                                                                     "orderColumn": {
                                                                         "title": "orderColumn",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksTotal": {
                                                                         "title": "unlocksTotal",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksHardcore": {
                                                                         "title": "unlocksHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockPercentage": {
                                                                         "title": "unlockPercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockHardcorePercentage": {
                                                                         "title": "unlockHardcorePercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSeconds": {
                                                                         "title": "medianTimeToUnlockSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSeconds": {
                                                                         "title": "medianTimeToUnlockHardcoreSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSamples": {
                                                                         "title": "medianTimeToUnlockSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSamples": {
                                                                         "title": "medianTimeToUnlockHardcoreSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
@@ -7770,6 +7866,7 @@
                                                                     "type": {
                                                                         "title": "type",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "state": {
@@ -7780,46 +7877,55 @@
                                                                     "orderColumn": {
                                                                         "title": "orderColumn",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksTotal": {
                                                                         "title": "unlocksTotal",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksHardcore": {
                                                                         "title": "unlocksHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockPercentage": {
                                                                         "title": "unlockPercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockHardcorePercentage": {
                                                                         "title": "unlockHardcorePercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSeconds": {
                                                                         "title": "medianTimeToUnlockSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSeconds": {
                                                                         "title": "medianTimeToUnlockHardcoreSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSamples": {
                                                                         "title": "medianTimeToUnlockSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSamples": {
                                                                         "title": "medianTimeToUnlockHardcoreSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
@@ -8297,16 +8403,19 @@
                                                                     "activeFrom": {
                                                                         "title": "activeFrom",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "activeUntil": {
                                                                         "title": "activeUntil",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "decorator": {
                                                                         "title": "decorator",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -8643,16 +8752,19 @@
                                                                     "activeFrom": {
                                                                         "title": "activeFrom",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "activeUntil": {
                                                                         "title": "activeUntil",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "decorator": {
                                                                         "title": "decorator",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -9361,7 +9473,8 @@
                                                                     },
                                                                     "manufacturer": {
                                                                         "title": "manufacturer",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "iconUrl": {
                                                                         "title": "iconUrl",
@@ -9400,6 +9513,7 @@
                                                                     "title": {
                                                                         "title": "title",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "pointsTotal": {
@@ -9435,11 +9549,13 @@
                                                                     "medianTimeToCompleteSeconds": {
                                                                         "title": "medianTimeToCompleteSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToMasterSeconds": {
                                                                         "title": "medianTimeToMasterSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "badgeUrl": {
@@ -9450,6 +9566,7 @@
                                                                     "achievementsFirstPublishedAt": {
                                                                         "title": "achievementsFirstPublishedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "types": {
@@ -9460,11 +9577,13 @@
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
                                                                         "title": "updatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -9780,6 +9899,7 @@
                                                                     "name": {
                                                                         "title": "name",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "compatibility": {
@@ -9790,16 +9910,19 @@
                                                                     "patchUrl": {
                                                                         "title": "patchUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
                                                                         "title": "updatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -9871,6 +9994,7 @@
                                                                     "hardcore": {
                                                                         "title": "hardcore",
                                                                         "type": "boolean",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "reportedAt": {
@@ -9881,6 +10005,7 @@
                                                                     "resolvedAt": {
                                                                         "title": "resolvedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "ticketableType": {
@@ -9896,11 +10021,13 @@
                                                                     "gameIconUrl": {
                                                                         "title": "gameIconUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "systemName": {
                                                                         "title": "systemName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -10268,7 +10395,8 @@
                                                                     },
                                                                     "manufacturer": {
                                                                         "title": "manufacturer",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "iconUrl": {
                                                                         "title": "iconUrl",
@@ -10307,6 +10435,7 @@
                                                                     "title": {
                                                                         "title": "title",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "pointsTotal": {
@@ -10342,11 +10471,13 @@
                                                                     "medianTimeToCompleteSeconds": {
                                                                         "title": "medianTimeToCompleteSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToMasterSeconds": {
                                                                         "title": "medianTimeToMasterSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "badgeUrl": {
@@ -10357,6 +10488,7 @@
                                                                     "achievementsFirstPublishedAt": {
                                                                         "title": "achievementsFirstPublishedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "types": {
@@ -10367,11 +10499,13 @@
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
                                                                         "title": "updatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -10687,6 +10821,7 @@
                                                                     "name": {
                                                                         "title": "name",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "compatibility": {
@@ -10697,16 +10832,19 @@
                                                                     "patchUrl": {
                                                                         "title": "patchUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
                                                                         "title": "updatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -10778,6 +10916,7 @@
                                                                     "hardcore": {
                                                                         "title": "hardcore",
                                                                         "type": "boolean",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "reportedAt": {
@@ -10788,6 +10927,7 @@
                                                                     "resolvedAt": {
                                                                         "title": "resolvedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "ticketableType": {
@@ -10803,11 +10943,13 @@
                                                                     "gameIconUrl": {
                                                                         "title": "gameIconUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "systemName": {
                                                                         "title": "systemName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -12453,11 +12595,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -12493,11 +12637,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -12806,11 +12952,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -12846,11 +12994,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -13906,11 +14056,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -13946,11 +14098,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -14141,11 +14295,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -14166,6 +14322,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -14186,16 +14343,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -14493,11 +14653,13 @@
                                                                     "rank": {
                                                                         "title": "rank",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
@@ -14842,11 +15004,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -14882,11 +15046,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -15077,11 +15243,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -15102,6 +15270,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -15122,16 +15291,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -15429,11 +15601,13 @@
                                                                     "rank": {
                                                                         "title": "rank",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
@@ -16542,6 +16716,7 @@
                                                                     "type": {
                                                                         "title": "type",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "state": {
@@ -16552,46 +16727,55 @@
                                                                     "orderColumn": {
                                                                         "title": "orderColumn",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksTotal": {
                                                                         "title": "unlocksTotal",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksHardcore": {
                                                                         "title": "unlocksHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockPercentage": {
                                                                         "title": "unlockPercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockHardcorePercentage": {
                                                                         "title": "unlockHardcorePercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSeconds": {
                                                                         "title": "medianTimeToUnlockSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSeconds": {
                                                                         "title": "medianTimeToUnlockHardcoreSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSamples": {
                                                                         "title": "medianTimeToUnlockSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSamples": {
                                                                         "title": "medianTimeToUnlockHardcoreSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
@@ -16793,6 +16977,7 @@
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
@@ -16926,11 +17111,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -16951,6 +17138,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -16971,16 +17159,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -17303,11 +17494,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -17328,6 +17521,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -17348,16 +17542,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -17680,11 +17877,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -17705,6 +17904,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -17725,16 +17925,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -18313,6 +18516,7 @@
                                                                     "type": {
                                                                         "title": "type",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "state": {
@@ -18323,46 +18527,55 @@
                                                                     "orderColumn": {
                                                                         "title": "orderColumn",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksTotal": {
                                                                         "title": "unlocksTotal",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlocksHardcore": {
                                                                         "title": "unlocksHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockPercentage": {
                                                                         "title": "unlockPercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "unlockHardcorePercentage": {
                                                                         "title": "unlockHardcorePercentage",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSeconds": {
                                                                         "title": "medianTimeToUnlockSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSeconds": {
                                                                         "title": "medianTimeToUnlockHardcoreSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockSamples": {
                                                                         "title": "medianTimeToUnlockSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "medianTimeToUnlockHardcoreSamples": {
                                                                         "title": "medianTimeToUnlockHardcoreSamples",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
@@ -18564,6 +18777,7 @@
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
@@ -18697,11 +18911,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -18722,6 +18938,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -18742,16 +18959,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -19074,11 +19294,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -19099,6 +19321,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -19119,16 +19342,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -19451,11 +19677,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -19476,6 +19704,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -19496,16 +19725,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -20197,11 +20429,13 @@
                                                                     "activeFrom": {
                                                                         "title": "activeFrom",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "activeThrough": {
                                                                         "title": "activeThrough",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -20306,11 +20540,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -20346,11 +20582,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -20541,11 +20779,13 @@
                                                                     "rankHardcore": {
                                                                         "title": "rankHardcore",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "rankCasual": {
                                                                         "title": "rankCasual",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "yieldUnlocks": {
@@ -20566,6 +20806,7 @@
                                                                     "lastActivityAt": {
                                                                         "title": "lastActivityAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "deletedAt": {
@@ -20586,16 +20827,19 @@
                                                                     "richPresence": {
                                                                         "title": "richPresence",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "richPresenceUpdatedAt": {
                                                                         "title": "richPresenceUpdatedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "visibleRole": {
                                                                         "title": "visibleRole",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayableRoles": {
@@ -21184,11 +21428,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -21224,11 +21470,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -21546,11 +21794,13 @@
                                                                     "rank": {
                                                                         "title": "rank",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
@@ -21638,6 +21888,7 @@
                                                                     "unlockedHardcoreAt": {
                                                                         "title": "unlockedHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -21771,21 +22022,25 @@
                                                                     "lastUnlockAt": {
                                                                         "title": "lastUnlockAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "lastUnlockHardcoreAt": {
                                                                         "title": "lastUnlockHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "completedAt": {
                                                                         "title": "completedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "completedHardcoreAt": {
                                                                         "title": "completedHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "timeTakenSeconds": {
@@ -21878,46 +22133,55 @@
                                                                     "lastPlayedAt": {
                                                                         "title": "lastPlayedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "firstUnlockAt": {
                                                                         "title": "firstUnlockAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "lastUnlockAt": {
                                                                         "title": "lastUnlockAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "lastUnlockHardcoreAt": {
                                                                         "title": "lastUnlockHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "beatenAt": {
                                                                         "title": "beatenAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "beatenHardcoreAt": {
                                                                         "title": "beatenHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "playtimeTotalSeconds": {
                                                                         "title": "playtimeTotalSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "timeToBeatSeconds": {
                                                                         "title": "timeToBeatSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "timeToBeatHardcoreSeconds": {
                                                                         "title": "timeToBeatHardcoreSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -22031,6 +22295,7 @@
                                                                     "hardcore": {
                                                                         "title": "hardcore",
                                                                         "type": "boolean",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "reportedAt": {
@@ -22041,6 +22306,7 @@
                                                                     "resolvedAt": {
                                                                         "title": "resolvedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "ticketableType": {
@@ -22056,11 +22322,13 @@
                                                                     "gameIconUrl": {
                                                                         "title": "gameIconUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "systemName": {
                                                                         "title": "systemName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -22403,11 +22671,13 @@
                                                                     "userDisplayName": {
                                                                         "title": "userDisplayName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "userId": {
                                                                         "title": "userId",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -22506,21 +22776,25 @@
                                                                     "followedAt": {
                                                                         "title": "followedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "userId": {
                                                                         "title": "userId",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayName": {
                                                                         "title": "displayName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "avatarUrl": {
                                                                         "title": "avatarUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "points": {
@@ -22592,21 +22866,25 @@
                                                                     "followedAt": {
                                                                         "title": "followedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "userId": {
                                                                         "title": "userId",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayName": {
                                                                         "title": "displayName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "avatarUrl": {
                                                                         "title": "avatarUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "points": {
@@ -22889,11 +23167,13 @@
                                                                     },
                                                                     "releasedAt": {
                                                                         "title": "releasedAt",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "releasedAtGranularity": {
                                                                         "title": "releasedAtGranularity",
-                                                                        "type": "string"
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "playersTotal": {
                                                                         "title": "playersTotal",
@@ -22929,11 +23209,13 @@
                                                                     },
                                                                     "medianTimeToBeatSeconds": {
                                                                         "title": "medianTimeToBeatSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     },
                                                                     "medianTimeToBeatHardcoreSeconds": {
                                                                         "title": "medianTimeToBeatHardcoreSeconds",
-                                                                        "type": "number"
+                                                                        "type": "number",
+                                                                        "nullable": true
                                                                     }
                                                                 }
                                                             },
@@ -23251,11 +23533,13 @@
                                                                     "rank": {
                                                                         "title": "rank",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "createdAt": {
                                                                         "title": "createdAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "updatedAt": {
@@ -23343,6 +23627,7 @@
                                                                     "unlockedHardcoreAt": {
                                                                         "title": "unlockedHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -23476,21 +23761,25 @@
                                                                     "lastUnlockAt": {
                                                                         "title": "lastUnlockAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "lastUnlockHardcoreAt": {
                                                                         "title": "lastUnlockHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "completedAt": {
                                                                         "title": "completedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "completedHardcoreAt": {
                                                                         "title": "completedHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "timeTakenSeconds": {
@@ -23583,46 +23872,55 @@
                                                                     "lastPlayedAt": {
                                                                         "title": "lastPlayedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "firstUnlockAt": {
                                                                         "title": "firstUnlockAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "lastUnlockAt": {
                                                                         "title": "lastUnlockAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "lastUnlockHardcoreAt": {
                                                                         "title": "lastUnlockHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "beatenAt": {
                                                                         "title": "beatenAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "beatenHardcoreAt": {
                                                                         "title": "beatenHardcoreAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "playtimeTotalSeconds": {
                                                                         "title": "playtimeTotalSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "timeToBeatSeconds": {
                                                                         "title": "timeToBeatSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "timeToBeatHardcoreSeconds": {
                                                                         "title": "timeToBeatHardcoreSeconds",
                                                                         "type": "number",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -23736,6 +24034,7 @@
                                                                     "hardcore": {
                                                                         "title": "hardcore",
                                                                         "type": "boolean",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "reportedAt": {
@@ -23746,6 +24045,7 @@
                                                                     "resolvedAt": {
                                                                         "title": "resolvedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "ticketableType": {
@@ -23761,11 +24061,13 @@
                                                                     "gameIconUrl": {
                                                                         "title": "gameIconUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "systemName": {
                                                                         "title": "systemName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -24108,11 +24410,13 @@
                                                                     "userDisplayName": {
                                                                         "title": "userDisplayName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "userId": {
                                                                         "title": "userId",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     }
                                                                 }
@@ -24211,21 +24515,25 @@
                                                                     "followedAt": {
                                                                         "title": "followedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "userId": {
                                                                         "title": "userId",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayName": {
                                                                         "title": "displayName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "avatarUrl": {
                                                                         "title": "avatarUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "points": {
@@ -24297,21 +24605,25 @@
                                                                     "followedAt": {
                                                                         "title": "followedAt",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "userId": {
                                                                         "title": "userId",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "displayName": {
                                                                         "title": "displayName",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "avatarUrl": {
                                                                         "title": "avatarUrl",
                                                                         "type": "string",
+                                                                        "nullable": true,
                                                                         "readOnly": true
                                                                     },
                                                                     "points": {
@@ -28091,6 +28403,7 @@
                             "title": {
                                 "title": "title",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "pointsTotal": {
@@ -28126,11 +28439,13 @@
                             "medianTimeToCompleteSeconds": {
                                 "title": "medianTimeToCompleteSeconds",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "medianTimeToMasterSeconds": {
                                 "title": "medianTimeToMasterSeconds",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "badgeUrl": {
@@ -28141,6 +28456,7 @@
                             "achievementsFirstPublishedAt": {
                                 "title": "achievementsFirstPublishedAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "types": {
@@ -28151,11 +28467,13 @@
                             "createdAt": {
                                 "title": "createdAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "updatedAt": {
                                 "title": "updatedAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             }
                         }
@@ -28262,6 +28580,7 @@
                             "type": {
                                 "title": "type",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "state": {
@@ -28272,46 +28591,55 @@
                             "orderColumn": {
                                 "title": "orderColumn",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "unlocksTotal": {
                                 "title": "unlocksTotal",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "unlocksHardcore": {
                                 "title": "unlocksHardcore",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "unlockPercentage": {
                                 "title": "unlockPercentage",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "unlockHardcorePercentage": {
                                 "title": "unlockHardcorePercentage",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "medianTimeToUnlockSeconds": {
                                 "title": "medianTimeToUnlockSeconds",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "medianTimeToUnlockHardcoreSeconds": {
                                 "title": "medianTimeToUnlockHardcoreSeconds",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "medianTimeToUnlockSamples": {
                                 "title": "medianTimeToUnlockSamples",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "medianTimeToUnlockHardcoreSamples": {
                                 "title": "medianTimeToUnlockHardcoreSamples",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "createdAt": {
@@ -28562,16 +28890,19 @@
                             "activeFrom": {
                                 "title": "activeFrom",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "activeUntil": {
                                 "title": "activeUntil",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "decorator": {
                                 "title": "decorator",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             }
                         }
@@ -28699,11 +29030,13 @@
                             "activeFrom": {
                                 "title": "activeFrom",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "activeThrough": {
                                 "title": "activeThrough",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             }
                         }
@@ -28785,6 +29118,7 @@
                             "name": {
                                 "title": "name",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "compatibility": {
@@ -28795,16 +29129,19 @@
                             "patchUrl": {
                                 "title": "patchUrl",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "createdAt": {
                                 "title": "createdAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "updatedAt": {
                                 "title": "updatedAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             }
                         }
@@ -28887,11 +29224,13 @@
                             },
                             "releasedAt": {
                                 "title": "releasedAt",
-                                "type": "string"
+                                "type": "string",
+                                "nullable": true
                             },
                             "releasedAtGranularity": {
                                 "title": "releasedAtGranularity",
-                                "type": "string"
+                                "type": "string",
+                                "nullable": true
                             },
                             "playersTotal": {
                                 "title": "playersTotal",
@@ -28927,11 +29266,13 @@
                             },
                             "medianTimeToBeatSeconds": {
                                 "title": "medianTimeToBeatSeconds",
-                                "type": "number"
+                                "type": "number",
+                                "nullable": true
                             },
                             "medianTimeToBeatHardcoreSeconds": {
                                 "title": "medianTimeToBeatHardcoreSeconds",
-                                "type": "number"
+                                "type": "number",
+                                "nullable": true
                             }
                         }
                     },
@@ -29212,11 +29553,13 @@
                             "rank": {
                                 "title": "rank",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "createdAt": {
                                 "title": "createdAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "updatedAt": {
@@ -29328,6 +29671,7 @@
                             "createdAt": {
                                 "title": "createdAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "updatedAt": {
@@ -29465,21 +29809,25 @@
                             "lastUnlockAt": {
                                 "title": "lastUnlockAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "lastUnlockHardcoreAt": {
                                 "title": "lastUnlockHardcoreAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "completedAt": {
                                 "title": "completedAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "completedHardcoreAt": {
                                 "title": "completedHardcoreAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "timeTakenSeconds": {
@@ -29576,6 +29924,7 @@
                             "unlockedHardcoreAt": {
                                 "title": "unlockedHardcoreAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             }
                         }
@@ -29673,46 +30022,55 @@
                             "lastPlayedAt": {
                                 "title": "lastPlayedAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "firstUnlockAt": {
                                 "title": "firstUnlockAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "lastUnlockAt": {
                                 "title": "lastUnlockAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "lastUnlockHardcoreAt": {
                                 "title": "lastUnlockHardcoreAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "beatenAt": {
                                 "title": "beatenAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "beatenHardcoreAt": {
                                 "title": "beatenHardcoreAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "playtimeTotalSeconds": {
                                 "title": "playtimeTotalSeconds",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "timeToBeatSeconds": {
                                 "title": "timeToBeatSeconds",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "timeToBeatHardcoreSeconds": {
                                 "title": "timeToBeatHardcoreSeconds",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             }
                         }
@@ -29821,7 +30179,8 @@
                             },
                             "manufacturer": {
                                 "title": "manufacturer",
-                                "type": "string"
+                                "type": "string",
+                                "nullable": true
                             },
                             "iconUrl": {
                                 "title": "iconUrl",
@@ -29874,6 +30233,7 @@
                             "hardcore": {
                                 "title": "hardcore",
                                 "type": "boolean",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "reportedAt": {
@@ -29884,6 +30244,7 @@
                             "resolvedAt": {
                                 "title": "resolvedAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "ticketableType": {
@@ -29899,11 +30260,13 @@
                             "gameIconUrl": {
                                 "title": "gameIconUrl",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "systemName": {
                                 "title": "systemName",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             }
                         }
@@ -30073,11 +30436,13 @@
                             "userDisplayName": {
                                 "title": "userDisplayName",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "userId": {
                                 "title": "userId",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             }
                         }
@@ -30175,21 +30540,25 @@
                             "followedAt": {
                                 "title": "followedAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "userId": {
                                 "title": "userId",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "displayName": {
                                 "title": "displayName",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "avatarUrl": {
                                 "title": "avatarUrl",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "points": {
@@ -30380,11 +30749,13 @@
                             "rankHardcore": {
                                 "title": "rankHardcore",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "rankCasual": {
                                 "title": "rankCasual",
                                 "type": "number",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "yieldUnlocks": {
@@ -30405,6 +30776,7 @@
                             "lastActivityAt": {
                                 "title": "lastActivityAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "deletedAt": {
@@ -30425,16 +30797,19 @@
                             "richPresence": {
                                 "title": "richPresence",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "richPresenceUpdatedAt": {
                                 "title": "richPresenceUpdatedAt",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "visibleRole": {
                                 "title": "visibleRole",
                                 "type": "string",
+                                "nullable": true,
                                 "readOnly": true
                             },
                             "displayableRoles": {

--- a/tests/Feature/Console/GenerateV2OpenApiSpecTest.php
+++ b/tests/Feature/Console/GenerateV2OpenApiSpecTest.php
@@ -58,6 +58,14 @@ function sharedSpec(): array
     return $document ??= specAt(sharedSpecPath());
 }
 
+/**
+ * @return array<string, array<string, mixed>>
+ */
+function resourceAttributes(string $type): array
+{
+    return sharedSpec()['components']['schemas']["resources.{$type}.resource.fetch"]['properties']['attributes']['properties'];
+}
+
 it('given the command runs, it writes the spec', function () {
     // Act
     generate()->assertSuccessful();
@@ -185,4 +193,12 @@ it('given a spec that will not parse, check fails', function () {
     generate(check: true)
         ->expectsOutputToContain('not valid JSON')
         ->assertFailed();
+});
+
+it('given a schema that declares nullability, it flags only the attributes that can be null', function () {
+    // Assert
+    $attributes = resourceAttributes('games');
+
+    expect($attributes['releasedAt']['nullable'])->toEqual(true);
+    expect($attributes['title'])->not->toHaveKey('nullable');
 });


### PR DESCRIPTION
Follow-up from https://github.com/RetroAchievements/RAWeb/pull/5158.

Currently in the spec in `master`, every attribute is treated as non-nullable. We have to explicitly set the nullability of each attribute, which this PR does.