### PR TITLE
feat(tickets): prepare BuildTicketListAction for React tickets list

### DIFF
--- a/app/Platform/Actions/BuildTicketListAction.php
+++ b/app/Platform/Actions/BuildTicketListAction.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Actions;
+
+use App\Community\Enums\TicketState;
+use App\Data\PaginatedData;
+use App\Models\Achievement;
+use App\Models\Game;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Platform\Actions\Concerns\LoadsTicketListEntryRelations;
+use App\Platform\Data\TicketListFilterData;
+use App\Platform\Data\TicketListStateCountsData;
+use App\Platform\Enums\TicketListFilterKind;
+use App\Platform\Enums\TicketListScope;
+use App\Platform\Enums\TicketListSortField;
+use App\Platform\Enums\TicketListStatusFilter;
+use App\Platform\Requests\TicketListRequest;
+use App\Platform\Services\TicketListService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class BuildTicketListAction
+{
+    use LoadsTicketListEntryRelations;
+
+    private const PER_PAGE = 50;
+
+    /**
+     * @return array{paginatedTickets: PaginatedData, stateCounts: TicketListStateCountsData}
+     */
+    public function execute(
+        TicketListScope $scope,
+        Game|Achievement|User|null $target,
+        TicketListRequest $request,
+    ): array {
+        $service = new TicketListService();
+
+        $filterOptions = $service->getFilterOptions($request, $scope->defaultStatusFilter());
+        $comparisonUser = $scope->comparisonUser($target);
+
+        $base = $scope->baseQuery($target)->withLiveTicketable();
+        $stateCounts = $service->getStateCounts($filterOptions, clone $base, $comparisonUser);
+
+        $total = TicketListStatusFilter::from($filterOptions['status'])->filteredTotal($stateCounts);
+        $lastPage = max(1, (int) ceil($total / self::PER_PAGE));
+        $page = $request->getPage();
+
+        if ($page > $lastPage) {
+            $page = 1;
+        }
+
+        $query = $service->applyFilters(clone $base, $filterOptions, $comparisonUser);
+        $this->applySort($query, $request->getSort());
+        $this->applyTicketListEntryEagerLoads($query);
+
+        $paginator = new LengthAwarePaginator(
+            items: $this->fetchTicketListEntries($query->forPage($page, self::PER_PAGE)),
+            total: $total,
+            perPage: self::PER_PAGE,
+            currentPage: $page,
+            options: ['path' => $request->url(), 'query' => $request->query()],
+        );
+
+        $paginatedTickets = PaginatedData::fromLengthAwarePaginator(
+            $paginator,
+            unfilteredTotal: (clone $base)->count(),
+        );
+
+        return [
+            'paginatedTickets' => $paginatedTickets,
+            'stateCounts' => TicketListStateCountsData::fromCounts($stateCounts),
+        ];
+    }
+
+    /**
+     * @return TicketListFilterData[]
+     */
+    public function getAvailableFilters(TicketListScope $scope, ?int $systemId = null): array
+    {
+        return array_map(
+            fn (TicketListFilterKind $kind) => new TicketListFilterData(
+                kind: $kind,
+                values: $kind->values($systemId),
+            ),
+            $scope->filterKinds(),
+        );
+    }
+
+    /**
+     * @param Builder<Ticket> $query
+     * @param array{field: TicketListSortField, direction: 'asc'|'desc'} $sort
+     */
+    private function applySort(Builder $query, array $sort): void
+    {
+        switch ($sort['field']) {
+            case TicketListSortField::State:
+                $stateOrder = [
+                    TicketState::Open,
+                    TicketState::Request,
+                    TicketState::Quarantined,
+                    TicketState::Resolved,
+                    TicketState::Closed,
+                ];
+                $cases = implode(' ', array_map(
+                    fn (int $index) => "WHEN ? THEN {$index}",
+                    array_keys($stateOrder),
+                ));
+                $query->orderByRaw(
+                    "CASE state {$cases} ELSE ? END {$sort['direction']}",
+                    [...array_map(fn (TicketState $state) => $state->value, $stateOrder), count($stateOrder)],
+                );
+                $query->orderByDesc('created_at');
+                break;
+
+            case TicketListSortField::ResolvedAt:
+                $query->orderBy('resolved_at', $sort['direction']);
+                $query->orderByDesc('created_at');
+                break;
+
+            case TicketListSortField::CreatedAt:
+            default:
+                $query->orderBy('created_at', $sort['direction']);
+                break;
+        }
+
+        $query->orderByDesc('id');
+    }
+}

--- a/app/Platform/Actions/Concerns/LoadsTicketListEntryRelations.php
+++ b/app/Platform/Actions/Concerns/LoadsTicketListEntryRelations.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Actions\Concerns;
+
+use App\Models\Achievement;
+use App\Models\Leaderboard;
+use App\Models\Ticket;
+use App\Platform\Data\TicketListEntryData;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+trait LoadsTicketListEntryRelations
+{
+    /**
+     * Loads every relation the ticket list row DTO reads.
+     *
+     * @param Builder<Ticket> $query
+     */
+    protected function applyTicketListEntryEagerLoads(Builder $query): void
+    {
+        $query->with([
+            'ticketable' => function (Relation $relation) {
+                if ($relation instanceof MorphTo) {
+                    $relation->morphWith([
+                        Achievement::class => ['game.system'],
+                        Leaderboard::class => ['game.system'],
+                    ]);
+                }
+            },
+            'author',
+            'reporter',
+            'resolver',
+            'emulator',
+            'gameHash',
+        ]);
+    }
+
+    /**
+     * @param Builder<Ticket> $query
+     * @return TicketListEntryData[]
+     */
+    protected function fetchTicketListEntries(Builder $query): array
+    {
+        return $query->get()
+            ->map(fn (Ticket $ticket) => TicketListEntryData::fromTicket($ticket))
+            ->all();
+    }
+}

--- a/app/Platform/Controllers/Api/TicketApiController.php
+++ b/app/Platform/Controllers/Api/TicketApiController.php
@@ -5,15 +5,29 @@ namespace App\Platform\Controllers\Api;
 use App\Community\Enums\TicketState;
 use App\Http\Controller;
 use App\Models\Ticket;
+use App\Platform\Actions\BuildTicketListAction;
 use App\Platform\Actions\CreateTicketAction;
 use App\Platform\Data\StoreTicketData;
+use App\Platform\Enums\TicketListScope;
 use App\Platform\Requests\StoreTicketRequest;
