### PR TITLE
perf(tickets): add more prefetches

### DIFF
--- a/resources/js/features/tickets/components/+index/TicketIndexRoot.test.tsx
+++ b/resources/js/features/tickets/components/+index/TicketIndexRoot.test.tsx
@@ -431,7 +431,7 @@ describe('Component: TicketIndexRoot', () => {
     });
 
     // ACT
-    await userEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+    await userEvent.hover(screen.getByRole('button', { name: 'Go to next page' }));
 
     // ASSERT
     await waitFor(() => {
@@ -446,6 +446,12 @@ describe('Component: TicketIndexRoot', () => {
         },
       ]);
     });
+
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('link', { name: 'Ticket #1001' })).toBeVisible();
+    expect(pushStateSpy).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
 
     await waitFor(() => {
       expect(getSpy).toHaveBeenCalledWith([
@@ -463,6 +469,8 @@ describe('Component: TicketIndexRoot', () => {
     await waitFor(() => {
       expect(screen.getByRole('link', { name: 'Ticket #2001' })).toBeVisible();
     });
+
+    expect(getSpy).toHaveBeenCalledTimes(2);
 
     expect(pushStateSpy).toHaveBeenCalledWith(
       { inertia: true, ticketListSortParam: '-createdAt' },
@@ -650,7 +658,7 @@ describe('Component: TicketIndexRoot', () => {
     // ACT
     await userEvent.click(screen.getByRole('button', { name: 'Display' }));
     await userEvent.click(screen.getByTestId('column-toggle-game'));
-    await userEvent.click(screen.getByTestId('reset-display'));
+    await userEvent.click(screen.getByTestId('reset-display'), { skipHover: true });
 
     // ASSERT
     expect(screen.getByRole('spinbutton', { name: 'current page number' })).toHaveValue(2);
@@ -746,5 +754,158 @@ describe('Component: TicketIndexRoot', () => {
 
     // ASSERT
     expect(screen.getByText('1 ticket')).toBeVisible();
+  });
+
+  it('given the user hovers a status chip option, reuses the prefetched first page on selection', async () => {
+    // ARRANGE
+    const pushStateSpy = vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+    const getSpy = vi.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: createTicketListResponse(createPaginatedData([createTicketListEntry({ id: 9001 })])),
+    });
+
+    renderTicketIndexRoot({
+      paginatedTickets: createPaginatedData([createTicketListEntry({ id: 1001 })], {
+        currentPage: 4,
+        lastPage: 5,
+        perPage: 50,
+        total: 250,
+      }),
+      ziggy: createZiggyProps({ query: { filter: { type: '1' } } }),
+    });
+
+    const originalRow = screen.getByRole('link', { name: 'Ticket #1001' });
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: 'Change Status filter' }));
+    await userEvent.hover(screen.getByRole('menuitem', { name: /^quarantined/i }));
+
+    // ASSERT
+    await waitFor(() => expect(getSpy).toHaveBeenCalledOnce());
+    expect(getSpy).toHaveBeenCalledWith([
+      'api.ticket.index',
+      {
+        scope: 'all',
+        sort: '-createdAt',
+        'filter[status]': 'quarantined',
+        'filter[type]': '1',
+        'page[number]': 1,
+      },
+    ]);
+    expect(originalRow).toBeVisible();
+    expect(originalRow).toHaveAttribute('aria-label', 'Ticket #1001');
+    expect(pushStateSpy).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('menuitem', { name: /^quarantined/i }));
+
+    await waitFor(() => expect(screen.getByRole('link', { name: 'Ticket #9001' })).toBeVisible());
+    expect(getSpy).toHaveBeenCalledOnce();
+  });
+
+  it('given the user hovers a status menu option, prefetches that status', async () => {
+    // ARRANGE
+    const getSpy = vi.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: createTicketListResponse(createPaginatedData([])),
+    });
+
+    renderTicketIndexRoot();
+
+    // ACT
+    await openPropertySubmenu(0);
+    await userEvent.hover(screen.getByRole('menuitem', { name: /^quarantined/i }));
+
+    // ASSERT
+    await waitFor(() => expect(getSpy).toHaveBeenCalledOnce());
+    expect(getSpy).toHaveBeenCalledWith([
+      'api.ticket.index',
+      {
+        scope: 'all',
+        sort: '-createdAt',
+        'filter[status]': 'quarantined',
+        'filter[type]': '0',
+        'page[number]': 1,
+      },
+    ]);
+  });
+
+  it('given the user hovers a sort field, prefetches it with the current direction', async () => {
+    // ARRANGE
+    const getSpy = vi.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: createTicketListResponse(createPaginatedData([])),
+    });
+
+    renderTicketIndexRoot();
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: 'Display' }));
+    await userEvent.click(screen.getByTestId('sort-field'));
+    await userEvent.hover(screen.getByRole('option', { name: 'Status' }));
+
+    // ASSERT
+    await waitFor(() => expect(getSpy).toHaveBeenCalledOnce());
+    expect(getSpy).toHaveBeenCalledWith([
+      'api.ticket.index',
+      {
+        scope: 'all',
+        sort: '-state',
+        'filter[status]': 'unresolved',
+        'filter[type]': '0',
+        'page[number]': 1,
+      },
+    ]);
+  });
+
+  it('given the user hovers the reset filters button, prefetches the default filters', async () => {
+    // ARRANGE
+    const getSpy = vi.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: createTicketListResponse(createPaginatedData([])),
+    });
+
+    renderTicketIndexRoot({
+      ziggy: createZiggyProps({ query: { 'filter[status]': 'resolved' } }),
+    });
+
+    // ACT
+    await userEvent.hover(screen.getByTestId('reset-all-filters'));
+
+    // ASSERT
+    await waitFor(() => expect(getSpy).toHaveBeenCalledOnce());
+    expect(getSpy).toHaveBeenCalledWith([
+      'api.ticket.index',
+      {
+        scope: 'all',
+        sort: '-createdAt',
+        'filter[status]': 'unresolved',
+        'filter[type]': '0',
+        'page[number]': 1,
+      },
+    ]);
+  });
+
+  it('given the user hovers the reset display button, prefetches the default sort', async () => {
+    // ARRANGE
+    const getSpy = vi.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: createTicketListResponse(createPaginatedData([])),
+    });
+
+    renderTicketIndexRoot({
+      ziggy: createZiggyProps({ query: { sort: 'state' } }),
+    });
+
+    // ACT
+    await userEvent.click(screen.getByRole('button', { name: 'Display' }));
+    await userEvent.hover(screen.getByTestId('reset-display'));
+
+    // ASSERT
+    await waitFor(() => expect(getSpy).toHaveBeenCalledOnce());
+    expect(getSpy).toHaveBeenCalledWith([
+      'api.ticket.index',
+      {
+        scope: 'all',
+        sort: '-createdAt',
+        'filter[status]': 'unresolved',
+        'filter[type]': '0',
+        'page[number]': 1,
+      },
+    ]);
   });
 });

