### PR TITLE
feat(tickets): improve the filtered empty state

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -1602,5 +1602,9 @@
     "{{val, number}} tickets_one": "{{val, number}} ticket",
     "{{visible, number}} of {{total, number}} tickets_one": "{{visible, number}} of {{total, number}} ticket",
     "{{val, number}} tickets need your attention._one": "{{val, number}} ticket needs your attention.",
-    "Unresolved": "Unresolved"
+    "Unresolved": "Unresolved",
+    "No tickets have been reported for this game.": "No tickets have been reported for this game.",
+    "No tickets have been reported for this achievement.": "No tickets have been reported for this achievement.",
+    "There are no tickets in this list.": "There are no tickets in this list.",
+    "View all tickets": "View all tickets"
 }

--- a/resources/js/common/components/CommentList/CommentList.test.tsx
+++ b/resources/js/common/components/CommentList/CommentList.test.tsx
@@ -371,6 +371,7 @@ describe('Component: CommentList', () => {
       { pageProps },
     );
 
+    // ACT
     await userEvent.type(
       screen.getByRole('textbox', { name: /comment/i }),
       'this comment is not finished',
@@ -378,7 +379,6 @@ describe('Component: CommentList', () => {
 
     await waitFor(() => expect(screen.getByRole('button', { name: /submit/i })).toBeEnabled());
 
-    // ACT
     unmount();
 
     render(
@@ -395,6 +395,7 @@ describe('Component: CommentList', () => {
     expect(screen.getByRole('textbox', { name: /comment/i })).toHaveValue(
       'this comment is not finished',
     );
+    await waitFor(() => expect(screen.getByRole('button', { name: /submit/i })).toBeEnabled());
   });
 
   it('given the user submits their comment, does not restore it as a draft afterwards', async () => {

--- a/resources/js/features/tickets/components/+index/TicketIndexRoot.test.tsx
+++ b/resources/js/features/tickets/components/+index/TicketIndexRoot.test.tsx
@@ -153,6 +153,136 @@ describe('Component: TicketIndexRoot', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
+  it('given the default status has no matches, shows ticket history and a recovery action', () => {
+    // ARRANGE
+    renderTicketIndexRoot({
+      scope: 'game',
+      game: createGame({ system: createSystem() }),
+      paginatedTickets: createPaginatedData([], { total: 0, unfilteredTotal: 24 }),
+    });
+
+    // ASSERT
+    expect(screen.getByText('No tickets match these filters.')).toBeVisible();
+    expect(screen.getByText('0 of 24 tickets')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'View all tickets' })).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Reset filters' })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['View all tickets', 'all'],
+    ['Reset', 'unresolved'],
+  ])(
+    '%s clears custom filters while preserving the game scope and sort',
+    async (action, status) => {
+      // ARRANGE
+      vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+      const getSpy = vi.spyOn(axios, 'get').mockResolvedValue({
+        data: createTicketListResponse(
+          createPaginatedData([createTicketListEntry({ id: 4001 })], {
+            total: 1,
+            unfilteredTotal: 24,
+            lastPage: 1,
+          }),
+        ),
+      });
+
+      renderTicketIndexRoot({
+        scope: 'game',
+        game: createGame({ id: 1701, system: createSystem() }),
+        availableFilters: [
+          { kind: 'type', values: ['0', '1', '2'] },
+          { kind: 'mode', values: ['all', 'hardcore', 'softcore'] },
+          { kind: 'emulator', values: ['all', 'RetroArch', 'unknown'] },
+        ],
+        paginatedTickets: createPaginatedData([], { total: 0, unfilteredTotal: 24 }),
+        ziggy: createZiggyProps({
+          query: {
+            sort: 'createdAt',
+            filter: { status: 'open', type: '1', mode: 'hardcore', emulator: 'RetroArch' },
+          },
+        }),
+      });
+
+      // ACT
+      await userEvent.click(screen.getByRole('button', { name: action }));
+
+      // ASSERT
+      await waitFor(() => {
+        expect(getSpy).toHaveBeenCalledWith([
+          'api.ticket.index',
+          {
+            scope: 'game',
+            game: 1701,
+            sort: 'createdAt',
+            'filter[status]': status,
+            'filter[type]': '0',
+            'filter[mode]': 'all',
+            'filter[emulator]': 'all',
+            'page[number]': 1,
+          },
+        ]);
+      });
+
+      expect(await screen.findByRole('link', { name: 'Ticket #4001' })).toBeVisible();
+      expect(screen.queryByText('No tickets match these filters.')).not.toBeInTheDocument();
+    },
+  );
+
+  it('given the user hovers the empty state button, prefetches all tickets', async () => {
+    // ARRANGE
+    const getSpy = vi.spyOn(axios, 'get').mockResolvedValue({
+      data: createTicketListResponse(
+        createPaginatedData([createTicketListEntry({ id: 4001 })], { total: 1, lastPage: 1 }),
+      ),
+    });
+    renderTicketIndexRoot({
+      scope: 'game',
+      game: createGame({ id: 1701, system: createSystem() }),
+      paginatedTickets: createPaginatedData([], { total: 0, unfilteredTotal: 24 }),
+      ziggy: createZiggyProps({ query: { sort: 'createdAt', filter: { type: '1' } } }),
+    });
+    const viewAllButton = screen.getByRole('button', { name: 'View all tickets' });
+
+    // ACT
+    await userEvent.hover(viewAllButton);
+
+    // ASSERT
+    await waitFor(() => {
+      expect(getSpy).toHaveBeenCalledWith([
+        'api.ticket.index',
+        {
+          scope: 'game',
+          game: 1701,
+          sort: 'createdAt',
+          'filter[status]': 'all',
+          'filter[type]': '0',
+          'page[number]': 1,
+        },
+      ]);
+    });
+  });
+
+  it.each([
+    ['awaitingReporter', 'request', false],
+    ['all', 'all', true],
+  ] as const)(
+    'does not offer to clear filters in an unfiltered %s scope',
+    (scope, status, hasStatusFilter) => {
+      // ARRANGE
+      renderTicketIndexRoot({
+        scope,
+        defaultStatusFilter: status,
+        hasStatusFilter,
+        availableFilters: [],
+        paginatedTickets: createPaginatedData([], { total: 0, unfilteredTotal: 24 }),
+      });
+
+      // ASSERT
+      expect(screen.queryByRole('button', { name: 'View all tickets' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Reset filters' })).not.toBeInTheDocument();
+    },
+  );
+
   it('given the scope exposes filters, offers them all behind one filter button', async () => {
     // ARRANGE
     renderTicketIndexRoot({

--- a/resources/js/features/tickets/components/+index/TicketIndexRoot.tsx
+++ b/resources/js/features/tickets/components/+index/TicketIndexRoot.tsx
@@ -11,7 +11,9 @@ import { useTicketListTableRoot } from '../../hooks/useTicketListTableRoot';
 import { buildTicketListTargetParams } from '../../utils/buildTicketListTargetParams';
 import { getActiveTicketListFilterProperties } from '../../utils/getActiveTicketListFilterProperties';
 import { getAreTicketListFiltersNonDefault } from '../../utils/getAreTicketListFiltersNonDefault';
+import { setTicketListColumnFilterValue } from '../../utils/setTicketListColumnFilterValue';
 import { TicketListDisplayPanel } from '../TicketListDisplayPanel';
+import { TicketListEmptyState } from '../TicketListEmptyState';
 import { TicketListFilterChips } from '../TicketListFilterChips';
 import { TicketListFilterControl } from '../TicketListFilterControl';
 import { TicketListHeading } from '../TicketListHeading';
@@ -68,6 +70,16 @@ export const TicketIndexRoot: FC = () => {
   const visibleTotal = ticketListTableProps.paginatedTickets.total;
   const unfilteredTotal = ticketListTableProps.paginatedTickets.unfilteredTotal;
 
+  const unfilteredColumnFilters = setTicketListColumnFilterValue(
+    serverDefaultColumnFilters,
+    'status',
+    hasStatusFilter ? 'all' : defaultStatusFilter,
+  );
+  const hasFiltersToClear = getAreTicketListFiltersNonDefault(
+    ticketListTableProps.columnFilters,
+    unfilteredColumnFilters,
+  );
+
   return (
     <div
       id="pagination-scroll-target"
@@ -105,7 +117,7 @@ export const TicketIndexRoot: FC = () => {
           ) : null}
 
           <div className="ml-auto flex items-center gap-2">
-            {visibleTotal > 0 ? (
+            {visibleTotal > 0 || (unfilteredTotal !== null && unfilteredTotal !== undefined) ? (
               <p className="whitespace-nowrap text-neutral-200 light:text-neutral-900">
                 {unfilteredTotal && unfilteredTotal !== visibleTotal
                   ? t('{{visible, number}} of {{total, number}} tickets', {
@@ -135,6 +147,18 @@ export const TicketIndexRoot: FC = () => {
         columnVisibility={ticketListTableProps.columnVisibility}
         isFetching={ticketListTableProps.isFetching}
         paginatedTickets={ticketListTableProps.paginatedTickets}
+        emptyStateNode={
+          <TicketListEmptyState
+            scope={scope}
+            unfilteredTotal={unfilteredTotal}
+            onPrefetchViewAll={() => ticketListTableProps.prefetchFilters(unfilteredColumnFilters)}
+            onViewAll={
+              hasFiltersToClear
+                ? () => ticketListTableProps.setColumnFilters(unfilteredColumnFilters)
+                : undefined
+            }
+          />
+        }
         paginatorNode={
           <div className="flex items-center justify-center sm:justify-end">
             <DataTablePaginationControls

--- a/resources/js/features/tickets/components/+mine/TicketInboxMainRoot.tsx
+++ b/resources/js/features/tickets/components/+mine/TicketInboxMainRoot.tsx
@@ -46,10 +46,7 @@ export const TicketInboxMainRoot: FC = () => {
       user: displayName,
       'filter[status]': 'open',
     }),
-    resolvedByYou: route('developer.tickets.resolved', {
-      user: displayName,
-      'filter[status]': 'resolved',
-    }),
+    resolvedByYou: route('developer.tickets.resolved', { user: displayName }),
   };
 
   return (

--- a/resources/js/features/tickets/components/TicketListEmptyState/TicketListEmptyState.test.tsx
+++ b/resources/js/features/tickets/components/TicketListEmptyState/TicketListEmptyState.test.tsx
@@ -18,4 +18,27 @@ describe('Component: TicketListEmptyState', () => {
     // ASSERT
     expect(screen.getByText('No tickets match these filters.')).toBeVisible();
   });
+
+  it('does not claim there is no ticket history when the total is unavailable', () => {
+    // ARRANGE
+    render(<TicketListEmptyState unfilteredTotal={null} onViewAll={vi.fn()} />);
+
+    // ASSERT
+    expect(screen.getByText('No tickets match these filters.')).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'View all tickets' })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['game', 'No tickets have been reported for this game.'],
+    ['achievement', 'No tickets have been reported for this achievement.'],
+    ['assignedTo', 'There are no tickets in this list.'],
+  ])('distinguishes a truly empty %s scope from filtered results', (scope, message) => {
+    // ARRANGE
+    render(<TicketListEmptyState scope={scope as any} unfilteredTotal={0} onViewAll={vi.fn()} />);
+
+    // ASSERT
+    expect(screen.getByText(message)).toBeVisible();
+    expect(screen.queryByText('No tickets match these filters.')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'View all tickets' })).not.toBeInTheDocument();
+  });
 });

--- a/resources/js/features/tickets/components/TicketListEmptyState/TicketListEmptyState.tsx
+++ b/resources/js/features/tickets/components/TicketListEmptyState/TicketListEmptyState.tsx
@@ -1,12 +1,52 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export const TicketListEmptyState: FC = () => {
+import { BaseButton } from '@/common/components/+vendor/BaseButton';
+import { EmptyState } from '@/common/components/EmptyState';
+
+interface TicketListEmptyStateProps {
+  onPrefetchViewAll?: () => void;
+  onViewAll?: () => void;
+  scope?: App.Platform.Enums.TicketListScope;
+  unfilteredTotal?: number | null;
+}
+
+export const TicketListEmptyState: FC<TicketListEmptyStateProps> = ({
+  onPrefetchViewAll,
+  onViewAll,
+  scope,
+  unfilteredTotal,
+}) => {
   const { t } = useTranslation();
 
+  const hasTicketHistory = (unfilteredTotal ?? 0) > 0;
+
+  let noTicketsMessage = t('There are no tickets in this list.');
+  if (scope === 'game') {
+    noTicketsMessage = t('No tickets have been reported for this game.');
+  } else if (scope === 'achievement') {
+    noTicketsMessage = t('No tickets have been reported for this achievement.');
+  }
+
   return (
-    <p className="py-[0.4em] pb-[1.2em] text-neutral-400 light:text-neutral-600">
-      {t('No tickets match these filters.')}
-    </p>
+    <div className="rounded-[0.3em] bg-embed">
+      <EmptyState shouldShowImage={false}>
+        <span className="block text-neutral-400 light:text-neutral-600">
+          {unfilteredTotal === 0 ? noTicketsMessage : t('No tickets match these filters.')}
+        </span>
+
+        {hasTicketHistory && onViewAll ? (
+          <BaseButton
+            variant="ghost"
+            size="sm"
+            className="mt-3 text-link"
+            onClick={onViewAll}
+            onMouseEnter={onPrefetchViewAll}
+          >
+            {t('View all tickets')}
+          </BaseButton>
+        ) : null}
+      </EmptyState>
+    </div>
   );
 };

--- a/resources/js/features/tickets/hooks/useTicketListPaginatedQuery.ts
+++ b/resources/js/features/tickets/hooks/useTicketListPaginatedQuery.ts
@@ -1,4 +1,5 @@
 import { hashKey, keepPreviousData, QueryClient, useQuery } from '@tanstack/react-query';
+import type { ColumnFiltersState } from '@tanstack/react-table';
 import { useRef, useState } from 'react';
 
 import type { TicketListQueryData, TicketListQueryOptionsInput } from '../models';
@@ -37,5 +38,11 @@ export function useTicketListPaginatedQuery({
     queryClient.prefetchQuery(buildTicketListQueryOptions({ ...queryOptionsInput, pageNumber }));
   };
 
-  return { data: data ?? initialData, isFetching, prefetchPage };
+  const prefetchFilters = (columnFilters: ColumnFiltersState) => {
+    queryClient.prefetchQuery(
+      buildTicketListQueryOptions({ ...queryOptionsInput, columnFilters, pageNumber: 1 }),
+    );
+  };
+
+  return { data: data ?? initialData, isFetching, prefetchFilters, prefetchPage };
 }

--- a/resources/js/features/tickets/hooks/useTicketListTableRoot.ts
+++ b/resources/js/features/tickets/hooks/useTicketListTableRoot.ts
@@ -83,10 +83,11 @@ export function useTicketListTableRoot({
       setSortParam,
       sortParam,
       toggleColumnVisibility,
-      prefetchPage: ticketListQuery.prefetchPage,
       columnVisibility: { ...defaultColumnVisibility, ...columnVisibilityOverrides },
       hasColumnVisibilityOverrides: Object.keys(columnVisibilityOverrides).length > 0,
       isFetching: ticketListQuery.isFetching,
+      prefetchFilters: ticketListQuery.prefetchFilters,
+      prefetchPage: ticketListQuery.prefetchPage,
       ...ticketListQuery.data,
     },
   };


### PR DESCRIPTION
This PR improves the empty state for filtered ticket list pages. Now, there's a button to remove your current filter selection. It prefetches on hover.

**Before**
<img width="1283" height="266" alt="Screenshot 2026-09-09 at 7 21 20 PM" src="https://github.com/user-attachments/assets/671497ac-236e-44ff-937a-70c18f6ed498" />


**After**
<img width="1294" height="325" alt="Screenshot 2026-09-09 at 7 21 14 PM" src="https://github.com/user-attachments/assets/aaa81326-ce9f-40ef-a715-40d3bbe3752d" />