+use App\Platform\Requests\TicketListApiRequest;
 use Illuminate\Http\JsonResponse;
 
 class TicketApiController extends Controller
 {
-    public function index(): void
+    public function index(TicketListApiRequest $request): JsonResponse
     {
+        $this->authorize('viewAny', Ticket::class);
+
+        $scope = TicketListScope::from($request->input('scope', TicketListScope::All->value));
+        $target = $scope->resolveTarget($request);
+
+        $result = (new BuildTicketListAction())->execute($scope, $target, $request);
+
+        return response()->json([
+            'paginatedTickets' => $result['paginatedTickets'],
+            'stateCounts' => $result['stateCounts'],
+        ]);
     }
 
     public function store(

--- a/app/Platform/Data/TicketListEntryData.php
+++ b/app/Platform/Data/TicketListEntryData.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Data;
+
+use App\Community\Enums\TicketState;
+use App\Community\Enums\TicketType;
+use App\Data\UserData;
+use App\Models\Ticket;
+use App\Platform\Enums\TicketableType;
+use Carbon\Carbon;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript('TicketListEntry')]
+class TicketListEntryData extends Data
+{
+    public function __construct(
+        public int $id,
+        public TicketState $state,
+        public TicketType $type,
+        public ?bool $hardcore,
+        public Carbon $createdAt,
+        public ?Carbon $resolvedAt,
+        public TicketableType $ticketableType,
+        public int $ticketableId,
+        public string $ticketableTitle,
+        public ?string $ticketableBadgeUrl,
+        public GameData $game,
+        public ?UserData $author,
+        public ?UserData $reporter,
+        public ?UserData $resolver,
+        public ?EmulatorData $emulator,
+        public ?string $emulatorVersion,
+        public ?string $emulatorCore,
+        public ?GameHashData $gameHash,
+    ) {
+    }
+
+    public static function fromTicket(Ticket $ticket): self
+    {
+        $ticketable = $ticket->getTicketableModel();
+
+        return new self(
+            id: $ticket->id,
+            state: $ticket->state,
+            type: $ticket->type,
+            hardcore: $ticket->hardcore === null ? null : (bool) $ticket->hardcore,
+            createdAt: Carbon::parse($ticket->created_at),
+            resolvedAt: $ticket->resolved_at ? Carbon::parse($ticket->resolved_at) : null,
+            ticketableType: TicketableType::from($ticket->ticketable_type),
+            ticketableId: $ticketable->id,
+            ticketableTitle: $ticketable->getTicketableTitle(),
+            ticketableBadgeUrl: $ticketable->getTicketableBadgeUrl(),
+            game: GameData::fromGame($ticketable->game)->include('badgeUrl', 'system.nameShort'),
+            author: $ticket->author ? UserData::fromUser($ticket->author) : null,
+            reporter: $ticket->reporter ? UserData::fromUser($ticket->reporter) : null,
+            resolver: $ticket->resolver ? UserData::fromUser($ticket->resolver) : null,
+            emulator: $ticket->emulator ? EmulatorData::fromEmulator($ticket->emulator) : null,
+            emulatorVersion: $ticket->emulator_version,
+            emulatorCore: $ticket->emulator_core,
+            gameHash: $ticket->gameHash ? GameHashData::fromGameHash($ticket->gameHash) : null,
+        );
+    }
+}

--- a/app/Platform/Data/TicketListFilterData.php
+++ b/app/Platform/Data/TicketListFilterData.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Data;
+
+use App\Platform\Enums\TicketListFilterKind;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript('TicketListFilter')]
+class TicketListFilterData extends Data
+{
+    /**
+     * @param string[] $values
+     */
+    public function __construct(
+        public TicketListFilterKind $kind,
+        #[LiteralTypeScriptType('string[]')]
+        public array $values,
+    ) {
+    }
+}

--- a/app/Platform/Data/TicketListStateCountsData.php
+++ b/app/Platform/Data/TicketListStateCountsData.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Data;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript('TicketListStateCounts')]
+class TicketListStateCountsData extends Data
+{
+    public function __construct(
+        public int $unresolved,
+        public int $request,
+        public int $resolved,
+        public int $quarantined,
+        public int $all,
+    ) {
+    }
+
+    /**
+     * @param array{unresolved: int, request: int, resolved: int, quarantined: int, all: int} $counts
+     */
+    public static function fromCounts(array $counts): self
+    {
+        return new self(
+            unresolved: $counts['unresolved'],
+            request: $counts['request'],
+            resolved: $counts['resolved'],
+            quarantined: $counts['quarantined'],
+            all: $counts['all'],
+        );
+    }
+}

