### PR TITLE
feat(tickets): add resolved date column

### DIFF
--- a/resources/js/features/tickets/components/+index/TicketIndexRoot.test.tsx
+++ b/resources/js/features/tickets/components/+index/TicketIndexRoot.test.tsx
@@ -109,7 +109,7 @@ describe('Component: TicketIndexRoot', () => {
       'Game',
       'Developer',
       'Reporter',
-      'Age',
+      'Created',
     ]);
 
     expect(screen.getAllByRole('row')).toHaveLength(3);
@@ -590,6 +590,38 @@ describe('Component: TicketIndexRoot', () => {
     expect(screen.getByRole('columnheader', { name: 'Game' })).toBeVisible();
     expect(screen.queryByTestId('reset-display')).not.toBeInTheDocument();
     expect(screen.queryByTestId('display-changed-dot')).not.toBeInTheDocument();
+  });
+
+  it('given a resolved date sort, shows the resolved column by default', () => {
+    // ARRANGE
+    renderTicketIndexRoot({
+      ziggy: createZiggyProps({ query: { sort: '-resolvedAt' } }),
+    });
+
+    // ASSERT
+    expect(screen.getByRole('columnheader', { name: 'Resolved' })).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Created' })).toBeVisible();
+  });
+
+  it('given a hidden resolved column preference, keeps it hidden under a resolved date sort', async () => {
+    // ARRANGE
+    renderTicketIndexRoot({
+      scope: 'resolvedBy',
+      user: createUser(),
+      persistedViewPreferences: {
+        columnVisibility: { resolvedAt: false },
+        sortParam: '-resolvedAt',
+      },
+    });
+
+    // ASSERT
+    expect(screen.queryByRole('columnheader', { name: 'Resolved' })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Display' }));
+    await userEvent.click(screen.getByTestId('column-toggle-resolvedAt'));
+
+    expect(screen.getByRole('columnheader', { name: 'Resolved' })).toBeVisible();
+    expect(screen.queryByRole('columnheader', { name: 'Resolved by' })).not.toBeInTheDocument();
   });
 
   it('given only column visibility changed, resetting the display keeps the current page', async () => {

--- a/resources/js/features/tickets/components/TicketInboxSection/TicketInboxSection.test.tsx
+++ b/resources/js/features/tickets/components/TicketInboxSection/TicketInboxSection.test.tsx
@@ -103,6 +103,20 @@ describe('Component: TicketInboxSection', () => {
 
     // ASSERT
     const headers = screen.getAllByRole('columnheader').map((header) => header.textContent);
-    expect(headers).toEqual(['ID', 'Issue with', 'Game', 'Developer', 'Age']);
+    expect(headers).toEqual(['ID', 'Issue with', 'Game', 'Developer', 'Created']);
+  });
+
+  it('given the resolved by you section, shows the resolved date column', () => {
+    // ARRANGE
+    renderSection({
+      section: createTicketInboxSection({
+        kind: 'resolvedByYou',
+        count: 1,
+        tickets: [createTicketListEntry()],
+      }),
+    });
+
+    // ASSERT
+    expect(screen.getByRole('columnheader', { name: 'Resolved' })).toBeVisible();
   });
 });

--- a/resources/js/features/tickets/components/TicketInboxSection/TicketInboxSection.tsx
+++ b/resources/js/features/tickets/components/TicketInboxSection/TicketInboxSection.tsx
@@ -44,6 +44,10 @@ export const TicketInboxSection: FC<TicketInboxSectionProps> = ({
     counterpartyColumnId,
     'age',
   ]);
+  if (section.kind === 'resolvedByYou') {
+    visibleColumnIds.add('resolvedAt');
+  }
+
   const columnVisibility: VisibilityState = Object.fromEntries(
     TICKET_LIST_COLUMN_IDS.map((columnId) => [columnId, visibleColumnIds.has(columnId)]),
   );

--- a/resources/js/features/tickets/components/TicketListTable/TicketListTable.test.tsx
+++ b/resources/js/features/tickets/components/TicketListTable/TicketListTable.test.tsx
@@ -81,7 +81,7 @@ describe('Component: TicketListTable', () => {
 
     // ASSERT
     const headers = screen.getAllByRole('columnheader');
-    expect(headers.map((header) => header.textContent)).toEqual(['ID', 'Issue with', 'Age']);
+    expect(headers.map((header) => header.textContent)).toEqual(['ID', 'Issue with', 'Created']);
   });
 
   it('given every column is visible, renders all the headers in registry order', () => {
@@ -102,8 +102,48 @@ describe('Component: TicketListTable', () => {
       'Version',
       'Core',
       'Hash',
-      'Age',
+      'Created',
+      'Resolved',
     ]);
+  });
+
+  it('given created and resolved dates, shows their separate values and the exact date on hover in a tooltip', async () => {
+    // ARRANGE
+    vi.setSystemTime(new Date('2026-09-10T12:00:00Z'));
+    const ticket = createTicketListEntry({
+      id: 501,
+      state: 'resolved',
+      createdAt: '2026-09-05T12:00:00Z',
+      resolvedAt: '2026-09-08T12:00:00Z',
+    });
+
+    render(
+      <TestHarness
+        tickets={[ticket]}
+        columnVisibility={{ ...noneVisible, age: true, resolvedAt: true }}
+      />,
+    );
+
+    // ASSERT
+    const cells = within(screen.getByRole('row', { name: /Ticket #501/ })).getAllByRole('cell');
+    expect(cells.at(-2)).toHaveTextContent('5d ago');
+    expect(cells.at(-1)).toHaveTextContent('2d ago');
+
+    await userEvent.hover(screen.getByText('2d ago'));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Sep 8, 2026 12:00 PM');
+  });
+
+  it('given no resolved date, shows a dash as the column value', () => {
+    // ARRANGE
+    render(
+      <TestHarness
+        tickets={[createTicketListEntry({ resolvedAt: null })]}
+        columnVisibility={{ ...noneVisible, resolvedAt: true }}
+      />,
+    );
+
+    // ASSERT
+    expect(screen.getByText('-')).toBeVisible();
   });
 
   it('given zero rows, shows the empty state copy and no table', () => {
@@ -313,7 +353,7 @@ describe('Component: TicketListTable', () => {
     // ASSERT
     expect(screen.getAllByRole('columnheader').map((el) => el.textContent)).toEqual([
       'Issue with',
-      'Age',
+      'Created',
     ]);
     expect(screen.getAllByRole('img', { name: 'Open' })).toHaveLength(2);
   });

--- a/resources/js/features/tickets/hooks/useTicketListColumnDefinitions.ts
+++ b/resources/js/features/tickets/hooks/useTicketListColumnDefinitions.ts
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
 import type { TicketListColumnDefinition } from '../models';
-import { buildAgeColumnDef } from '../utils/column-definitions/buildAgeColumnDef';
+import { buildDateColumnDef } from '../utils/column-definitions/buildDateColumnDef';
 import { buildGameColumnDef } from '../utils/column-definitions/buildGameColumnDef';
 import { buildHashColumnDef } from '../utils/column-definitions/buildHashColumnDef';
 import { buildIdColumnDef } from '../utils/column-definitions/buildIdColumnDef';
@@ -81,6 +81,7 @@ export function useTicketListColumnDefinitions(): TicketListColumnDefinition[] {
     }),
     buildHashColumnDef({ t_label: t('Hash') }),
 
-    buildAgeColumnDef({ t_label: t('Age') }),
+    buildDateColumnDef({ id: 'age', t_label: t('Created') }),
+    buildDateColumnDef({ id: 'resolvedAt', t_label: t('Resolved') }),
   ];
 }

--- a/resources/js/features/tickets/hooks/useTicketListTableRoot.ts
+++ b/resources/js/features/tickets/hooks/useTicketListTableRoot.ts
@@ -43,7 +43,11 @@ export function useTicketListTableRoot({
     'status',
   ) as App.Platform.Enums.TicketListStatusFilter;
 
-  const defaultColumnVisibility = getTicketListDefaultColumnVisibility(scope, statusValue);
+  const defaultColumnVisibility = getTicketListDefaultColumnVisibility(
+    scope,
+    statusValue,
+    sortParam,
+  );
 
   const toggleColumnVisibility = (columnId: TicketListColumnId) => {
     setColumnVisibilityOverrides((previousOverrides) =>

--- a/resources/js/features/tickets/utils/column-definitions/buildDateColumnDef.tsx
+++ b/resources/js/features/tickets/utils/column-definitions/buildDateColumnDef.tsx
@@ -13,43 +13,52 @@ import type { TranslatedString } from '@/types/i18next';
 import type { TicketListColumnDefinition } from '../../models';
 import { ticketListCellClassNames } from './ticketListCellClassNames';
 
-interface BuildAgeColumnDefProps {
+interface BuildDateColumnDefProps {
+  id: 'age' | 'resolvedAt';
   t_label: TranslatedString;
 }
 
-export function buildAgeColumnDef({ t_label }: BuildAgeColumnDefProps): TicketListColumnDefinition {
+export function buildDateColumnDef({
+  id,
+  t_label,
+}: BuildDateColumnDefProps): TicketListColumnDefinition {
   return {
-    id: 'age',
+    id,
     meta: {
       t_label,
       align: 'right',
       responsiveClassName: 'w-[6em] flex-none text-right tabular-nums',
     },
 
-    cell: ({ row }) => <AgeCell createdAt={row.original.createdAt} />,
+    cell: ({ row }) => <DateCell date={row.original[id === 'age' ? 'createdAt' : 'resolvedAt']} />,
   };
 }
 
-interface AgeCellProps {
-  createdAt: string;
+interface DateCellProps {
+  date: string | null;
 }
 
-const AgeCell: FC<AgeCellProps> = ({ createdAt }) => {
+// TODO extract to common when something like this is needed later
+const DateCell: FC<DateCellProps> = ({ date }) => {
   const { formatDate } = useFormatDate();
   const { diffForHumans } = useDiffForHumans();
+
+  if (!date) {
+    return <span className={ticketListCellClassNames.dimText}>{'-'}</span>;
+  }
 
   return (
     <BaseTooltip>
       <BaseTooltipTrigger asChild>
         <span
-          className={cn(ticketListCellClassNames.dimText, 'block truncate')}
+          className={cn(ticketListCellClassNames.dimText, 'relative z-10 block truncate')}
           suppressHydrationWarning={true}
         >
-          {diffForHumans(createdAt, { style: 'narrow' })}
+          {diffForHumans(date, { style: 'narrow' })}
         </span>
       </BaseTooltipTrigger>
 
-      <BaseTooltipContent>{formatDate(createdAt, 'MMM DD, YYYY, HH:mm')}</BaseTooltipContent>
+      <BaseTooltipContent>{formatDate(date, 'lll')}</BaseTooltipContent>
     </BaseTooltip>
   );
 };

--- a/resources/js/features/tickets/utils/getTicketListDefaultColumnVisibility.test.ts
+++ b/resources/js/features/tickets/utils/getTicketListDefaultColumnVisibility.test.ts
@@ -20,6 +20,7 @@ describe('Util: getTicketListDefaultColumnVisibility', () => {
       core: false,
       hash: false,
       age: true,
+      resolvedAt: false,
     });
   });
 
@@ -42,8 +43,11 @@ describe('Util: getTicketListDefaultColumnVisibility', () => {
 
     // ASSERT
     expect(resolvedResult.resolver).toEqual(true);
+    expect(resolvedResult.resolvedAt).toEqual(true);
     expect(closedResult.resolver).toEqual(true);
+    expect(closedResult.resolvedAt).toEqual(true);
     expect(allResult.resolver).toEqual(true);
+    expect(allResult.resolvedAt).toEqual(true);
     expect(unresolvedResult.resolver).toEqual(false);
   });
 
@@ -53,5 +57,21 @@ describe('Util: getTicketListDefaultColumnVisibility', () => {
 
     // ASSERT
     expect(result.resolver).toEqual(false);
+  });
+
+  it('given a resolution date sort, shows the resolved column in either direction', () => {
+    // ACT
+    const ascendingResult = getTicketListDefaultColumnVisibility('all', 'unresolved', 'resolvedAt');
+    const descendingResult = getTicketListDefaultColumnVisibility(
+      'all',
+      'unresolved',
+      '-resolvedAt',
+    );
+
+    // ASSERT
+    expect(ascendingResult.resolvedAt).toEqual(true);
+    expect(descendingResult.resolvedAt).toEqual(true);
+    expect(ascendingResult.resolver).toEqual(false);
+    expect(descendingResult.resolver).toEqual(false);
   });
 });

--- a/resources/js/features/tickets/utils/getTicketListDefaultColumnVisibility.ts
+++ b/resources/js/features/tickets/utils/getTicketListDefaultColumnVisibility.ts
@@ -1,16 +1,23 @@
 import type { VisibilityState } from '@tanstack/react-table';
 
-import type { TicketListColumnId } from '../models';
+import type { TicketListColumnId, TicketListSortParam } from '../models';
 import { TICKET_LIST_COLUMN_IDS } from './ticketListColumnIds';
+import { ticketListSort } from './ticketListSort';
 
 export function getTicketListDefaultColumnVisibility(
   scope: App.Platform.Enums.TicketListScope,
   statusValue: App.Platform.Enums.TicketListStatusFilter,
+  sortParam: TicketListSortParam = ticketListSort.defaultParam,
 ): VisibilityState {
   const visibleColumnIds = new Set<TicketListColumnId>(visibleColumnIdsByScope[scope]);
 
   if (scope !== 'resolvedBy' && statusValuesShowingResolver.includes(statusValue)) {
     visibleColumnIds.add('resolver');
+    visibleColumnIds.add('resolvedAt');
+  }
+
+  if (ticketListSort.field(sortParam) === 'resolvedAt') {
+    visibleColumnIds.add('resolvedAt');
   }
 
   return Object.fromEntries(
@@ -28,7 +35,7 @@ const visibleColumnIdsByScope: Record<
   assignedTo: ['id', 'ticketable', 'game', 'reporter', 'age'],
   reportedBy: ['id', 'ticketable', 'game', 'developer', 'age'],
   awaitingReporter: ['id', 'ticketable', 'game', 'developer', 'age'],
-  resolvedBy: ['id', 'ticketable', 'game', 'reporter', 'age'],
+  resolvedBy: ['id', 'ticketable', 'game', 'reporter', 'age', 'resolvedAt'],
 };
 
 const statusValuesShowingResolver: App.Platform.Enums.TicketListStatusFilter[] = [

--- a/resources/js/features/tickets/utils/ticketListColumnIds.ts
+++ b/resources/js/features/tickets/utils/ticketListColumnIds.ts
@@ -12,4 +12,5 @@ export const TICKET_LIST_COLUMN_IDS = [
   'core',
   'hash',
   'age',
+  'resolvedAt',
 ] as const;


### PR DESCRIPTION
It's possible to sort by resolved date in the new tickets list, but the field itself is missing a column definition. This PR adds the column definition, and automatically toggles column visibility when the sort is active.

<img width="310" height="352" alt="Screenshot 2026-09-10 at 8 57 04 AM" src="https://github.com/user-attachments/assets/77766280-cf3c-4dc0-a0a5-00d57f729a5c" />