--- a/resources/js/features/tickets/components/+index/TicketIndexRoot.test.tsx
+++ b/resources/js/features/tickets/components/+index/TicketIndexRoot.test.tsx
@@ -658,7 +658,8 @@ describe('Component: TicketIndexRoot', () => {
     // ACT
     await userEvent.click(screen.getByRole('button', { name: 'Display' }));
     await userEvent.click(screen.getByTestId('column-toggle-game'));
-    await userEvent.click(screen.getByTestId('reset-display'), { skipHover: true });
+    await userEvent.hover(screen.getByTestId('reset-display'));
+    await userEvent.click(screen.getByTestId('reset-display'));
 
     // ASSERT
     expect(screen.getByRole('spinbutton', { name: 'current page number' })).toHaveValue(2);
@@ -861,7 +862,7 @@ describe('Component: TicketIndexRoot', () => {
     });
 
     renderTicketIndexRoot({
-      ziggy: createZiggyProps({ query: { 'filter[status]': 'resolved' } }),
+      ziggy: createZiggyProps({ query: { filter: { status: 'resolved' } } }),
     });
 
     // ACT

--- a/resources/js/features/tickets/components/+index/TicketIndexRoot.tsx
+++ b/resources/js/features/tickets/components/+index/TicketIndexRoot.tsx
@@ -11,6 +11,7 @@ import { useTicketListTableRoot } from '../../hooks/useTicketListTableRoot';
 import { buildTicketListTargetParams } from '../../utils/buildTicketListTargetParams';
 import { getActiveTicketListFilterProperties } from '../../utils/getActiveTicketListFilterProperties';
 import { getAreTicketListFiltersNonDefault } from '../../utils/getAreTicketListFiltersNonDefault';
+import { setTicketListColumnFilterValue } from '../../utils/setTicketListColumnFilterValue';
 import { TicketListDisplayPanel } from '../TicketListDisplayPanel';
 import { TicketListFilterChips } from '../TicketListFilterChips';
 import { TicketListFilterControl } from '../TicketListFilterControl';
@@ -68,6 +69,16 @@ export const TicketIndexRoot: FC = () => {
   const visibleTotal = ticketListTableProps.paginatedTickets.total;
   const unfilteredTotal = ticketListTableProps.paginatedTickets.unfilteredTotal;
 
+  const prefetchStatus = (value: string) => {
+    ticketListTableProps.prefetchList({
+      columnFilters: setTicketListColumnFilterValue(
+        ticketListTableProps.columnFilters,
+        'status',
+        value,
+      ),
+    });
+  };
+
   return (
     <div
       id="pagination-scroll-target"
@@ -80,6 +91,7 @@ export const TicketIndexRoot: FC = () => {
         {hasFilterChips ? (
           <div className="flex flex-wrap items-center gap-2 sm:contents">
             <TicketListFilterChips
+              onPrefetchStatus={prefetchStatus}
               columnFilters={ticketListTableProps.columnFilters}
               properties={filterProperties}
               setColumnFilters={ticketListTableProps.setColumnFilters}
@@ -92,6 +104,7 @@ export const TicketIndexRoot: FC = () => {
             <TicketListFilterControl
               columnFilters={ticketListTableProps.columnFilters}
               isLabelHidden={hasFilterChips && hasNonDefaultFilters}
+              onPrefetchStatus={prefetchStatus}
               properties={filterProperties}
               setColumnFilters={ticketListTableProps.setColumnFilters}
             />
@@ -99,6 +112,9 @@ export const TicketIndexRoot: FC = () => {
 
           {hasNonDefaultFilters ? (
             <TicketListResetFiltersButton
+              onPrefetch={() =>
+                ticketListTableProps.prefetchList({ columnFilters: serverDefaultColumnFilters })
+              }
               serverDefaultColumnFilters={serverDefaultColumnFilters}
               setColumnFilters={ticketListTableProps.setColumnFilters}
             />
@@ -121,6 +137,7 @@ export const TicketIndexRoot: FC = () => {
               columnDefinitions={columnDefinitions}
               columnVisibility={ticketListTableProps.columnVisibility}
               hasColumnVisibilityOverrides={ticketListTableProps.hasColumnVisibilityOverrides}
+              onPrefetchSort={(sortParam) => ticketListTableProps.prefetchList({ sortParam })}
               onResetDisplay={ticketListTableProps.resetDisplay}
               onSortChange={ticketListTableProps.setSortParam}
               onToggleColumn={ticketListTableProps.toggleColumnVisibility}
@@ -141,7 +158,7 @@ export const TicketIndexRoot: FC = () => {
               currentPage={ticketListTableProps.paginatedTickets.currentPage}
               lastPage={ticketListTableProps.paginatedTickets.lastPage}
               onPageChange={ticketListTableProps.setPageNumber}
-              onPrefetchPage={ticketListTableProps.prefetchPage}
+              onPrefetchPage={(pageNumber) => ticketListTableProps.prefetchList({ pageNumber })}
             />
           </div>
         }

--- a/resources/js/features/tickets/components/TicketListDisplayPanel/TicketListDisplayPanel.tsx
+++ b/resources/js/features/tickets/components/TicketListDisplayPanel/TicketListDisplayPanel.tsx
@@ -42,12 +42,15 @@ interface TicketListDisplayPanelProps {
   onSortChange: (sortParam: TicketListSortParam) => void;
   onToggleColumn: (columnId: TicketListColumnId) => void;
   sortParam: TicketListSortParam;
+
+  onPrefetchSort?: (sortParam: TicketListSortParam) => void;
 }
 
 export const TicketListDisplayPanel: FC<TicketListDisplayPanelProps> = ({
   columnDefinitions,
   columnVisibility,
   hasColumnVisibilityOverrides,
+  onPrefetchSort,
   onResetDisplay,
   onSortChange,
   onToggleColumn,
@@ -115,6 +118,9 @@ export const TicketListDisplayPanel: FC<TicketListDisplayPanelProps> = ({
                   className="size-8 flex-none p-0"
                   data-testid="toggle-sort-direction"
                   onClick={() => onSortChange(ticketListSort.build(sortField, !isAscending))}
+                  onMouseEnter={() =>
+                    onPrefetchSort?.(ticketListSort.build(sortField, !isAscending))
+                  }
                 >
                   {isAscending ? (
                     <LuArrowUpNarrowWide className="size-4" />
@@ -138,7 +144,11 @@ export const TicketListDisplayPanel: FC<TicketListDisplayPanelProps> = ({
 
               <BaseSelectContent>
                 {ticketListSort.fields.map((field) => (
-                  <BaseSelectItem key={field} value={field}>
+                  <BaseSelectItem
+                    key={field}
+                    value={field}
+                    onMouseEnter={() => onPrefetchSort?.(ticketListSort.build(field, isAscending))}
+                  >
                     {sortFieldLabels[field]}
                   </BaseSelectItem>
                 ))}
@@ -179,7 +189,12 @@ export const TicketListDisplayPanel: FC<TicketListDisplayPanelProps> = ({
           <>
             <BaseSeparator className="my-3" />
 
-            <BaseButton size="xs" data-testid="reset-display" onClick={onResetDisplay}>
+            <BaseButton
+              size="xs"
+              data-testid="reset-display"
+              onClick={onResetDisplay}
+              onMouseEnter={() => onPrefetchSort?.(ticketListSort.defaultParam)}
+            >
               {t('Reset to defaults')}
             </BaseButton>
           </>

--- a/resources/js/features/tickets/components/TicketListDisplayPanel/TicketListDisplayPanel.tsx
+++ b/resources/js/features/tickets/components/TicketListDisplayPanel/TicketListDisplayPanel.tsx
@@ -193,7 +193,11 @@ export const TicketListDisplayPanel: FC<TicketListDisplayPanelProps> = ({
               size="xs"
               data-testid="reset-display"
               onClick={onResetDisplay}
-              onMouseEnter={() => onPrefetchSort?.(ticketListSort.defaultParam)}
+              onMouseEnter={() => {
+                if (sortParam !== ticketListSort.defaultParam) {
+                  onPrefetchSort?.(ticketListSort.defaultParam);
+                }
+              }}
             >
               {t('Reset to defaults')}
             </BaseButton>

--- a/resources/js/features/tickets/components/TicketListFilterChips/TicketListFilterChips.tsx
+++ b/resources/js/features/tickets/components/TicketListFilterChips/TicketListFilterChips.tsx
@@ -19,10 +19,13 @@ interface TicketListFilterChipsProps {
   columnFilters: ColumnFiltersState;
   properties: TicketListFilterProperty[];
   setColumnFilters: (updaterOrValue: Updater<ColumnFiltersState>) => void;
+
+  onPrefetchStatus?: (value: string) => void;
 }
 
 export const TicketListFilterChips: FC<TicketListFilterChipsProps> = ({
   columnFilters,
+  onPrefetchStatus,
   properties,
   setColumnFilters,
 }) => {
@@ -91,9 +94,10 @@ export const TicketListFilterChips: FC<TicketListFilterChipsProps> = ({
 
               <BaseDropdownMenuContent align="start" className="min-w-64 p-0">
                 <TicketListFilterValueList
+                  onPrefetchStatus={onPrefetchStatus}
+                  onSelect={(nextValue) => handleValueChange(property, nextValue)}
                   property={property}
                   selectedValue={value}
-                  onSelect={(nextValue) => handleValueChange(property, nextValue)}
                 />
               </BaseDropdownMenuContent>
             </BaseDropdownMenu>

--- a/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterControl.tsx
+++ b/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterControl.tsx
@@ -30,10 +30,12 @@ interface TicketListFilterControlProps {
   setColumnFilters: (updaterOrValue: Updater<ColumnFiltersState>) => void;
 
   isLabelHidden?: boolean;
+  onPrefetchStatus?: (value: string) => void;
 }
 
 export const TicketListFilterControl: FC<TicketListFilterControlProps> = ({
   columnFilters,
+  onPrefetchStatus,
   properties,
   setColumnFilters,
   isLabelHidden = false,
@@ -106,9 +108,10 @@ export const TicketListFilterControl: FC<TicketListFilterControlProps> = ({
               <BaseDropdownMenuSeparator />
 
               <TicketListFilterValueList
+                onPrefetchStatus={onPrefetchStatus}
+                onSelect={(value) => handleValueSelect(selectedFilter, value)}
                 property={selectedFilter}
                 selectedValue={getSelectedValue(selectedFilter)}
-                onSelect={(value) => handleValueSelect(selectedFilter, value)}
               />
             </>
           ) : (
@@ -158,9 +161,10 @@ export const TicketListFilterControl: FC<TicketListFilterControlProps> = ({
 
                 <BaseDropdownMenuSubContent className="min-w-64 p-0">
                   <TicketListFilterValueList
+                    onPrefetchStatus={onPrefetchStatus}
+                    onSelect={(value) => handleValueSelect(property, value)}
                     property={property}
                     selectedValue={selectedValue}
-                    onSelect={(value) => handleValueSelect(property, value)}
                   />
                 </BaseDropdownMenuSubContent>
               </BaseDropdownMenuSub>

--- a/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterValueList.tsx
+++ b/resources/js/features/tickets/components/TicketListFilterControl/TicketListFilterValueList.tsx
@@ -21,6 +21,8 @@ interface TicketListFilterValueListProps {
   onSelect: (value: string) => void;
   property: TicketListFilterProperty;
   selectedValue: string;
+
+  onPrefetchStatus?: (value: string) => void;
 }
 
 const MAX_OPTIONS_WITHOUT_SEARCH = 8;
@@ -29,6 +31,7 @@ export const TicketListFilterValueList: FC<TicketListFilterValueListProps> = ({
   onSelect,
   property,
   selectedValue,
+  onPrefetchStatus,
 }) => {
   const { t } = useTranslation();
 
@@ -40,8 +43,11 @@ export const TicketListFilterValueList: FC<TicketListFilterValueListProps> = ({
         {property.options.map((option) => (
           <BaseDropdownMenuItem
             key={option.value}
-            onSelect={() => onSelect(option.value)}
             className="gap-0"
+            onSelect={() => onSelect(option.value)}
+            onMouseEnter={
+              property.id === 'status' ? () => onPrefetchStatus?.(option.value) : undefined
+            }
           >
             <TicketListFilterValueRow
               hasGlyphSlot={hasGlyphSlot}

--- a/resources/js/features/tickets/components/TicketListResetFiltersButton/TicketListResetFiltersButton.tsx
+++ b/resources/js/features/tickets/components/TicketListResetFiltersButton/TicketListResetFiltersButton.tsx
@@ -8,11 +8,14 @@ import { BaseButton } from '@/common/components/+vendor/BaseButton';
 interface TicketListResetFiltersButtonProps {
   serverDefaultColumnFilters: ColumnFiltersState;
   setColumnFilters: (updaterOrValue: Updater<ColumnFiltersState>) => void;
+
+  onPrefetch?: () => void;
 }
 
 export const TicketListResetFiltersButton: FC<TicketListResetFiltersButtonProps> = ({
   serverDefaultColumnFilters,
   setColumnFilters,
+  onPrefetch,
 }) => {
   const { t } = useTranslation();
 
@@ -20,8 +23,9 @@ export const TicketListResetFiltersButton: FC<TicketListResetFiltersButtonProps>
     <BaseButton
       variant="ghost"
       size="sm"
-      onClick={() => setColumnFilters(serverDefaultColumnFilters)}
       className="px-2 text-link max-sm:h-9 lg:px-3"
+      onClick={() => setColumnFilters(serverDefaultColumnFilters)}
+      onMouseEnter={onPrefetch}
       data-testid="reset-all-filters"
     >
       {t('Reset')} <RxCross2 className="ml-2 size-4" />

--- a/resources/js/features/tickets/hooks/useTicketListPaginatedQuery.ts
+++ b/resources/js/features/tickets/hooks/useTicketListPaginatedQuery.ts
@@ -33,9 +33,15 @@ export function useTicketListPaginatedQuery({
     queryClient,
   );
 
-  const prefetchPage = (pageNumber: number) => {
-    queryClient.prefetchQuery(buildTicketListQueryOptions({ ...queryOptionsInput, pageNumber }));
+  const prefetchList = (
+    overrides: Partial<
+      Pick<TicketListQueryOptionsInput, 'columnFilters' | 'sortParam' | 'pageNumber'>
+    >,
+  ) => {
+    queryClient.prefetchQuery(
+      buildTicketListQueryOptions({ ...queryOptionsInput, pageNumber: 1, ...overrides }),
+    );
   };
 
-  return { data: data ?? initialData, isFetching, prefetchPage };
+  return { data: data ?? initialData, isFetching, prefetchList };
 }

--- a/resources/js/features/tickets/hooks/useTicketListTableRoot.ts
+++ b/resources/js/features/tickets/hooks/useTicketListTableRoot.ts
@@ -87,7 +87,7 @@ export function useTicketListTableRoot({
       setSortParam,
       sortParam,
       toggleColumnVisibility,
-      prefetchPage: ticketListQuery.prefetchPage,
+      prefetchList: ticketListQuery.prefetchList,
       columnVisibility: { ...defaultColumnVisibility, ...columnVisibilityOverrides },
       hasColumnVisibilityOverrides: Object.keys(columnVisibilityOverrides).length > 0,
       isFetching: ticketListQuery.isFetching,


### PR DESCRIPTION
This PR brings over the prefetching pattern from other datatables to the tickets datatable. Filter options, sort settings, and reset buttons now all prefetch their destination on hover (observable in the network tab). On a slower connection, this results in considerably improved perceived performance of the page due to prewarming the React Query cache.

Will have a small conflict with #5215's changes.