--- a/app/Platform/Enums/TicketListFilterKind.php
+++ b/app/Platform/Enums/TicketListFilterKind.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Enums;
+
+use App\Community\Enums\TicketType;
+use App\Models\Emulator;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+enum TicketListFilterKind: string
+{
+    case Type = 'type';
+    case PublishedStatus = 'publishedStatus';
+    case Mode = 'mode';
+    case DeveloperType = 'developerType';
+    case Developer = 'developer';
+    case Reporter = 'reporter';
+    case Emulator = 'emulator';
+
+    /**
+     * These are listed in display order.
+     *
+     * @return string[]
+     */
+    public function values(?int $systemId = null): array
+    {
+        return match ($this) {
+            self::Type => [
+                '0',
+                (string) TicketType::TriggeredAtWrongTime->toLegacyInteger(),
+                (string) TicketType::DidNotTrigger->toLegacyInteger(),
+            ],
+            self::PublishedStatus => ['all', 'published', 'unpublished'],
+            self::Mode => ['all', 'hardcore', 'softcore', 'unspecified'],
+            self::DeveloperType => ['all', 'active', 'junior', 'inactive'],
+            self::Developer, self::Reporter => ['all', 'self', 'others'],
+            self::Emulator => ['all', ...self::emulatorNames($systemId), 'unknown'],
+        };
+    }
+
+    /**
+     * @return array<int, string|\Illuminate\Validation\Rules\In>
+     */
+    public function validationRules(): array
+    {
+        return match ($this) {
+            self::Type => ['sometimes', 'integer', Rule::in($this->values())],
+            self::Emulator => ['sometimes', 'string'],
+            default => ['sometimes', 'string', Rule::in($this->values())],
+        };
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function emulatorNames(?int $systemId): array
+    {
+        $emulators = $systemId
+            ? Emulator::forSystem($systemId)
+            : Emulator::whereIn('id', DB::table('system_emulators')->distinct()->pluck('emulator_id')->all());
+
+        return $emulators->orderBy('name')->pluck('name')->all();
+    }
+}

--- a/app/Platform/Enums/TicketListScope.php
+++ b/app/Platform/Enums/TicketListScope.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Enums;
+
+use App\Models\Achievement;
+use App\Models\Game;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Platform\Requests\TicketListRequest;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+/**
+ * Drives filtering the ticket list/page by a specific criteria.
+ */
+#[TypeScript]
+enum TicketListScope: string
+{
+    case All = 'all';
+    case Game = 'game';
+    case Achievement = 'achievement';
+    case AssignedTo = 'assignedTo';
+    case ReportedBy = 'reportedBy';
+    case AwaitingReporter = 'awaitingReporter';
+    case ResolvedBy = 'resolvedBy';
+
+    public function resolveTarget(TicketListRequest $request): Game|Achievement|User|null
+    {
+        return match ($this) {
+            self::All => null,
+            self::Game => Game::findOrFail((int) $request->input('game')),
+            self::Achievement => Achievement::findOrFail((int) $request->input('achievement')),
+            self::AssignedTo => User::withTrashed()->findOrFail((int) $request->input('user')),
+            self::ReportedBy, self::AwaitingReporter, self::ResolvedBy => User::findOrFail((int) $request->input('user')),
+        };
+    }
+
+    /**
+     * @return Builder<Ticket>
+     */
+    public function baseQuery(Game|Achievement|User|null $target): Builder
+    {
+        return match ($this) {
+            self::All => Ticket::query(),
+            self::Game => Ticket::forGame($target),
+            self::Achievement => Ticket::forAchievement($target),
+            self::AssignedTo => Ticket::forAssignee($target),
+            self::ReportedBy => Ticket::query()
+                ->where('reporter_id', $target->id),
+            self::AwaitingReporter => Ticket::query()
+                ->where('reporter_id', $target->id),
+            self::ResolvedBy => Ticket::query()
+                ->where('resolver_id', $target->id),
+        };
+    }
+
+    /**
+     * The filters usable by a given scope.
+     *
+     * @return TicketListFilterKind[]
+     */
+    public function filterKinds(): array
+    {
+        return match ($this) {
+            self::All, self::Game => [
+                TicketListFilterKind::Type,
+                TicketListFilterKind::PublishedStatus,
+                TicketListFilterKind::Mode,
+                TicketListFilterKind::DeveloperType,
+                TicketListFilterKind::Emulator,
+            ],
+            self::Achievement => [
+                TicketListFilterKind::Type,
+                TicketListFilterKind::Mode,
+                TicketListFilterKind::Emulator,
+            ],
+            self::AssignedTo, self::ReportedBy => [
+                TicketListFilterKind::Type,
+                TicketListFilterKind::PublishedStatus,
+                TicketListFilterKind::Mode,
+                TicketListFilterKind::Emulator,
+            ],
+            self::AwaitingReporter => [],
+            self::ResolvedBy => [
+                TicketListFilterKind::Type,
+                TicketListFilterKind::PublishedStatus,
+                TicketListFilterKind::Mode,
+                TicketListFilterKind::Developer,
+                TicketListFilterKind::Reporter,
+                TicketListFilterKind::Emulator,
+            ],
+        };
+    }
+
+    public function defaultStatusFilter(): TicketListStatusFilter
+    {
+        return match ($this) {
+            self::ResolvedBy => TicketListStatusFilter::Resolved,
+            self::AwaitingReporter => TicketListStatusFilter::Request,
+            default => TicketListStatusFilter::Unresolved,
+        };
+    }
+
+    public function comparisonUser(?Model $target): ?User
+    {
+        return match ($this) {
+            self::ResolvedBy => $target instanceof User ? $target : null,
+            default => null,
+        };
+    }
+}

--- a/app/Platform/Enums/TicketListSortField.php
+++ b/app/Platform/Enums/TicketListSortField.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Enums;
+
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+enum TicketListSortField: string
+{
+    case CreatedAt = 'createdAt';
+    case State = 'state';
+    case ResolvedAt = 'resolvedAt';
+}

--- a/app/Platform/Enums/TicketListStatusFilter.php
+++ b/app/Platform/Enums/TicketListStatusFilter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Enums;
+
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+enum TicketListStatusFilter: string
+{
+    case All = 'all';
+    case Unresolved = 'unresolved';
+    case Request = 'request';
+    case Resolved = 'resolved';
+    case Quarantined = 'quarantined';
+
+    /**
+     * @return 'all'|'unresolved'|'request'|'resolved'|'quarantined'
+     */
+    public function stateCountsBucket(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param array{unresolved: int, request: int, resolved: int, quarantined: int, all: int} $stateCounts
+     */
+    public function filteredTotal(array $stateCounts): int
+    {
+        return $stateCounts[$this->stateCountsBucket()];
+    }
+}

--- a/app/Platform/Requests/TicketListApiRequest.php
+++ b/app/Platform/Requests/TicketListApiRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Requests;
+
+use App\Platform\Enums\TicketListScope;
+use Illuminate\Validation\Rules\Enum;
+
+class TicketListApiRequest extends TicketListRequest
+{
+    public function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            'scope' => ['sometimes', 'string', new Enum(TicketListScope::class)],
+            'game' => 'required_if:scope,' . TicketListScope::Game->value . '|integer',
+            'achievement' => 'required_if:scope,' . TicketListScope::Achievement->value . '|integer',
+            'user' => 'required_if:scope,' . implode(',', [
+                TicketListScope::AssignedTo->value,
+                TicketListScope::ReportedBy->value,
+                TicketListScope::AwaitingReporter->value,
+                TicketListScope::ResolvedBy->value,
+            ]) . '|integer',
+        ]);
+    }
+}

