### PR TITLE
feat(api/v2): adjust quarantined ticket visibility

### DIFF
--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -187,18 +187,12 @@ class Ticket extends BaseModel
      */
     public function scopeVisibleTo(Builder $query, ?User $user = null): Builder
     {
+        // Guests can't see tickets.
         if ($user === null) {
             return $query->whereRaw('1 = 0');
         }
 
-        if ($user->can('manage', self::class)) {
-            return $query;
-        }
-
-        return $query->where(function (Builder $q) use ($user) {
-            $q->where('state', '!=', TicketState::Quarantined->value)
-                ->orWhere('reporter_id', $user->id);
-        });
+        return $query;
     }
 
     /**

--- a/tests/Feature/Api/V2/TicketsTest.php
+++ b/tests/Feature/Api/V2/TicketsTest.php
@@ -344,7 +344,7 @@ class TicketsTest extends TestCase
         $this->assertEquals((string) $leaderboardTicket->id, $response->json('data.0.id'));
     }
 
-    public function testItHidesQuarantinedTicketsFromNonManagersOnIndex(): void
+    public function testItShowsQuarantinedTicketsToNonManagersOnIndex(): void
     {
         // Arrange
         User::factory()->create(['web_api_key' => 'test-key']);
@@ -353,7 +353,7 @@ class TicketsTest extends TestCase
         $openTicket = Ticket::factory()->forAchievement($achievement)->open()->create([
             'ticketable_author_id' => $author->id,
         ]);
-        Ticket::factory()->forAchievement($achievement)->quarantined()->create([
+        $quarantinedTicket = Ticket::factory()->forAchievement($achievement)->quarantined()->create([
             'ticketable_author_id' => $author->id,
         ]);
 
@@ -365,8 +365,11 @@ class TicketsTest extends TestCase
 
         // Assert
         $response->assertSuccessful();
-        $this->assertCount(1, $response->json('data'));
-        $this->assertEquals((string) $openTicket->id, $response->json('data.0.id'));
+        $this->assertCount(2, $response->json('data'));
+        $this->assertEqualsCanonicalizing(
+            [(string) $openTicket->id, (string) $quarantinedTicket->id],
+            collect($response->json('data'))->pluck('id')->all(),
+        );
     }
 
     public function testItInlinesAchievementContextOnAchievementTickets(): void


### PR DESCRIPTION
I changed my mind on a V2 API implementation detail.

Quarantined tickets are now exposed through the V2 API regardless of the consumer context. This makes the API consistent with the website UI.