### PR TITLE
refactor(tickets): extract applyFilters from TicketListService::buildQuery, add coverage

### DIFF
--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -182,6 +182,17 @@ class Ticket extends BaseModel
     }
 
     /**
+     * Excludes tickets whose ticketable was deleted.
+     *
+     * @param Builder<Ticket> $query
+     * @return Builder<Ticket>
+     */
+    public function scopeWithLiveTicketable(Builder $query): Builder
+    {
+        return $query->whereHasMorph('ticketable', [Achievement::class, Leaderboard::class]);
+    }
+
+    /**
      * @param Builder<Ticket> $query
      * @return Builder<Ticket>
      */

--- a/app/Platform/Services/TicketListService.php
+++ b/app/Platform/Services/TicketListService.php
@@ -8,8 +8,8 @@ use App\Community\Enums\TicketType;
 use App\Enums\Permissions;
 use App\Models\Achievement;
 use App\Models\Emulator;
-use App\Models\Leaderboard;
 use App\Models\Ticket;
+use App\Models\User;
 use App\Platform\Enums\TicketableType;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -189,17 +189,44 @@ class TicketListService
      *
      * @return Builder<Ticket>
      */
-    public function buildQuery(array $filterOptions, ?Builder $tickets = null): Builder
+    public function buildQuery(array $filterOptions, ?Builder $tickets = null, ?User $comparisonUser = null): Builder
     {
         if ($tickets === null) {
             $tickets = Ticket::query();
         }
 
-        // Don't include tickets where the ticketable is hard deleted.
-        $tickets->whereHasMorph('ticketable', [Achievement::class, Leaderboard::class]);
+        $tickets->withLiveTicketable();
 
         $this->totalTickets = $tickets->count();
 
+        // buildQuery keeps the legacy userId array contract for the Blade pages until they are gone.
+        if ($comparisonUser === null && array_key_exists('userId', $filterOptions)) {
+            $comparisonUser = User::withTrashed()->find($filterOptions['userId']);
+        }
+
+        $tickets = $this->applyFilters($tickets, $filterOptions, $comparisonUser);
+
+        $this->numFilteredTickets = $tickets->count();
+
+        if ($this->perPage > 0) {
+            $this->totalPages = (int) ceil($this->numFilteredTickets / $this->perPage);
+
+            if ($this->pageNumber < 1 || $this->pageNumber > $this->totalPages) {
+                $this->pageNumber = 1;
+            }
+
+            $tickets->offset(($this->pageNumber - 1) * $this->perPage)->take($this->perPage);
+        }
+
+        return $tickets->with(['ticketable', 'author', 'reporter', 'resolver']);
+    }
+
+    /**
+     * @param Builder<Ticket> $tickets
+     * @return Builder<Ticket>
+     */
+    public function applyFilters(Builder $tickets, array $filterOptions, ?User $comparisonUser = null): Builder
+    {
         switch ($filterOptions['status']) {
             case 'unresolved':
                 $tickets->open();
@@ -274,17 +301,17 @@ class TicketListService
                 break;
         }
 
-        if (array_key_exists('userId', $filterOptions)) {
+        if ($comparisonUser !== null) {
             switch ($filterOptions['developer']) {
                 case 'all':
                     break;
 
                 case 'self':
-                    $tickets->where('ticketable_author_id', '=', $filterOptions['userId']);
+                    $tickets->where('ticketable_author_id', '=', $comparisonUser->id);
                     break;
 
                 case 'others':
-                    $tickets->where('ticketable_author_id', '!=', $filterOptions['userId']);
+                    $tickets->where('ticketable_author_id', '!=', $comparisonUser->id);
                     break;
             }
 
@@ -293,11 +320,11 @@ class TicketListService
                     break;
 
                 case 'self':
-                    $tickets->where('reporter_id', '=', $filterOptions['userId']);
+                    $tickets->where('reporter_id', '=', $comparisonUser->id);
                     break;
 
                 case 'others':
-                    $tickets->where('reporter_id', '!=', $filterOptions['userId']);
+                    $tickets->where('reporter_id', '!=', $comparisonUser->id);
                     break;
             }
         }
@@ -313,18 +340,6 @@ class TicketListService
             }
         }
 
-        $this->numFilteredTickets = $tickets->count();
-
-        if ($this->perPage > 0) {
-            $this->totalPages = (int) ceil($this->numFilteredTickets / $this->perPage);
-
-            if ($this->pageNumber < 1 || $this->pageNumber > $this->totalPages) {
-                $this->pageNumber = 1;
-            }
-
-            $tickets->offset(($this->pageNumber - 1) * $this->perPage)->take($this->perPage);
-        }
-
-        return $tickets->with(['ticketable', 'author', 'reporter', 'resolver']);
+        return $tickets;
     }
 }