--- a/app/Platform/Requests/TicketListRequest.php
+++ b/app/Platform/Requests/TicketListRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Requests;
+
+use App\Platform\Enums\TicketListSortField;
+use Illuminate\Foundation\Http\FormRequest;
+
+class TicketListRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        $sortValues = array_merge(
+            array_map(fn (TicketListSortField $field) => $field->value, TicketListSortField::cases()),
+            array_map(fn (TicketListSortField $field) => '-' . $field->value, TicketListSortField::cases()),
+        );
+
+        return [
+            'page.number' => 'sometimes|integer|min:1',
+            'sort' => 'sometimes|string|in:' . implode(',', $sortValues),
+        ];
+    }
+
+    public function getPage(): int
+    {
+        return (int) $this->input('page.number', 1);
+    }
+
+    /**
+     * @return array{field: TicketListSortField, direction: 'asc'|'desc'}
+     */
+    public function getSort(): array
+    {
+        $sortParam = $this->input('sort');
+
+        // Newest first is the default sort order.
+        if (!is_string($sortParam) || $sortParam === '') {
+            return ['field' => TicketListSortField::CreatedAt, 'direction' => 'desc'];
+        }
+
+        $direction = 'asc';
+        if (str_starts_with($sortParam, '-')) {
+            $direction = 'desc';
+            $sortParam = ltrim($sortParam, '-');
+        }
+
+        return ['field' => TicketListSortField::from($sortParam), 'direction' => $direction];
+    }
+}

--- a/app/Platform/RouteServiceProvider.php
+++ b/app/Platform/RouteServiceProvider.php
@@ -168,6 +168,7 @@ class RouteServiceProvider extends ServiceProvider
                     Route::put('user/media-contribution/tier-preference', [UserDisplayedBadgePreferenceApiController::class, 'updateMediaContributionTier'])
                         ->name('api.user.media-contribution-tier-preference.update');
 
+                    Route::get('tickets', [TicketApiController::class, 'index'])->name('api.ticket.index');
                     Route::post('ticket', [TicketApiController::class, 'store'])->name('api.ticket.store');
 
                     Route::post('game/{game}/screenshots', [GameScreenshotApiController::class, 'store'])

--- a/app/Platform/Services/TicketListService.php
+++ b/app/Platform/Services/TicketListService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Platform\Services;
 
+use App\Community\Enums\TicketState;
 use App\Community\Enums\TicketType;
 use App\Enums\Permissions;
 use App\Models\Achievement;
@@ -11,10 +12,13 @@ use App\Models\Emulator;
 use App\Models\Ticket;
 use App\Models\User;
 use App\Platform\Enums\TicketableType;
+use App\Platform\Enums\TicketListFilterKind;
+use App\Platform\Enums\TicketListStatusFilter;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
 
 class TicketListService
 {
@@ -29,7 +33,10 @@ class TicketListService
         return in_array($filterOptions['status'] ?? 'unresolved', ['all', 'resolved'], true);
     }
 
