### PR TITLE
feat(tickets): make the table header sticky

### DIFF
--- a/resources/js/features/tickets/components/TicketListTable/TicketListTable.test.tsx
+++ b/resources/js/features/tickets/components/TicketListTable/TicketListTable.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { FC } from 'react';
 import { route } from 'ziggy-js';
 
-import { render, screen, within } from '@/test';
+import { fireEvent, render, screen, within } from '@/test';
 import {
   createEmulator,
   createGame,
@@ -104,6 +104,23 @@ describe('Component: TicketListTable', () => {
       'Hash',
       'Age',
     ]);
+  });
+
+  it('synchronizes horizontal scrolling between the separate header element and row elements', () => {
+    // ARRANGE
+    render(<TestHarness columnVisibility={allVisible} />);
+
+    const table = screen.getByRole('table');
+    const header = screen.getAllByRole('columnheader')[0].parentElement!;
+    const headerViewport = header.parentElement!;
+    const row = within(table).getAllByRole('row')[1];
+    const bodyViewport = row.parentElement!;
+
+    // ASSERT
+    fireEvent.scroll(bodyViewport, { target: { scrollLeft: 200 } });
+    expect(headerViewport.scrollLeft).toBe(200);
+    fireEvent.scroll(headerViewport, { target: { scrollLeft: 100 } });
+    expect(bodyViewport.scrollLeft).toBe(100);
   });
 
   it('given zero rows, shows the empty state copy and no table', () => {

--- a/resources/js/features/tickets/components/TicketListTable/TicketListTable.tsx
+++ b/resources/js/features/tickets/components/TicketListTable/TicketListTable.tsx
@@ -10,10 +10,13 @@ import { route } from 'ziggy-js';
 
 import { cn } from '@/common/utils/cn';
 
+import { useSyncedHorizontalScroll } from '../../hooks/useSyncedHorizontalScroll';
 import type { TicketListColumnDefinition } from '../../models';
 import { TicketListEmptyState } from '../TicketListEmptyState';
 import { TicketStateGlyph } from '../TicketStateGlyph';
 import { TicketListMobileRow } from './TicketListMobileRow';
+
+const glyphSlotClassName = 'mx-[0.6em] flex w-4 flex-none items-center justify-center';
 
 type TicketListTablePage = Pick<
   App.Data.PaginatedData<App.Platform.Data.TicketListEntry>,
@@ -30,8 +33,6 @@ interface TicketListTableProps {
   paginatorNode?: ReactNode;
 }
 
-const glyphSlotClassName = 'mx-[0.6em] flex w-4 flex-none items-center justify-center';
-
 export const TicketListTable: FC<TicketListTableProps> = ({
   columnDefinitions,
   columnVisibility,
@@ -41,6 +42,15 @@ export const TicketListTable: FC<TicketListTableProps> = ({
   isFetching = false,
 }) => {
   const { t } = useTranslation();
+
+  /**
+   * The header and row elements use separate horizontal scroll containers
+   * so the header can stay sticky while other things scroll around on desktop.
+   * The browser doesn't sync scroll positions of the containers automatically,
+   * so we do it ourselves with a little bit of JS.
+   */
+  const { headerElRef, bodyElRef, handleHeaderScroll, handleBodyScroll } =
+    useSyncedHorizontalScroll();
 
   const table = useReactTable({
     columns: columnDefinitions,
@@ -69,18 +79,25 @@ export const TicketListTable: FC<TicketListTableProps> = ({
 
   return (
     <div className="flex flex-col gap-[0.6em]">
-      <div className="max-w-full overflow-x-auto">
+      <div
+        role="table"
+        aria-busy={isFetching ? true : undefined}
+        className={cn(
+          'min-w-0 max-w-full rounded-[0.3em] bg-embed',
+          isFetching ? 'opacity-50' : null,
+        )}
+      >
         <div
-          role="table"
-          aria-busy={isFetching ? true : undefined}
+          ref={headerElRef}
           className={cn(
-            'flex min-w-full flex-col overflow-hidden rounded-[0.3em] bg-embed sm:w-fit',
-            isFetching ? 'opacity-50' : null,
+            'scrollbar-none overflow-x-auto rounded-t-[0.3em] bg-embed',
+            'max-sm:hidden lg:sticky lg:top-10.25 lg:z-20 [&::-webkit-scrollbar]:hidden',
           )}
+          onScroll={handleHeaderScroll}
         >
           <div
             role="row"
-            className="flex min-w-full items-center gap-[0.6em] p-[0.6em] text-menu-link max-sm:hidden"
+            className="flex w-min min-w-full items-center gap-[0.6em] p-[0.6em] text-menu-link"
           >
             {hasIdColumn ? null : <span aria-hidden="true" className={glyphSlotClassName} />}
 
@@ -88,7 +105,10 @@ export const TicketListTable: FC<TicketListTableProps> = ({
               <Fragment key={column.id}>
                 <div
                   role="columnheader"
-                  className={cn('truncate', column.columnDef.meta?.responsiveClassName)}
+                  className={cn(
+                    'truncate contain-[inline-size]',
+                    column.columnDef.meta?.responsiveClassName,
+                  )}
                 >
                   {column.columnDef.meta?.t_label}
                 </div>
@@ -99,12 +119,21 @@ export const TicketListTable: FC<TicketListTableProps> = ({
               </Fragment>
             ))}
           </div>
+        </div>
 
+        <div
+          ref={bodyElRef}
+          className="overflow-x-auto rounded-b-[0.3em]"
+          onScroll={handleBodyScroll}
+        >
           {rows.map((row) => (
             <div
               key={row.id}
               role="row"
-              className="relative flex h-[2.6em] min-w-full items-center px-[0.6em] focus-within:bg-embed-highlight hover:bg-embed-highlight"
+              className={cn(
+                'relative flex h-[2.6em] min-w-full items-center gap-[0.6em] px-[0.6em]',
+                'focus-within:bg-embed-highlight hover:bg-embed-highlight sm:w-min',
+              )}
             >
               <a
                 href={route('ticket.show', { ticket: row.original.id })}
@@ -114,7 +143,7 @@ export const TicketListTable: FC<TicketListTableProps> = ({
 
               <TicketListMobileRow entry={row.original} />
 
-              <div className="min-w-0 flex-1 items-center gap-[0.6em] max-sm:hidden sm:flex">
+              <div className="max-sm:hidden sm:contents">
                 {hasIdColumn ? null : (
                   <div role="cell" className={glyphSlotClassName}>
                     <TicketStateGlyph state={row.original.state} />
@@ -126,7 +155,7 @@ export const TicketListTable: FC<TicketListTableProps> = ({
                     <div
                       role="cell"
                       className={cn(
-                        'min-w-0 overflow-hidden',
+                        'min-w-0 overflow-hidden contain-[inline-size]',
                         cell.column.columnDef.meta?.responsiveClassName,
                       )}
                     >

--- a/resources/js/features/tickets/hooks/useSyncedHorizontalScroll.ts
+++ b/resources/js/features/tickets/hooks/useSyncedHorizontalScroll.ts
@@ -1,0 +1,20 @@
+import { type UIEvent, useRef } from 'react';
+
+export function useSyncedHorizontalScroll() {
+  const headerElRef = useRef<HTMLDivElement>(null);
+  const bodyElRef = useRef<HTMLDivElement>(null);
+
+  const handleHeaderScroll = (event: UIEvent<HTMLDivElement>) => {
+    if (bodyElRef.current) {
+      bodyElRef.current.scrollLeft = event.currentTarget.scrollLeft;
+    }
+  };
+
+  const handleBodyScroll = (event: UIEvent<HTMLDivElement>) => {
+    if (headerElRef.current) {
+      headerElRef.current.scrollLeft = event.currentTarget.scrollLeft;
+    }
+  };
+
+  return { bodyElRef, handleBodyScroll, handleHeaderScroll, headerElRef };
+}


### PR DESCRIPTION
Adds sticky header support to the new tickets list. Had to use a different solution than the games datatable due to the table element structure being different. Extracted the necessary JS into a custom hook.

<img width="1242" height="281" alt="Screenshot 2026-09-10 at 6 08 37 PM" src="https://github.com/user-attachments/assets/076cf7a8-1cca-4a9b-b148-d26518227ce0" />
