### PR TITLE
feat(tickets): dim zero-result filter options

### DIFF
--- a/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterControl.test.tsx
+++ b/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterControl.test.tsx
@@ -160,6 +160,26 @@ describe('Component: TicketListFilterControl', () => {
     expect(screen.getByRole('menuitem', { name: /resolved/i })).toHaveTextContent('0');
   });
 
+  it('given a filter option would return zero results, dims the option', async () => {
+    // ARRANGE
+    const setColumnFilters = vi.fn();
+
+    render(
+      <TicketListFilterControl
+        columnFilters={[]}
+        properties={[statusProperty]}
+        setColumnFilters={setColumnFilters}
+      />,
+    );
+
+    // ACT
+    await openPropertySubmenu(0);
+
+    // ASSERT
+    expect(screen.getByText('Resolved').parentElement).toHaveClass('opacity-50');
+    expect(screen.getByText('Open').parentElement).not.toHaveClass('opacity-50');
+  });
+
   it('given the user picks a value, sets the filter', async () => {
     // ARRANGE
     const setColumnFilters = vi.fn();

--- a/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterValueList.tsx
+++ b/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterValueList.tsx
@@ -98,7 +98,7 @@ const TicketListFilterValueRow: FC<TicketListFilterValueRowProps> = ({
   const glyph = option.glyphState ? TICKET_STATE_GLYPHS[option.glyphState] : null;
 
   return (
-    <span className="flex w-full items-center">
+    <span className={cn('flex w-full items-center', option.count === 0 ? 'opacity-50' : null)}>
       <span
         className={cn(
           'mr-2 flex size-4 min-w-4 items-center justify-center rounded-full',


### PR DESCRIPTION
This PR makes a minor CSS adjustment to ticket filter options that would narrow the list to 0 results. They're now visually dimmed, though still selectable.

**Before**
<img width="466" height="338" alt="Screenshot 2026-09-11 at 9 37 46 AM" src="https://github.com/user-attachments/assets/2964a1af-7c0b-48c1-8407-1df5c3fbdfdc" />


**After**
<img width="469" height="328" alt="Screenshot 2026-09-11 at 9 37 36 AM" src="https://github.com/user-attachments/assets/f2fba4ee-da33-4d58-9c33-34146deefd47" />