-    public function getFilterOptions(Request $request): array
+    /**
+     * @return array{status: string, type: int, publishedStatus: string, mode: string, developerType: string, developer: string, reporter: string, emulator: string}
+     */
+    public function getFilterOptions(Request $request, TicketListStatusFilter $defaultStatus = TicketListStatusFilter::Unresolved): array
     {
         if ($this->perPage !== 0) {
             $validatedData = $request->validate([
@@ -38,19 +45,15 @@ class TicketListService
             $this->pageNumber = (int) ($validatedData['page']['number'] ?? 1);
         }
 
-        $validatedData = $request->validate([
-            'filter.status' => 'sometimes|string|in:all,unresolved,resolved,quarantined',
-            'filter.type' => 'sometimes|integer|min:0|max:2',
-            'filter.publishedStatus' => 'sometimes|string|in:all,published,unpublished',
-            'filter.mode' => 'sometimes|string|in:all,hardcore,softcore,unspecified',
-            'filter.developerType' => 'sometimes|string|in:all,active,junior,inactive',
-            'filter.developer' => 'sometimes|string|in:all,self,others',
-            'filter.reporter' => 'sometimes|string|in:all,self,others',
-            'filter.emulator' => 'sometimes|string',
-        ]);
+        $rules = ['filter.status' => ['sometimes', Rule::enum(TicketListStatusFilter::class)]];
+        foreach (TicketListFilterKind::cases() as $kind) {
+            $rules["filter.{$kind->value}"] = $kind->validationRules();
+        }
+
+        $validatedData = $request->validate($rules);
 
         return [
-            'status' => $validatedData['filter']['status'] ?? 'unresolved',
+            'status' => $validatedData['filter']['status'] ?? $defaultStatus->value,
             'type' => (int) ($validatedData['filter']['type'] ?? 0),
             'publishedStatus' => $validatedData['filter']['publishedStatus'] ?? 'all',
             'mode' => $validatedData['filter']['mode'] ?? 'all',
@@ -227,17 +230,24 @@ class TicketListService
      */
     public function applyFilters(Builder $tickets, array $filterOptions, ?User $comparisonUser = null): Builder
     {
-        switch ($filterOptions['status']) {
-            case 'unresolved':
+        switch (TicketListStatusFilter::from($filterOptions['status'])) {
+            case TicketListStatusFilter::Unresolved:
                 $tickets->open();
                 break;
 
-            case 'resolved':
+            case TicketListStatusFilter::Request:
+                $tickets->where('state', TicketState::Request);
+                break;
+
+            case TicketListStatusFilter::Resolved:
                 $tickets->resolved();
                 break;
 
-            case 'quarantined':
+            case TicketListStatusFilter::Quarantined:
                 $tickets->quarantined();
+                break;
+
+            case TicketListStatusFilter::All:
                 break;
         }
 
@@ -341,5 +351,45 @@ class TicketListService
         }
 
         return $tickets;
+    }
+
+    /**
+     * Returns a count of tickets per status bucket under every filter except
+     * status itself. The counts describe what each status choice would show
+     * for a given set of filter options in the UI.
+     *
+     * @param Builder<Ticket> $tickets
+     * @param User|null $comparisonUser the user the developer and reporter filters compare against
+     * @return array{unresolved: int, request: int, resolved: int, quarantined: int, all: int}
+     */
+    public function getStateCounts(array $filterOptions, ?Builder $tickets = null, ?User $comparisonUser = null): array
+    {
+        $countQuery = $tickets === null ? Ticket::query() : clone $tickets;
+
+        $countQuery->withLiveTicketable();
+
+        $countQuery = $this->applyFilters($countQuery, array_merge($filterOptions, ['status' => TicketListStatusFilter::All->value]), $comparisonUser);
+
+        $countsByState = $countQuery
+            ->reorder()
+            ->select('state', DB::raw('count(*) as aggregate'))
+            ->groupBy('state')
+            ->pluck('aggregate', 'state')
+            ->map(fn (mixed $count) => (int) $count);
+
+        $countFor = fn (TicketState $state): int => $countsByState->get($state->value, 0);
+
+        $request = $countFor(TicketState::Request);
+        $unresolved = $countFor(TicketState::Open) + $request;
+        $resolved = $countFor(TicketState::Resolved) + $countFor(TicketState::Closed);
+        $quarantined = $countFor(TicketState::Quarantined);
+
+        return [
+            'unresolved' => $unresolved,
+            'request' => $request,
+            'resolved' => $resolved,
+            'quarantined' => $quarantined,
+            'all' => $unresolved + $resolved + $quarantined,
+        ];
     }
 }

--- a/resources/js/types/generated.d.ts
+++ b/resources/js/types/generated.d.ts
@@ -1185,6 +1185,37 @@ ticketableType: App.Platform.Enums.TicketableType;
 state?: App.Community.Enums.TicketState;
 ticketable?: App.Platform.Data.Achievement | App.Platform.Data.Leaderboard | App.Platform.Data.Game;
 };
+export type TicketListEntry = {
+id: number;
+state: App.Community.Enums.TicketState;
+type: App.Community.Enums.TicketType;
+hardcore: boolean | null;
+createdAt: string;
+resolvedAt: string | null;
+ticketableType: App.Platform.Enums.TicketableType;
+ticketableId: number;
+ticketableTitle: string;
+ticketableBadgeUrl: string | null;
+game: App.Platform.Data.Game;
+author: App.Data.User | null;
+reporter: App.Data.User | null;
+resolver: App.Data.User | null;
+emulator: App.Platform.Data.Emulator | null;
+emulatorVersion: string | null;
+emulatorCore: string | null;
+gameHash: App.Platform.Data.GameHash | null;
+};
+export type TicketListFilter = {
+kind: App.Platform.Enums.TicketListFilterKind;
+values: string[];
+};
+export type TicketListStateCounts = {
+unresolved: number;
+request: number;
+resolved: number;
+quarantined: number;
+all: number;
+};
 export type UserCredits = {
 displayName: string;
 avatarUrl: string;
@@ -1234,6 +1265,10 @@ export type PlayerStatRankingKind = 'retail_beaten' | 'homebrew_beaten' | 'hacks
 export type ReleasedAtGranularity = 'day' | 'month' | 'year';
 export type ScreenshotReviewDecision = 'primary' | 'primary_keep_gallery' | 'gallery' | 'reject';
 export type ScreenshotType = 'title' | 'ingame' | 'completion';
+export type TicketListFilterKind = 'type' | 'publishedStatus' | 'mode' | 'developerType' | 'developer' | 'reporter' | 'emulator';
+export type TicketListScope = 'all' | 'game' | 'achievement' | 'assignedTo' | 'reportedBy' | 'awaitingReporter' | 'resolvedBy';
+export type TicketListSortField = 'createdAt' | 'state' | 'resolvedAt';
+export type TicketListStatusFilter = 'all' | 'unresolved' | 'request' | 'resolved' | 'quarantined';
 export type TicketableType = 'achievement' | 'leaderboard' | 'game.rich-presence';
 export type TriggerableType = 'achievement' | 'leaderboard' | 'game';
 }

--- a/resources/views/pages/demo/ticket-list.blade.php
+++ b/resources/views/pages/demo/ticket-list.blade.php
@@ -1,0 +1,103 @@
+<?php
+
+// Temporary QA page to demo the ticket list backend functionality.
+// This will be deleted in favor of a React page.
+// This code is pretty messy, but this is a temporary file.
+
+use App\Models\Achievement;
+use App\Models\Game;
+use App\Platform\Actions\BuildTicketListAction;
+use App\Platform\Enums\TicketListScope;
+use App\Platform\Enums\TicketListSortField;
+use App\Platform\Enums\TicketListStatusFilter;
+use App\Platform\Requests\TicketListApiRequest;
+use Illuminate\View\View;
+
+use function Laravel\Folio\{middleware, name, render};
+
+middleware(['auth', 'can:root']);
+name('demo.ticket-list');
+
+render(function (View $view) {
+    $request = TicketListApiRequest::createFrom(request());
+    $scope = TicketListScope::from((string) $request->query('scope', TicketListScope::All->value));
+
+    $action = app(BuildTicketListAction::class);
+
+    $hasRequiredTarget = $scope === TicketListScope::All || $request->filled(match ($scope) {
+        TicketListScope::Game => 'game',
+        TicketListScope::Achievement => 'achievement',
+        default => 'user',
+    });
+    $target = $hasRequiredTarget ? $scope->resolveTarget($request) : null;
+    $result = $hasRequiredTarget ? $action->execute($scope, $target, $request) : null;
+
+    $systemId = match (true) {
+        $target instanceof Game => $target->system_id,
+        $target instanceof Achievement => $target->game->system_id,
+        default => null,
+    };
+
+    return $view->with([
+        'result' => $result,
+        'availableFilters' => $action->getAvailableFilters($scope, $systemId),
+        'scopes' => TicketListScope::cases(),
+        'statuses' => TicketListStatusFilter::cases(),
+        'defaultStatus' => $scope->defaultStatusFilter()->value,
+        'sortFields' => TicketListSortField::cases(),
+        'apiUrl' => route('api.ticket.index', request()->query()),
+    ]);
+});
+
+?>
+
+<x-app-layout pageTitle="Ticket List Demo">
+    <p class="mb-8">This page is just here to prove the back-end stuff works. Pay no attention to this page's code. This file is going to be deleted.</p>
+
+    <div class="flex flex-col gap-4">
+        <form method="GET" action="" class="flex flex-wrap items-end gap-3" x-data="{ scope: '{{ request('scope', 'all') }}' }">
+            <label class="flex flex-col">Scope
+                <select name="scope" class="px-2 py-1 border" x-model="scope" @change="$el.form.requestSubmit()">
+                    @foreach ($scopes as $case)
+                        <option value="{{ $case->value }}" @selected(request('scope', 'all') === $case->value)>{{ $case->value }}</option>
+                    @endforeach
+                </select>
+            </label>
+            <label class="flex flex-col" x-show="scope === 'game'" x-cloak>Game id<input type="number" name="game" value="{{ request('game') }}" class="px-2 py-1 border" :disabled="scope !== 'game'" /></label>
+            <label class="flex flex-col" x-show="scope === 'achievement'" x-cloak>Achievement id<input type="number" name="achievement" value="{{ request('achievement') }}" class="px-2 py-1 border" :disabled="scope !== 'achievement'" /></label>
+            <label class="flex flex-col" x-show="['assignedTo', 'reportedBy', 'awaitingReporter', 'resolvedBy'].includes(scope)" x-cloak>User id<input type="number" name="user" value="{{ request('user') }}" class="px-2 py-1 border" :disabled="!['assignedTo', 'reportedBy', 'awaitingReporter', 'resolvedBy'].includes(scope)" /></label>
+            <label class="flex flex-col">Status
+                <select name="filter[status]" class="px-2 py-1 border">
+                    @foreach ($statuses as $case)
+                        <option value="{{ $case->value }}" @selected(request('filter.status', $defaultStatus) === $case->value)>{{ $case->value }}</option>
+                    @endforeach
+                </select>
+            </label>
+            <label class="flex flex-col">Sort
+                <select name="sort" class="px-2 py-1 border">
+                    @foreach ($sortFields as $case)
+                        <option value="-{{ $case->value }}" @selected(request('sort', '-createdAt') === "-{$case->value}")>-{{ $case->value }}</option>
+                        <option value="{{ $case->value }}" @selected(request('sort') === $case->value)>{{ $case->value }}</option>
+                    @endforeach
+                </select>
+            </label>
+            @foreach ($availableFilters as $filter)
+                <label class="flex flex-col">{{ $filter->kind->value }}
+                    <select name="filter[{{ $filter->kind->value }}]" class="px-2 py-1 border">
+                        @foreach ($filter->values as $value)
+                            <option value="{{ $value }}" @selected((string) request("filter.{$filter->kind->value}", $filter->values[0]) === (string) $value)>{{ $value }}</option>
+                        @endforeach
+                    </select>
+                </label>
+            @endforeach
+            <label class="flex flex-col">Page<input type="number" name="page[number]" value="{{ request('page.number', 1) }}" min="1" class="px-2 py-1 border" /></label>
+            <button type="submit" class="px-3 py-1 btn">Load</button>
+        </form>
+
+        @if ($result)
+            <p><a href="{{ $apiUrl }}">Open this query on the internal API route (TicketApiController)</a></p>
+
+            @dump($result)
+        @endif
+    </div>
+</x-app-layout>

--- a/tests/Feature/Platform/Actions/BuildTicketListActionTest.php
+++ b/tests/Feature/Platform/Actions/BuildTicketListActionTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Community\Enums\TicketState;
+use App\Models\Achievement;
+use App\Models\Emulator;
+use App\Models\Game;
+use App\Models\System;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Platform\Actions\BuildTicketListAction;
+use App\Platform\Data\TicketListEntryData;
+use App\Platform\Enums\TicketListFilterKind;
+use App\Platform\Enums\TicketListScope;
+use App\Platform\Requests\TicketListRequest;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+
+uses(LazilyRefreshDatabase::class);
+
+/**
+ * @return array{developer: User, reporter: User, resolver: User, game: Game, achievement: Achievement, otherAchievement: Achievement, tickets: Ticket[]}
+ */
+function createTicketListFixture(int $ticketCount = 12): array
+{
+    $developer = User::factory()->create();
+    $reporter = User::factory()->create();
+    $resolver = User::factory()->create();
+
+    $game = Game::factory()->create(['system_id' => System::factory()->create()->id]);
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+    $otherAchievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+
+    $states = [
+        TicketState::Open,
+        TicketState::Request,
+        TicketState::Quarantined,
+        TicketState::Resolved,
+        TicketState::Closed,
+    ];
+
+    $tickets = [];
+    for ($i = 0; $i < $ticketCount; $i++) {
+        $state = $states[$i % count($states)];
+        $isTerminal = in_array($state, [TicketState::Resolved, TicketState::Closed], true);
+
+        $tickets[] = Ticket::factory()
+            ->forAchievement($i % 2 === 0 ? $achievement : $otherAchievement)
+            ->create([
+                'ticketable_author_id' => $developer->id,
+                'reporter_id' => $reporter->id,
+                'resolver_id' => $isTerminal ? $resolver->id : null,
+                'state' => $state,
+                'created_at' => Carbon::parse('2024-01-01 00:00:00')->addHours($i),
+                'resolved_at' => $isTerminal ? Carbon::parse('2024-06-01 00:00:00')->addHours($i) : null,
+            ]);
+    }
+
+    return [
+        'developer' => $developer,
+        'reporter' => $reporter,
+        'resolver' => $resolver,
+        'game' => $game,
+        'achievement' => $achievement,
+        'otherAchievement' => $otherAchievement,
+        'tickets' => $tickets,
+    ];
+}
+
+/**
+ * @return int[]
+ */
+function entryIds(array $result): array
+{
+    return array_map(fn (TicketListEntryData $entry) => $entry->id, $result['paginatedTickets']->items);
+}
+
+describe('scope default values', function () {
+    it('given scope is set to game and there is no query string, only the open and request tickets are returned for the game, sorted by newest tickets first', function () {
+        // ARRANGE
+        $developer = User::factory()->create();
+        $reporter = User::factory()->create();
+        $game = Game::factory()->create(['system_id' => System::factory()->create()->id]);
+        $otherGame = Game::factory()->create(['system_id' => System::factory()->create()->id]);
+        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+        $otherAchievement = Achievement::factory()->promoted()->create(['game_id' => $otherGame->id, 'user_id' => $developer->id]);
+        $attributes = ['ticketable_author_id' => $developer->id, 'reporter_id' => $reporter->id];
+
+        $oldest = Ticket::factory()->forAchievement($achievement)->open()->create([
+            ...$attributes,
+            'created_at' => Carbon::parse('2024-01-01 00:00:00'),
+        ]);
+        $middle = Ticket::factory()->forAchievement($achievement)->request()->create([
+            ...$attributes,
+            'created_at' => Carbon::parse('2024-01-02 00:00:00'),
+        ]);
+        $newest = Ticket::factory()->forAchievement($achievement)->open()->create([
+            ...$attributes,
+            'created_at' => Carbon::parse('2024-01-03 00:00:00'),
+        ]);
+
+        Ticket::factory()->forAchievement($achievement)->resolved()->create($attributes);
+        Ticket::factory()->forAchievement($otherAchievement)->open()->create($attributes);
+
+        // ACT
+        $result = (new BuildTicketListAction())->execute(
+            TicketListScope::Game,
+            $game,
+            TicketListRequest::create('/internal-api/tickets', 'GET'),
+        );
+
+        // ASSERT
+        expect(entryIds($result))->toEqual([$newest->id, $middle->id, $oldest->id]);
+        expect($result['paginatedTickets']->total)->toEqual(3);
+        expect($result['paginatedTickets']->unfilteredTotal)->toEqual(4);
+    });
+
+    it('given scope is set to assignedTo and there is no query string, only the open tickets assigned to that specific developer are returned', function () {
+        // ARRANGE
+        $developer = User::factory()->create();
+        $otherDeveloper = User::factory()->create();
+        $reporter = User::factory()->create();
+        $game = Game::factory()->create(['system_id' => System::factory()->create()->id]);
+        $ownAchievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+        $otherAchievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $otherDeveloper->id]);
+
+        $assigned = Ticket::factory()->forAchievement($ownAchievement)->open()->create([
+            'ticketable_author_id' => $developer->id,
+            'reporter_id' => $reporter->id,
+        ]);
+
+        Ticket::factory()->forAchievement($ownAchievement)->closed()->create([
+            'ticketable_author_id' => $developer->id,
+            'reporter_id' => $reporter->id,
+        ]);
+
+        Ticket::factory()->forAchievement($otherAchievement)->open()->create([
+            'ticketable_author_id' => $otherDeveloper->id,
+            'reporter_id' => $developer->id,
+        ]);
+
+        // ACT
+        $result = (new BuildTicketListAction())->execute(
+            TicketListScope::AssignedTo,
+            $developer,
+            TicketListRequest::create('/internal-api/tickets', 'GET'),
+        );
+
+        // ASSERT
+        expect(entryIds($result))->toEqual([$assigned->id]);
+    });
+
+    it('given scope is set to resolvedBy and there is no query string, only the tickets resolved by the user or are closed are returned', function () {
+        // ARRANGE
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $reporter = User::factory()->create();
+        $game = Game::factory()->create(['system_id' => System::factory()->create()->id]);
+        $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $user->id]);
+        $attributes = ['ticketable_author_id' => $user->id, 'reporter_id' => $reporter->id];
+
+        $resolved = Ticket::factory()->forAchievement($achievement)->resolved()->create([
+            ...$attributes,
+            'resolver_id' => $user->id,
+            'created_at' => Carbon::parse('2024-01-02 00:00:00'),
+        ]);
+        $closed = Ticket::factory()->forAchievement($achievement)->closed()->create([
+            ...$attributes,
+            'resolver_id' => $user->id,
+            'created_at' => Carbon::parse('2024-01-01 00:00:00'),
+        ]);
+
+        Ticket::factory()->forAchievement($achievement)->resolved()->create([
+            ...$attributes,
+            'resolver_id' => $otherUser->id,
+        ]);
+        Ticket::factory()->forAchievement($achievement)->open()->create($attributes);
+
+        // ACT
+        $result = (new BuildTicketListAction())->execute(
+            TicketListScope::ResolvedBy,
+            $user,
+            TicketListRequest::create('/internal-api/tickets', 'GET'),
+        );
+
+        // ASSERT
+        expect(entryIds($result))->toEqual([$resolved->id, $closed->id]);
+        expect($result['stateCounts']->request)->toBeInt();
+    });
+});
+
+describe('available filters', function () {
+    it('given each scope, only its filter kinds are exposed', function (TicketListScope $scope, array $expectedKinds) {
+        // ARRANGE
+        $action = new BuildTicketListAction();
+
+        // ACT
+        $filters = $action->getAvailableFilters($scope);
+
+        // ASSERT
+        expect(array_map(fn ($filter) => $filter->kind, $filters))->toEqual($expectedKinds);
+
+        $emulatorFilter = collect($filters)->firstWhere('kind', TicketListFilterKind::Emulator);
+        if ($emulatorFilter !== null) {
+            expect($emulatorFilter->values[0])->toEqual('all');
+            expect(end($emulatorFilter->values))->toEqual('unknown');
+        }
+    })->with([
+        'all' => [TicketListScope::All, [TicketListFilterKind::Type, TicketListFilterKind::PublishedStatus, TicketListFilterKind::Mode, TicketListFilterKind::DeveloperType, TicketListFilterKind::Emulator]],
+        'game' => [TicketListScope::Game, [TicketListFilterKind::Type, TicketListFilterKind::PublishedStatus, TicketListFilterKind::Mode, TicketListFilterKind::DeveloperType, TicketListFilterKind::Emulator]],
+        'achievement' => [TicketListScope::Achievement, [TicketListFilterKind::Type, TicketListFilterKind::Mode, TicketListFilterKind::Emulator]],
+        'assignedTo' => [TicketListScope::AssignedTo, [TicketListFilterKind::Type, TicketListFilterKind::PublishedStatus, TicketListFilterKind::Mode, TicketListFilterKind::Emulator]],
+        'reportedBy' => [TicketListScope::ReportedBy, [TicketListFilterKind::Type, TicketListFilterKind::PublishedStatus, TicketListFilterKind::Mode, TicketListFilterKind::Emulator]],
+        'awaitingReporter' => [TicketListScope::AwaitingReporter, []],
+        'resolvedBy' => [TicketListScope::ResolvedBy, [TicketListFilterKind::Type, TicketListFilterKind::PublishedStatus, TicketListFilterKind::Mode, TicketListFilterKind::Developer, TicketListFilterKind::Reporter, TicketListFilterKind::Emulator]],
+    ]);
+
+    it('given a system id, then the emulator options are limited to that system', function () {
+        // ARRANGE
+        $system = System::factory()->create();
+        $otherSystem = System::factory()->create();
+        $emulator = Emulator::factory()->create(['name' => 'Bizhawk']);
+        $otherEmulator = Emulator::factory()->create(['name' => 'PCSX2']);
+        $emulator->systems()->attach($system->id);
+        $otherEmulator->systems()->attach($otherSystem->id);
+
+        // ACT
+        $filters = (new BuildTicketListAction())->getAvailableFilters(TicketListScope::Game, $system->id);
+
+        // ASSERT
+        $emulatorFilter = collect($filters)->firstWhere('kind', TicketListFilterKind::Emulator);
+        expect($emulatorFilter->values)->toEqual(['all', 'Bizhawk', 'unknown']);
+    });
+});

