### PR TITLE
feat(tickets): do a desktop+mobile polish pass

### DIFF
--- a/resources/js/features/tickets/components/+index/TicketIndexRoot.tsx
+++ b/resources/js/features/tickets/components/+index/TicketIndexRoot.tsx
@@ -76,48 +76,58 @@ export const TicketIndexRoot: FC = () => {
     >
       <TicketListHeading />
 
-      <div className="flex w-full flex-wrap items-center gap-2">
-        <TicketListFilterChips
-          columnFilters={ticketListTableProps.columnFilters}
-          properties={filterProperties}
-          setColumnFilters={ticketListTableProps.setColumnFilters}
-        />
-
-        {filterProperties.length ? (
-          <TicketListFilterControl
-            columnFilters={ticketListTableProps.columnFilters}
-            isLabelHidden={hasFilterChips && hasNonDefaultFilters}
-            properties={filterProperties}
-            setColumnFilters={ticketListTableProps.setColumnFilters}
-          />
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+        {hasFilterChips ? (
+          <div className="flex flex-wrap items-center gap-2 sm:contents">
+            <TicketListFilterChips
+              columnFilters={ticketListTableProps.columnFilters}
+              properties={filterProperties}
+              setColumnFilters={ticketListTableProps.setColumnFilters}
+            />
+          </div>
         ) : null}
 
-        {hasNonDefaultFilters ? (
-          <TicketListResetFiltersButton
-            serverDefaultColumnFilters={serverDefaultColumnFilters}
-            setColumnFilters={ticketListTableProps.setColumnFilters}
-          />
-        ) : null}
+        <div className="flex flex-wrap items-center gap-2 sm:contents">
+          {filterProperties.length ? (
+            <TicketListFilterControl
+              columnFilters={ticketListTableProps.columnFilters}
+              isLabelHidden={hasFilterChips && hasNonDefaultFilters}
+              properties={filterProperties}
+              setColumnFilters={ticketListTableProps.setColumnFilters}
+            />
+          ) : null}
 
-        <p className="ml-auto text-neutral-200 light:text-neutral-900">
-          {unfilteredTotal && unfilteredTotal !== visibleTotal
-            ? t('{{visible, number}} of {{total, number}} tickets', {
-                visible: visibleTotal,
-                total: unfilteredTotal,
-                count: unfilteredTotal,
-              })
-            : t('{{val, number}} tickets', { count: visibleTotal, val: visibleTotal })}
-        </p>
+          {hasNonDefaultFilters ? (
+            <TicketListResetFiltersButton
+              serverDefaultColumnFilters={serverDefaultColumnFilters}
+              setColumnFilters={ticketListTableProps.setColumnFilters}
+            />
+          ) : null}
 
-        <TicketListDisplayPanel
-          columnDefinitions={columnDefinitions}
-          columnVisibility={ticketListTableProps.columnVisibility}
-          hasColumnVisibilityOverrides={ticketListTableProps.hasColumnVisibilityOverrides}
-          onResetDisplay={ticketListTableProps.resetDisplay}
-          onSortChange={ticketListTableProps.setSortParam}
-          onToggleColumn={ticketListTableProps.toggleColumnVisibility}
-          sortParam={ticketListTableProps.sortParam}
-        />
+          <div className="ml-auto flex items-center gap-2">
+            {visibleTotal > 0 ? (
+              <p className="whitespace-nowrap text-neutral-200 light:text-neutral-900">
+                {unfilteredTotal && unfilteredTotal !== visibleTotal
+                  ? t('{{visible, number}} of {{total, number}} tickets', {
+                      visible: visibleTotal,
+                      total: unfilteredTotal,
+                      count: unfilteredTotal,
+                    })
+                  : t('{{val, number}} tickets', { count: visibleTotal, val: visibleTotal })}
+              </p>
+            ) : null}
+
+            <TicketListDisplayPanel
+              columnDefinitions={columnDefinitions}
+              columnVisibility={ticketListTableProps.columnVisibility}
+              hasColumnVisibilityOverrides={ticketListTableProps.hasColumnVisibilityOverrides}
+              onResetDisplay={ticketListTableProps.resetDisplay}
+              onSortChange={ticketListTableProps.setSortParam}
+              onToggleColumn={ticketListTableProps.toggleColumnVisibility}
+              sortParam={ticketListTableProps.sortParam}
+            />
+          </div>
+        </div>
       </div>
 
       <TicketListTable

--- a/resources/js/features/tickets/components/TicketListDisplayPanel/TicketListDisplayPanel.tsx
+++ b/resources/js/features/tickets/components/TicketListDisplayPanel/TicketListDisplayPanel.tsx
@@ -82,7 +82,7 @@ export const TicketListDisplayPanel: FC<TicketListDisplayPanelProps> = ({
         <BaseButton
           size="sm"
           aria-label={t('Display')}
-          className={cn('relative', buildTrackingClassNames('Click Ticket Display'))}
+          className={cn('relative max-sm:h-9', buildTrackingClassNames('Click Ticket Display'))}
           data-testid="open-display-panel"
         >
           <RxMixerHorizontal className="size-4" />
@@ -147,30 +147,32 @@ export const TicketListDisplayPanel: FC<TicketListDisplayPanelProps> = ({
           </div>
         </div>
 
-        <BaseSeparator className="my-3" />
+        <div className="max-sm:hidden">
+          <BaseSeparator className="my-3" />
 
-        <p className="mb-2 text-neutral-400 light:text-neutral-600">{t('Columns')}</p>
+          <p className="mb-2 text-neutral-400 light:text-neutral-600">{t('Columns')}</p>
 
-        <div className="flex flex-wrap gap-1.5">
-          {columnDefinitions
-            .filter((columnDefinition) => columnDefinition.enableHiding !== false)
-            .map((columnDefinition) => (
-              <BaseToggle
-                key={columnDefinition.id}
-                pressed={columnVisibility[columnDefinition.id]}
-                data-testid={`column-toggle-${columnDefinition.id}`}
-                onPressedChange={() => onToggleColumn(columnDefinition.id)}
-                className={cn(
-                  'h-auto rounded-full border border-neutral-800 px-2.5 py-1',
-                  'text-xs font-normal text-neutral-500',
-                  'data-[state=on]:border-neutral-600 data-[state=on]:bg-neutral-700',
-                  'data-[state=on]:text-neutral-100 light:border-neutral-200 light:text-neutral-400',
-                  'data-[state=on]:light:border-neutral-300 data-[state=on]:light:bg-neutral-200 data-[state=on]:light:text-neutral-900',
-                )}
-              >
-                {columnDefinition.meta.t_label}
-              </BaseToggle>
-            ))}
+          <div className="flex flex-wrap gap-1.5">
+            {columnDefinitions
+              .filter((columnDefinition) => columnDefinition.enableHiding !== false)
+              .map((columnDefinition) => (
+                <BaseToggle
+                  key={columnDefinition.id}
+                  pressed={columnVisibility[columnDefinition.id]}
+                  data-testid={`column-toggle-${columnDefinition.id}`}
+                  onPressedChange={() => onToggleColumn(columnDefinition.id)}
+                  className={cn(
+                    'h-auto rounded-full border border-neutral-800 px-2.5 py-1',
+                    'text-xs font-normal text-neutral-500',
+                    'data-[state=on]:border-neutral-600 data-[state=on]:bg-neutral-700',
+                    'data-[state=on]:text-neutral-100 light:border-neutral-200 light:text-neutral-400',
+                    'data-[state=on]:light:border-neutral-300 data-[state=on]:light:bg-neutral-200 data-[state=on]:light:text-neutral-900',
+                  )}
+                >
+                  {columnDefinition.meta.t_label}
+                </BaseToggle>
+              ))}
+          </div>
         </div>
 
         {hasDisplayChanges ? (

--- a/resources/js/features/tickets/components/TicketListFilterChips/TicketListFilterChips.tsx
+++ b/resources/js/features/tickets/components/TicketListFilterChips/TicketListFilterChips.tsx
@@ -57,7 +57,7 @@ export const TicketListFilterChips: FC<TicketListFilterChipsProps> = ({
             key={property.id}
             data-testid={`chip-${property.id}`}
             className={cn(
-              'flex h-7.5 items-center divide-x divide-neutral-700 rounded-md border border-neutral-700 text-[13px]',
+              'flex h-7.5 items-center divide-x divide-neutral-700 rounded-md border border-neutral-700 text-[13px] max-sm:h-9',
               'bg-neutral-950 light:divide-neutral-200 light:border-neutral-200 light:bg-white',
             )}
           >

--- a/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterControl.test.tsx
+++ b/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterControl.test.tsx
@@ -64,7 +64,7 @@ describe('Component: TicketListFilterControl', () => {
 
   it('keeps an accessible name when its text is hidden', () => {
     // ARRANGE
-    render(
+    const { rerender } = render(
       <TicketListFilterControl
         columnFilters={[]}
         isLabelHidden={true}
@@ -74,9 +74,19 @@ describe('Component: TicketListFilterControl', () => {
     );
 
     // ASSERT
-    const triggerEl = screen.getByTestId('add-filter');
-    expect(triggerEl).toHaveTextContent('');
-    expect(triggerEl).toHaveAccessibleName('Filter');
+    expect(screen.getByTestId('add-filter')).toHaveAccessibleName('Filter');
+    expect(screen.getByText('Filter', { selector: 'span' })).toHaveClass('sm:hidden');
+
+    rerender(
+      <TicketListFilterControl
+        columnFilters={[]}
+        isLabelHidden={false}
+        properties={[statusProperty]}
+        setColumnFilters={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Filter', { selector: 'span' })).not.toHaveClass('sm:hidden');
   });
 
   it('given the user opens the menu, lists each possible property', async () => {
@@ -281,6 +291,87 @@ describe('Component: TicketListFilterControl', () => {
 
     // ASSERT
     expect(screen.getByText('No results found.')).toBeVisible();
+  });
+
+  describe('mobile', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: query === '(max-width: 639px)',
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    });
+
+    it('maintains one panel rather than branching submenus', async () => {
+      // ARRANGE
+      render(
+        <TicketListFilterControl
+          columnFilters={[]}
+          properties={[statusProperty, typeProperty]}
+          setColumnFilters={vi.fn()}
+        />,
+      );
+
+      // ACT
+      await userEvent.click(screen.getByTestId('add-filter'));
+      await userEvent.click(screen.getByTestId('filter-property-status'));
+
+      // ASSERT
+      expect(screen.getByRole('menuitem', { name: /open/i })).toBeVisible();
+      expect(screen.queryByTestId('filter-property-type')).not.toBeInTheDocument();
+    });
+
+    it('given the user drills into a filter, the back button returns to the user to the list of filters', async () => {
+      // ARRANGE
+      render(
+        <TicketListFilterControl
+          columnFilters={[]}
+          properties={[statusProperty, typeProperty]}
+          setColumnFilters={vi.fn()}
+        />,
+      );
+
+      // ACT
+      await userEvent.click(screen.getByTestId('add-filter'));
+      await userEvent.click(screen.getByTestId('filter-property-type'));
+      await userEvent.click(screen.getByTestId('filter-back'));
+
+      // ASSERT
+      expect(screen.getByTestId('filter-property-status')).toBeVisible();
+      expect(screen.getByTestId('filter-property-type')).toBeVisible();
+    });
+
+    it('given the user picks a filter value, sets the filter and closes the panel', async () => {
+      // ARRANGE
+      const setColumnFilters = vi.fn();
+
+      render(
+        <TicketListFilterControl
+          columnFilters={[]}
+          properties={[statusProperty, typeProperty]}
+          setColumnFilters={setColumnFilters}
+        />,
+      );
+
+      // ACT
+      await userEvent.click(screen.getByTestId('add-filter'));
+      await userEvent.click(screen.getByTestId('filter-property-type'));
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Did not trigger' }));
+
+      // ASSERT
+      const [updater] = setColumnFilters.mock.calls[0];
+      expect(updater([])).toEqual([{ id: 'type', value: ['2'] }]);
+
+      expect(screen.queryByTestId('filter-property-type')).not.toBeInTheDocument();
+    });
   });
 
   it('supports keyboard selection without a search field', async () => {

--- a/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterControl.tsx
+++ b/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterControl.tsx
@@ -1,12 +1,16 @@
 import type { ColumnFiltersState, Updater } from '@tanstack/react-table';
 import { type FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LuChevronLeft, LuChevronRight } from 'react-icons/lu';
 import { RxPlusCircled } from 'react-icons/rx';
+import { useMedia } from 'react-use';
 
 import { BaseButton } from '@/common/components/+vendor/BaseButton';
 import {
   BaseDropdownMenu,
   BaseDropdownMenuContent,
+  BaseDropdownMenuItem,
+  BaseDropdownMenuSeparator,
   BaseDropdownMenuSub,
   BaseDropdownMenuSubContent,
   BaseDropdownMenuSubTrigger,
@@ -36,68 +40,156 @@ export const TicketListFilterControl: FC<TicketListFilterControlProps> = ({
 }) => {
   const { t } = useTranslation();
 
+  const isMobile = useMedia('(max-width: 639px)', false); // also applies to narrow viewports
+
   const [isOpen, setIsOpen] = useState(false);
+  const [selectedFilterId, setSelectedFilterId] = useState<string | null>(null);
+
+  const selectedFilter = properties.find((property) => property.id === selectedFilterId) ?? null;
+
+  const handleOpenChange = (nextIsOpen: boolean) => {
+    setIsOpen(nextIsOpen);
+
+    if (!nextIsOpen) {
+      setSelectedFilterId(null);
+    }
+  };
 
   const handleValueSelect = (property: TicketListFilterProperty, value: string) => {
     setColumnFilters((previousFilters) =>
       setTicketListColumnFilterValue(previousFilters, property.id, value),
     );
 
-    setIsOpen(false);
+    handleOpenChange(false);
   };
 
+  const getSelectedValue = (property: TicketListFilterProperty) =>
+    getTicketListFilterValue(columnFilters, property.id) ?? property.noFilterValue;
+
   return (
-    <BaseDropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+    <BaseDropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
       <BaseDropdownMenuTrigger asChild>
         <BaseButton
           size="sm"
           aria-label={t('Filter')}
           className={cn(
-            'border-dashed bg-neutral-950 light:bg-white',
+            'border-dashed bg-neutral-950 max-sm:h-9 light:bg-white',
             buildTrackingClassNames('Click Ticket Filter'),
           )}
           data-testid="add-filter"
         >
-          <RxPlusCircled className={cn('size-4', isLabelHidden ? null : 'mr-2')} />
-          {isLabelHidden ? null : t('Filter')}
+          <RxPlusCircled className="size-4" />
+          <span className={cn('ml-2', isLabelHidden ? 'sm:hidden' : null)}>{t('Filter')}</span>
         </BaseButton>
       </BaseDropdownMenuTrigger>
 
-      <BaseDropdownMenuContent align="start" className="min-w-48">
-        {properties.map((property) => {
-          const selectedValue =
-            getTicketListFilterValue(columnFilters, property.id) ?? property.noFilterValue;
-          const isActive = selectedValue !== property.noFilterValue;
+      {isMobile ? (
+        <BaseDropdownMenuContent
+          align="start"
+          collisionPadding={16}
+          className={cn('w-[calc(100vw-2rem)] max-w-96', selectedFilter ? 'p-0' : null)}
+        >
+          {selectedFilter ? (
+            <>
+              <BaseDropdownMenuItem
+                data-testid="filter-back"
+                className="m-1 gap-2 py-2 font-medium"
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setSelectedFilterId(null);
+                }}
+              >
+                <LuChevronLeft className="size-4" aria-hidden={true} />
+                {selectedFilter.label}
+              </BaseDropdownMenuItem>
 
-          return (
-            <BaseDropdownMenuSub key={property.id}>
-              <BaseDropdownMenuSubTrigger
+              <BaseDropdownMenuSeparator />
+
+              <TicketListFilterValueList
+                property={selectedFilter}
+                selectedValue={getSelectedValue(selectedFilter)}
+                onSelect={(value) => handleValueSelect(selectedFilter, value)}
+              />
+            </>
+          ) : (
+            properties.map((property) => (
+              <BaseDropdownMenuItem
+                key={property.id}
                 data-testid={`filter-property-${property.id}`}
-                className="gap-2"
+                className="gap-2 py-2"
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setSelectedFilterId(property.id);
+                }}
               >
                 {property.label}
 
-                {isActive ? (
-                  <span
-                    role="img"
-                    aria-label={t('Active')}
-                    data-testid={`filter-property-${property.id}-active`}
-                    className="size-1.5 rounded-full bg-neutral-400 light:bg-neutral-500"
-                  />
-                ) : null}
-              </BaseDropdownMenuSubTrigger>
-
-              <BaseDropdownMenuSubContent className="min-w-64 p-0">
-                <TicketListFilterValueList
+                <PropertyActiveDot
                   property={property}
-                  selectedValue={selectedValue}
-                  onSelect={(value) => handleValueSelect(property, value)}
+                  isActive={getSelectedValue(property) !== property.noFilterValue}
                 />
-              </BaseDropdownMenuSubContent>
-            </BaseDropdownMenuSub>
-          );
-        })}
-      </BaseDropdownMenuContent>
+
+                <LuChevronRight
+                  className="ml-auto size-4 text-neutral-500 light:text-neutral-400"
+                  aria-hidden={true}
+                />
+              </BaseDropdownMenuItem>
+            ))
+          )}
+        </BaseDropdownMenuContent>
+      ) : (
+        <BaseDropdownMenuContent align="start" className="min-w-48">
+          {properties.map((property) => {
+            const selectedValue = getSelectedValue(property);
+
+            return (
+              <BaseDropdownMenuSub key={property.id}>
+                <BaseDropdownMenuSubTrigger
+                  data-testid={`filter-property-${property.id}`}
+                  className="gap-2"
+                >
+                  {property.label}
+
+                  <PropertyActiveDot
+                    property={property}
+                    isActive={selectedValue !== property.noFilterValue}
+                  />
+                </BaseDropdownMenuSubTrigger>
+
+                <BaseDropdownMenuSubContent className="min-w-64 p-0">
+                  <TicketListFilterValueList
+                    property={property}
+                    selectedValue={selectedValue}
+                    onSelect={(value) => handleValueSelect(property, value)}
+                  />
+                </BaseDropdownMenuSubContent>
+              </BaseDropdownMenuSub>
+            );
+          })}
+        </BaseDropdownMenuContent>
+      )}
     </BaseDropdownMenu>
+  );
+};
+
+interface PropertyActiveDotProps {
+  isActive: boolean;
+  property: TicketListFilterProperty;
+}
+
+const PropertyActiveDot: FC<PropertyActiveDotProps> = ({ isActive, property }) => {
+  const { t } = useTranslation();
+
+  if (!isActive) {
+    return null;
+  }
+
+  return (
+    <span
+      role="img"
+      aria-label={t('Active')}
+      data-testid={`filter-property-${property.id}-active`}
+      className="size-1.5 rounded-full bg-neutral-400 light:bg-neutral-500"
+    />
   );
 };

--- a/resources/js/features/tickets/components/TicketListResetFiltersButton/TicketListResetFiltersButton.tsx
+++ b/resources/js/features/tickets/components/TicketListResetFiltersButton/TicketListResetFiltersButton.tsx
@@ -21,7 +21,7 @@ export const TicketListResetFiltersButton: FC<TicketListResetFiltersButtonProps>
       variant="ghost"
       size="sm"
       onClick={() => setColumnFilters(serverDefaultColumnFilters)}
-      className="px-2 text-link lg:px-3"
+      className="px-2 text-link max-sm:h-9 lg:px-3"
       data-testid="reset-all-filters"
     >
       {t('Reset')} <RxCross2 className="ml-2 size-4" />

--- a/resources/js/features/tickets/components/TicketListTable/TicketListMobileRow.tsx
+++ b/resources/js/features/tickets/components/TicketListTable/TicketListMobileRow.tsx
@@ -45,7 +45,7 @@ export const TicketListMobileRow: FC<TicketListMobileRowProps> = ({ entry }) => 
             width={16}
             height={16}
             src={entry.reporter.avatarUrl}
-            alt={entry.reporter.avatarUrl}
+            alt="" // empty string is actually a sentinel value for assistive devices
             className="rounded-xs"
           />
         ) : null}

--- a/resources/js/features/tickets/components/TicketListTable/TicketListTable.test.tsx
+++ b/resources/js/features/tickets/components/TicketListTable/TicketListTable.test.tsx
@@ -432,9 +432,7 @@ describe('Component: TicketListTable', () => {
 
     // ... the full name and md5 are available in a tooltip ...
     await userEvent.hover(screen.getByText('(USA, Europe)'));
-    expect(
-      (await screen.findAllByText('Sonic The Hedgehog (USA, Europe).md'))[0],
-    ).toBeVisible();
+    expect((await screen.findAllByText('Sonic The Hedgehog (USA, Europe).md'))[0]).toBeVisible();
   });
 
   it('given the ticket has no emulator or hash, those cells stay empty', () => {

--- a/resources/js/features/tickets/components/TicketListTable/TicketListTable.tsx
+++ b/resources/js/features/tickets/components/TicketListTable/TicketListTable.tsx
@@ -74,7 +74,7 @@ export const TicketListTable: FC<TicketListTableProps> = ({
           role="table"
           aria-busy={isFetching ? true : undefined}
           className={cn(
-            'flex min-w-full flex-col overflow-hidden rounded-[0.3em] bg-embed',
+            'flex min-w-full flex-col overflow-hidden rounded-[0.3em] bg-embed sm:w-fit',
             isFetching ? 'opacity-50' : null,
           )}
         >

--- a/resources/js/features/tickets/utils/column-definitions/buildGameColumnDef.tsx
+++ b/resources/js/features/tickets/utils/column-definitions/buildGameColumnDef.tsx
@@ -30,7 +30,6 @@ export function buildGameColumnDef({
           <GameAvatar
             {...game}
             size={24}
-            hasTooltip={false}
             wrapperClassName={cn(
               'min-w-0 flex-1 overflow-hidden',
               ticketListCellClassNames.entityLinkWrapper,

--- a/resources/js/features/tickets/utils/column-definitions/buildTicketableColumnDef.tsx
+++ b/resources/js/features/tickets/utils/column-definitions/buildTicketableColumnDef.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { route } from 'ziggy-js';
 
+import { useCardTooltip } from '@/common/hooks/useCardTooltip';
 import { cn } from '@/common/utils/cn';
 import type { TranslatedString } from '@/types/i18next';
 
@@ -33,6 +34,11 @@ interface TicketableCellProps {
 const TicketableCell: FC<TicketableCellProps> = ({ entry }) => {
   const { t } = useTranslation();
 
+  const { cardTooltipProps } = useCardTooltip({
+    dynamicType: 'achievement', // TODO leaderboards
+    dynamicId: entry.ticketableId,
+  });
+
   if (entry.ticketableType === 'leaderboard') {
     return (
       <span className={cn(ticketListCellClassNames.dimText, ticketListCellClassNames.truncate)}>
@@ -50,6 +56,7 @@ const TicketableCell: FC<TicketableCellProps> = ({ entry }) => {
         'flex max-w-full min-w-0 items-center gap-2',
         ticketListCellClassNames.entityLinkWrapper,
       )}
+      {...cardTooltipProps}
     >
       {badgeUrl ? (
         <img

--- a/resources/js/features/tickets/utils/column-definitions/buildUserColumnDef.tsx
+++ b/resources/js/features/tickets/utils/column-definitions/buildUserColumnDef.tsx
@@ -66,7 +66,6 @@ const UserCell: FC<UserCellProps> = ({ shouldHideWhenUserIsMissing, user }) => {
     <UserAvatar
       {...user}
       size={16}
-      hasTooltip={false}
       wrapperClassName={cn('max-w-full min-w-0', ticketListCellClassNames.entityLinkWrapper)}
       labelClassName={cn(
         ticketListCellClassNames.entityLinkLabel,


### PR DESCRIPTION
This PR does a desktop & mobile polish pass of the React tickets list UX. There are a bunch of misc changes included in this branch to help tighten things up.

**Mobile Only Changes**

1. At this screen size, the mobile filter menu will no longer pop submenus that clip past the boundary of the screen.

<img width="371" height="288" alt="Screenshot 2026-08-31 at 6 06 00 PM" src="https://github.com/user-attachments/assets/1dac1ddc-57ab-4a01-9507-37efa018ad0e" />
<img width="367" height="210" alt="Screenshot 2026-08-31 at 6 06 10 PM" src="https://github.com/user-attachments/assets/4f80dc40-ccb5-4564-b0c5-b73a69a63c53" />

---

2. The toolbar at this narrow viewport has been restructured.

<img width="367" height="210" alt="Screenshot 2026-08-31 at 6 06 10 PM" src="https://github.com/user-attachments/assets/8637bcb4-3352-4008-bd0c-9010219d3051" />

---

3. Touch target sizes have been increased.

---

4. Columns are no longer configurable at this viewport size. Mobile is not intended to be used for triage, which is what those other columns tend to support. We just want to facilitate the user getting to the ticket they're looking for.

<img width="307" height="117" alt="Screenshot 2026-08-31 at 6 07 59 PM" src="https://github.com/user-attachments/assets/1549eca9-0a2b-4ebb-8981-bed784705d86" />

---

**Desktop Only Changes**

1. Tooltip cards are now displayed where appropriate.

<img width="460" height="177" alt="Screenshot 2026-08-31 at 6 10 24 PM" src="https://github.com/user-attachments/assets/8bc55e9c-1155-4904-9b38-4a37e69d4e54" />

---

2. Horizontal scroll works when there are enough columns to support it.