--- a/tests/Feature/Platform/Services/TicketListServiceTest.php
+++ b/tests/Feature/Platform/Services/TicketListServiceTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Achievement;
+use App\Models\Emulator;
+use App\Models\Game;
+use App\Models\System;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Platform\Services\TicketListService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+
+uses(LazilyRefreshDatabase::class);
+
+function defaultTicketListFilterOptions(array $overrides = []): array
+{
+    return array_merge([
+        'status' => 'unresolved',
+        'type' => 0,
+        'publishedStatus' => 'all',
+        'mode' => 'all',
+        'developerType' => 'all',
+        'developer' => 'all',
+        'reporter' => 'all',
+        'emulator' => 'all',
+    ], $overrides);
+}
+
+function createTicketableAchievement(?User $author = null): Achievement
+{
+    $author ??= User::factory()->create();
+    $game = Game::factory()->create(['system_id' => System::factory()->create()->id]);
+
+    return Achievement::factory()->create([
+        'game_id' => $game->id,
+        'user_id' => $author->id,
+    ]);
+}
+
+/**
+ * @return array<string, Ticket>
+ */
+function createTicketInEveryState(Achievement $achievement): array
+{
+    return [
+        'open' => Ticket::factory()->forAchievement($achievement)->open()->create(),
+        'request' => Ticket::factory()->forAchievement($achievement)->request()->create(),
+        'resolved' => Ticket::factory()->forAchievement($achievement)->resolved()->create(),
+        'closed' => Ticket::factory()->forAchievement($achievement)->closed()->create(),
+        'quarantined' => Ticket::factory()->forAchievement($achievement)->quarantined()->create(),
+    ];
+}
+
+/**
+ * @return int[]
+ */
+function buildTicketIds(TicketListService $service, array $filterOptions, ?User $comparisonUser = null): array
+{
+    $ids = $service->applyFilters(Ticket::query()->withLiveTicketable(), $filterOptions, $comparisonUser)->pluck('id')->all();
+    sort($ids);
+
+    return $ids;
+}
+
+/**
+ * @param Ticket[] $tickets
+ * @return int[]
+ */
+function sortedTicketIds(array $tickets): array
+{
+    $ids = array_map(fn (Ticket $ticket) => $ticket->id, $tickets);
+    sort($ids);
+
+    return $ids;
+}
+
+describe('applyFilters', function () {
+    it('given a status filter, only tickets with matching status values are returned', function (string $status, array $expectedStateKeys) {
+        // ARRANGE
+        $tickets = createTicketInEveryState(createTicketableAchievement());
+        $service = new TicketListService();
+
+        // ACT
+        $ids = buildTicketIds($service, defaultTicketListFilterOptions(['status' => $status]));
+
+        // ASSERT
+        $expectedTickets = array_map(fn (string $key) => $tickets[$key], $expectedStateKeys);
+        expect($ids)->toEqual(sortedTicketIds($expectedTickets));
+    })->with([
+        'unresolved' => ['unresolved', ['open', 'request']],
+        'resolved' => ['resolved', ['resolved', 'closed']],
+        'quarantined' => ['quarantined', ['quarantined']],
+        'all' => ['all', ['open', 'request', 'resolved', 'closed', 'quarantined']],
+    ]);
+
+    it('given a comparison user, the developer and reporter filters compare against that user', function (string $kind, string $value, string $expectedTicketKey) {
+        // ARRANGE
+        $comparisonUser = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $ownAchievement = createTicketableAchievement($comparisonUser);
+        $otherAchievement = createTicketableAchievement($otherUser);
+        $tickets = [
+            'own' => Ticket::factory()->forAchievement($ownAchievement)->open()->create([
+                'ticketable_author_id' => $comparisonUser->id,
+                'reporter_id' => $comparisonUser->id,
+            ]),
+            'other' => Ticket::factory()->forAchievement($otherAchievement)->open()->create([
+                'ticketable_author_id' => $otherUser->id,
+                'reporter_id' => $otherUser->id,
+            ]),
+        ];
+        $service = new TicketListService();
+
+        // ACT
+        $ids = buildTicketIds($service, defaultTicketListFilterOptions([$kind => $value]), $comparisonUser);
+
+        // ASSERT
+        expect($ids)->toEqual([$tickets[$expectedTicketKey]->id]);
+    })->with([
+        'developer self' => ['developer', 'self', 'own'],
+        'developer others' => ['developer', 'others', 'other'],
+        'reporter self' => ['reporter', 'self', 'own'],
+        'reporter others' => ['reporter', 'others', 'other'],
+    ]);
+
+    it('given no comparison user, the developer and reporter values are ignored', function () {
+        // ARRANGE
+        $developer = User::factory()->create();
+        $reporter = User::factory()->create();
+        $achievement = createTicketableAchievement($developer);
+        $ticketA = Ticket::factory()->forAchievement($achievement)->open()->create([
+            'ticketable_author_id' => $developer->id,
+            'reporter_id' => $reporter->id,
+        ]);
+        $ticketB = Ticket::factory()->forAchievement($achievement)->open()->create([
+            'ticketable_author_id' => User::factory()->create()->id,
+            'reporter_id' => User::factory()->create()->id,
+        ]);
+        $service = new TicketListService();
+
+        // ACT
+        $ids = buildTicketIds($service, defaultTicketListFilterOptions([
+            'developer' => 'self',
+            'reporter' => 'self',
+        ]));
+
+        // ASSERT
+        expect($ids)->toEqual(sortedTicketIds([$ticketA, $ticketB]));
+    });
+
+    it('given an emulator, only tickets for that emulator are returned', function () {
+        // ARRANGE
+        $achievement = createTicketableAchievement();
+        $emulator = Emulator::factory()->create(['name' => 'RAlibretro']);
+        $otherEmulator = Emulator::factory()->create(['name' => 'RANes']);
+        $matchingTicket = Ticket::factory()->forAchievement($achievement)->open()->create([
+            'emulator_id' => $emulator->id,
+        ]);
+        Ticket::factory()->forAchievement($achievement)->open()->create([
+            'emulator_id' => $otherEmulator->id,
+        ]);
+        $service = new TicketListService();
+
+        // ACT
+        $ids = buildTicketIds($service, defaultTicketListFilterOptions(['emulator' => 'RAlibretro']));
+
+        // ASSERT
+        expect($ids)->toEqual([$matchingTicket->id]);
+    });
+});


### PR DESCRIPTION
This PR rips the filter step out of `TicketListService::buildQuery()` into a new `applyFilters()` function in the same service. This is prep work for migrating the tickets list pages to React.

There should be no visible change caused by this PR into the current Blade pages. Also, coverage is added for `TicketListService`.