--- a/tests/Feature/Platform/Controllers/Api/TicketApiControllerTest.php
+++ b/tests/Feature/Platform/Controllers/Api/TicketApiControllerTest.php
@@ -465,3 +465,76 @@ it('given a subset achievement, a session only on the parent game, and an emulat
         'state' => TicketState::Quarantined,
     ]);
 });
+
+/**
+ * @return array{developer: User, game: Game, tickets: Ticket[]}
+ */
+function createTicketIndexFixture(int $ticketCount = 3): array
+{
+    $developer = User::factory()->create();
+    $reporter = User::factory()->create();
+    $game = Game::factory()->create(['system_id' => System::factory()->create()->id]);
+    $achievement = Achievement::factory()->promoted()->create(['game_id' => $game->id, 'user_id' => $developer->id]);
+
+    $tickets = [];
+    for ($i = 0; $i < $ticketCount; $i++) {
+        $tickets[] = Ticket::factory()->forAchievement($achievement)->open()->create([
+            'ticketable_author_id' => $developer->id,
+            'reporter_id' => $reporter->id,
+            'created_at' => Carbon::parse('2024-01-01')->addHours($i),
+        ]);
+    }
+
+    return ['developer' => $developer, 'game' => $game, 'tickets' => $tickets];
+}
+
+describe('index', function () {
+    it('given a guest, they are unauthorized', function () {
+        // ARRANGE
+        $fixture = createTicketIndexFixture();
+
+        // ACT
+        $response = $this->getJson(route('api.ticket.index', ['scope' => 'game', 'game' => $fixture['game']->id]));
+
+        // ASSERT
+        $response->assertUnauthorized();
+    });
+
+    it('given scope game and a game id, the JSON has paginated tickets and four state counts', function () {
+        // ARRANGE
+        $fixture = createTicketIndexFixture(3);
+        $this->actingAs(User::factory()->create());
+
+        // ACT
+        $response = $this->getJson(route('api.ticket.index', ['scope' => 'game', 'game' => $fixture['game']->id]));
+
+        // ASSERT
+        $response->assertOk();
+        $response->assertJsonPath('paginatedTickets.total', 3);
+        $response->assertJsonPath('paginatedTickets.perPage', 50);
+        $response->assertJsonCount(3, 'paginatedTickets.items');
+        $response->assertJsonStructure([
+            'paginatedTickets' => ['currentPage', 'lastPage', 'perPage', 'total', 'unfilteredTotal', 'items', 'links'],
+            'stateCounts' => ['unresolved', 'request', 'resolved', 'quarantined', 'all'],
+        ]);
+        $response->assertJsonPath('stateCounts.unresolved', 3);
+        $response->assertJsonPath('stateCounts.all', 3);
+
+        $ids = collect($response->json('paginatedTickets.items'))->pluck('id')->all();
+        $expectedIds = collect($fixture['tickets'])->sortByDesc('created_at')->pluck('id')->values()->all();
+        expect($ids)->toEqual($expectedIds);
+    });
+
+    it('given the scope is unset, the global list is returned', function () {
+        // ARRANGE
+        createTicketIndexFixture(2);
+        $this->actingAs(User::factory()->create());
+
+        // ACT
+        $response = $this->getJson(route('api.ticket.index'));
+
+        // ASSERT
+        $response->assertOk();
+        $response->assertJsonPath('paginatedTickets.total', 2);
+    });
+});

