### PR TITLE
fix(api/v2): enforce a cap on number of leaderboard entries that can be returned

### DIFF
--- a/app/Api/V2/LeaderboardEntries/LeaderboardEntryCollectionQuery.php
+++ b/app/Api/V2/LeaderboardEntries/LeaderboardEntryCollectionQuery.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Api\V2\LeaderboardEntries;
+
+use App\Api\V2\DefaultCollectionQuery;
+
+class LeaderboardEntryCollectionQuery extends DefaultCollectionQuery
+{
+    /**
+     * Get the validation rules for the request.
+     */
+    public function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            'filter.maxRank' => ['integer', 'min:1', 'max:100'],
+        ]);
+    }
+}

--- a/tests/Feature/Api/V2/LeaderboardEntriesTest.php
+++ b/tests/Feature/Api/V2/LeaderboardEntriesTest.php
@@ -395,6 +395,22 @@ class LeaderboardEntriesTest extends TestCase
         ], collect($response->json('data'))->pluck('id')->all());
     }
 
+    public function testItLimitsTheMaximumNumberOfReturnedResults(): void
+    {
+        // Arrange
+        User::factory()->create(['web_api_key' => 'test-key']);
+        $leaderboard = Leaderboard::factory()->create();
+
+        // Act
+        $response = $this->jsonApi('v2')
+            ->expects('leaderboard-entries')
+            ->withHeader('X-API-Key', 'test-key')
+            ->get("/api/v2/leaderboards/{$leaderboard->id}/entries?filter[maxRank]=101");
+
+        // Assert
+        $response->assertStatus(400);
+    }
+
     public function testItReturnsFormattedScore(): void
     {
         // Arrange


### PR DESCRIPTION
Currently, `?filter[maxRank]` has no maximum allowed value. This PR sets a cap at 100.