### PR TITLE
fix: remove foreign keys from materialized tables

### DIFF
--- a/database/migrations/2026_08_15_000000_drop_parent_foreign_keys_from_ranking_tables.php
+++ b/database/migrations/2026_08_15_000000_drop_parent_foreign_keys_from_ranking_tables.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * player_global_rankings and player_stat_rankings are materialized views
+     * that are fully rebuilt on write.
+     * 
+     * InnoDB locks each referenced parent row during FK checks. It holds these
+     * locks until the rebuild actually commits. This blocks writes to the parent
+     * table. Transaction isolation does not change these locks, so we're removing
+     * the constraint altogether.
+     */
+    public function up(): void
+    {
+        if (DB::connection()->getDriverName() === 'sqlite') {
+            return;
+        }
+
+        Schema::table('player_global_rankings', function (Blueprint $table) {
+            $table->dropForeign('player_global_rankings_user_id_foreign');
+            $table->dropIndex('player_global_rankings_user_id_foreign');
+        });
+
+        Schema::table('player_stat_rankings', function (Blueprint $table) {
+            $table->dropForeign('player_stat_rankings_user_id_foreign');
+
+            $table->dropForeign('player_stat_rankings_last_game_id_foreign');
+            $table->dropIndex('player_stat_rankings_last_game_id_foreign');
+        });
+    }
+
+    public function down(): void
+    {
+        if (DB::connection()->getDriverName() === 'sqlite') {
+            return;
+        }
+
+        Schema::table('player_global_rankings', function (Blueprint $table) {
+            $table->foreign('user_id', 'player_global_rankings_user_id_foreign')
+                ->references('id')
+                ->on('users')
+                ->cascadeOnDelete();
+        });
+
+        Schema::table('player_stat_rankings', function (Blueprint $table) {
+            $table->foreign('user_id', 'player_stat_rankings_user_id_foreign')
+                ->references('id')
+                ->on('users')
+                ->cascadeOnDelete();
+
+            $table->foreign('last_game_id', 'player_stat_rankings_last_game_id_foreign')
+                ->references('id')
+                ->on('games')
+                ->nullOnDelete();
+        });
+    }
+};

--- a/database/migrations/2026_08_15_000000_drop_parent_foreign_keys_from_ranking_tables.php
+++ b/database/migrations/2026_08_15_000000_drop_parent_foreign_keys_from_ranking_tables.php
@@ -11,7 +11,7 @@ return new class extends Migration {
     /**
      * player_global_rankings and player_stat_rankings are materialized views
      * that are fully rebuilt on write.
-     * 
+     *
      * InnoDB locks each referenced parent row during FK checks. It holds these
      * locks until the rebuild actually commits. This blocks writes to the parent
      * table. Transaction isolation does not change these locks, so we're removing


### PR DESCRIPTION
One more follow-up to the production incident that occurred during the last full deploy. As a sanity test this morning, I did significant load testing against a local clone of the production DB. I discovered even with recent changes, `users` can still lock for ~15 seconds.

This PR drops `users` and `games` foreign keys from our materialized tables. With this migration in place, the issue goes away. There is virtually no downside or performance impact by doing this. We lose cascade deletes and referential integrity, which is totally fine for materialized views.