--- a/tests/Feature/Platform/Services/TicketListServiceTest.php
+++ b/tests/Feature/Platform/Services/TicketListServiceTest.php
@@ -8,8 +8,10 @@ use App\Models\Game;
 use App\Models\System;
 use App\Models\Ticket;
 use App\Models\User;
+use App\Platform\Enums\TicketListStatusFilter;
 use App\Platform\Services\TicketListService;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Http\Request;
 
 uses(LazilyRefreshDatabase::class);
 
@@ -75,6 +77,42 @@ function sortedTicketIds(array $tickets): array
     return $ids;
 }
 
+describe('getFilterOptions', function () {
+    it('given no filter params, every default is filled', function () {
+        // ARRANGE
+        $service = new TicketListService();
+
+        // ACT
+        $options = $service->getFilterOptions(Request::create('/tickets', 'GET'));
+
+        // ASSERT
+        expect($options)->toEqual(defaultTicketListFilterOptions());
+    });
+
+    it('given a default status and no status in the URL, the default status is used', function () {
+        // ARRANGE
+        $service = new TicketListService();
+
+        // ACT
+        $options = $service->getFilterOptions(Request::create('/tickets', 'GET'), TicketListStatusFilter::Request);
+
+        // ASSERT
+        expect($options['status'])->toEqual('request');
+    });
+
+    it('given a default status and a status in the URL, the URL status is used', function () {
+        // ARRANGE
+        $service = new TicketListService();
+        $request = Request::create('/tickets', 'GET', ['filter' => ['status' => 'all']]);
+
+        // ACT
+        $options = $service->getFilterOptions($request, TicketListStatusFilter::Request);
+
+        // ASSERT
+        expect($options['status'])->toEqual('all');
+    });
+});
+
 describe('applyFilters', function () {
     it('given a status filter, only tickets with matching status values are returned', function (string $status, array $expectedStateKeys) {
         // ARRANGE
@@ -89,6 +127,7 @@ describe('applyFilters', function () {
         expect($ids)->toEqual(sortedTicketIds($expectedTickets));
     })->with([
         'unresolved' => ['unresolved', ['open', 'request']],
+        'request' => ['request', ['request']],
         'resolved' => ['resolved', ['resolved', 'closed']],
         'quarantined' => ['quarantined', ['quarantined']],
         'all' => ['all', ['open', 'request', 'resolved', 'closed', 'quarantined']],


### PR DESCRIPTION
This is a native stacked PR. #5173 should be reviewed first. Some of the changes in this PR may contextually make more sense after additional stacked PRs are opened. The entire React tickets index feature is already built on my local, but I am splitting it up into multiple PRs so it can be viewed through less-overwhelming chunks.

---

This PR prepares a `BuildTicketListAction` to ultimately support a React/Inertia-powered tickets index page. There will be a number of PRs required to facilitate this migration in order to cover the 7 existing pages.

`BuildTicketListAction` is hooked into _TicketApiController.php_ and a _ticket-list.blade.php_ demo page (to prove it works). This demo page is accessible only by Root users and will be deleted in a subsequent PR.

There are three behavior differences in the backend contract for this diff:
* `filter[status]` has a new "request" value.
* resolved-by now defaults to Resolved and Closed.
* awaiting-reporter now honors an explicit status value instead of clobbering it.

The legacy Blade pages are unaffected by these changes.

http://localhost:64000/demo/ticket-list

<img width="1093" height="295" alt="Screenshot 2026-08-17 at 5 43 31 PM" src="https://github.com/user-attachments/assets/0d581baa-0edc-402c-ab9f-470afde2b94b" />
